### PR TITLE
META-2738 Update entity with POST /entity does not update classifications/BMs

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasEntityStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasEntityStore.java
@@ -151,6 +151,14 @@ public interface AtlasEntityStore {
      */
     EntityMutationResponse createOrUpdateGlossary(EntityStream entityStream, boolean isPartialUpdate,  boolean replaceClassifications) throws AtlasBaseException;
 
+    /**
+     * Create or update  entities in the stream
+     * @param entityStream AtlasEntityStream
+     * @return EntityMutationResponse Entity mutations operations with the corresponding set of entities on which these operations were performed
+     * @throws AtlasBaseException
+     */
+    EntityMutationResponse createOrUpdate(EntityStream entityStream, boolean replaceClassifications, boolean replaceBusinessAttributes) throws AtlasBaseException;
+
 
     /**
      * Create or update  entities with parameters necessary for import process

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -364,10 +364,15 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
 
     @Override
     @GraphTransaction
+    public EntityMutationResponse createOrUpdate(EntityStream entityStream,  boolean replaceClassifications, boolean replaceBusinessAttributes) throws AtlasBaseException {
+        return createOrUpdate(entityStream, false, replaceClassifications, replaceBusinessAttributes);
+    }
+
+    @Override
+    @GraphTransaction
     public EntityMutationResponse createOrUpdateGlossary(EntityStream entityStream, boolean isPartialUpdate, boolean replaceClassification) throws AtlasBaseException {
         return createOrUpdate(entityStream, isPartialUpdate, true, false);
     }
-
 
     @Override
     @GraphTransaction(logRollback = false)

--- a/webapp/src/main/java/org/apache/atlas/web/resources/EntityResource.java
+++ b/webapp/src/main/java/org/apache/atlas/web/resources/EntityResource.java
@@ -161,7 +161,7 @@ public class EntityResource {
             }
 
             AtlasEntitiesWithExtInfo entitiesInfo     = restAdapters.toAtlasEntities(jsonStrings);
-            EntityMutationResponse   mutationResponse = entityREST.createOrUpdate(entitiesInfo);
+            EntityMutationResponse   mutationResponse = entityREST.createOrUpdate(entitiesInfo, false, false);
 
             final List<String> guids = restAdapters.getGuids(mutationResponse.getCreatedEntities());
 
@@ -286,7 +286,7 @@ public class EntityResource {
             }
 
             AtlasEntitiesWithExtInfo   entitiesInfo     = restAdapters.toAtlasEntities(jsonStrings);
-            EntityMutationResponse     mutationResponse = entityREST.createOrUpdate(entitiesInfo);
+            EntityMutationResponse     mutationResponse = entityREST.createOrUpdate(entitiesInfo, false, false);
             CreateUpdateEntitiesResult result           = restAdapters.toCreateUpdateEntitiesResult(mutationResponse);
 
             if (LOG.isDebugEnabled()) {

--- a/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
@@ -422,7 +422,9 @@ public class EntityREST {
      */
     @POST
     @Timed
-    public EntityMutationResponse createOrUpdate(AtlasEntityWithExtInfo entity) throws AtlasBaseException {
+    public EntityMutationResponse createOrUpdate(AtlasEntityWithExtInfo entity,
+                                                 @QueryParam("replaceClassifications") @DefaultValue("false") boolean replaceClassifications,
+                                                 @QueryParam("replaceBusinessAttributes") @DefaultValue("false") boolean replaceBusinessAttributes) throws AtlasBaseException {
         AtlasPerfTracer perf = null;
 
         try {
@@ -430,7 +432,7 @@ public class EntityREST {
                 perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "EntityREST.createOrUpdate()");
             }
 
-            return entitiesStore.createOrUpdate(new AtlasEntityStream(entity), false);
+            return entitiesStore.createOrUpdate(new AtlasEntityStream(entity), replaceClassifications, replaceBusinessAttributes);
         } finally {
             AtlasPerfTracer.log(perf);
         }
@@ -821,7 +823,9 @@ public class EntityREST {
     @POST
     @Path("/bulk")
     @Timed
-    public EntityMutationResponse createOrUpdate(AtlasEntitiesWithExtInfo entities) throws AtlasBaseException {
+    public EntityMutationResponse createOrUpdate(AtlasEntitiesWithExtInfo entities,
+                                                 @QueryParam("replaceClassifications") @DefaultValue("false") boolean replaceClassifications,
+                                                 @QueryParam("replaceBusinessAttributes") @DefaultValue("false") boolean replaceBusinessAttributes) throws AtlasBaseException {
         AtlasPerfTracer perf = null;
 
         try {
@@ -832,7 +836,7 @@ public class EntityREST {
 
             EntityStream entityStream = new AtlasEntityStream(entities);
 
-            return entitiesStore.createOrUpdate(entityStream, false);
+            return entitiesStore.createOrUpdate(entityStream, replaceClassifications, replaceBusinessAttributes);
         } finally {
             AtlasPerfTracer.log(perf);
         }

--- a/webapp/src/test/java/org/apache/atlas/web/adapters/TestEntitiesREST.java
+++ b/webapp/src/test/java/org/apache/atlas/web/adapters/TestEntitiesREST.java
@@ -162,7 +162,7 @@ public class TestEntitiesREST {
         dbWithCustomAttr.setCustomAttributes(customAttr);
 
         AtlasEntitiesWithExtInfo atlasEntitiesWithExtInfo = new AtlasEntitiesWithExtInfo(dbWithCustomAttr);
-        EntityMutationResponse   response                 = entityREST.createOrUpdate(atlasEntitiesWithExtInfo);
+        EntityMutationResponse   response                 = entityREST.createOrUpdate(atlasEntitiesWithExtInfo, false, false);
 
         Assert.assertNotNull(response.getUpdatedEntitiesByTypeName(DATABASE_TYPE));
 
@@ -646,7 +646,7 @@ public class TestEntitiesREST {
             newEntities.addReferredEntity(serDeserEntity(column));
         }
 
-        EntityMutationResponse response2 = entityREST.createOrUpdate(newEntities);
+        EntityMutationResponse response2 = entityREST.createOrUpdate(newEntities, false, false);
 
         List<AtlasEntityHeader> newGuids = response2.getEntitiesByOperation(EntityMutations.EntityOperation.CREATE);
         Assert.assertNotNull(newGuids);
@@ -775,7 +775,7 @@ public class TestEntitiesREST {
             entities.addReferredEntity(column);
         }
 
-        EntityMutationResponse response = entityREST.createOrUpdate(entities);
+        EntityMutationResponse response = entityREST.createOrUpdate(entities, false, false);
         List<AtlasEntityHeader> guids = response.getEntitiesByOperation(EntityMutations.EntityOperation.CREATE);
 
         Assert.assertNotNull(guids);

--- a/webapp/src/test/java/org/apache/atlas/web/adapters/TestEntityREST.java
+++ b/webapp/src/test/java/org/apache/atlas/web/adapters/TestEntityREST.java
@@ -87,7 +87,7 @@ public class TestEntityREST {
     private void createTestEntity() throws Exception {
         AtlasEntity dbEntity = TestUtilsV2.createDBEntity();
 
-        final EntityMutationResponse response = entityREST.createOrUpdate(new AtlasEntitiesWithExtInfo(dbEntity));
+        final EntityMutationResponse response = entityREST.createOrUpdate(new AtlasEntitiesWithExtInfo(dbEntity), false, false);
 
         Assert.assertNotNull(response);
         List<AtlasEntityHeader> entitiesMutated = response.getEntitiesByOperation(EntityMutations.EntityOperation.CREATE);
@@ -391,7 +391,7 @@ public class TestEntityREST {
     @Test
     public void  testPartialUpdateByUniqueAttribute() throws Exception {
         AtlasEntity            dbEntity = TestUtilsV2.createDBEntity();
-        EntityMutationResponse response = entityREST.createOrUpdate(new AtlasEntitiesWithExtInfo(dbEntity));
+        EntityMutationResponse response = entityREST.createOrUpdate(new AtlasEntitiesWithExtInfo(dbEntity), false, false);
         String                 dbGuid   = response.getEntitiesByOperation(EntityMutations.EntityOperation.CREATE).get(0).getGuid();
 
         Assert.assertTrue(AtlasTypeUtil.isAssignedGuid(dbGuid));
@@ -422,7 +422,7 @@ public class TestEntityREST {
     @Test
     public void  testUpdateGetDeleteEntityByUniqueAttribute() throws Exception {
         AtlasEntity            dbEntity = TestUtilsV2.createDBEntity();
-        EntityMutationResponse response = entityREST.createOrUpdate(new AtlasEntitiesWithExtInfo(dbEntity));
+        EntityMutationResponse response = entityREST.createOrUpdate(new AtlasEntitiesWithExtInfo(dbEntity), false, false);
         String                 dbGuid   = response.getEntitiesByOperation(EntityMutations.EntityOperation.CREATE).get(0).getGuid();
 
         Assert.assertTrue(AtlasTypeUtil.isAssignedGuid(dbGuid));

--- a/webapp/src/test/java/org/apache/atlas/web/adapters/TestEntityRESTDelete.java
+++ b/webapp/src/test/java/org/apache/atlas/web/adapters/TestEntityRESTDelete.java
@@ -90,7 +90,7 @@ public class TestEntityRESTDelete {
         for (int i = 1; i <= 2; i++) {
             AtlasEntity dbEntity = TestUtilsV2.createDBEntity();
 
-            final EntityMutationResponse response = entityREST.createOrUpdate(new AtlasEntity.AtlasEntitiesWithExtInfo(dbEntity));
+            final EntityMutationResponse response = entityREST.createOrUpdate(new AtlasEntity.AtlasEntitiesWithExtInfo(dbEntity), false, false);
 
             assertNotNull(response);
             List<AtlasEntityHeader> entitiesMutated = response.getEntitiesByOperation(EntityMutations.EntityOperation.CREATE);

--- a/webapp/src/test/java/org/apache/atlas/web/adapters/TypeDefsRESTTest.java
+++ b/webapp/src/test/java/org/apache/atlas/web/adapters/TypeDefsRESTTest.java
@@ -80,7 +80,7 @@ public class TypeDefsRESTTest {
     private void createTestEntity() throws AtlasBaseException {
         AtlasEntity dbEntity = TestUtilsV2.createDBEntity();
 
-        final EntityMutationResponse response = entityREST.createOrUpdate(new AtlasEntity.AtlasEntitiesWithExtInfo(dbEntity));
+        final EntityMutationResponse response = entityREST.createOrUpdate(new AtlasEntity.AtlasEntitiesWithExtInfo(dbEntity), false, false);
 
         Assert.assertNotNull(response);
         List<AtlasEntityHeader> entitiesMutated = response.getEntitiesByOperation(EntityMutations.EntityOperation.CREATE);


### PR DESCRIPTION


(cherry picked from commit 8ca5a3b3489a87b2056434b420525daaf9ce056f)

## Change description

https://linear.app/atlanproduct/issue/META-2738/update-entity-with-post-entity-does-not-update-classifications

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
