### PR TITLE
META-2929 Fix AuditSearch creating rogue accesslogs

### DIFF
--- a/intg/src/main/java/org/apache/atlas/model/audit/AuditSearchParams.java
+++ b/intg/src/main/java/org/apache/atlas/model/audit/AuditSearchParams.java
@@ -22,11 +22,14 @@ public class AuditSearchParams {
 
     private Map dsl;
 
+    private boolean suppressLogs;
+
     public AuditSearchParams() {
         Map<String, Object> order = new HashMap<>();
         order.put("order", "desc");
 
         defaultSort.put("created", order);
+        suppressLogs = true;
     }
 
     public void setDsl(Map dsl) {
@@ -35,6 +38,14 @@ public class AuditSearchParams {
 
     public Map getDsl() {
         return this.dsl;
+    }
+
+    public boolean getSuppressLogs() {
+        return suppressLogs;
+    }
+
+    public void setSuppressLogs(boolean suppressLogs) {
+        this.suppressLogs = suppressLogs;
     }
 
     public String getQueryStringForGuid(String guid) {


### PR DESCRIPTION
AuditSearch API creating ranger audit logs

## Change description
suppressLogs property added to skip audit log by default.
> Description here
Testing done update on linear
https://linear.app/atlanproduct/issue/META-2929/auditsearch-creating-rogue-accesslogs
## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
