### PR TITLE
Meta 2809 META-2805

### DIFF
--- a/addons/elasticsearch/es-audit-mappings.json
+++ b/addons/elasticsearch/es-audit-mappings.json
@@ -1,10 +1,13 @@
 {
   "mappings": {
     "properties": {
-      "entityid": {
+      "entityId": {
         "type": "keyword"
       },
       "created": {
+        "type": "date"
+      },
+      "timestamp": {
         "type": "date"
       },
       "action": {
@@ -14,6 +17,9 @@
         "type": "nested"
       },
       "user": {
+        "type": "keyword"
+      },
+      "eventKey": {
         "type": "keyword"
       }
     }

--- a/addons/elasticsearch/es-audit-mappings.json
+++ b/addons/elasticsearch/es-audit-mappings.json
@@ -1,6 +1,9 @@
 {
   "mappings": {
     "properties": {
+      "entityQualifiedName": {
+        "type": "keyword"
+      },
       "entityId": {
         "type": "keyword"
       },

--- a/intg/src/main/java/org/apache/atlas/model/audit/AuditSearchParams.java
+++ b/intg/src/main/java/org/apache/atlas/model/audit/AuditSearchParams.java
@@ -27,10 +27,10 @@ public class AuditSearchParams {
     public String getQueryStringForGuid(String guid) {
         String queryWithEntityFilter;
         if (dsl.get("query") == null || ((Map) dsl.get("query")).isEmpty()) {
-            String queryTemplate = "{\"bool\":{\"minimum_should_match\":\"100%\",\"should\":[{\"term\":{\"entityid\":\"entity_id\"}}]}}";
+            String queryTemplate = "{\"bool\":{\"minimum_should_match\":\"100%\",\"should\":[{\"term\":{\"entityId.keyword\":\"entity_id\"}}]}}";
             queryWithEntityFilter = queryTemplate.replace("entity_id", guid);
         } else {
-            String queryTemplate = "{\"bool\":{\"minimum_should_match\":\"100%\",\"should\":[{\"term\":{\"entityid\":\"entity_id\"}}, query_from_payload]}}";
+            String queryTemplate = "{\"bool\":{\"minimum_should_match\":\"100%\",\"should\":[{\"term\":{\"entityId.keyword\":\"entity_id\"}}, query_from_payload]}}";
             queryWithEntityFilter = queryTemplate.replace("entity_id", guid);
             String queryValue = AtlasType.toJson(dsl.get("query"));
             queryWithEntityFilter = queryWithEntityFilter.replace("query_from_payload", queryValue);

--- a/intg/src/main/java/org/apache/atlas/model/audit/AuditSearchParams.java
+++ b/intg/src/main/java/org/apache/atlas/model/audit/AuditSearchParams.java
@@ -3,7 +3,11 @@ package org.apache.atlas.model.audit;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.apache.atlas.type.AtlasType;
+import org.apache.commons.collections.CollectionUtils;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
@@ -14,7 +18,16 @@ import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.PUBLIC_
 
 public class AuditSearchParams {
 
+    private static Map<String, Object> defaultSort = new HashMap<>();
+
     private Map dsl;
+
+    public AuditSearchParams() {
+        Map<String, Object> order = new HashMap<>();
+        order.put("order", "desc");
+
+        defaultSort.put("created", order);
+    }
 
     public void setDsl(Map dsl) {
         this.dsl = dsl;
@@ -40,6 +53,12 @@ public class AuditSearchParams {
     }
 
     public String getQueryString() {
-        return dsl != null ? AtlasType.toJson(dsl) : "";
+        if (this.dsl != null) {
+            if (!this.dsl.containsKey("sort")) {
+                dsl.put("sort", Collections.singleton(defaultSort));
+            }
+            return AtlasType.toJson(dsl);
+        }
+        return "";
     }
 }

--- a/intg/src/main/java/org/apache/atlas/model/audit/EntityAuditEventV2.java
+++ b/intg/src/main/java/org/apache/atlas/model/audit/EntityAuditEventV2.java
@@ -25,6 +25,7 @@ import org.apache.atlas.model.Clearable;
 import org.apache.atlas.model.instance.AtlasEntity;
 import org.apache.atlas.model.instance.AtlasEntityHeader;
 import org.apache.atlas.type.AtlasType;
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -112,6 +113,7 @@ public class EntityAuditEventV2 implements Serializable, Clearable {
         }
     }
 
+    private String              entityQualifiedName;
     private String              entityId;
     private long                timestamp;
     private long                created;
@@ -235,6 +237,14 @@ public class EntityAuditEventV2 implements Serializable, Clearable {
         this.entity = AtlasType.fromJson(entityDefinition, AtlasEntity.class);
     }
 
+    public String getEntityQualifiedName() {
+        return entityQualifiedName;
+    }
+
+    public void setEntityQualifiedName(String entityQualifiedName) {
+        this.entityQualifiedName = entityQualifiedName;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) { return true; }
@@ -250,12 +260,13 @@ public class EntityAuditEventV2 implements Serializable, Clearable {
                Objects.equals(entity, that.entity) &&
                Objects.equals(type, that.type) &&
                Objects.equals(detail, that.detail) &&
-               Objects.equals(created, that.created);
+               Objects.equals(created, that.created) &&
+               Objects.equals(entityQualifiedName, that.entityQualifiedName);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(entityId, timestamp, user, action, details, eventKey, entity, type, detail, created);
+        return Objects.hash(entityId, timestamp, user, action, details, eventKey, entity, type, detail, created, entityQualifiedName);
     }
 
     @Override
@@ -263,6 +274,7 @@ public class EntityAuditEventV2 implements Serializable, Clearable {
         final StringBuilder sb = new StringBuilder("EntityAuditEventV2{");
 
         sb.append("entityId='").append(entityId).append('\'');
+        sb.append("entityQualifiedName='").append(entityQualifiedName).append('\'');
         sb.append(", timestamp=").append(timestamp);
         sb.append(", user='").append(user).append('\'');
         sb.append(", action=").append(action);
@@ -309,6 +321,8 @@ public class EntityAuditEventV2 implements Serializable, Clearable {
             if(bracketStartPosition != -1) {
                 ret = details.substring(bracketStartPosition);
             }
+        } else if(MapUtils.isNotEmpty(detail)) {
+            ret = AtlasType.toJson(detail);
         }
 
         return ret;

--- a/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
@@ -51,6 +51,8 @@ import java.util.*;
 
 import javax.inject.Singleton;
 
+import static org.apache.atlas.repository.Constants.QUALIFIED_NAME;
+
 /**
  * This class provides cassandra support as the backend for audit storage support.
  */
@@ -62,6 +64,7 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
     public static final String INDEX_BACKEND_CONF = "atlas.graph.index.search.hostname";
     public static final String INDEX_NAME = "entity_audits";
     private static final String ENTITYID = "entityId";
+    private static final String ENTITY_QUALIFIED_NAME = "entityQualifiedName";
     private static final String CREATED = "created";
     private static final String EVENT_KEY = "eventKey";
     private static final String ACTION = "action";
@@ -85,20 +88,17 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
     public void putEventsV2(List<EntityAuditEventV2> events) throws AtlasBaseException {
         try {
             if (events != null && events.size() > 0) {
-                String entityPayloadTemplate = "'{'\"entityId\":\"{0}\",\"created\":{1},\"action\":\"{2}\",\"detail\":{3},\"user\":\"{4}\", \"eventKey\":\"{5}\"'}'";
+                String entityPayloadTemplate = "'{'\"entityId\":\"{0}\",\"created\":{1},\"action\":\"{2}\",\"detail\":{3},\"user\":\"{4}\", \"eventKey\":\"{5}\", " +
+                        "\"entityQualifiedName\": \"{6}\"'}'";
                 String bulkMetadata = String.format("{ \"index\" : { \"_index\" : \"%s\" } }%n", INDEX_NAME);
                 StringBuilder bulkRequestBody = new StringBuilder();
                 for (EntityAuditEventV2 event : events) {
                     String created = String.format("%s", event.getTimestamp());
-                    String details;
-                    if (event.getAction().equals(EntityAuditEventV2.EntityAuditActionV2.ENTITY_DELETE) || event.getAction().equals(EntityAuditEventV2.EntityAuditActionV2.ENTITY_PURGE)) {
-                        details = "{}";
-                    } else {
-                        String auditDetailPrefix = EntityAuditListenerV2.getV2AuditPrefix(event.getAction());
-                        details = event.getDetails().substring(auditDetailPrefix.length());
-                    }
+                    String auditDetailPrefix = EntityAuditListenerV2.getV2AuditPrefix(event.getAction());
+                    String details = event.getDetails().substring(auditDetailPrefix.length());
+
                     String bulkItem = MessageFormat.format(entityPayloadTemplate, event.getEntityId(), created, event.getAction(), details,
-                            event.getUser(), event.getEntityId() + ":" + created);
+                            event.getUser(), event.getEntityId() + ":" + created, event.getEntity().getAttribute(QUALIFIED_NAME));
                     bulkRequestBody.append(bulkMetadata);
                     bulkRequestBody.append(bulkItem);
                     bulkRequestBody.append("\n");
@@ -125,7 +125,12 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
 
     @Override
     public List<EntityAuditEventV2> listEventsV2(String entityId, EntityAuditEventV2.EntityAuditActionV2 auditAction, String startKey, short maxResultCount) throws AtlasBaseException {
-        return null;
+        List<EntityAuditEventV2> ret;
+        String queryTemplate = "{\"query\":{\"bool\":{\"must\":[{\"term\":{\"entityId.keyword\":\"%s\"}},{\"term\":{\"action.keyword\":\"%s\"}}]}}}";
+        String queryWithEntityFilter = String.format(queryTemplate, entityId, auditAction);
+        ret = searchEvents(queryWithEntityFilter).getEntityAudits();
+
+        return ret;
     }
 
     @Override
@@ -159,6 +164,7 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
             event.setUser((String) source.get(USER));
             event.setCreated((long) source.get(CREATED));
             event.setTimestamp((long) source.get(CREATED));
+            event.setEntityQualifiedName((String) source.get(ENTITY_QUALIFIED_NAME));
 
             String eventKey = (String) source.get(EVENT_KEY);
             if (StringUtils.isEmpty(eventKey)) {

--- a/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
@@ -47,6 +47,7 @@ import org.apache.atlas.type.AtlasEntityType;
 import org.apache.atlas.type.AtlasType;
 import org.apache.atlas.type.AtlasTypeRegistry;
 import org.apache.atlas.util.FileUtils;
+import org.apache.atlas.utils.AtlasPerfMetrics;
 import org.apache.atlas.utils.AtlasPerfTracer;
 import org.apache.atlas.web.util.Servlets;
 import org.apache.commons.collections.CollectionUtils;
@@ -1144,16 +1145,48 @@ public class EntityREST {
                 perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "EntityREST.searchAuditEvents");
             }
 
-            AtlasAuthorizationUtils.verifyAccess(new AtlasAdminAccessRequest(AtlasPrivilege.ADMIN_ENTITY_AUDITS), "search audit events!");
-
             String dslString = parameters.getQueryString();
 
             EntityAuditSearchResult ret = esBasedAuditRepository.searchEvents(dslString);
+
+            scrubEntityAudits(ret);
 
             return ret;
         } finally {
             AtlasPerfTracer.log(perf);
         }
+    }
+
+    private void scrubEntityAudits(EntityAuditSearchResult result) throws AtlasBaseException {
+        AtlasPerfMetrics.MetricRecorder metric = RequestContext.get().startMetricRecord("scrubEntityAudits");
+        for (EntityAuditEventV2 event : result.getEntityAudits()) {
+            try {
+                AtlasEntityWithExtInfo entityWithExtInfo = entitiesStore.getByIdWithoutAuthorization(event.getEntityId());
+                AtlasEntityHeader entityHeader = new AtlasEntityHeader(entityWithExtInfo.getEntity());
+
+                AtlasAuthorizationUtils.verifyAccess(new AtlasEntityAccessRequest(typeRegistry, ENTITY_READ, entityHeader), "read entity audit: guid=", event.getEntityId());
+
+            } catch (AtlasBaseException e) {
+                if (e.getAtlasErrorCode() == AtlasErrorCode.INSTANCE_GUID_NOT_FOUND) {
+                    try {
+                        AtlasEntityHeader entityHeader = getEntityHeaderFromPurgedOrDeletedAudit(event.getEntityId());
+
+                        AtlasAuthorizationUtils.verifyAccess(new AtlasEntityAccessRequest(typeRegistry, ENTITY_READ, entityHeader), "read entity audit: guid=", event.getEntityId());
+                    } catch (AtlasBaseException abe) {
+                        if (abe.getAtlasErrorCode() == AtlasErrorCode.UNAUTHORIZED_ACCESS) {
+                            event.setDetail(null);
+                        } else {
+                            throw abe;
+                        }
+                    }
+                } else if (e.getAtlasErrorCode() == AtlasErrorCode.UNAUTHORIZED_ACCESS) {
+                    event.setDetail(null);
+                } else {
+                    throw e;
+                }
+            }
+        }
+        RequestContext.get().endMetricRecord(metric);
     }
 
     @GET
@@ -1594,6 +1627,27 @@ public class EntityREST {
 
         if (ret == null) {
             throw new AtlasBaseException(AtlasErrorCode.INSTANCE_GUID_NOT_FOUND, guid);
+        }
+
+        return ret;
+    }
+
+    private AtlasEntityHeader getEntityHeaderFromPurgedOrDeletedAudit(String guid) throws AtlasBaseException {
+        List<EntityAuditEventV2> auditEvents = esBasedAuditRepository.listEventsV2(guid, EntityAuditActionV2.ENTITY_DELETE, null, (short)1);
+        AtlasEntityHeader        ret         = CollectionUtils.isNotEmpty(auditEvents) ? auditEvents.get(0).getEntityHeader() : null;
+
+        if (ret == null) {
+            auditEvents = esBasedAuditRepository.listEventsV2(guid, EntityAuditActionV2.ENTITY_PURGE, null, (short)1);
+            ret         = CollectionUtils.isNotEmpty(auditEvents) ? auditEvents.get(0).getEntityHeader() : null;
+
+            if (ret == null) {
+                auditEvents = esBasedAuditRepository.listEventsV2(guid, EntityAuditActionV2.ENTITY_IMPORT_DELETE, null, (short)1);
+                ret         = CollectionUtils.isNotEmpty(auditEvents) ? auditEvents.get(0).getEntityHeader() : null;
+
+                if (ret == null) {
+                    throw new AtlasBaseException(AtlasErrorCode.INSTANCE_GUID_NOT_FOUND, guid);
+                }
+            }
         }
 
         return ret;


### PR DESCRIPTION
## Change description

1. **ES Audits key changes**
    * timestamp is 0, populate created as timestamp
    * change entityid → entityId
    * add eventKey → "guid:timestamp" 

2. Like indexsearch for Asset discovery, this API will act for audit logs (Activity Logs on product)
If unauthorized access, entityAudits.detail will be omitted for the particular log

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
