### PR TITLE
META-2723:- Set property isScrubbed in entityHeader for unauthorized entities while search

### DIFF
--- a/authorization/src/main/java/org/apache/atlas/authorize/AtlasAuthorizer.java
+++ b/authorization/src/main/java/org/apache/atlas/authorize/AtlasAuthorizer.java
@@ -118,24 +118,20 @@ public interface AtlasAuthorizer {
     default void scrubEntityHeader(AtlasEntityHeader entity, AtlasTypeRegistry typeRegistry) {
 
         AtlasEntityType entityType = typeRegistry.getEntityTypeByName(entity.getTypeName());
-        boolean skippedSrubbing = false;
+        boolean isScrubbed = false;
 
         if (entityType != null) {
             if (entity.getAttributes() != null) {
                 for (AtlasStructType.AtlasAttribute attribute : entityType.getAllAttributes().values()) {
                     if (!attribute.getAttributeDef().getSkipScrubbing()) {
                         entity.getAttributes().remove(attribute.getAttributeDef().getName());
-                    }else {
-                        skippedSrubbing = true;
+                        isScrubbed = true;
                     }
                 }
             }
         }
 
-        if(skippedSrubbing) {
-            entity.setAuthorized(false);
-        }
-
+        entity.setScrubbed(isScrubbed);
 
         if (entity.getClassifications() != null) {
             entity.getClassifications().clear();

--- a/intg/src/main/java/org/apache/atlas/model/instance/AtlasEntityHeader.java
+++ b/intg/src/main/java/org/apache/atlas/model/instance/AtlasEntityHeader.java
@@ -63,7 +63,7 @@ public class AtlasEntityHeader extends AtlasStruct implements Serializable {
     private List<AtlasTermAssignmentHeader> meanings            = null;
     private Boolean                         isIncomplete        = Boolean.FALSE;
     private Set<String>                     labels              = null;
-    private Boolean                         isAuthorized        = null;
+    private Boolean                         isScrubbed          = null;
 
     public AtlasEntityHeader() {
         this(null, null);
@@ -185,12 +185,13 @@ public class AtlasEntityHeader extends AtlasStruct implements Serializable {
         this.isIncomplete = isIncomplete;
     }
 
-    public Boolean getAuthorized() {
-        return isAuthorized;
+
+    public Boolean getScrubbed() {
+        return isScrubbed;
     }
 
-    public void setAuthorized(Boolean authorized) {
-        this.isAuthorized = authorized;
+    public void setScrubbed(Boolean scrubbed) {
+        isScrubbed = scrubbed;
     }
 
     @Override


### PR DESCRIPTION
## Change description

Added `isAuthorized` properties to entity header if an unauthorised entity is skipped from scrubbing

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
