### PR TITLE
META-2820 Delete entity fails due to stale propagated classification

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -566,8 +566,12 @@ public class EntityGraphRetriever {
     private void traverseImpactedVertices(final AtlasVertex entityVertexStart, final String relationshipGuidToExclude,
                                           final String classificationId, final List<AtlasVertex> result) {
         Set<String>              visitedVertices = new HashSet<>();
-        Queue<AtlasVertex>       queue           = new ArrayDeque<AtlasVertex>() {{ add(entityVertexStart); }};
+        Queue<AtlasVertex>       queue           = new ArrayDeque<>();
         Map<String, AtlasVertex> resultsMap      = new HashMap<>();
+
+        if (entityVertexStart != null) {
+            queue.add(entityVertexStart);
+        }
 
         while (!queue.isEmpty()) {
             AtlasVertex entityVertex   = queue.poll();


### PR DESCRIPTION
## Change description

https://linear.app/atlanproduct/issue/META-2820/delete-entity-fails-due-to-stale-propagated-classification