### PR TITLE
META-2807 Lookup deleted logs in ES instead of cassandra

### DIFF
--- a/intg/src/main/java/org/apache/atlas/model/audit/EntityAuditEventV2.java
+++ b/intg/src/main/java/org/apache/atlas/model/audit/EntityAuditEventV2.java
@@ -25,6 +25,7 @@ import org.apache.atlas.model.Clearable;
 import org.apache.atlas.model.instance.AtlasEntity;
 import org.apache.atlas.model.instance.AtlasEntityHeader;
 import org.apache.atlas.type.AtlasType;
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -320,6 +321,8 @@ public class EntityAuditEventV2 implements Serializable, Clearable {
             if(bracketStartPosition != -1) {
                 ret = details.substring(bracketStartPosition);
             }
+        } else if(MapUtils.isNotEmpty(detail)) {
+            ret = AtlasType.toJson(detail);
         }
 
         return ret;

--- a/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
@@ -126,7 +126,7 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
     @Override
     public List<EntityAuditEventV2> listEventsV2(String entityId, EntityAuditEventV2.EntityAuditActionV2 auditAction, String startKey, short maxResultCount) throws AtlasBaseException {
         List<EntityAuditEventV2> ret;
-        String queryTemplate = "{\"query\":{\"bool\":{\"must\":[{\"term\":{\"entityId.keyword\":\"%s\"}},{\"term\":{\"action.keyword\":\"%s\"}}]}}}";
+        String queryTemplate = "{\"query\":{\"bool\":{\"must\":[{\"term\":{\"entityId\":\"%s\"}},{\"term\":{\"action\":\"%s\"}}]}}}";
         String queryWithEntityFilter = String.format(queryTemplate, entityId, auditAction);
         ret = searchEvents(queryWithEntityFilter).getEntityAudits();
 

--- a/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
@@ -126,7 +126,7 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
     @Override
     public List<EntityAuditEventV2> listEventsV2(String entityId, EntityAuditEventV2.EntityAuditActionV2 auditAction, String startKey, short maxResultCount) throws AtlasBaseException {
         List<EntityAuditEventV2> ret;
-        String queryTemplate = "{\"query\":{\"bool\":{\"must\":[{\"term\":{\"entityId\":\"%s\"}},{\"term\":{\"action\":\"%s\"}}]}}}";
+        String queryTemplate = "{\"query\":{\"bool\":{\"must\":[{\"term\":{\"entityId.keyword\":\"%s\"}},{\"term\":{\"action.keyword\":\"%s\"}}]}}}";
         String queryWithEntityFilter = String.format(queryTemplate, entityId, auditAction);
         ret = searchEvents(queryWithEntityFilter).getEntityAudits();
 

--- a/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
@@ -125,7 +125,12 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
 
     @Override
     public List<EntityAuditEventV2> listEventsV2(String entityId, EntityAuditEventV2.EntityAuditActionV2 auditAction, String startKey, short maxResultCount) throws AtlasBaseException {
-        return null;
+        List<EntityAuditEventV2> ret;
+        String queryTemplate = "{\"query\":{\"bool\":{\"must\":[{\"term\":{\"entityId.keyword\":\"%s\"}},{\"term\":{\"action.keyword\":\"%s\"}}]}}}";
+        String queryWithEntityFilter = String.format(queryTemplate, entityId, auditAction);
+        ret = searchEvents(queryWithEntityFilter).getEntityAudits();
+
+        return ret;
     }
 
     @Override

--- a/repository/src/main/java/org/apache/atlas/repository/audit/EntityAuditListenerV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/EntityAuditListenerV2.java
@@ -81,6 +81,7 @@ public class EntityAuditListenerV2 implements EntityChangeListenerV2 {
                     AtlasConfiguration.NOTIFICATION_FIXED_BUFFER_ITEMS_INCREMENT_COUNT.getInt()));
 
     private static final long AUDIT_REPOSITORY_MAX_SIZE_DEFAULT = 1024 * 1024;
+    private static final String QUALIFIED_NAME = "qualifiedName";
     private final Set<EntityAuditRepository>  auditRepositories;
     private final AtlasTypeRegistry      typeRegistry;
     private final AtlasInstanceConverter instanceConverter;
@@ -483,7 +484,7 @@ public class EntityAuditListenerV2 implements EntityChangeListenerV2 {
             entity.setAttributes(null);
             entity.setRelationshipAttributes(null);
 
-            auditString = auditPrefix + AtlasType.toJson(entity);
+            auditString = auditPrefix + getAuditString(entity, attrValues, action);
             auditBytes  = auditString.getBytes(StandardCharsets.UTF_8); // recheck auditString size
             auditSize   = auditBytes != null ? auditBytes.length : 0;
 
@@ -501,6 +502,9 @@ public class EntityAuditListenerV2 implements EntityChangeListenerV2 {
                 shallowEntity.setUpdatedBy(entity.getUpdatedBy());
                 shallowEntity.setStatus(entity.getStatus());
                 shallowEntity.setVersion(entity.getVersion());
+
+                //entity.attributes will only have uniqueAttributes
+                shallowEntity.setAttribute(QUALIFIED_NAME, entity.getAttribute(QUALIFIED_NAME));
 
                 auditString = auditPrefix + AtlasType.toJson(shallowEntity);
             }
@@ -543,6 +547,24 @@ public class EntityAuditListenerV2 implements EntityChangeListenerV2 {
         }
 
         return ret;
+    }
+
+    private String getAuditString(AtlasEntity entity, Map<String, Object> attrValues, EntityAuditActionV2 action) {
+        AtlasEntityType     entityType        = typeRegistry.getEntityTypeByName(entity.getTypeName());
+        StringBuilder sb = new StringBuilder();
+
+        if (action == ENTITY_DELETE || action == ENTITY_IMPORT_DELETE || action == ENTITY_PURGE) {
+            entity.setAttributes(null);
+            for (AtlasAttribute attribute : entityType.getUniqAttributes().values()) {
+
+                String attrName  = attribute.getName();
+                Object attrValue = attrValues.get(attrName);
+
+                entity.setAttribute(attrName, attrValue);
+            }
+        }
+        sb.append(AtlasType.toJson(entity));
+        return sb.toString();
     }
 
     private String getAuditString(AtlasEntity entity, EntityAuditActionV2 action) {

--- a/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
@@ -53,7 +53,6 @@ import org.apache.atlas.web.util.Servlets;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.bouncycastle.cert.ocsp.Req;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;

--- a/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
@@ -47,11 +47,13 @@ import org.apache.atlas.type.AtlasEntityType;
 import org.apache.atlas.type.AtlasType;
 import org.apache.atlas.type.AtlasTypeRegistry;
 import org.apache.atlas.util.FileUtils;
+import org.apache.atlas.utils.AtlasPerfMetrics;
 import org.apache.atlas.utils.AtlasPerfTracer;
 import org.apache.atlas.web.util.Servlets;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.bouncycastle.cert.ocsp.Req;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -1198,6 +1200,7 @@ public class EntityREST {
     }
 
     private void scrubEntityAudits(EntityAuditSearchResult result) throws AtlasBaseException {
+        AtlasPerfMetrics.MetricRecorder metric = RequestContext.get().startMetricRecord("scrubEntityAudits");
         for (EntityAuditEventV2 event : result.getEntityAudits()) {
             try {
                 AtlasEntityWithExtInfo entityWithExtInfo = entitiesStore.getByIdWithoutAuthorization(event.getEntityId());
@@ -1218,15 +1221,14 @@ public class EntityREST {
                             throw abe;
                         }
                     }
+                } else if (e.getAtlasErrorCode() == AtlasErrorCode.UNAUTHORIZED_ACCESS) {
+                    event.setDetail(null);
                 } else {
-                    if (e.getAtlasErrorCode() == AtlasErrorCode.UNAUTHORIZED_ACCESS) {
-                        event.setDetail(null);
-                    } else {
-                        throw e;
-                    }
+                    throw e;
                 }
             }
         }
+        RequestContext.get().endMetricRecord(metric);
     }
 
     @GET
