### PR TITLE
Meta 2694 META-2668 Add name attribute in AtlasObjectId: accept attrs from request

### DIFF
--- a/intg/src/main/java/org/apache/atlas/model/discovery/SearchParameters.java
+++ b/intg/src/main/java/org/apache/atlas/model/discovery/SearchParameters.java
@@ -57,6 +57,7 @@ public class SearchParameters implements Serializable {
     private FilterCriteria entityFilters;
     private FilterCriteria tagFilters;
     private Set<String>    attributes;
+    private Set<String>    relationAttributes;
     private SortOrder      sortOrder;
 
     public static final String WILDCARD_CLASSIFICATIONS = "*";
@@ -297,6 +298,22 @@ public class SearchParameters implements Serializable {
      * @param sortOrder ASCENDING vs DESCENDING
      */
     public void setSortOrder(SortOrder sortOrder) { this.sortOrder = sortOrder; }
+
+    /**
+     * Attributes values for related entities in the result response
+     */
+    public Set<String> getRelationAttributes() {
+        return relationAttributes;
+    }
+
+    /**
+     * Return these attributes for related entities in the result response
+     * @param relationAttributes
+     */
+    public void setRelationAttributes(Set<String> relationAttributes) {
+        this.relationAttributes = relationAttributes;
+    }
+
 
     @Override
     public boolean equals(Object o) {

--- a/repository/src/main/java/org/apache/atlas/discovery/SearchContext.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/SearchContext.java
@@ -104,6 +104,9 @@ public class SearchContext {
         this.entityTypes        = getEntityTypes(searchParameters.getTypeName());
         this.classificationNames = getClassificationNames(searchParameters.getClassification());
         this.classificationTypes = getClassificationTypes(this.classificationNames);
+        //Set<String> attrsForRel = RequestContext.get().getRelationAttrsForSearch();
+        //attrsForRel.addAll(searchParameters.getRelationAttributes());
+        RequestContext.get().setRelationAttrsForSearch(searchParameters.getRelationAttributes());
 
         AtlasVertex glossaryTermVertex = getGlossaryTermVertex(searchParameters.getTermName());
 

--- a/repository/src/main/java/org/apache/atlas/discovery/SearchContext.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/SearchContext.java
@@ -104,8 +104,6 @@ public class SearchContext {
         this.entityTypes        = getEntityTypes(searchParameters.getTypeName());
         this.classificationNames = getClassificationNames(searchParameters.getClassification());
         this.classificationTypes = getClassificationTypes(this.classificationNames);
-        //Set<String> attrsForRel = RequestContext.get().getRelationAttrsForSearch();
-        //attrsForRel.addAll(searchParameters.getRelationAttributes());
         RequestContext.get().setRelationAttrsForSearch(searchParameters.getRelationAttributes());
 
         AtlasVertex glossaryTermVertex = getGlossaryTermVertex(searchParameters.getTermName());

--- a/repository/src/main/java/org/apache/atlas/glossary/GlossaryService.java
+++ b/repository/src/main/java/org/apache/atlas/glossary/GlossaryService.java
@@ -431,7 +431,7 @@ public class GlossaryService {
         }
 
         if (!storeObject.equals(atlasGlossaryTerm)) {
-            if (termExists(atlasGlossaryTerm)) {
+            if (!storeObject.getName().equals(atlasGlossaryTerm.getName()) && termExists(atlasGlossaryTerm)) {
                 throw new AtlasBaseException(AtlasErrorCode.GLOSSARY_TERM_ALREADY_EXISTS, atlasGlossaryTerm.getName());
             }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -20,6 +20,7 @@ package org.apache.atlas.repository.store.graph.v2;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.atlas.AtlasConfiguration;
 import org.apache.atlas.AtlasErrorCode;
+import org.apache.atlas.RequestContext;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.TimeBoundary;
 import org.apache.atlas.model.TypeCategory;
@@ -324,12 +325,12 @@ public class EntityGraphRetriever {
             }
 
             Map<String, Object> attributes = new HashMap<>();
-            if (allowAttributesObjectId && attributesObjectIdMap.containsKey(typeName)) {
-                for (String attributeName : attributesObjectIdMap.get(typeName)) {
+            Set<String> relationAttributes = RequestContext.get().getRelationAttrsForSearch();
+            if (CollectionUtils.isNotEmpty(relationAttributes)) {
+                for (String attributeName : relationAttributes) {
                     AtlasAttribute attribute = entityType.getAttribute(attributeName);
                     if (attribute != null
-                            && !uniqueAttributes.containsKey(attributeName)
-                            && attribute.getAttributeType().getTypeCategory().equals(TypeCategory.PRIMITIVE)) {
+                            && !uniqueAttributes.containsKey(attributeName)) {
                         Object attrValue = getVertexAttribute(entityVertex, attribute);
                         if (attrValue != null) {
                             attributes.put(attribute.getName(), attrValue);
@@ -359,12 +360,12 @@ public class EntityGraphRetriever {
             }
 
             Map<String, Object> attributes = new HashMap<>();
-            if (allowAttributesObjectId && attributesObjectIdMap.containsKey(entity.getTypeName())) {
-                for (String attributeName : attributesObjectIdMap.get(entity.getTypeName())) {
+            Set<String> relationAttributes = RequestContext.get().getRelationAttrsForSearch();
+            if (CollectionUtils.isNotEmpty(relationAttributes)) {
+                for (String attributeName : relationAttributes) {
                     AtlasAttribute attribute = entityType.getAttribute(attributeName);
                     if (attribute != null
-                            && !uniqueAttributes.containsKey(attributeName)
-                            && attribute.getAttributeType().getTypeCategory().equals(TypeCategory.PRIMITIVE)) {
+                            && !uniqueAttributes.containsKey(attributeName)) {
                         Object attrValue = entity.getAttribute(attributeName);
                         if (attrValue != null) {
                             attributes.put(attribute.getName(), attrValue);

--- a/server-api/src/main/java/org/apache/atlas/RequestContext.java
+++ b/server-api/src/main/java/org/apache/atlas/RequestContext.java
@@ -26,6 +26,7 @@ import org.apache.atlas.model.instance.AtlasObjectId;
 import org.apache.atlas.model.tasks.AtlasTask;
 import org.apache.atlas.utils.AtlasPerfMetrics;
 import org.apache.atlas.utils.AtlasPerfMetrics.MetricRecorder;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
@@ -63,6 +64,7 @@ public class RequestContext {
     private final Set<String>                            onlyCAUpdateEntities = new HashSet<>();
     private final Set<String>                            onlyBAUpdateEntities = new HashSet<>();
     private final List<AtlasTask>                        queuedTasks          = new ArrayList<>();
+    private final Set<String> relationAttrsForSearch = new HashSet<>();
 
 
     private String       user;
@@ -79,6 +81,7 @@ public class RequestContext {
     private boolean     createShellEntityForNonExistingReference = false;
     private boolean     skipFailedEntities = false;
     private String      currentTypePatchAction = "";
+
 
     private RequestContext() {
     }
@@ -125,6 +128,7 @@ public class RequestContext {
         this.entitiesToSkipUpdate.clear();
         this.onlyCAUpdateEntities.clear();
         this.onlyBAUpdateEntities.clear();
+        this.relationAttrsForSearch.clear();
         this.queuedTasks.clear();
 
         if (metrics != null && !metrics.isEmpty()) {
@@ -135,6 +139,15 @@ public class RequestContext {
 
         if (this.entityGuidInRequest != null) {
             this.entityGuidInRequest.clear();
+        }
+    }
+
+    public Set<String> getRelationAttrsForSearch() {
+        return relationAttrsForSearch;
+    }
+    public void setRelationAttrsForSearch(Set<String> relationAttrsForSearch) {
+        if (CollectionUtils.isNotEmpty(relationAttrsForSearch)){
+            this.relationAttrsForSearch.addAll(relationAttrsForSearch);
         }
     }
 


### PR DESCRIPTION
## Change description

Add name attribute in AtlasObjectId: accept attrs from request
Basic POST request will now accept param called "relationAttributes" & add those attributes (if present) into relationship object

Request Sample:
`{
"tagFilters": null,
"classification": null, 
"entityFilters": null,
"excludeDeletedEntities": false, 
"typeName": "AtlasGlossary",
"limit": 100,
"offset": 0,
"includeClassificationAttributes": true, 
"attributes": ["terms", "categories", "anchor"]	,
"relationAttributes": ["name", "shortDescription", "longDescription", "examples"]
}
`

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
