### PR TITLE
Meta 3003 clean metastore event notifications to beta

### DIFF
--- a/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
@@ -35,7 +35,7 @@ public enum AtlasConfiguration {
     QUERY_PARAM_MAX_LENGTH("atlas.query.param.max.length", 4*1024),
 
     REST_API_ENABLE_DELETE_TYPE_OVERRIDE("atlas.rest.enable.delete.type.override", false),
-    NOTIFICATION_RELATIONSHIPS_ENABLED("atlas.notification.relationships.enabled", false),
+    NOTIFICATION_RELATIONSHIPS_ENABLED("atlas.notification.relationships.enabled", true),
 
     NOTIFICATION_HOOK_TOPIC_NAME("atlas.notification.hook.topic.name", "ATLAS_HOOK"),
     NOTIFICATION_ENTITIES_TOPIC_NAME("atlas.notification.entities.topic.name", "ATLAS_ENTITIES"),

--- a/intg/src/main/java/org/apache/atlas/model/notification/EntityNotification.java
+++ b/intg/src/main/java/org/apache/atlas/model/notification/EntityNotification.java
@@ -20,6 +20,7 @@ package org.apache.atlas.model.notification;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.apache.atlas.model.instance.AtlasEntity;
 import org.apache.atlas.model.instance.AtlasEntityHeader;
 import org.apache.atlas.model.instance.AtlasRelationshipHeader;
 
@@ -99,15 +100,21 @@ public class EntityNotification implements Serializable {
     public static class EntityNotificationV2 extends EntityNotification implements Serializable {
         private static final long serialVersionUID = 1L;
 
+        public void setMutatedObject(Object mutatedObject) {
+            this.mutatedObject = mutatedObject;
+        }
+
         public enum OperationType {
             ENTITY_CREATE, ENTITY_UPDATE, ENTITY_DELETE,
             CLASSIFICATION_ADD, CLASSIFICATION_DELETE, CLASSIFICATION_UPDATE,
             RELATIONSHIP_CREATE, RELATIONSHIP_UPDATE, RELATIONSHIP_DELETE
         }
 
-        private AtlasEntityHeader entity;
+        private AtlasEntityHeader       entity;
+        private AtlasEntityHeader       diffEntity;
         private AtlasRelationshipHeader relationship;
-        private OperationType     operationType;
+        private OperationType           operationType;
+        private Object mutatedObject;
         private long              eventTime;
 
         public EntityNotificationV2() {
@@ -118,14 +125,22 @@ public class EntityNotification implements Serializable {
             setEventTime(System.currentTimeMillis());
         }
 
-        public EntityNotificationV2(AtlasEntityHeader entity, OperationType operationType) {
-            this(entity, operationType, System.currentTimeMillis());
-        }
 
-        public EntityNotificationV2(AtlasEntityHeader entity, OperationType operationType, long eventTime) {
+        public EntityNotificationV2(AtlasEntityHeader entity, OperationType operationType, long eventTime, Object mutatedObject) {
             super(ENTITY_NOTIFICATION_V2);
 
             setEntity(entity);
+            setOperationType(operationType);
+            setEventTime(eventTime);
+            setMutatedObject(mutatedObject);
+        }
+
+        public EntityNotificationV2(AtlasEntityHeader entity,AtlasEntityHeader diffEntity, OperationType operationType, long eventTime, Object mutatedObject) {
+            super(ENTITY_NOTIFICATION_V2);
+
+            setEntity(entity);
+            setMutatedObject(mutatedObject);
+            setDiffEntity(diffEntity);
             setOperationType(operationType);
             setEventTime(eventTime);
         }
@@ -144,6 +159,10 @@ public class EntityNotification implements Serializable {
 
         public void setEntity(AtlasEntityHeader entity) {
             this.entity = entity;
+        }
+
+        public void setDiffEntity(AtlasEntityHeader diffEntity){
+            this.diffEntity = diffEntity;
         }
 
         public AtlasRelationshipHeader getRelationship() {

--- a/intg/src/main/java/org/apache/atlas/model/notification/EntityNotification.java
+++ b/intg/src/main/java/org/apache/atlas/model/notification/EntityNotification.java
@@ -100,22 +100,17 @@ public class EntityNotification implements Serializable {
     public static class EntityNotificationV2 extends EntityNotification implements Serializable {
         private static final long serialVersionUID = 1L;
 
-        public void setMutatedObject(Object mutatedObject) {
-            this.mutatedObject = mutatedObject;
-        }
-
         public enum OperationType {
-            ENTITY_CREATE, ENTITY_UPDATE, ENTITY_DELETE,
-            CLASSIFICATION_ADD, CLASSIFICATION_DELETE, CLASSIFICATION_UPDATE,
-            RELATIONSHIP_CREATE, RELATIONSHIP_UPDATE, RELATIONSHIP_DELETE
+            ENTITY_CREATE, ENTITY_UPDATE, ENTITY_DELETE, CLASSIFICATION_ADD,
+            CLASSIFICATION_DELETE, CLASSIFICATION_UPDATE, RELATIONSHIP_CREATE,
+            RELATIONSHIP_UPDATE, RELATIONSHIP_DELETE, BUSINESS_ATTRIBUTE_UPDATE
         }
 
         private AtlasEntityHeader       entity;
-        private AtlasEntityHeader       diffEntity;
         private AtlasRelationshipHeader relationship;
         private OperationType           operationType;
-        private Object mutatedObject;
         private long              eventTime;
+        private Object       mutatedDetails;
 
         public EntityNotificationV2() {
             super(ENTITY_NOTIFICATION_V2);
@@ -126,23 +121,14 @@ public class EntityNotification implements Serializable {
         }
 
 
-        public EntityNotificationV2(AtlasEntityHeader entity, OperationType operationType, long eventTime, Object mutatedObject) {
+
+        public EntityNotificationV2(AtlasEntityHeader entity, Object mutatedDetails, OperationType operationType, long eventTime) {
             super(ENTITY_NOTIFICATION_V2);
 
             setEntity(entity);
             setOperationType(operationType);
             setEventTime(eventTime);
-            setMutatedObject(mutatedObject);
-        }
-
-        public EntityNotificationV2(AtlasEntityHeader entity,AtlasEntityHeader diffEntity, OperationType operationType, long eventTime, Object mutatedObject) {
-            super(ENTITY_NOTIFICATION_V2);
-
-            setEntity(entity);
-            setMutatedObject(mutatedObject);
-            setDiffEntity(diffEntity);
-            setOperationType(operationType);
-            setEventTime(eventTime);
+            setMutatedDetails(mutatedDetails);
         }
 
         public EntityNotificationV2(AtlasRelationshipHeader relationship, OperationType operationType, long eventTime) {
@@ -161,8 +147,8 @@ public class EntityNotification implements Serializable {
             this.entity = entity;
         }
 
-        public void setDiffEntity(AtlasEntityHeader diffEntity){
-            this.diffEntity = diffEntity;
+        public void setMutatedDetails(Object mutatedDetails){
+            this.mutatedDetails = mutatedDetails;
         }
 
         public AtlasRelationshipHeader getRelationship() {

--- a/server-api/src/main/java/org/apache/atlas/RequestContext.java
+++ b/server-api/src/main/java/org/apache/atlas/RequestContext.java
@@ -445,6 +445,8 @@ public class RequestContext {
 
     public Collection<AtlasEntity> getDifferentialEntities() { return diffEntityCache.values(); }
 
+    public Map<String,AtlasEntity> getDifferentialEntitiesMap() { return diffEntityCache; }
+
     public Collection<AtlasEntityHeader> getUpdatedEntities() {
         return updatedEntities.values();
     }


### PR DESCRIPTION
Clean metastore event notifications to only emit the changed fields in the update event instead of larger set of attributes
