### PR TITLE
META-2923 :- Skip Assets that are already delinked from input/output in getlineage API

### DIFF
--- a/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
@@ -368,8 +368,10 @@ public class EntityLineageService implements AtlasLineageService {
         List<AtlasEdge> qualifyingEdges = new ArrayList<>();
         while (processEdges.hasNext()) {
             AtlasEdge processEdge = processEdges.next();
-            if (GraphHelper.getStatus(processEdge) == AtlasEntity.Status.ACTIVE && lineageContext.evaluate(processEdge.getInVertex())) {
-                qualifyingEdges.add(processEdge);
+            if(lineageContext.isAllowDeletedProcess() || GraphHelper.getStatus(processEdge) == AtlasEntity.Status.ACTIVE ) {
+                if (lineageContext.evaluate(processEdge.getInVertex())) {
+                    qualifyingEdges.add(processEdge);
+                }
             }
         }
 
@@ -411,8 +413,10 @@ public class EntityLineageService implements AtlasLineageService {
                     List<AtlasEdge> qualifyingOutgoingEdges = new ArrayList<>();
                     while (outgoingEdges.hasNext()) {
                         AtlasEdge edge = outgoingEdges.next();
-                        if (GraphHelper.getStatus(edge) == AtlasEntity.Status.ACTIVE && (edge.getInVertex().equals(lineageContext.getStartDatasetVertex()) || lineageContext.evaluate(edge.getInVertex()))) {
-                            qualifyingOutgoingEdges.add(edge);
+                        if (lineageContext.isAllowDeletedProcess() || GraphHelper.getStatus(edge) == AtlasEntity.Status.ACTIVE) {
+                            if ((edge.getInVertex().equals(lineageContext.getStartDatasetVertex()) || lineageContext.evaluate(edge.getInVertex()))) {
+                                qualifyingOutgoingEdges.add(edge);
+                            }
                         }
                     }
                     ret.addChildrenCount(GraphHelper.getGuid(processVertex), isInput ? INPUT : OUTPUT, qualifyingOutgoingEdges.size());
@@ -446,17 +450,18 @@ public class EntityLineageService implements AtlasLineageService {
 
             int qualifyingEdges = 0;
             for (AtlasEdge incomingEdge : processEdgesList) {
-                if (GraphHelper.getStatus(incomingEdge) == AtlasEntity.Status.ACTIVE) {
+                if (lineageContext.isAllowDeletedProcess() || GraphHelper.getStatus(incomingEdge) == AtlasEntity.Status.ACTIVE) {
 
                     AtlasVertex processVertex = incomingEdge.getOutVertex();
                     Iterator<AtlasEdge> outgoingEdges = processVertex.getEdges(OUT, isInput ? PROCESS_INPUTS_EDGE : PROCESS_OUTPUTS_EDGE).iterator();
 
                     while (outgoingEdges.hasNext()) {
                         AtlasEdge edge = outgoingEdges.next();
-                        if (GraphHelper.getStatus(edge) == AtlasEntity.Status.ACTIVE && (edge.getInVertex().equals(lineageContext.getStartDatasetVertex())
-                                || lineageContext.evaluate(edge.getInVertex()))) {
-                            qualifyingEdges++;
-                            break;
+                        if (lineageContext.isAllowDeletedProcess() || GraphHelper.getStatus(edge) == AtlasEntity.Status.ACTIVE) {
+                            if ((edge.getInVertex().equals(lineageContext.getStartDatasetVertex()) || lineageContext.evaluate(edge.getInVertex()))) {
+                                qualifyingEdges++;
+                                break;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Change description
From Atlas, if we update the inputs in a process without changing the qualified name, the getLineage API still links to the older table.

Added status check for edges to consider only ACTIVE edge while traversing lineage 
> Description here

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
