### PR TITLE
Fix/meta 3049

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/ClassificationAssociator.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/ClassificationAssociator.java
@@ -190,7 +190,6 @@ public class ClassificationAssociator {
             Map<String, List<AtlasClassification>> operationListMap = new HashMap<>();
 
             bucket(PROCESS_DELETE, operationListMap, listOps.subtract(entityClassifications, incomingClassifications));
-            bucket(PROCESS_UPDATE, operationListMap, listOps.intersect(incomingClassifications, entityClassifications));
             bucket(PROCESS_ADD, operationListMap, listOps.subtract(incomingClassifications, entityClassifications));
 
             return operationListMap;
@@ -346,7 +345,7 @@ public class ClassificationAssociator {
 
         private V findFrom(List<V> reference, V check) {
             return (V) CollectionUtils.find(reference, ox ->
-                    ((V) ox).getTypeName().equals(check.getTypeName()));
+                    ((V) ox).equals(check));
         }
 
         public List<V> filter(String guid, List<V> list) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/ClassificationAssociator.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/ClassificationAssociator.java
@@ -319,8 +319,8 @@ public class ClassificationAssociator {
 
             List<V> result = new ArrayList<>();
             for (V c : rhs) {
-                V foundSameTypeName = findObjectFrom(lhs, c);
-                V foundSame = findFrom(lhs, c);
+                V foundSame = findObjectFrom(lhs, c);
+                V foundSameTypeName = findFrom(lhs, c);
                 if ((foundSameTypeName != null) && (foundSame == null)) {
                     result.add(foundSameTypeName);
                 }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/ClassificationAssociator.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/ClassificationAssociator.java
@@ -190,6 +190,7 @@ public class ClassificationAssociator {
             Map<String, List<AtlasClassification>> operationListMap = new HashMap<>();
 
             bucket(PROCESS_DELETE, operationListMap, listOps.subtract(entityClassifications, incomingClassifications));
+            bucket(PROCESS_UPDATE, operationListMap, listOps.intersect(incomingClassifications, entityClassifications));
             bucket(PROCESS_ADD, operationListMap, listOps.subtract(incomingClassifications, entityClassifications));
 
             return operationListMap;
@@ -318,9 +319,10 @@ public class ClassificationAssociator {
 
             List<V> result = new ArrayList<>();
             for (V c : rhs) {
-                V found = findFrom(lhs, c);
-                if (found != null) {
-                    result.add(found);
+                V foundSameTypeName = findObjectFrom(lhs, c);
+                V foundSame = findFrom(lhs, c);
+                if ((foundSameTypeName != null) && (foundSame == null)) {
+                    result.add(foundSameTypeName);
                 }
             }
 
@@ -343,9 +345,14 @@ public class ClassificationAssociator {
             return result;
         }
 
-        private V findFrom(List<V> reference, V check) {
+        private V findObjectFrom(List<V> reference, V check) {
             return (V) CollectionUtils.find(reference, ox ->
                     ((V) ox).equals(check));
+        }
+
+        private V findFrom(List<V> reference, V check) {
+            return (V) CollectionUtils.find(reference, ox ->
+                    ((V) ox).getTypeName().equals(check.getTypeName()));
         }
 
         public List<V> filter(String guid, List<V> list) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/ClassificationAssociator.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/ClassificationAssociator.java
@@ -325,7 +325,6 @@ public class ClassificationAssociator {
                     result.add(foundSameTypeName);
                 }
             }
-
             return result;
         }
 


### PR DESCRIPTION
## Change description

> On /v2/entity/bulk/setClassifications endpoint, unnecessary ADD tasks were getting created even when the classification already associated. There was an update operation that causes this behavior because update operation's scope was the same classifications that did not need to be updated.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
