### PR TITLE
ATLAS-4622: import fix to handle invalid zip entry

### DIFF
--- a/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
@@ -178,7 +178,7 @@ public enum AtlasErrorCode {
     TYPEDEF_ATTR_DISPLAY_NAME_IS_REQUIRED(400, "ATLAS-400-00-09F", "displayName is required for typedef \"{0}\" attribute"),
     EMPTY_REQUEST(400, "ATLAS-400-00-100", "Empty Request or null, expects Map of List of RelatedObjects with term-id as key"),
     TYPEDEF_DISPLAY_NAME_IS_REQUIRED(400, "ATLAS-400-00-101", "displayName is required for typedef"),
-    IMPORT_INVALID_ZIP_ENTRY(400, "ATLAS-400-00-09F", "{0}: invalid zip entry. Reason: {1}"),
+    IMPORT_INVALID_ZIP_ENTRY(400, "ATLAS-400-00-10F", "{0}: invalid zip entry. Reason: {1}"),
 
     // All Not found enums go here
     TYPE_NAME_NOT_FOUND(404, "ATLAS-404-00-001", "Given typename {0} was invalid"),

--- a/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
@@ -178,6 +178,7 @@ public enum AtlasErrorCode {
     TYPEDEF_ATTR_DISPLAY_NAME_IS_REQUIRED(400, "ATLAS-400-00-09F", "displayName is required for typedef \"{0}\" attribute"),
     EMPTY_REQUEST(400, "ATLAS-400-00-100", "Empty Request or null, expects Map of List of RelatedObjects with term-id as key"),
     TYPEDEF_DISPLAY_NAME_IS_REQUIRED(400, "ATLAS-400-00-101", "displayName is required for typedef"),
+    IMPORT_INVALID_ZIP_ENTRY(400, "ATLAS-400-00-09F", "{0}: invalid zip entry. Reason: {1}"),
 
     // All Not found enums go here
     TYPE_NAME_NOT_FOUND(404, "ATLAS-404-00-001", "Given typename {0} was invalid"),

--- a/repository/src/main/java/org/apache/atlas/repository/impexp/ZipSourceWithBackingDirectory.java
+++ b/repository/src/main/java/org/apache/atlas/repository/impexp/ZipSourceWithBackingDirectory.java
@@ -45,11 +45,15 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 import static org.apache.atlas.AtlasErrorCode.IMPORT_ATTEMPTING_EMPTY_ZIP;
+import static org.apache.atlas.AtlasErrorCode.IMPORT_INVALID_ZIP_ENTRY;
 
 public class ZipSourceWithBackingDirectory implements EntityImportStream {
     private static final Logger LOG = LoggerFactory.getLogger(ZipSourceWithBackingDirectory.class);
     private static final String TEMPORARY_DIRECTORY_PREFIX = "atlas-import-temp-";
     private static final String EXT_JSON = ".json";
+    private static final String RELATIVE_PARENT_PATH                 = "..";
+    private static final String RELATIVE_PARENT_PATH_WITH_SEP_PREFIX = File.separator + RELATIVE_PARENT_PATH;
+    private static final String RELATIVE_PARENT_PATH_WITH_SEP_SUFFIX = RELATIVE_PARENT_PATH + File.separator;
 
     private Path tempDirectory;
 
@@ -174,7 +178,11 @@ public class ZipSourceWithBackingDirectory implements EntityImportStream {
 
     @Override
     public void onImportComplete(String guid) {
-        getFileFromTemporaryDirectory(guid + EXT_JSON).delete();
+        try {
+            getFileFromTemporaryDirectory(guid + EXT_JSON).delete();
+        } catch (AtlasBaseException excp) {
+            LOG.error("onImportComplete(guid={}): failed", guid, excp);
+        }
     }
 
     @Override
@@ -277,13 +285,38 @@ public class ZipSourceWithBackingDirectory implements EntityImportStream {
     }
 
     private void writeJsonToFile(String entryName, byte[] jsonPayload) throws IOException {
-        File f = getFileFromTemporaryDirectory(entryName);
-        Files.write(f.toPath(), jsonPayload);
+        try {
+            File f = getFileFromTemporaryDirectory(entryName);
+            Files.write(f.toPath(), jsonPayload);
+        } catch (AtlasBaseException excp) {
+            LOG.error("writeJsonToFile(entryName={}): failed", entryName, excp);
+
+            throw new IOException(excp);
+        }
     }
 
-    private File getFileFromTemporaryDirectory(String entryName) {
+    private File getFileFromTemporaryDirectory(String entryName) throws AtlasBaseException {
+        if (hasRelativeParentPath(entryName)) {
+            LOG.error("failed to initialize import: found zipEntry having relative parent path - {}", entryName);
+
+            throw new AtlasBaseException(IMPORT_INVALID_ZIP_ENTRY, entryName, "has relative parent path");
+        }
         return new File(tempDirectory.toFile(), entryName);
     }
+
+        private boolean hasRelativeParentPath(String path) {
+            final boolean ret;
+
+            if (path == null || !path.contains(RELATIVE_PARENT_PATH)) {
+                ret = false;
+            } else {
+                ret = path.startsWith(RELATIVE_PARENT_PATH) ||
+                        path.contains(RELATIVE_PARENT_PATH_WITH_SEP_PREFIX) ||
+                        path.contains(RELATIVE_PARENT_PATH_WITH_SEP_SUFFIX);
+            }
+
+            return ret;
+        }
 
     private void setupIterator() {
         try {


### PR DESCRIPTION
## Change description
ATLAS-4622: To fix invalid zip file entries to handle CVE.
Testing detail updated in [linear](https://linear.app/atlanproduct/issue/META-3043/cve-metastore-apache-atlas-bug-reported-by-apache-security-170622-01)

> Description here

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