@@ -1673,14 +1675,20 @@ public class EntityREST {
     }
 
     private AtlasEntityHeader getEntityHeaderFromPurgedOrDeletedAudit(String guid) throws AtlasBaseException {
-        List<EntityAuditEventV2> auditEvents = cassandraBasedAuditRepository.listEventsV2(guid, EntityAuditActionV2.ENTITY_PURGE, null, (short)1);
+        List<EntityAuditEventV2> auditEvents = esBasedAuditRepository.listEventsV2(guid, EntityAuditActionV2.ENTITY_DELETE, null, (short)1);
         AtlasEntityHeader        ret         = CollectionUtils.isNotEmpty(auditEvents) ? auditEvents.get(0).getEntityHeader() : null;
 
         if (ret == null) {
-            auditEvents = cassandraBasedAuditRepository.listEventsV2(guid, EntityAuditActionV2.ENTITY_DELETE, null, (short)1);
+            auditEvents = esBasedAuditRepository.listEventsV2(guid, EntityAuditActionV2.ENTITY_PURGE, null, (short)1);
             ret         = CollectionUtils.isNotEmpty(auditEvents) ? auditEvents.get(0).getEntityHeader() : null;
+
             if (ret == null) {
-                throw new AtlasBaseException(AtlasErrorCode.INSTANCE_GUID_NOT_FOUND, guid);
+                auditEvents = esBasedAuditRepository.listEventsV2(guid, EntityAuditActionV2.ENTITY_IMPORT_DELETE, null, (short)1);
+                ret         = CollectionUtils.isNotEmpty(auditEvents) ? auditEvents.get(0).getEntityHeader() : null;
+
+                if (ret == null) {
+                    throw new AtlasBaseException(AtlasErrorCode.INSTANCE_GUID_NOT_FOUND, guid);
+                }
             }
         }
 


### PR DESCRIPTION
## Change description

https://linear.app/atlanproduct/issue/META-2807/es-audits-add-entityqualifiedname-of-the-entity-to-audit-entry

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
