### PR TITLE
META-2895 Prevent attribute value exceeding 100K characters

### DIFF
--- a/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
@@ -17,6 +17,7 @@
  */
 package org.apache.atlas.web.rest;
 
+import com.google.common.collect.Lists;
 import com.sun.jersey.core.header.FormDataContentDisposition;
 import com.sun.jersey.multipart.FormDataParam;
 import org.apache.atlas.AtlasErrorCode;
@@ -68,6 +69,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.*;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import static org.apache.atlas.AtlasErrorCode.BAD_REQUEST;
 import static org.apache.atlas.AtlasErrorCode.DEPRECATED_API;
@@ -89,6 +92,7 @@ public class EntityREST {
     public static final String PREFIX_ATTR  = "attr:";
     public static final String PREFIX_ATTR_ = "attr_";
     public static final String QUALIFIED_NAME  = "qualifiedName";
+    private static final int HUNDRED_THOUSAND = 100000;
 
 
     private final AtlasTypeRegistry      typeRegistry;
@@ -457,6 +461,7 @@ public class EntityREST {
             if (AtlasPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
                 perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "EntityREST.createOrUpdate()");
             }
+            validateAttributeLength(Lists.newArrayList(entity.getEntity()));
 
             return entitiesStore.createOrUpdate(new AtlasEntityStream(entity), replaceClassifications, replaceBusinessAttributes);
         } finally {
@@ -860,11 +865,27 @@ public class EntityREST {
                         (CollectionUtils.isEmpty(entities.getEntities()) ? 0 : entities.getEntities().size()) + ")");
             }
 
+            validateAttributeLength(entities.getEntities());
+
             EntityStream entityStream = new AtlasEntityStream(entities);
 
             return entitiesStore.createOrUpdate(entityStream, replaceClassifications, replaceBusinessAttributes);
         } finally {
             AtlasPerfTracer.log(perf);
+        }
+    }
+
+    private void validateAttributeLength(final List<AtlasEntity> entities) throws AtlasBaseException {
+        //Predicate to check attribute value exceeding length
+        Predicate<Map.Entry<String, Object>> predicateOfAttributeLengthExceedingLimit = attribute ->
+                attribute.getValue() instanceof String && ((String) attribute.getValue()).length() > HUNDRED_THOUSAND;
+
+        for (final AtlasEntity atlasEntity : entities) {
+            Set<String> attributeKeys = org.apache.commons.collections4.MapUtils.emptyIfNull(atlasEntity.getAttributes())
+                    .entrySet().stream().filter(predicateOfAttributeLengthExceedingLimit).map(Map.Entry::getKey).collect(Collectors.toSet());
+            if (!attributeKeys.isEmpty()) {
+                throw new AtlasBaseException("Attribute(s) " + String.join(",", attributeKeys) + " exceeds limit of "+HUNDRED_THOUSAND+" characters");
+            }
         }
     }
 


### PR DESCRIPTION
Prevent attribute value exceeding length of 100K char

## Change description

> 

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> https://linear.app/atlanproduct/issue/META-2895/prevent-ingesting-an-entity-with-attribute-length-exceeding-100k

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
