### PR TITLE
META-2771 Inputs & outputs in properties section not visible from ColumnProcess entity

### DIFF
--- a/intg/src/main/java/org/apache/atlas/type/AtlasStructType.java
+++ b/intg/src/main/java/org/apache/atlas/type/AtlasStructType.java
@@ -766,7 +766,7 @@ public class AtlasStructType extends AtlasType {
             this.vertexPropertyName       = generateVertexPropertyName(attributeDef);
             this.vertexUniquePropertyName = attrDef.getIsUnique() ? encodePropertyKey(UNIQUE_ATTRIBUTE_SHADE_PROPERTY_PREFIX + attributeDef.getName()) : null;
             this.relationshipName         = relationshipName;
-            this.relationshipEdgeLabel    = getRelationshipEdgeLabel(relationshipLabel);
+            this.relationshipEdgeLabel    = getRelationshipEdgeLabel(definedInType.getStructDef(), relationshipLabel);
             boolean isOwnedRef            = false;
             String  inverseRefAttribute   = null;
 
@@ -1142,7 +1142,19 @@ public class AtlasStructType extends AtlasType {
             return false;
         }
 
-        private String getRelationshipEdgeLabel(String relationshipLabel) {
+        private static boolean isRootType(AtlasStructDef structDef) {
+            return StringUtils.equals(structDef.getName(), AtlasEntityType.ENTITY_ROOT.getTypeName()) ||
+                    StringUtils.equals(structDef.getName(), AtlasClassificationType.CLASSIFICATION_ROOT.getTypeName());
+        }
+
+        private String getRelationshipEdgeLabel(AtlasStructDef structDef, String relationshipLabel) {
+            String qualifiedName = "";
+            if (isRootType(structDef)) {
+                qualifiedName = this.qualifiedName;
+            } else {
+                qualifiedName = String.format("%s.%s", structDef.getName(), this.qualifiedName);
+            }
+
             return (relationshipLabel == null) ? getEdgeLabel(qualifiedName) : relationshipLabel;
         }
 


### PR DESCRIPTION
…

(cherry picked from commit 5fdab0a16ac077137b3c10d1902b54d921620a5c)

## Change description

https://linear.app/atlanproduct/issue/META-2771/inputs-and-outputs-in-properties-section-not-visible-from

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
