### PR TITLE
META-2862: Skip EntityUpdate authz for Aseet Term linking

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -29,6 +29,7 @@ import org.apache.atlas.model.TypeCategory;
 import org.apache.atlas.model.instance.AtlasClassification;
 import org.apache.atlas.model.instance.AtlasEntity;
 import org.apache.atlas.model.instance.AtlasEntityHeader;
+import org.apache.atlas.model.instance.AtlasRelationshipHeader;
 import org.apache.atlas.model.instance.AtlasObjectId;
 import org.apache.atlas.model.instance.AtlasRelationship;
 import org.apache.atlas.model.tasks.AtlasTask;
@@ -511,6 +512,9 @@ public abstract class DeleteHandlerV1 {
         end2Entity = entityRetriever.toAtlasEntityHeaderWithClassifications(edge.getInVertex());
 
         AtlasAuthorizationUtils.verifyAccess(new AtlasRelationshipAccessRequest(typeRegistry, AtlasPrivilege.RELATIONSHIP_REMOVE, relationShipType, end1Entity, end2Entity ));
+
+        RequestContext.get().setEntityWithRelationship(end1Entity.getGuid(), new AtlasRelationshipHeader(relationShipType,null,new AtlasObjectId(end1Entity.getGuid() ,end1Entity.getTypeName())
+                , new AtlasObjectId(end2Entity.getGuid(), end2Entity.getTypeName()), null ));
 
         RequestContext.get().endMetricRecord(metric);
     }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -40,6 +40,7 @@ import org.apache.atlas.model.instance.AtlasEntity.AtlasEntitiesWithExtInfo;
 import org.apache.atlas.model.instance.AtlasEntity.AtlasEntityWithExtInfo;
 import org.apache.atlas.model.instance.AtlasEntity.Status;
 import org.apache.atlas.model.instance.AtlasEntityHeader;
+import org.apache.atlas.model.instance.AtlasRelationshipHeader;
 import org.apache.atlas.model.instance.AtlasEntityHeaders;
 import org.apache.atlas.model.instance.AtlasObjectId;
 import org.apache.atlas.model.instance.EntityMutationResponse;
@@ -1338,14 +1339,14 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
                             "create entity: type=", entity.getTypeName());
                 }
             }
