### PR TITLE
META-2707 Basic Search with param termName is not working

### DIFF
--- a/repository/src/main/java/org/apache/atlas/discovery/TermSearchProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/TermSearchProcessor.java
@@ -35,8 +35,10 @@ public class TermSearchProcessor extends SearchProcessor {
     private static final Logger LOG      = LoggerFactory.getLogger(TermSearchProcessor.class);
     private static final Logger PERF_LOG = AtlasPerfTracer.getPerfLogger("TermSearchProcessor");
 
+    public static final String ATLAS_ATTR_NAME                            = "name";
+    public static final String ATLAS_ATTR_QNAME                           = "qualifiedName";
+    public static final String ATLAS_GLOSSARY_ENTITY_TYPE                 = "AtlasGlossary";
     public static final String ATLAS_GLOSSARY_TERM_ENTITY_TYPE            = "AtlasGlossaryTerm";
-    public static final String ATLAS_GLOSSARY_TERM_ATTR_QNAME             = "qualifiedName";
     public static final String ATLAS_GLOSSARY_TERM_ATTR_ASSIGNED_ENTITIES = "assignedEntities";
     public static final String ATLAS_GLOSSARY_TERM_ATTR_MEANINGS          = "meanings";
 


### PR DESCRIPTION
## Change description
We changed qualifiedName pattern for Glossary, Category & Terms.
Basic search expects param 'termName' as qualifiedName of term i.e. in form of <term_name>@<glossary_name>
As we have used Nanoid for qualifiedName, this search does not return anything.

With this change API will handle scenario & will parse termName & do lookup with accordingly

> Description here

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
