### PR TITLE
Meta 2772 TypeDefs GET: query param support multiple types of defs

### DIFF
--- a/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
@@ -51,6 +51,7 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
@@ -511,13 +512,21 @@ public class TypesREST {
 
         for (String k : keySet) {
             String key   = String.valueOf(k);
-            String value = String.valueOf(httpServletRequest.getParameter(k));
 
-            if (key.equalsIgnoreCase("excludeInternalTypesAndReferences") && value.equalsIgnoreCase("true")) {
-                FilterUtil.addParamsToHideInternalType(ret);
+            if (key.equalsIgnoreCase("type")) {
+                String[] values = httpServletRequest.getParameterValues(k);
+                ret.setParam(key, Arrays.asList(values));
+
             } else {
-                ret.setParam(key, value);
+                String value = String.valueOf(httpServletRequest.getParameter(k));
+
+                if (key.equalsIgnoreCase("excludeInternalTypesAndReferences") && value.equalsIgnoreCase("true")) {
+                    FilterUtil.addParamsToHideInternalType(ret);
+                } else {
+                    ret.setParam(key, value);
+                }
             }
+
         }
 
         return ret;


### PR DESCRIPTION
## Change description

https://linear.app/atlanproduct/issue/META-2772/typedefs-get-query-param-support-multiple-types-of-defs

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