-
+            RequestContext        reqContext           = RequestContext.get();
             // for existing entities, skip update if incoming entity doesn't have any change
             if (CollectionUtils.isNotEmpty(context.getUpdatedEntities())) {
                 MetricRecorder checkForUnchangedEntities = RequestContext.get().startMetricRecord("checkForUnchangedEntities");
 
                 List<AtlasEntity>     entitiesToSkipUpdate = new ArrayList<>();
                 AtlasEntityComparator entityComparator     = new AtlasEntityComparator(typeRegistry, entityRetriever, context.getGuidAssignments(), !replaceClassifications, !replaceBusinessAttributes);
-                RequestContext        reqContext           = RequestContext.get();
+
 
                 for (AtlasEntity entity : context.getUpdatedEntities()) {
                     if (entity.getStatus() == AtlasEntity.Status.DELETED) {// entity status could be updated during import
@@ -1383,23 +1384,27 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
                     context.getUpdatedEntities().removeAll(entitiesToSkipUpdate);
                 }
 
-                // Check if authorized to update entities
-                if (!reqContext.isImportInProgress()) {
-                    for (AtlasEntity entity : context.getUpdatedEntities()) {
+                reqContext.endMetricRecord(checkForUnchangedEntities);
+            }
+
+            EntityMutationResponse ret = entityGraphMapper.mapAttributesAndClassifications(context, isPartialUpdate, replaceClassifications, replaceBusinessAttributes);
+
+            // Check if authorized to update entities
+            if (!reqContext.isImportInProgress()) {
+                Map<String, AtlasRelationshipHeader> entityRelationShipMap = RequestContext.get().getEntityWithRelationship();
+
+                for (AtlasEntity entity : context.getUpdatedEntities()) {
+                    if(skipAuthorizationForGlossaryTermRelationship(entityRelationShipMap, entity.getGuid()))  {
                         AtlasEntityHeader entityHeaderWithClassifications = entityRetriever.toAtlasEntityHeaderWithClassifications(entity.getGuid());
                         AtlasEntityHeader entityHeader = new AtlasEntityHeader(entity);
-                        if(!entityHeaderWithClassifications.getClassifications().isEmpty()) {
+                        if (CollectionUtils.isNotEmpty(entityHeaderWithClassifications.getClassifications())) {
                             entityHeader.setClassifications(entityHeaderWithClassifications.getClassifications());
                         }
                         AtlasAuthorizationUtils.verifyAccess(new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_UPDATE, entityHeader),
                                 "update entity: type=", entity.getTypeName());
                     }
                 }
-
-                reqContext.endMetricRecord(checkForUnchangedEntities);
             }
-
-            EntityMutationResponse ret = entityGraphMapper.mapAttributesAndClassifications(context, isPartialUpdate, replaceClassifications, replaceBusinessAttributes);
 
             ret.setGuidAssignments(context.getGuidAssignments());
 
@@ -1416,6 +1421,26 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
 
             AtlasPerfTracer.log(perf);
         }
+    }
+
+    private boolean skipAuthorizationForGlossaryTermRelationship(Map<String,AtlasRelationshipHeader> entityRelationShipMap, String guid) {
+
+        AtlasRelationshipHeader relationshipHeader = entityRelationShipMap.get(guid);
+
+        String relationShipTypeName = null, end1TypeName = null, end2TypeName = null;
+        Set<String> end2SuperType = null;
+        if (relationshipHeader != null) {
+            relationShipTypeName = relationshipHeader.getTypeName();
+
+            end1TypeName = relationshipHeader.getEnd1().getTypeName();
+            end2TypeName = relationshipHeader.getEnd2().getTypeName();
+
+            AtlasEntityType entType = typeRegistry.getEntityTypeByName(end2TypeName);
+            end2SuperType = entType.getTypeAndAllSuperTypes();
+        }
+
+        return (!"AtlasGlossarySemanticAssignment".equals(relationShipTypeName) && "AtlasGlossaryTerm".equals(end1TypeName)
+                && (end2SuperType != null && end2SuperType.contains("Asset")));
     }
 
     private EntityMutationContext preCreateOrUpdate(EntityStream entityStream, EntityGraphMapper entityGraphMapper, boolean isPartialUpdate) throws AtlasBaseException {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasRelationshipStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasRelationshipStoreV2.java
@@ -31,6 +31,7 @@ import org.apache.atlas.model.instance.AtlasEntityHeader;
 import org.apache.atlas.model.instance.AtlasObjectId;
 import org.apache.atlas.model.instance.AtlasRelationship;
 import org.apache.atlas.model.instance.AtlasRelationship.AtlasRelationshipWithExtInfo;
+import org.apache.atlas.model.instance.AtlasRelationshipHeader;
 import org.apache.atlas.model.notification.EntityNotification.EntityNotificationV2.OperationType;
 import org.apache.atlas.model.typedef.AtlasRelationshipDef;
 import org.apache.atlas.model.typedef.AtlasRelationshipDef.PropagateTags;
@@ -437,6 +438,8 @@ public class AtlasRelationshipStoreV2 implements AtlasRelationshipStore {
             AtlasAuthorizationUtils.verifyAccess(new AtlasRelationshipAccessRequest(typeRegistry, AtlasPrivilege.RELATIONSHIP_ADD,
                                                                                         relationship.getTypeName(), end1Entity, end2Entity));
 
+            RequestContext.get().setEntityWithRelationship(end1Entity.getGuid(), new AtlasRelationshipHeader(relationship.getTypeName(),null,new AtlasObjectId(end1Entity.getGuid() ,end1Entity.getTypeName())
+                    , new AtlasObjectId(end2Entity.getGuid(), end2Entity.getTypeName()), null ));
 
             if (existingRelationshipCheck) {
                 ret = graphHelper.getOrCreateEdge(end1Vertex, end2Vertex, relationshipLabel);
@@ -495,6 +498,9 @@ public class AtlasRelationshipStoreV2 implements AtlasRelationshipStore {
         AtlasEntityHeader     end2Entity   = entityRetriever.toAtlasEntityHeaderWithClassifications(end2Vertex);
 
         AtlasAuthorizationUtils.verifyAccess(new AtlasRelationshipAccessRequest(typeRegistry, AtlasPrivilege.RELATIONSHIP_UPDATE, relationship.getTypeName(), end1Entity, end2Entity));
+
+        RequestContext.get().setEntityWithRelationship(end1Entity.getGuid(), new AtlasRelationshipHeader(relationship.getTypeName(),null,new AtlasObjectId(end1Entity.getGuid() ,end1Entity.getTypeName())
+                , new AtlasObjectId(end2Entity.getGuid(), end2Entity.getTypeName()), null ));
 
         updateTagPropagations(relationshipEdge, relationship);
 

--- a/server-api/src/main/java/org/apache/atlas/RequestContext.java
+++ b/server-api/src/main/java/org/apache/atlas/RequestContext.java
@@ -23,6 +23,7 @@ import org.apache.atlas.model.instance.AtlasEntity;
 import org.apache.atlas.model.instance.AtlasEntity.AtlasEntityWithExtInfo;
 import org.apache.atlas.model.instance.AtlasEntityHeader;
 import org.apache.atlas.model.instance.AtlasObjectId;
+import org.apache.atlas.model.instance.AtlasRelationshipHeader;
 import org.apache.atlas.model.tasks.AtlasTask;
 import org.apache.atlas.utils.AtlasPerfMetrics;
 import org.apache.atlas.utils.AtlasPerfMetrics.MetricRecorder;
@@ -66,6 +67,7 @@ public class RequestContext {
     private final Set<String>                            onlyBAUpdateEntities = new HashSet<>();
     private final List<AtlasTask>                        queuedTasks          = new ArrayList<>();
     private final Set<String> relationAttrsForSearch = new HashSet<>();
+    private final Map<String, AtlasRelationshipHeader>   entityWithRelationship = new HashMap<>();
 
 
     private String       user;
@@ -131,6 +133,7 @@ public class RequestContext {
         this.onlyBAUpdateEntities.clear();
         this.relationAttrsForSearch.clear();
         this.queuedTasks.clear();
+        this.entityWithRelationship.clear();
 
         if (metrics != null && !metrics.isEmpty()) {
             METRICS.debug(metrics.toString());
@@ -526,6 +529,12 @@ public class RequestContext {
         }
     }
 
+    public Map<String, AtlasRelationshipHeader> getEntityWithRelationship() {
+        return entityWithRelationship;
+    }
+    public void  setEntityWithRelationship(String guid, AtlasRelationshipHeader relheader) {
+         entityWithRelationship.put(guid, relheader);
+    }
     public List<String> getForwardedAddresses() {
         return forwardedAddresses;
     }


### PR DESCRIPTION
## Change description

Adding term to Asset currently checks for Entity update permission as well
    Skip  Entity update permission authz for RELATIONSHIP-ADD/RELATIONSHIP-REMOVE/RELATIONSHIP-UPDATE for Asset to Term Relationship

Testing Done
* Imported snowflake data dump from local hubble script as `atlan-argo` user.
* From API attached/removed term to Asset before and after giving `RELATIONSHIP-ADD / RELATIONSHIP-REMOVE / RELATIONSHIP-UPDATE` permission for a user with only Entity-READ  from Ranger Admin UI.
* Verified from Product UI that term getting linked to entity while entity has no permission to apply classification etc.
* Verified the policy evaluate API results.


## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
