### PR TITLE
META-2714 - Linking multiple terms to multiple entities

### DIFF
--- a/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
@@ -174,6 +174,7 @@ public enum AtlasErrorCode {
     NOT_VALID_FILE(400, "ATLAS-400-00-09C", "Invalid {0} file"),
     ATTRIBUTE_NAME_ALREADY_EXISTS_IN_PARENT_TYPE(400, "ATLAS-400-00-09D", "Invalid attribute name: {0}.{1}. Attribute already exists in parent type: {2}"),
     UNAUTHORIZED_ACCESS(403, "ATLAS-403-00-001", "{0} is not authorized to perform {1}"),
+    EMPTY_REQUEST(400, "ATLAS-400-00-100", "Empty Request or null, expects Map of List of RelatedObjects with term-id as key"),
 
     // All Not found enums go here
     TYPE_NAME_NOT_FOUND(404, "ATLAS-404-00-001", "Given typename {0} was invalid"),

--- a/repository/src/main/java/org/apache/atlas/glossary/GlossaryService.java
+++ b/repository/src/main/java/org/apache/atlas/glossary/GlossaryService.java
@@ -30,6 +30,7 @@ import org.apache.atlas.model.glossary.relations.AtlasRelatedCategoryHeader;
 import org.apache.atlas.model.glossary.relations.AtlasRelatedTermHeader;
 import org.apache.atlas.model.glossary.relations.AtlasTermCategorizationHeader;
 import org.apache.atlas.model.instance.AtlasEntity;
+import org.apache.atlas.model.instance.AtlasEntityHeader;
 import org.apache.atlas.model.instance.AtlasRelatedObjectId;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
 import org.apache.atlas.repository.ogm.DataAccess;
@@ -491,6 +492,30 @@ public class GlossaryService {
         if (DEBUG_ENABLED) {
             LOG.debug("<== GlossaryService.deleteTerm()");
         }
+    }
+
+    @GraphTransaction
+    public void assignTermToEntities(Map<String, List<AtlasRelatedObjectId>>  mapOfTermRelatedObjectIds) throws AtlasBaseException {
+
+        for (String termGuid : mapOfTermRelatedObjectIds.keySet()) {
+
+            List<AtlasRelatedObjectId>  relatedObjectIds =    mapOfTermRelatedObjectIds.get(termGuid);
+
+            if (DEBUG_ENABLED) {
+                LOG.debug("==> GlossaryService.assignTermToEntities({}, {})", termGuid, relatedObjectIds);
+            }
+
+            AtlasGlossaryTerm glossaryTerm = dataAccess.load(getAtlasGlossaryTermSkeleton(termGuid));
+
+            glossaryTermUtils.processTermAssignments(glossaryTerm, relatedObjectIds);
+
+            entityChangeNotifier.onTermAddedToEntities(glossaryTerm, relatedObjectIds);
+
+        }
+        if (DEBUG_ENABLED) {
+            LOG.debug("<== GlossaryService.assignTermToEntities()");
+        }
+
     }
 
     @GraphTransaction

--- a/webapp/src/main/java/org/apache/atlas/web/rest/GlossaryREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/GlossaryREST.java
@@ -34,7 +34,9 @@ import org.apache.atlas.model.glossary.relations.AtlasRelatedTermHeader;
 import org.apache.atlas.model.instance.AtlasRelatedObjectId;
 import org.apache.atlas.utils.AtlasPerfTracer;
 import org.apache.atlas.web.util.Servlets;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -886,6 +888,36 @@ public class GlossaryREST {
             }
 
             glossaryService.assignTermToEntities(termGuid, relatedObjectIds);
+        } finally {
+            AtlasPerfTracer.log(perf);
+        }
+    }
+
+    /**
+     * Assign the given term to the provided list of entity headers
+     *
+     * @param mapOfTermToRelatedObjectIds Related Entity IDs to which the term has to be associated in Map with termGuid as key
+     * @throws AtlasBaseException
+     * @HTTP 204 If the term assignment was successful
+     * @HTTP 400 If ANY of the entity header is invalid
+     * @HTTP 404 If glossary guid in invalid
+     */
+    @POST
+    @Path("/terms/assignedEntities")
+    @Timed
+    public void assignTermsToMultipleEntities(Map<String, List<AtlasRelatedObjectId>> mapOfTermToRelatedObjectIds) throws AtlasBaseException {
+
+        if (mapOfTermToRelatedObjectIds == null || mapOfTermToRelatedObjectIds.isEmpty()) {
+            throw new AtlasBaseException(AtlasErrorCode.EMPTY_REQUEST);
+        }
+
+        AtlasPerfTracer perf = null;
+        try {
+            if (AtlasPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
+                perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "GlossaryREST.assignTermsToMultipleEntities()");
+            }
+
+            glossaryService.assignTermToEntities(mapOfTermToRelatedObjectIds);
         } finally {
             AtlasPerfTracer.log(perf);
         }


### PR DESCRIPTION
**Change Description**

Adding new REST end point to add multiple terms to multiple entities.

API -> _v2/glossary/terms/assignedEntities_

Request Body

```
{
    "<%term-guid%>": [
        {
            "guid": "9c1599c6-6681-4466-9005-c49e9cce2948"
        },
        {
            "guid": "7c81962c-57e6-455d-be07-c60883c30bec"
        }
    ],

    "bf8f4cd7-ef5a-4c32-b04e-7f5948c21bc9":[
                {
            "guid": "9c1599c6-6681-4466-9005-c49e9cce2948"
        },
        {
            "guid": "7c81962c-57e6-455d-be07-c60883c30bec"
        }
    ]
}
```