### PR TITLE
 Pass entityHeader with classifications for tag-based authz

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -1407,7 +1407,7 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
                                 CollectionUtils.isEmpty(diffEntity.getLabels())) {
                             //do nothing, only diff is relationshipAttributes.meanings, allow update
                         } else {
-                            AtlasEntityAccessRequest accessRequest = new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_UPDATE, new AtlasEntityHeader(entity));
+                            AtlasEntityAccessRequest accessRequest = new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_UPDATE, entityHeader);
                             AtlasAuthorizationUtils.verifyAccess(accessRequest, "update entity: type=", entity.getTypeName());
                         }
                     }


### PR DESCRIPTION
Problem:-
Classification not passed correctly in entity-update for Purposes to work correctly

Testing done updated in [linear](https://linear.app/atlanproduct/issue/META-2921/classification-not-passed-correctly-in-entity-update-for-purposes-to) 