### PR TITLE
META-2862: Skip EntityUpdate authz for Asset - Term linking

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -29,6 +29,7 @@ import org.apache.atlas.model.TypeCategory;
 import org.apache.atlas.model.instance.AtlasClassification;
 import org.apache.atlas.model.instance.AtlasEntity;
 import org.apache.atlas.model.instance.AtlasEntityHeader;
+import org.apache.atlas.model.instance.AtlasRelationshipHeader;
 import org.apache.atlas.model.instance.AtlasObjectId;
 import org.apache.atlas.model.instance.AtlasRelationship;
 import org.apache.atlas.model.tasks.AtlasTask;
@@ -511,6 +512,9 @@ public abstract class DeleteHandlerV1 {
         end2Entity = entityRetriever.toAtlasEntityHeaderWithClassifications(edge.getInVertex());
 
         AtlasAuthorizationUtils.verifyAccess(new AtlasRelationshipAccessRequest(typeRegistry, AtlasPrivilege.RELATIONSHIP_REMOVE, relationShipType, end1Entity, end2Entity ));
+
+        RequestContext.get().setEntityWithRelationship(end1Entity.getGuid(), new AtlasRelationshipHeader(relationShipType,null,new AtlasObjectId(end1Entity.getGuid() ,end1Entity.getTypeName())
+                , new AtlasObjectId(end2Entity.getGuid(), end2Entity.getTypeName()), null ));
 
         RequestContext.get().endMetricRecord(metric);
     }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasRelationshipStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasRelationshipStoreV2.java
@@ -31,6 +31,7 @@ import org.apache.atlas.model.instance.AtlasEntityHeader;
 import org.apache.atlas.model.instance.AtlasObjectId;
 import org.apache.atlas.model.instance.AtlasRelationship;
 import org.apache.atlas.model.instance.AtlasRelationship.AtlasRelationshipWithExtInfo;
+import org.apache.atlas.model.instance.AtlasRelationshipHeader;
 import org.apache.atlas.model.notification.EntityNotification.EntityNotificationV2.OperationType;
 import org.apache.atlas.model.typedef.AtlasRelationshipDef;
 import org.apache.atlas.model.typedef.AtlasRelationshipDef.PropagateTags;
@@ -437,6 +438,8 @@ public class AtlasRelationshipStoreV2 implements AtlasRelationshipStore {
             AtlasAuthorizationUtils.verifyAccess(new AtlasRelationshipAccessRequest(typeRegistry, AtlasPrivilege.RELATIONSHIP_ADD,
                                                                                         relationship.getTypeName(), end1Entity, end2Entity));
 
+            RequestContext.get().setEntityWithRelationship(end1Entity.getGuid(), new AtlasRelationshipHeader(relationship.getTypeName(),null,new AtlasObjectId(end1Entity.getGuid() ,end1Entity.getTypeName())
+                    , new AtlasObjectId(end2Entity.getGuid(), end2Entity.getTypeName()), null ));
 
             if (existingRelationshipCheck) {
                 ret = graphHelper.getOrCreateEdge(end1Vertex, end2Vertex, relationshipLabel);
@@ -495,6 +498,9 @@ public class AtlasRelationshipStoreV2 implements AtlasRelationshipStore {
         AtlasEntityHeader     end2Entity   = entityRetriever.toAtlasEntityHeaderWithClassifications(end2Vertex);
 
         AtlasAuthorizationUtils.verifyAccess(new AtlasRelationshipAccessRequest(typeRegistry, AtlasPrivilege.RELATIONSHIP_UPDATE, relationship.getTypeName(), end1Entity, end2Entity));
+
+        RequestContext.get().setEntityWithRelationship(end1Entity.getGuid(), new AtlasRelationshipHeader(relationship.getTypeName(),null,new AtlasObjectId(end1Entity.getGuid() ,end1Entity.getTypeName())
+                , new AtlasObjectId(end2Entity.getGuid(), end2Entity.getTypeName()), null ));
 
         updateTagPropagations(relationshipEdge, relationship);
 

--- a/server-api/src/main/java/org/apache/atlas/RequestContext.java
+++ b/server-api/src/main/java/org/apache/atlas/RequestContext.java
@@ -23,6 +23,7 @@ import org.apache.atlas.model.instance.AtlasEntity;
 import org.apache.atlas.model.instance.AtlasEntity.AtlasEntityWithExtInfo;
 import org.apache.atlas.model.instance.AtlasEntityHeader;
 import org.apache.atlas.model.instance.AtlasObjectId;
+import org.apache.atlas.model.instance.AtlasRelationshipHeader;
 import org.apache.atlas.model.tasks.AtlasTask;
 import org.apache.atlas.utils.AtlasPerfMetrics;
 import org.apache.atlas.utils.AtlasPerfMetrics.MetricRecorder;
@@ -67,6 +68,7 @@ public class RequestContext {
     private final Set<String>                            onlyBAUpdateEntities = new HashSet<>();
     private final List<AtlasTask>                        queuedTasks          = new ArrayList<>();
     private final Set<String> relationAttrsForSearch = new HashSet<>();
+    private final Map<String, AtlasRelationshipHeader>   entityWithRelationship = new HashMap<>();
 
     private static String USERNAME = "";
 
@@ -134,6 +136,7 @@ public class RequestContext {
         this.onlyBAUpdateEntities.clear();
         this.relationAttrsForSearch.clear();
         this.queuedTasks.clear();
+        this.entityWithRelationship.clear();
 
         if (metrics != null && !metrics.isEmpty()) {
             METRICS.debug(metrics.toString());
@@ -539,6 +542,12 @@ public class RequestContext {
         }
     }
 
+    public Map<String, AtlasRelationshipHeader> getEntityWithRelationship() {
+        return entityWithRelationship;
+    }
+    public void  setEntityWithRelationship(String guid, AtlasRelationshipHeader relheader) {
+         entityWithRelationship.put(guid, relheader);
+    }
     public List<String> getForwardedAddresses() {
         return forwardedAddresses;
     }


### PR DESCRIPTION
## Change description
Adding term to Asset currently checks for Entity update permission as well
Skipping Entity update permission authz for RELATIONSHIP-ADD/RELATIONSHIP-REMOVE/RELATIONSHIP-UPDATE for Asset to Term Relationship


> Description here

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
