### PR TITLE
META-2705: NPE while creating entity which has attribute of Array of structs

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -1389,6 +1389,7 @@ public class EntityGraphMapper {
         List           newElements         = (List) ctx.getValue();
         AtlasArrayType arrType             = (AtlasArrayType) attribute.getAttributeType();
         AtlasType      elementType         = arrType.getElementType();
+        boolean        isStructType        = (elementType.getTypeCategory() == TypeCategory.STRUCT);
         boolean        isReference         = isReference(elementType);
         boolean        isSoftReference     = ctx.getAttribute().getAttributeDef().isSoftReferenced();
         AtlasAttribute inverseRefAttribute = attribute.getInverseRefAttribute();
@@ -1444,8 +1445,9 @@ public class EntityGraphMapper {
             }
         }
 
-        if (isReference && !isSoftReference) {
-            boolean isAppendOnPartialUpdate = getAppendOptionForRelationship(ctx.getReferringVertex(), attribute.getName());
+        if (isReference && !isSoftReference ) {
+
+            boolean isAppendOnPartialUpdate = !isStructType ? getAppendOptionForRelationship(ctx.getReferringVertex(), attribute.getName()) : false;
 
             if (isAppendOnPartialUpdate) {
                 allArrayElements = unionCurrentAndNewElements(attribute, (List) currentElements, (List) newElementsCreated);
@@ -1484,11 +1486,13 @@ public class EntityGraphMapper {
         boolean                             ret                       = false;
         String                              entityTypeName            = AtlasGraphUtilsV2.getTypeName(entityVertex);
         AtlasEntityDef                      entityDef                 = typeRegistry.getEntityDefByName(entityTypeName);
-        List<AtlasRelationshipAttributeDef> relationshipAttributeDefs = entityDef.getRelationshipAttributeDefs();
+        if (entityDef != null) {
+            List<AtlasRelationshipAttributeDef> relationshipAttributeDefs = entityDef.getRelationshipAttributeDefs();
 
-        if (CollectionUtils.isNotEmpty(relationshipAttributeDefs)) {
-            ret = relationshipAttributeDefs.stream().anyMatch(relationshipAttrDef -> relationshipAttrDef.getName().equals(relationshipAttributeName)
-                    && relationshipAttrDef.isAppendOnPartialUpdate());
+            if (CollectionUtils.isNotEmpty(relationshipAttributeDefs)) {
+                ret = relationshipAttributeDefs.stream().anyMatch(relationshipAttrDef -> relationshipAttrDef.getName().equals(relationshipAttributeName)
+                        && relationshipAttrDef.isAppendOnPartialUpdate());
+            }
         }
 
         return ret;

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -1486,13 +1486,11 @@ public class EntityGraphMapper {
         boolean                             ret                       = false;
         String                              entityTypeName            = AtlasGraphUtilsV2.getTypeName(entityVertex);
         AtlasEntityDef                      entityDef                 = typeRegistry.getEntityDefByName(entityTypeName);
-        if (entityDef != null) {
-            List<AtlasRelationshipAttributeDef> relationshipAttributeDefs = entityDef.getRelationshipAttributeDefs();
+        List<AtlasRelationshipAttributeDef> relationshipAttributeDefs = entityDef.getRelationshipAttributeDefs();
 
-            if (CollectionUtils.isNotEmpty(relationshipAttributeDefs)) {
-                ret = relationshipAttributeDefs.stream().anyMatch(relationshipAttrDef -> relationshipAttrDef.getName().equals(relationshipAttributeName)
-                        && relationshipAttrDef.isAppendOnPartialUpdate());
-            }
+        if (CollectionUtils.isNotEmpty(relationshipAttributeDefs)) {
+            ret = relationshipAttributeDefs.stream().anyMatch(relationshipAttrDef -> relationshipAttrDef.getName().equals(relationshipAttributeName)
+                    && relationshipAttrDef.isAppendOnPartialUpdate());
         }
 
         return ret;


### PR DESCRIPTION
Found NPE while creating entity which has attribute of Array of struct. 

```
2021-09-27 09:47:41,202 ERROR - [etp561480862-228 - e3a8175a-692c-4d0e-976b-883d7026614d:] ~ Error handling a request: 2d67e70e541c57aa (ExceptionMapperUtil:32)
java.lang.NullPointerException
	at org.apache.atlas.repository.store.graph.v2.EntityGraphMapper.getAppendOptionForRelationship(EntityGraphMapper.java:1487)
	at org.apache.atlas.repository.store.graph.v2.EntityGraphMapper.mapArrayValue(EntityGraphMapper.java:1448)
	at org.apache.atlas.repository.store.graph.v2.EntityGraphMapper.mapToVertexByTypeCategory(EntityGraphMapper.java:858)
	at org.apache.atlas.repository.store.graph.v2.EntityGraphMapper.mapAttribute(EntityGraphMapper.java:751)
	at org.apache.atlas.repository.store.graph.v2.EntityGraphMapper.mapAttributes(EntityGraphMapper.java:660)
	at org.apache.atlas.repository.store.graph.v2.EntityGraphMapper.mapAttributes(EntityGraphMapper.java:645)
	at org.apache.atlas.repository.store.graph.v2.EntityGraphMapper.createVertex(EntityGraphMapper.java:1500)
	at org.apache.atlas.repository.store.graph.v2.EntityGraphMapper.mapStructValue(EntityGraphMapper.java:1123)
	at org.apache.atlas.repository.store.graph.v2.EntityGraphMapper.mapCollectionElementsToVertex(EntityGraphMapper.java:1559)
	at org.apache.atlas.repository.store.graph.v2.EntityGraphMapper.mapArrayValue(EntityGraphMapper.java:1433)
	at org.apache.atlas.repository.store.graph.v2.EntityGraphMapper.mapToVertexByTypeCategory(EntityGraphMapper.java:858)
	at org.apache.atlas.repository.store.graph.v2.EntityGraphMapper.mapAttribute(EntityGraphMapper.java:751)
	at org.apache.atlas.repository.store.graph.v2.EntityGraphMapper.mapAttributes(EntityGraphMapper.java:660)
	at org.apache.atlas.repository.store.graph.v2.EntityGraphMapper.mapAttributes(EntityGraphMapper.java:645)
	at org.apache.atlas.repository.store.graph.v2.EntityGraphMapper.createVertex(EntityGraphMapper.java:1500)
	at org.apache.atlas.repository.store.graph.v2.EntityGraphMapper.mapStructValue(EntityGraphMapper.java:1123)
	at org.apache.atlas.repository.store.graph.v2.EntityGraphMapper.mapToVertexByTypeCategory(EntityGraphMapper.java:772)
	at org.apache.atlas.repository.store.graph.v2.EntityGraphMapper.mapAttribute(EntityGraphMapper.java:751)
	at org.apache.atlas.repository.store.graph.v2.EntityGraphMapper.mapAttributes(EntityGraphMapper.java:660)
	at org.apache.atlas.repository.store.graph.v2.EntityGraphMapper.mapAttributesAndClassifications(EntityGraphMapper.java:309)
```

Testing Done:- Creating Bot entities with payload provided.