### PR TITLE
META-3026 - Do not scrub classifications and terms while entity authorization

### DIFF
--- a/authorization/src/main/java/org/apache/atlas/authorize/AtlasAuthorizer.java
+++ b/authorization/src/main/java/org/apache/atlas/authorize/AtlasAuthorizer.java
@@ -139,21 +139,6 @@ public interface AtlasAuthorizer {
 
         entity.setScrubbed(isScrubbed);
 
-        if (entity.getClassifications() != null) {
-            entity.getClassifications().clear();
-        }
-
-        if (entity.getClassificationNames() != null) {
-            entity.getClassificationNames().clear();
-        }
-
-        if (entity.getMeanings() != null) {
-            entity.getMeanings().clear();
-        }
-
-        if (entity.getMeaningNames() != null) {
-            entity.getMeaningNames().clear();
-        }
     }
 
 


### PR DESCRIPTION
META-3026 - Do not scrub classifications and terms while entity authorization

testing done updated in [linear](https://linear.app/atlanproduct/issue/META-3026/do-not-scrub-classifications-and-term)