### PR TITLE
META-2807 ES audits: add qualifedName of the entity to audit entry

### DIFF
--- a/addons/elasticsearch/es-audit-mappings.json
+++ b/addons/elasticsearch/es-audit-mappings.json
@@ -1,6 +1,9 @@
 {
   "mappings": {
     "properties": {
+      "entityQualifiedName": {
+        "type": "keyword"
+      },
       "entityId": {
         "type": "keyword"
       },

--- a/intg/src/main/java/org/apache/atlas/model/audit/AuditSearchParams.java
+++ b/intg/src/main/java/org/apache/atlas/model/audit/AuditSearchParams.java
@@ -3,7 +3,11 @@ package org.apache.atlas.model.audit;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.apache.atlas.type.AtlasType;
+import org.apache.commons.collections.CollectionUtils;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
@@ -14,7 +18,16 @@ import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.PUBLIC_
 
 public class AuditSearchParams {
 
+    private static Map<String, Object> defaultSort = new HashMap<>();
+
     private Map dsl;
+
+    public AuditSearchParams() {
+        Map<String, Object> order = new HashMap<>();
+        order.put("order", "desc");
+
+        defaultSort.put("created", order);
+    }
 
     public void setDsl(Map dsl) {
         this.dsl = dsl;
@@ -40,6 +53,12 @@ public class AuditSearchParams {
     }
 
     public String getQueryString() {
-        return dsl != null ? AtlasType.toJson(dsl) : "";
+        if (this.dsl != null) {
+            if (!this.dsl.containsKey("sort")) {
+                dsl.put("sort", Collections.singleton(defaultSort));
+            }
+            return AtlasType.toJson(dsl);
+        }
+        return "";
     }
 }

--- a/intg/src/main/java/org/apache/atlas/model/audit/EntityAuditEventV2.java
+++ b/intg/src/main/java/org/apache/atlas/model/audit/EntityAuditEventV2.java
@@ -112,6 +112,7 @@ public class EntityAuditEventV2 implements Serializable, Clearable {
         }
     }
 
+    private String              entityQualifiedName;
     private String              entityId;
     private long                timestamp;
     private long                created;
@@ -235,6 +236,14 @@ public class EntityAuditEventV2 implements Serializable, Clearable {
         this.entity = AtlasType.fromJson(entityDefinition, AtlasEntity.class);
     }
 
+    public String getEntityQualifiedName() {
+        return entityQualifiedName;
+    }
+
+    public void setEntityQualifiedName(String entityQualifiedName) {
+        this.entityQualifiedName = entityQualifiedName;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) { return true; }
@@ -250,12 +259,13 @@ public class EntityAuditEventV2 implements Serializable, Clearable {
                Objects.equals(entity, that.entity) &&
                Objects.equals(type, that.type) &&
                Objects.equals(detail, that.detail) &&
-               Objects.equals(created, that.created);
+               Objects.equals(created, that.created) &&
+               Objects.equals(entityQualifiedName, that.entityQualifiedName);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(entityId, timestamp, user, action, details, eventKey, entity, type, detail, created);
+        return Objects.hash(entityId, timestamp, user, action, details, eventKey, entity, type, detail, created, entityQualifiedName);
     }
 
     @Override
@@ -263,6 +273,7 @@ public class EntityAuditEventV2 implements Serializable, Clearable {
         final StringBuilder sb = new StringBuilder("EntityAuditEventV2{");
 
         sb.append("entityId='").append(entityId).append('\'');
+        sb.append("entityQualifiedName='").append(entityQualifiedName).append('\'');
         sb.append(", timestamp=").append(timestamp);
         sb.append(", user='").append(user).append('\'');
         sb.append(", action=").append(action);

--- a/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
@@ -51,6 +51,8 @@ import java.util.*;
 
 import javax.inject.Singleton;
 
+import static org.apache.atlas.repository.Constants.QUALIFIED_NAME;
+
 /**
  * This class provides cassandra support as the backend for audit storage support.
  */
@@ -62,6 +64,7 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
     public static final String INDEX_BACKEND_CONF = "atlas.graph.index.search.hostname";
     public static final String INDEX_NAME = "entity_audits";
     private static final String ENTITYID = "entityId";
+    private static final String ENTITY_QUALIFIED_NAME = "entityQualifiedName";
     private static final String CREATED = "created";
     private static final String EVENT_KEY = "eventKey";
     private static final String ACTION = "action";
@@ -85,20 +88,17 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
     public void putEventsV2(List<EntityAuditEventV2> events) throws AtlasBaseException {
         try {
             if (events != null && events.size() > 0) {
-                String entityPayloadTemplate = "'{'\"entityId\":\"{0}\",\"created\":{1},\"action\":\"{2}\",\"detail\":{3},\"user\":\"{4}\", \"eventKey\":\"{5}\"'}'";
+                String entityPayloadTemplate = "'{'\"entityId\":\"{0}\",\"created\":{1},\"action\":\"{2}\",\"detail\":{3},\"user\":\"{4}\", \"eventKey\":\"{5}\", " +
+                        "\"entityQualifiedName\": \"{6}\"'}'";
                 String bulkMetadata = String.format("{ \"index\" : { \"_index\" : \"%s\" } }%n", INDEX_NAME);
                 StringBuilder bulkRequestBody = new StringBuilder();
                 for (EntityAuditEventV2 event : events) {
                     String created = String.format("%s", event.getTimestamp());
-                    String details;
-                    if (event.getAction().equals(EntityAuditEventV2.EntityAuditActionV2.ENTITY_DELETE) || event.getAction().equals(EntityAuditEventV2.EntityAuditActionV2.ENTITY_PURGE)) {
-                        details = "{}";
-                    } else {
-                        String auditDetailPrefix = EntityAuditListenerV2.getV2AuditPrefix(event.getAction());
-                        details = event.getDetails().substring(auditDetailPrefix.length());
-                    }
+                    String auditDetailPrefix = EntityAuditListenerV2.getV2AuditPrefix(event.getAction());
+                    String details = event.getDetails().substring(auditDetailPrefix.length());
+
                     String bulkItem = MessageFormat.format(entityPayloadTemplate, event.getEntityId(), created, event.getAction(), details,
-                            event.getUser(), event.getEntityId() + ":" + created);
+                            event.getUser(), event.getEntityId() + ":" + created, event.getEntity().getAttribute(QUALIFIED_NAME));
                     bulkRequestBody.append(bulkMetadata);
                     bulkRequestBody.append(bulkItem);
                     bulkRequestBody.append("\n");
@@ -159,6 +159,7 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
             event.setUser((String) source.get(USER));
             event.setCreated((long) source.get(CREATED));
             event.setTimestamp((long) source.get(CREATED));
+            event.setEntityQualifiedName((String) source.get(ENTITY_QUALIFIED_NAME));
 
             String eventKey = (String) source.get(EVENT_KEY);
             if (StringUtils.isEmpty(eventKey)) {


### PR DESCRIPTION
## Change description

https://linear.app/atlanproduct/issue/META-2807/es-audits-add-qualifedname-of-the-entity-to-audit-entry

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
