### PR TITLE
META-2814 ES Audits: entityQualifiedName is null for some records

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
@@ -98,7 +98,7 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
                     String details = event.getDetails().substring(auditDetailPrefix.length());
 
                     String bulkItem = MessageFormat.format(entityPayloadTemplate, event.getEntityId(), created, event.getAction(), details,
-                            event.getUser(), event.getEntityId() + ":" + created, event.getEntity().getAttribute(QUALIFIED_NAME));
+                            event.getUser(), event.getEntityId() + ":" + created, event.getEntityQualifiedName());
                     bulkRequestBody.append(bulkMetadata);
                     bulkRequestBody.append(bulkItem);
                     bulkRequestBody.append("\n");

--- a/repository/src/main/java/org/apache/atlas/repository/audit/EntityAuditListenerV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/EntityAuditListenerV2.java
@@ -27,11 +27,7 @@ import org.apache.atlas.model.audit.EntityAuditEventV2.EntityAuditActionV2;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.listener.EntityChangeListenerV2;
 import org.apache.atlas.model.glossary.AtlasGlossaryTerm;
-import org.apache.atlas.model.instance.AtlasClassification;
-import org.apache.atlas.model.instance.AtlasEntity;
-import org.apache.atlas.model.instance.AtlasRelatedObjectId;
-import org.apache.atlas.model.instance.AtlasRelationship;
-import org.apache.atlas.model.instance.AtlasStruct;
+import org.apache.atlas.model.instance.*;
 import org.apache.atlas.repository.converters.AtlasInstanceConverter;
 import org.apache.atlas.type.AtlasEntityType;
 import org.apache.atlas.type.AtlasStructType.AtlasAttribute;
@@ -51,6 +47,8 @@ import org.springframework.stereotype.Component;
 import javax.inject.Inject;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.apache.atlas.AtlasConfiguration.STORE_DIFFERENTIAL_AUDITS;
 import static org.apache.atlas.model.audit.EntityAuditEventV2.EntityAuditActionV2.BUSINESS_ATTRIBUTE_UPDATE;
@@ -89,11 +87,15 @@ public class EntityAuditListenerV2 implements EntityChangeListenerV2 {
     protected Map<String, List<String>> auditExcludedAttributesCache = new HashMap<>();
     private   static final String AUDIT_EXCLUDE_ATTRIBUTE_PROPERTY   = "atlas.audit.hbase.entity";
 
+    private static boolean DIFFERENTIAL_AUDITS = false;
+
     @Inject
     public EntityAuditListenerV2(Set<EntityAuditRepository> auditRepositories, AtlasTypeRegistry typeRegistry, AtlasInstanceConverter instanceConverter) {
         this.auditRepositories   = auditRepositories;
         this.typeRegistry      = typeRegistry;
         this.instanceConverter = instanceConverter;
+
+        DIFFERENTIAL_AUDITS = STORE_DIFFERENTIAL_AUDITS.getBoolean();
     }
 
     @Override
@@ -119,7 +121,9 @@ public class EntityAuditListenerV2 implements EntityChangeListenerV2 {
         FixedBufferList<EntityAuditEventV2> updatedEvents = getAuditEventsList();
         Collection<AtlasEntity>             updatedEntites;
 
-        if (STORE_DIFFERENTIAL_AUDITS.getBoolean()) {
+        Map<String, AtlasEntity> entitiesMap = entities.stream().collect(Collectors.toMap(AtlasEntity::getGuid, Function.identity()));
+
+        if (DIFFERENTIAL_AUDITS) {
             updatedEntites = reqContext.getDifferentialEntities();
         } else {
             updatedEntites = entities;
@@ -138,7 +142,11 @@ public class EntityAuditListenerV2 implements EntityChangeListenerV2 {
                 action = ENTITY_UPDATE;
             }
 
-            createEvent(updatedEvents.next(), entity, action);
+            if (DIFFERENTIAL_AUDITS) {
+                createEvent(updatedEvents.next(), entity, entitiesMap.get(entity.getGuid()), action);
+            } else {
+                createEvent(updatedEvents.next(), entity, action);
+            }
         }
 
         for (EntityAuditRepository auditRepository: auditRepositories) {
@@ -447,14 +455,23 @@ public class EntityAuditListenerV2 implements EntityChangeListenerV2 {
         }
     }
 
-
     private EntityAuditEventV2 createEvent(EntityAuditEventV2 entityAuditEventV2, AtlasEntity entity, EntityAuditActionV2 action, String details) {
+        return createEvent(entityAuditEventV2, entity, null, action, details);
+    }
+
+    private EntityAuditEventV2 createEvent(EntityAuditEventV2 entityAuditEventV2, AtlasEntity entity,
+                                           AtlasEntity originalEntity, EntityAuditActionV2 action, String details) {
         entityAuditEventV2.setEntityId(entity.getGuid());
         entityAuditEventV2.setTimestamp(System.currentTimeMillis());
         entityAuditEventV2.setUser(RequestContext.get().getUser());
         entityAuditEventV2.setAction(action);
         entityAuditEventV2.setDetails(details);
         entityAuditEventV2.setEntity(entity);
+        if (originalEntity != null) {
+            entityAuditEventV2.setEntityQualifiedName((String) originalEntity.getAttribute(QUALIFIED_NAME));
+        } else {
+            entityAuditEventV2.setEntityQualifiedName((String) entity.getAttribute(QUALIFIED_NAME));
+        }
 
         return entityAuditEventV2;
     }
@@ -464,6 +481,13 @@ public class EntityAuditListenerV2 implements EntityChangeListenerV2 {
 
         return createEvent(event, entity, action, detail);
     }
+
+    private EntityAuditEventV2 createEvent(EntityAuditEventV2 event, AtlasEntity entity, AtlasEntity originalEntity, EntityAuditActionV2 action) {
+        String detail = getAuditEventDetail(entity, action);
+
+        return createEvent(event, entity, originalEntity, action, detail);
+    }
+
 
     private String getAuditEventDetail(AtlasEntity entity, EntityAuditActionV2 action) {
         Map<String, Object> prunedAttributes = pruneEntityAttributesForAudit(entity);


### PR DESCRIPTION
(cherry picked from commit cc3d4dcf9bd29730346f0cd8f43709cee4282b95)

https://linear.app/atlanproduct/issue/META-2814/es-audits-entityqualifiedname-is-null-for-some-records

> Description here

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
