### PR TITLE
META-2813 ES Audits: remove '.keyword' from ES query for deleted/purg…

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
@@ -126,7 +126,7 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
     @Override
     public List<EntityAuditEventV2> listEventsV2(String entityId, EntityAuditEventV2.EntityAuditActionV2 auditAction, String startKey, short maxResultCount) throws AtlasBaseException {
         List<EntityAuditEventV2> ret;
-        String queryTemplate = "{\"query\":{\"bool\":{\"must\":[{\"term\":{\"entityId.keyword\":\"%s\"}},{\"term\":{\"action.keyword\":\"%s\"}}]}}}";
+        String queryTemplate = "{\"query\":{\"bool\":{\"must\":[{\"term\":{\"entityId\":\"%s\"}},{\"term\":{\"action\":\"%s\"}}]}}}";
         String queryWithEntityFilter = String.format(queryTemplate, entityId, auditAction);
         ret = searchEvents(queryWithEntityFilter).getEntityAudits();
 

--- a/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
@@ -1217,7 +1217,7 @@ public class EntityREST {
             } catch (AtlasBaseException e) {
                 if (e.getAtlasErrorCode() == AtlasErrorCode.INSTANCE_GUID_NOT_FOUND) {
                     try {
-                        AtlasEntityHeader entityHeader = getEntityHeaderFromPurgedOrDeletedAudit(event.getEntityId());
+                        AtlasEntityHeader entityHeader = event.getEntityHeader();
 
                         AtlasAuthorizationUtils.verifyAccess(new AtlasEntityAccessRequest(typeRegistry, ENTITY_READ, entityHeader), "read entity audit: guid=", event.getEntityId());
                     } catch (AtlasBaseException abe) {
@@ -1675,27 +1675,6 @@ public class EntityREST {
 
         if (ret == null) {
             throw new AtlasBaseException(AtlasErrorCode.INSTANCE_GUID_NOT_FOUND, guid);
-        }
-
-        return ret;
-    }
-
-    private AtlasEntityHeader getEntityHeaderFromPurgedOrDeletedAudit(String guid) throws AtlasBaseException {
-        List<EntityAuditEventV2> auditEvents = esBasedAuditRepository.listEventsV2(guid, EntityAuditActionV2.ENTITY_DELETE, null, (short)1);
-        AtlasEntityHeader        ret         = CollectionUtils.isNotEmpty(auditEvents) ? auditEvents.get(0).getEntityHeader() : null;
-
-        if (ret == null) {
-            auditEvents = esBasedAuditRepository.listEventsV2(guid, EntityAuditActionV2.ENTITY_PURGE, null, (short)1);
-            ret         = CollectionUtils.isNotEmpty(auditEvents) ? auditEvents.get(0).getEntityHeader() : null;
-
-            if (ret == null) {
-                auditEvents = esBasedAuditRepository.listEventsV2(guid, EntityAuditActionV2.ENTITY_IMPORT_DELETE, null, (short)1);
-                ret         = CollectionUtils.isNotEmpty(auditEvents) ? auditEvents.get(0).getEntityHeader() : null;
-
-                if (ret == null) {
-                    throw new AtlasBaseException(AtlasErrorCode.INSTANCE_GUID_NOT_FOUND, guid);
-                }
-            }
         }
 
         return ret;


### PR DESCRIPTION
## Change description

https://linear.app/atlanproduct/issue/META-2813/es-audits-remove-keyword-from-es-query-for-deletedpurged-entities

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
