### PR TITLE
Include others attributes of Term in Response

### DIFF
--- a/intg/src/main/java/org/apache/atlas/model/glossary/relations/AtlasRelatedTermHeader.java
+++ b/intg/src/main/java/org/apache/atlas/model/glossary/relations/AtlasRelatedTermHeader.java
@@ -19,6 +19,7 @@ package org.apache.atlas.model.glossary.relations;
 
 import org.apache.atlas.model.annotation.AtlasJSON;
 import org.apache.atlas.model.glossary.enums.AtlasTermRelationshipStatus;
+import org.apache.commons.collections.CollectionUtils;
 
 import java.util.HashMap;
 import java.util.List;
@@ -34,27 +35,8 @@ public class AtlasRelatedTermHeader {
     private String expression;
     private String steward;
     private String source;
+    private Map<String, Object> attributes;
 
-    public Map<String, Object> getOtherAttributes() {
-        return otherAttributes;
-    }
-
-    private Map<String, Object> otherAttributes;
-
-
-
-    public void setOtherAttributes(Map<String, List<String>> rs, List includeAttributes) {
-        if (this.otherAttributes == null) {
-            this.otherAttributes = new HashMap<>();
-        }
-        if (includeAttributes!=null) {
-            for (String key : rs.keySet()) {
-                if (includeAttributes.contains(key)) {
-                    this.otherAttributes.put(key, rs.get(key).get(0));
-                }
-            }
-        }
-    }
 
     private AtlasTermRelationshipStatus status;
 
@@ -109,6 +91,23 @@ public class AtlasRelatedTermHeader {
         this.status = status;
     }
 
+    public void setAttributes(Map<String, List<String>> rs, List<String> includeAttributes) {
+        if (this.attributes == null) {
+            this.attributes = new HashMap<>();
+        }
+        if (CollectionUtils.isNotEmpty(includeAttributes)) {
+            for (String key : includeAttributes) {
+                if (includeAttributes.contains(key) &&  rs.get(key) != null) {
+                    this.attributes.put(key, rs.get(key).get(0));
+                }
+            }
+        }
+    }
+
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
@@ -120,13 +119,14 @@ public class AtlasRelatedTermHeader {
                        Objects.equals(expression, that.expression) &&
                        Objects.equals(steward, that.steward) &&
                        Objects.equals(source, that.source) &&
-                       status == that.status;
+                       status == that.status &&
+                       Objects.equals(attributes, that.attributes);
     }
 
     @Override
     public int hashCode() {
 
-        return Objects.hash(termGuid, relationGuid, description, expression, steward, source, status);
+        return Objects.hash(termGuid, relationGuid, description, expression, steward, source, status, attributes);
     }
 
     @Override
@@ -139,6 +139,7 @@ public class AtlasRelatedTermHeader {
         sb.append(", expression='").append(expression).append('\'');
         sb.append(", steward='").append(steward).append('\'');
         sb.append(", source='").append(source).append('\'');
+        sb.append(", attributes='").append(attributes).append('\'');
         sb.append(", status=").append(status);
         sb.append('}');
         return sb.toString();

--- a/intg/src/main/java/org/apache/atlas/model/glossary/relations/AtlasRelatedTermHeader.java
+++ b/intg/src/main/java/org/apache/atlas/model/glossary/relations/AtlasRelatedTermHeader.java
@@ -20,6 +20,9 @@ package org.apache.atlas.model.glossary.relations;
 import org.apache.atlas.model.annotation.AtlasJSON;
 import org.apache.atlas.model.glossary.enums.AtlasTermRelationshipStatus;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 @AtlasJSON
@@ -31,6 +34,27 @@ public class AtlasRelatedTermHeader {
     private String expression;
     private String steward;
     private String source;
+
+    public Map<String, Object> getOtherAttributes() {
+        return otherAttributes;
+    }
+
+    private Map<String, Object> otherAttributes;
+
+
+
+    public void setOtherAttributes(Map<String, List<String>> rs, List includeAttributes) {
+        if (this.otherAttributes == null) {
+            this.otherAttributes = new HashMap<>();
+        }
+        if (includeAttributes!=null) {
+            for (String key : rs.keySet()) {
+                if (includeAttributes.contains(key)) {
+                    this.otherAttributes.put(key, rs.get(key).get(0));
+                }
+            }
+        }
+    }
 
     private AtlasTermRelationshipStatus status;
 

--- a/repository/src/main/java/org/apache/atlas/glossary/GlossaryService.java
+++ b/repository/src/main/java/org/apache/atlas/glossary/GlossaryService.java
@@ -29,8 +29,6 @@ import org.apache.atlas.model.glossary.AtlasGlossaryTerm;
 import org.apache.atlas.model.glossary.relations.AtlasRelatedCategoryHeader;
 import org.apache.atlas.model.glossary.relations.AtlasRelatedTermHeader;
 import org.apache.atlas.model.glossary.relations.AtlasTermCategorizationHeader;
-import org.apache.atlas.model.instance.AtlasEntity;
-import org.apache.atlas.model.instance.AtlasEntityHeader;
 import org.apache.atlas.model.instance.AtlasRelatedObjectId;
 import org.apache.atlas.repository.Constants;
 import org.apache.atlas.repository.graph.AtlasGraphProvider;
@@ -832,7 +830,7 @@ public class GlossaryService {
         return ret;
     }
 
-    private void runPaginatedTermsQuery(int offset, int limit, SortOrder sortOrder, List<AtlasRelatedTermHeader> ret, GraphTraversal baseQuery, List attributes) {
+    private void runPaginatedTermsQuery(int offset, int limit, SortOrder sortOrder, List<AtlasRelatedTermHeader> ret, GraphTraversal baseQuery, List<String> attributes) {
         if (sortOrder != null) {
             Order order = sortOrder == SortOrder.ASCENDING ? Order.asc : Order.desc;
             baseQuery = baseQuery.order().by(Constants.TERM_DISPLAY_TEXT_KEY, order);
@@ -845,12 +843,12 @@ public class GlossaryService {
         constructTermsHeaders(ret, results, attributes);
     }
 
-    private void constructTermsHeaders(List<AtlasRelatedTermHeader> ret, Set<Map<String, List<String>>> queryResult, List attributes) {
+    private void constructTermsHeaders(List<AtlasRelatedTermHeader> ret, Set<Map<String, List<String>>> queryResult, List<String> attributes) {
         for (Map<String, List<String>> res : queryResult) {
             AtlasRelatedTermHeader atlasRelatedTermHeader = new AtlasRelatedTermHeader();
             atlasRelatedTermHeader.setTermGuid(res.get(Constants.GUID_PROPERTY_KEY).get(0));
             atlasRelatedTermHeader.setDisplayText(res.get(Constants.TERM_DISPLAY_TEXT_KEY).get(0));
-            atlasRelatedTermHeader.setOtherAttributes(res, attributes);
+            atlasRelatedTermHeader.setAttributes(res, attributes);
             ret.add(atlasRelatedTermHeader);
         }
     }

--- a/repository/src/main/java/org/apache/atlas/glossary/GlossaryService.java
+++ b/repository/src/main/java/org/apache/atlas/glossary/GlossaryService.java
@@ -783,7 +783,7 @@ public class GlossaryService {
 
 
     @GraphTransaction
-    public List<AtlasRelatedTermHeader> getCategoryTermsHeaders(String categoryGuid, int offset, int limit, SortOrder sortOrder) throws AtlasBaseException {
+    public List<AtlasRelatedTermHeader> getCategoryTermsHeaders(String categoryGuid, int offset, int limit, SortOrder sortOrder, List includeAttributes) throws AtlasBaseException {
         if (Objects.isNull(categoryGuid)) {
             throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST, "categoryGuid is null/empty");
         }
@@ -800,7 +800,7 @@ public class GlossaryService {
                 .out(Constants.CATEGORY_TERMS_EDGE_LABEL)
                 .has(Constants.STATE_PROPERTY_KEY, Constants.ACTIVE_STATE_VALUE);
 
-        runPaginatedTermsQuery(offset, limit, sortOrder, ret, query);
+        runPaginatedTermsQuery(offset, limit, sortOrder, ret, query, includeAttributes);
 
         return ret;
     }
@@ -827,32 +827,35 @@ public class GlossaryService {
             query = query.where(__.inE(Constants.CATEGORY_TERMS_EDGE_LABEL).count().is(P.eq(0)));
         }
 
-        runPaginatedTermsQuery(offset, limit, sortOrder, ret, query);
+        runPaginatedTermsQuery(offset, limit, sortOrder, ret, query , null);
 
         return ret;
     }
 
-    private void runPaginatedTermsQuery(int offset, int limit, SortOrder sortOrder, List<AtlasRelatedTermHeader> ret, GraphTraversal baseQuery) {
+    private void runPaginatedTermsQuery(int offset, int limit, SortOrder sortOrder, List<AtlasRelatedTermHeader> ret, GraphTraversal baseQuery, List attributes) {
         if (sortOrder != null) {
             Order order = sortOrder == SortOrder.ASCENDING ? Order.asc : Order.desc;
             baseQuery = baseQuery.order().by(Constants.TERM_DISPLAY_TEXT_KEY, order);
         }
 
         Set<Map<String, List<String>>> results = baseQuery
-                .valueMap(Constants.GUID_PROPERTY_KEY, Constants.TERM_DISPLAY_TEXT_KEY)
+                .valueMap()
                 .range(offset, limit + offset).toSet();
 
-        constructTermsHeaders(ret, results);
+        constructTermsHeaders(ret, results, attributes);
     }
 
-    private void constructTermsHeaders(List<AtlasRelatedTermHeader> ret, Set<Map<String, List<String>>> queryResult) {
+    private void constructTermsHeaders(List<AtlasRelatedTermHeader> ret, Set<Map<String, List<String>>> queryResult, List attributes) {
         for (Map<String, List<String>> res : queryResult) {
             AtlasRelatedTermHeader atlasRelatedTermHeader = new AtlasRelatedTermHeader();
             atlasRelatedTermHeader.setTermGuid(res.get(Constants.GUID_PROPERTY_KEY).get(0));
             atlasRelatedTermHeader.setDisplayText(res.get(Constants.TERM_DISPLAY_TEXT_KEY).get(0));
+            atlasRelatedTermHeader.setOtherAttributes(res, attributes);
             ret.add(atlasRelatedTermHeader);
         }
     }
+
+
 
     @GraphTransaction
     public List<AtlasRelatedCategoryHeader> getGlossaryCategoriesHeadersFull(String glossaryGuid, int offset, int limit, SortOrder sortOrder) throws AtlasBaseException {

--- a/webapp/src/main/java/org/apache/atlas/web/rest/GlossaryREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/GlossaryREST.java
@@ -866,7 +866,7 @@ public class GlossaryREST {
     public List<AtlasRelatedTermHeader> getCategoryTermFull(@PathParam("categoryGuid") String categoryGuid,
                                                          @DefaultValue("-1") @QueryParam("limit") String limit,
                                                          @DefaultValue("0") @QueryParam("offset") String offset,
-                                                         @DefaultValue("ASC") @QueryParam("sort") final String sort) throws AtlasBaseException {
+                                                         @DefaultValue("ASC") @QueryParam("sort") final String sort, @QueryParam("attributes") List<String> includeAttributes) throws AtlasBaseException {
         Servlets.validateQueryParamLength("categoryGuid", categoryGuid);
 
         AtlasPerfTracer perf = null;
@@ -875,7 +875,7 @@ public class GlossaryREST {
                 perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "GlossaryREST.getCategoryTerms(" + categoryGuid + ")");
             }
 
-            return glossaryService.getCategoryTermsHeaders(categoryGuid, Integer.parseInt(offset), Integer.parseInt(limit), toSortOrder(sort));
+            return glossaryService.getCategoryTermsHeaders(categoryGuid, Integer.parseInt(offset), Integer.parseInt(limit), toSortOrder(sort), includeAttributes);
 
         } finally {
             AtlasPerfTracer.log(perf);


### PR DESCRIPTION
## Change description

Added list of include attribute has a API Parameter to include attributes in API response

`curl -X GET "http://localhost:21000/api/atlas/v2/glossary/category/35758c73-3393-4869-aefc-8c88900dcb8a/terms/full?attributes=__modifiedBy&attributes=__createdBy&limit=-1&offset=0&sort=ASC" -H  "accept: application/json"
`


## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
