### PR TITLE
META-2814 ES Audits: entityQualifiedName is null for some records

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
@@ -98,7 +98,7 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
                     String details = event.getDetails().substring(auditDetailPrefix.length());
 
                     String bulkItem = MessageFormat.format(entityPayloadTemplate, event.getEntityId(), created, event.getAction(), details,
-                            event.getUser(), event.getEntityId() + ":" + created, event.getEntity().getAttribute(QUALIFIED_NAME));
+                            event.getUser(), event.getEntityId() + ":" + created, event.getEntityQualifiedName());
                     bulkRequestBody.append(bulkMetadata);
                     bulkRequestBody.append(bulkItem);
                     bulkRequestBody.append("\n");

--- a/server-api/src/main/java/org/apache/atlas/RequestContext.java
+++ b/server-api/src/main/java/org/apache/atlas/RequestContext.java
@@ -405,6 +405,10 @@ public class RequestContext {
         return updatedEntities.values();
     }
 
+    public AtlasEntityHeader getUpdatedEntity(String guid) {
+        return updatedEntities.get(guid);
+    }
+
     public Collection<AtlasEntityHeader> getDeletedEntities() {
         return deletedEntities.values();
     }


### PR DESCRIPTION
## Change description

https://linear.app/atlanproduct/issue/META-2814/es-audits-entityqualifiedname-is-null-for-some-records

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
