### PR TITLE
Restrict classification propagation only to asset hierarchy

### DIFF
--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -23,6 +23,9 @@ import org.apache.atlas.AtlasException;
 import org.apache.commons.configuration.Configuration;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 
 import static org.apache.atlas.type.AtlasStructType.AtlasAttribute.encodePropertyKey;
 
@@ -67,7 +70,7 @@ public final class Constants {
      */
     public static final String TYPE_CATEGORY_PROPERTY_KEY   = getEncodedTypePropertyKey(INTERNAL_PROPERTY_KEY_PREFIX + "type.category");
     public static final String VERTEX_TYPE_PROPERTY_KEY     = getEncodedTypePropertyKey(INTERNAL_PROPERTY_KEY_PREFIX + "type");
-    public static final String TYPENAME_PROPERTY_KEY        = getEncodedTypePropertyKey(INTERNAL_PROPERTY_KEY_PREFIX + "type.name");
+    public static final String  TYPENAME_PROPERTY_KEY        = getEncodedTypePropertyKey(INTERNAL_PROPERTY_KEY_PREFIX + "type.name");
     public static final String TYPE_DISPLAYNAME_PROPERTY_KEY= getEncodedTypePropertyKey(INTERNAL_PROPERTY_KEY_PREFIX + "type.displayName");
     public static final String TYPEDESCRIPTION_PROPERTY_KEY = getEncodedTypePropertyKey(INTERNAL_PROPERTY_KEY_PREFIX + "type.description");
     public static final String TYPEVERSION_PROPERTY_KEY     = getEncodedTypePropertyKey(INTERNAL_PROPERTY_KEY_PREFIX + "type.version");
@@ -218,6 +221,7 @@ public final class Constants {
     public static final String CLASSIFICATION_VALIDITY_PERIODS_KEY            = encodePropertyKey(INTERNAL_PROPERTY_KEY_PREFIX + "validityPeriods");
     public static final String CLASSIFICATION_VERTEX_PROPAGATE_KEY            = encodePropertyKey(INTERNAL_PROPERTY_KEY_PREFIX + "propagate");
     public static final String CLASSIFICATION_VERTEX_REMOVE_PROPAGATIONS_KEY  = encodePropertyKey(INTERNAL_PROPERTY_KEY_PREFIX + "removePropagations");
+    public static final String CLASSIFICATION_VERTEX_PROPAGATE_THROUGH_LINEAGE= encodePropertyKey(INTERNAL_PROPERTY_KEY_PREFIX + "propagateThroughLineage");
     public static final String CLASSIFICATION_VERTEX_NAME_KEY                 = encodePropertyKey(TYPE_NAME_PROPERTY_KEY);
     public static final String CLASSIFICATION_EDGE_NAME_PROPERTY_KEY          = encodePropertyKey(INTERNAL_PROPERTY_KEY_PREFIX + "name");
     public static final String CLASSIFICATION_EDGE_IS_PROPAGATED_PROPERTY_KEY = encodePropertyKey(INTERNAL_PROPERTY_KEY_PREFIX + "isPropagated");
@@ -323,6 +327,18 @@ public final class Constants {
     public static final String CLASSIFICATION_PROPAGATION_JOB_COUNT_METRIC = "classification.propagation.job.count";
 
     public static final int ELASTICSEARCH_PAGINATION_SIZE = 50;
+
+    public static final String CATALOG_PROCESS_INPUT_RELATIONSHIP_LABEL = "__Process.inputs";
+    public static final String CATALOG_PROCESS_OUTPUT_RELATIONSHIP_LABEL = "__Process.outputs";
+    public static final String COLUMN_LINEAGE_RELATIONSHIP_LABEL = "__Process.columnProcesses";
+
+    public static final HashMap<String, ArrayList<String>> CLASSIFICATION_PROPAGATION_MAP = new HashMap<String, ArrayList<String>>(){{
+        put("EXCLUDE_LINEAGE", new ArrayList<>(Arrays.asList(CATALOG_PROCESS_INPUT_RELATIONSHIP_LABEL,
+                CATALOG_PROCESS_OUTPUT_RELATIONSHIP_LABEL,
+                COLUMN_LINEAGE_RELATIONSHIP_LABEL
+        )));
+        put("DEFAULT", null);
+    }};
 
     private Constants() {
     }

--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -331,13 +331,15 @@ public final class Constants {
     public static final String CATALOG_PROCESS_INPUT_RELATIONSHIP_LABEL = "__Process.inputs";
     public static final String CATALOG_PROCESS_OUTPUT_RELATIONSHIP_LABEL = "__Process.outputs";
     public static final String COLUMN_LINEAGE_RELATIONSHIP_LABEL = "__Process.columnProcesses";
+    public static final String CLASSIFICATION_PROPAGATION_MODE_DEFAULT  ="DEFAULT";
+    public static final String CLASSIFICATION_PROPAGATION_MODE_LINEAGE  ="LINEAGE";
 
-    public static final HashMap<String, ArrayList<String>> CLASSIFICATION_PROPAGATION_MAP = new HashMap<String, ArrayList<String>>(){{
-        put("EXCLUDE_LINEAGE", new ArrayList<>(Arrays.asList(CATALOG_PROCESS_INPUT_RELATIONSHIP_LABEL,
+    public static final HashMap<String, ArrayList<String>> CLASSIFICATION_PROPAGATION_EXCLUSION_MAP = new HashMap<String, ArrayList<String>>(){{
+        put(CLASSIFICATION_PROPAGATION_MODE_DEFAULT, new ArrayList<>(Arrays.asList(CATALOG_PROCESS_INPUT_RELATIONSHIP_LABEL,
                 CATALOG_PROCESS_OUTPUT_RELATIONSHIP_LABEL,
                 COLUMN_LINEAGE_RELATIONSHIP_LABEL
         )));
-        put("DEFAULT", null);
+        put(CLASSIFICATION_PROPAGATION_MODE_LINEAGE, null);
     }};
 
     private Constants() {

--- a/intg/src/main/java/org/apache/atlas/model/instance/AtlasClassification.java
+++ b/intg/src/main/java/org/apache/atlas/model/instance/AtlasClassification.java
@@ -60,6 +60,7 @@ public class AtlasClassification extends AtlasStruct implements Serializable {
     private Boolean            propagate                         = null;
     private List<TimeBoundary> validityPeriods                   = null;
     private Boolean            removePropagationsOnEntityDelete  = null;
+    private Boolean            propagateThroughLineage           = null;
 
     public AtlasClassification() {
         this(null, null);
@@ -91,6 +92,7 @@ public class AtlasClassification extends AtlasStruct implements Serializable {
             setValidityPeriods(other.getValidityPeriods());
             setDisplayName(other.getDisplayName());
             setRemovePropagationsOnEntityDelete(other.getRemovePropagationsOnEntityDelete());
+            setPropagateThroughLineage(other.getPropagateThroughLineage());
         }
     }
 
@@ -174,7 +176,7 @@ public class AtlasClassification extends AtlasStruct implements Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), entityGuid, entityStatus, propagate, removePropagationsOnEntityDelete);
+        return Objects.hash(super.hashCode(), entityGuid, entityStatus, propagate, removePropagationsOnEntityDelete, propagateThroughLineage);
     }
 
     @Override
@@ -187,8 +189,17 @@ public class AtlasClassification extends AtlasStruct implements Serializable {
         sb.append(", removePropagationsOnEntityDelete=").append(removePropagationsOnEntityDelete);
         sb.append(", displayName=").append(displayName);
         sb.append(", validityPeriods=").append(validityPeriods);
+        sb.append(", propagateThroughLineage=").append(propagateThroughLineage);
         sb.append('}');
         return sb.toString();
+    }
+
+    public Boolean getPropagateThroughLineage() {
+        return propagateThroughLineage;
+    }
+
+    public void setPropagateThroughLineage(Boolean propagateThroughLineage) {
+        this.propagateThroughLineage = propagateThroughLineage;
     }
 
     /**

--- a/intg/src/main/java/org/apache/atlas/model/instance/AtlasClassification.java
+++ b/intg/src/main/java/org/apache/atlas/model/instance/AtlasClassification.java
@@ -171,7 +171,7 @@ public class AtlasClassification extends AtlasStruct implements Serializable {
                Objects.equals(removePropagationsOnEntityDelete, that.removePropagationsOnEntityDelete) &&
                Objects.equals(entityGuid, that.entityGuid) &&
                entityStatus == that.entityStatus &&
-               Objects.equals(validityPeriods, that.validityPeriods);
+               Objects.equals(validityPeriods, that.validityPeriods) && Objects.equals(propagateThroughLineage, that.propagateThroughLineage);
     }
 
     @Override

--- a/notification/src/main/java/org/apache/atlas/notification/AbstractNotification.java
+++ b/notification/src/main/java/org/apache/atlas/notification/AbstractNotification.java
@@ -96,7 +96,7 @@ public abstract class AbstractNotification implements NotificationInterface {
             createNotificationMessages(messages.get(index), strMessages, source);
         }
 
-        sendInternal(type, strMessages);
+//        sendInternal(type, strMessages);
     }
 
     @Override

--- a/notification/src/main/java/org/apache/atlas/notification/AbstractNotification.java
+++ b/notification/src/main/java/org/apache/atlas/notification/AbstractNotification.java
@@ -96,7 +96,7 @@ public abstract class AbstractNotification implements NotificationInterface {
             createNotificationMessages(messages.get(index), strMessages, source);
         }
 
-//        sendInternal(type, strMessages);
+        sendInternal(type, strMessages);
     }
 
     @Override

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -341,6 +341,18 @@ public final class GraphHelper {
         return ret;
     }
 
+    public static boolean getPropagateThroughLineage(AtlasVertex classificationVertex) {
+        boolean ret = false;
+
+        if (classificationVertex != null) {
+            Boolean enabled = AtlasGraphUtilsV2.getEncodedProperty(classificationVertex, CLASSIFICATION_VERTEX_PROPAGATE_THROUGH_LINEAGE, Boolean.class);
+
+            ret = (enabled == null) ? true : enabled;
+        }
+
+        return ret;
+    }
+
     public static AtlasVertex getClassificationVertex(AtlasVertex entityVertex, String classificationName) {
         AtlasVertex ret   = null;
         Iterable    edges = entityVertex.query().direction(AtlasEdgeDirection.OUT).label(CLASSIFICATION_LABEL)

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -1249,6 +1249,21 @@ public abstract class DeleteHandlerV1 {
         }
     }
 
+    public void createAndQueueTask(String taskType, AtlasVertex entityVertex, String classificationVertexId, String relationshipGuid, Boolean propagateThroughLineage) {
+        String              currentUser = RequestContext.getCurrentUser();
+        String              entityGuid  = GraphHelper.getGuid(entityVertex);
+        String propagationMode = "DEFAULT";
+        if(!propagateThroughLineage){
+            propagationMode = "EXCLUDE_LINEAGE";
+        }
+        Map<String, Object> taskParams  = ClassificationTask.toParameters(entityGuid, classificationVertexId, relationshipGuid, propagationMode);
+        AtlasTask           task        = taskManagement.createTask(taskType, currentUser, taskParams);
+
+        AtlasGraphUtilsV2.addEncodedProperty(entityVertex, PENDING_TASKS_PROPERTY_KEY, task.getGuid());
+
+        RequestContext.get().queueTask(task);
+    }
+
     public void createAndQueueTask(String taskType, AtlasVertex entityVertex, String classificationVertexId, String relationshipGuid) {
         String              currentUser = RequestContext.getCurrentUser();
         String              entityGuid  = GraphHelper.getGuid(entityVertex);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -1252,11 +1252,7 @@ public abstract class DeleteHandlerV1 {
     public void createAndQueueTask(String taskType, AtlasVertex entityVertex, String classificationVertexId, String relationshipGuid, Boolean propagateThroughLineage) {
         String              currentUser = RequestContext.getCurrentUser();
         String              entityGuid  = GraphHelper.getGuid(entityVertex);
-        String propagationMode = "DEFAULT";
-        if(!propagateThroughLineage){
-            propagationMode = "EXCLUDE_LINEAGE";
-        }
-        Map<String, Object> taskParams  = ClassificationTask.toParameters(entityGuid, classificationVertexId, relationshipGuid, propagationMode);
+        Map<String, Object> taskParams  = ClassificationTask.toParameters(entityGuid, classificationVertexId, relationshipGuid, propagateThroughLineage);
         AtlasTask           task        = taskManagement.createTask(taskType, currentUser, taskParams);
 
         AtlasGraphUtilsV2.addEncodedProperty(entityVertex, PENDING_TASKS_PROPERTY_KEY, task.getGuid());

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -2632,7 +2632,7 @@ public class EntityGraphMapper {
                 if (propagateTags && taskManagement != null && DEFERRED_ACTION_ENABLED) {
                     propagateTags = false;
 
-                    createAndQueueTask(CLASSIFICATION_PROPAGATION_ADD, entityVertex, classificationVertex.getIdForDisplay(), classification.getPropagateThroughLineage());
+                    createAndQueueTask(CLASSIFICATION_PROPAGATION_ADD, entityVertex, classificationVertex.getIdForDisplay());
                 }
 
                 // add the attributes for the trait instance
@@ -2693,7 +2693,7 @@ public class EntityGraphMapper {
     }
 
     @GraphTransaction
-    public List<String> propagateClassification(String entityGuid, String classificationVertexId, String relationshipGuid, String propagationMode) throws AtlasBaseException {
+    public List<String> propagateClassification(String entityGuid, String classificationVertexId, String relationshipGuid, Boolean currentPropagateThroughLineage) throws AtlasBaseException {
         try {
             if (StringUtils.isEmpty(entityGuid) || StringUtils.isEmpty(classificationVertexId)) {
                 LOG.error("propagateClassification(entityGuid={}, classificationVertexId={}): entityGuid and/or classification vertex id is empty", entityGuid, classificationVertexId);
@@ -2714,13 +2714,31 @@ public class EntityGraphMapper {
 
                 throw new AtlasBaseException(String.format("propagateClassification(entityGuid=%s, classificationVertexId=%s): classification vertex not found", entityGuid, classificationVertexId));
             }
+
+            /*
+                If propagateThroughLineage was true at past then updated to false we need to delete the propagated
+             */
+            Boolean updatedPropagateThroughLineage = entityRetriever.toAtlasClassification(classificationVertex).getPropagateThroughLineage();
+
+            if(updatedPropagateThroughLineage!= null && currentPropagateThroughLineage!=null && updatedPropagateThroughLineage != currentPropagateThroughLineage){
+                if(!updatedPropagateThroughLineage){
+                    deleteDelegate.getHandler().removeTagPropagation(classificationVertex);
+                }
+            }
+
+            String propagationMode = CLASSIFICATION_PROPAGATION_MODE_DEFAULT;
+            if(updatedPropagateThroughLineage){
+                propagationMode = CLASSIFICATION_PROPAGATION_MODE_LINEAGE;
+            }
+
             List<String> edgeLabelsToExclude = new ArrayList<>();
 
-            if(propagationMode!=null || !propagationMode.isEmpty()){
-                edgeLabelsToExclude = CLASSIFICATION_PROPAGATION_MAP.get(propagationMode);
+            if(propagationMode!=null && !propagationMode.isEmpty()){
+                edgeLabelsToExclude = CLASSIFICATION_PROPAGATION_EXCLUSION_MAP.get(propagationMode);
             }
 
             List<AtlasVertex> impactedVertices = entityRetriever.getIncludedImpactedVerticesV2(entityVertex, relationshipGuid, classificationVertexId, edgeLabelsToExclude);
+
             if (CollectionUtils.isEmpty(impactedVertices)) {
                 LOG.debug("propagateClassification(entityGuid={}, classificationVertexId={}): found no entities to propagate the classification", entityGuid, classificationVertexId);
 
@@ -3070,7 +3088,7 @@ public class EntityGraphMapper {
             if (taskManagement != null && DEFERRED_ACTION_ENABLED) {
                 String propagationType = updatedTagPropagation ? CLASSIFICATION_PROPAGATION_ADD : CLASSIFICATION_PROPAGATION_DELETE;
 
-                createAndQueueTask(propagationType, entityVertex, classificationVertex.getIdForDisplay(), classification.getPropagateThroughLineage());
+                createAndQueueTask(propagationType, entityVertex, classificationVertex.getIdForDisplay(), currentClassification.getPropagateThroughLineage());
 
                 updatedTagPropagation = null;
             }
@@ -3563,9 +3581,9 @@ public class EntityGraphMapper {
         attributes.put(bmAttribute.getName(), attrValue);
     }
 
-    private void createAndQueueTask(String taskType, AtlasVertex entityVertex, String classificationVertexId, Boolean propagateThroughLineage) {
+    private void createAndQueueTask(String taskType, AtlasVertex entityVertex, String classificationVertexId, Boolean currentPropagateThroughLineage) {
 
-        deleteDelegate.getHandler().createAndQueueTask(taskType, entityVertex, classificationVertexId, null, propagateThroughLineage);
+        deleteDelegate.getHandler().createAndQueueTask(taskType, entityVertex, classificationVertexId, null, currentPropagateThroughLineage);
     }
 
     private void createAndQueueTask(String taskType, AtlasVertex entityVertex, String classificationVertexId) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -2574,6 +2574,7 @@ public class EntityGraphMapper {
                 String              classificationName  = classification.getTypeName();
                 Boolean             propagateTags       = classification.isPropagate();
                 Boolean             removePropagations  = classification.getRemovePropagationsOnEntityDelete();
+                Boolean propagateThroughLineage         = classification.getPropagateThroughLineage();
 
                 if (propagateTags != null && propagateTags &&
                         classification.getEntityGuid() != null &&
@@ -2609,6 +2610,10 @@ public class EntityGraphMapper {
                     classification.setEntityStatus(ACTIVE);
                 }
 
+                if (propagateThroughLineage == null) {
+                    classification.setPropagateThroughLineage(true);
+                }
+
                 // ignore propagated classifications
 
                 if (LOG.isDebugEnabled()) {
@@ -2627,7 +2632,7 @@ public class EntityGraphMapper {
                 if (propagateTags && taskManagement != null && DEFERRED_ACTION_ENABLED) {
                     propagateTags = false;
 
-                    createAndQueueTask(CLASSIFICATION_PROPAGATION_ADD, entityVertex, classificationVertex.getIdForDisplay());
+                    createAndQueueTask(CLASSIFICATION_PROPAGATION_ADD, entityVertex, classificationVertex.getIdForDisplay(), classification.getPropagateThroughLineage());
                 }
 
                 // add the attributes for the trait instance
@@ -2688,7 +2693,7 @@ public class EntityGraphMapper {
     }
 
     @GraphTransaction
-    public List<String> propagateClassification(String entityGuid, String classificationVertexId, String relationshipGuid) throws AtlasBaseException {
+    public List<String> propagateClassification(String entityGuid, String classificationVertexId, String relationshipGuid, String propagationMode) throws AtlasBaseException {
         try {
             if (StringUtils.isEmpty(entityGuid) || StringUtils.isEmpty(classificationVertexId)) {
                 LOG.error("propagateClassification(entityGuid={}, classificationVertexId={}): entityGuid and/or classification vertex id is empty", entityGuid, classificationVertexId);
@@ -2709,8 +2714,13 @@ public class EntityGraphMapper {
 
                 throw new AtlasBaseException(String.format("propagateClassification(entityGuid=%s, classificationVertexId=%s): classification vertex not found", entityGuid, classificationVertexId));
             }
+            List<String> edgeLabelsToExclude = new ArrayList<>();
 
-            List<AtlasVertex> impactedVertices = entityRetriever.getIncludedImpactedVerticesV2(entityVertex, relationshipGuid, classificationVertexId);
+            if(propagationMode!=null || !propagationMode.isEmpty()){
+                edgeLabelsToExclude = CLASSIFICATION_PROPAGATION_MAP.get(propagationMode);
+            }
+
+            List<AtlasVertex> impactedVertices = entityRetriever.getIncludedImpactedVerticesV2(entityVertex, relationshipGuid, classificationVertexId, edgeLabelsToExclude);
             if (CollectionUtils.isEmpty(impactedVertices)) {
                 LOG.debug("propagateClassification(entityGuid={}, classificationVertexId={}): found no entities to propagate the classification", entityGuid, classificationVertexId);
 
@@ -2978,6 +2988,10 @@ public class EntityGraphMapper {
                 throw new AtlasBaseException(AtlasErrorCode.CLASSIFICATION_NOT_ASSOCIATED_WITH_ENTITY, classificationName);
             }
 
+            if(classification.getPropagateThroughLineage() == null){
+                classification.setPropagateThroughLineage(true);
+            }
+
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Updating classification {} for entity {}", classification, guid);
             }
@@ -3056,7 +3070,7 @@ public class EntityGraphMapper {
             if (taskManagement != null && DEFERRED_ACTION_ENABLED) {
                 String propagationType = updatedTagPropagation ? CLASSIFICATION_PROPAGATION_ADD : CLASSIFICATION_PROPAGATION_DELETE;
 
-                createAndQueueTask(propagationType, entityVertex, classificationVertex.getIdForDisplay());
+                createAndQueueTask(propagationType, entityVertex, classificationVertex.getIdForDisplay(), classification.getPropagateThroughLineage());
 
                 updatedTagPropagation = null;
             }
@@ -3151,6 +3165,10 @@ public class EntityGraphMapper {
 
         if (classification.getRemovePropagationsOnEntityDelete() != null) {
             AtlasGraphUtilsV2.setEncodedProperty(traitInstanceVertex, CLASSIFICATION_VERTEX_REMOVE_PROPAGATIONS_KEY, classification.getRemovePropagationsOnEntityDelete());
+        }
+
+        if(classification.getPropagateThroughLineage() != null){
+            AtlasGraphUtilsV2.setEncodedProperty(traitInstanceVertex, CLASSIFICATION_VERTEX_PROPAGATE_THROUGH_LINEAGE, classification.getPropagateThroughLineage());
         }
 
         // map all the attributes to this newly created AtlasVertex
@@ -3543,6 +3561,11 @@ public class EntityGraphMapper {
         }
 
         attributes.put(bmAttribute.getName(), attrValue);
+    }
+
+    private void createAndQueueTask(String taskType, AtlasVertex entityVertex, String classificationVertexId, Boolean propagateThroughLineage) {
+
+        deleteDelegate.getHandler().createAndQueueTask(taskType, entityVertex, classificationVertexId, null, propagateThroughLineage);
     }
 
     private void createAndQueueTask(String taskType, AtlasVertex entityVertex, String classificationVertexId) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -110,11 +110,7 @@ import static org.apache.atlas.model.typedef.AtlasBaseTypeDef.ATLAS_TYPE_STRING;
 import static org.apache.atlas.model.typedef.AtlasRelationshipDef.PropagateTags.NONE;
 import static org.apache.atlas.model.typedef.AtlasRelationshipDef.PropagateTags.ONE_TO_TWO;
 import static org.apache.atlas.model.typedef.AtlasRelationshipDef.PropagateTags.TWO_TO_ONE;
-import static org.apache.atlas.repository.Constants.CLASSIFICATION_ENTITY_GUID;
-import static org.apache.atlas.repository.Constants.CLASSIFICATION_LABEL;
-import static org.apache.atlas.repository.Constants.CLASSIFICATION_VALIDITY_PERIODS_KEY;
-import static org.apache.atlas.repository.Constants.TERM_ASSIGNMENT_LABEL;
-import static org.apache.atlas.repository.Constants.CLASSIFICATION_PROPAGATION_MAP;
+import static org.apache.atlas.repository.Constants.*;
 import static org.apache.atlas.repository.graph.GraphHelper.*;
 import static org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2.getIdFromVertex;
 import static org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2.isReference;
@@ -525,14 +521,14 @@ public class EntityGraphRetriever {
                 String            classificationId      = classificationVertex.getIdForDisplay();
                 String            sourceEntityId        = getClassificationEntityGuid(classificationVertex);
                 AtlasVertex       sourceEntityVertex    = AtlasGraphUtilsV2.findByGuid(this.graph, sourceEntityId);
-                String propagationMode = "DEFAULT";
+                String propagationMode = CLASSIFICATION_PROPAGATION_MODE_DEFAULT;
 
                 if(!toAtlasClassification(classificationVertex).getPropagateThroughLineage()){
-                    propagationMode = "EXCLUDE_LINEAGE";
+                    propagationMode = CLASSIFICATION_PROPAGATION_MODE_LINEAGE;
                 }
 
                 List<AtlasVertex> entitiesPropagatingTo = getImpactedVerticesV2(sourceEntityVertex, relationshipGuidToExclude,
-                        classificationId, CLASSIFICATION_PROPAGATION_MAP.get(propagationMode));
+                        classificationId, CLASSIFICATION_PROPAGATION_EXCLUSION_MAP.get(propagationMode));
 
                 ret.put(classificationVertex, entitiesPropagatingTo);
             }
@@ -621,7 +617,7 @@ public class EntityGraphRetriever {
             }
             if(edgeLabelsToExclude != null) {
                 if (!edgeLabelsToExclude.isEmpty()) {
-                    tagPropagationEdges = Arrays.stream(tagPropagationEdges).filter(x -> edgeLabelsToExclude.contains(x)).collect(Collectors.toList()).toArray(new String[0]);
+                    tagPropagationEdges = Arrays.stream(tagPropagationEdges).filter(x -> !edgeLabelsToExclude.contains(x)).collect(Collectors.toList()).toArray(new String[0]);
                 }
             }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tasks/ClassificationPropagationTasks.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tasks/ClassificationPropagationTasks.java
@@ -38,12 +38,12 @@ public class ClassificationPropagationTasks {
 
         @Override
         protected void run(Map<String, Object> parameters) throws AtlasBaseException {
-            String entityGuid             = (String) parameters.get(PARAM_ENTITY_GUID);
-            String classificationVertexId = (String) parameters.get(PARAM_CLASSIFICATION_VERTEX_ID);
-            String relationshipGuid       = (String) parameters.get(PARAM_RELATIONSHIP_GUID);
-            String propagationMode        = (String) parameters.get(PARAM_CLASSIFICATION_PROPAGATION_MODE);
+            String entityGuid               = (String) parameters.get(PARAM_ENTITY_GUID);
+            String classificationVertexId   = (String) parameters.get(PARAM_CLASSIFICATION_VERTEX_ID);
+            String relationshipGuid         = (String) parameters.get(PARAM_RELATIONSHIP_GUID);
+            Boolean propagateThroughLineage = (Boolean) parameters.get(PARAM_CLASSIFICATION_PROPAGATE_THROUGH_LINEAGE);
 
-            entityGraphMapper.propagateClassification(entityGuid, classificationVertexId, relationshipGuid, propagationMode);
+            entityGraphMapper.propagateClassification(entityGuid, classificationVertexId, relationshipGuid, propagateThroughLineage);
         }
     }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tasks/ClassificationPropagationTasks.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tasks/ClassificationPropagationTasks.java
@@ -41,8 +41,9 @@ public class ClassificationPropagationTasks {
             String entityGuid             = (String) parameters.get(PARAM_ENTITY_GUID);
             String classificationVertexId = (String) parameters.get(PARAM_CLASSIFICATION_VERTEX_ID);
             String relationshipGuid       = (String) parameters.get(PARAM_RELATIONSHIP_GUID);
+            String propagationMode        = (String) parameters.get(PARAM_CLASSIFICATION_PROPAGATION_MODE);
 
-            entityGraphMapper.propagateClassification(entityGuid, classificationVertexId, relationshipGuid);
+            entityGraphMapper.propagateClassification(entityGuid, classificationVertexId, relationshipGuid, propagationMode);
         }
     }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tasks/ClassificationTask.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tasks/ClassificationTask.java
@@ -50,7 +50,7 @@ public abstract class ClassificationTask extends AbstractTask {
     public static final String PARAM_RELATIONSHIP_GUID        = "relationshipGuid";
     public static final String PARAM_RELATIONSHIP_OBJECT      = "relationshipObject";
     public static final String PARAM_RELATIONSHIP_EDGE_ID     = "relationshipEdgeId";
-    public static final String PARAM_CLASSIFICATION_PROPAGATION_MODE = "propagationMode";
+    public static final String PARAM_CLASSIFICATION_PROPAGATE_THROUGH_LINEAGE = "propagateThroughLineage";
   
     protected final AtlasGraph             graph;
     protected final EntityGraphMapper      entityGraphMapper;
@@ -107,12 +107,12 @@ public abstract class ClassificationTask extends AbstractTask {
         return getStatus();
     }
 
-    public static Map<String, Object> toParameters(String entityGuid, String classificationVertexId, String relationshipGuid, String propagationMode) {
+    public static Map<String, Object> toParameters(String entityGuid, String classificationVertexId, String relationshipGuid, Boolean propagateThroughLineage) {
         return new HashMap<String, Object>() {{
             put(PARAM_ENTITY_GUID, entityGuid);
             put(PARAM_CLASSIFICATION_VERTEX_ID, classificationVertexId);
             put(PARAM_RELATIONSHIP_GUID, relationshipGuid);
-            put(PARAM_CLASSIFICATION_PROPAGATION_MODE, propagationMode);
+            put(PARAM_CLASSIFICATION_PROPAGATE_THROUGH_LINEAGE, propagateThroughLineage);
         }};
     }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tasks/ClassificationTask.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tasks/ClassificationTask.java
@@ -50,6 +50,7 @@ public abstract class ClassificationTask extends AbstractTask {
     public static final String PARAM_RELATIONSHIP_GUID        = "relationshipGuid";
     public static final String PARAM_RELATIONSHIP_OBJECT      = "relationshipObject";
     public static final String PARAM_RELATIONSHIP_EDGE_ID     = "relationshipEdgeId";
+    public static final String PARAM_CLASSIFICATION_PROPAGATION_MODE = "propagationMode";
   
     protected final AtlasGraph             graph;
     protected final EntityGraphMapper      entityGraphMapper;
@@ -104,6 +105,15 @@ public abstract class ClassificationTask extends AbstractTask {
         }
 
         return getStatus();
+    }
+
+    public static Map<String, Object> toParameters(String entityGuid, String classificationVertexId, String relationshipGuid, String propagationMode) {
+        return new HashMap<String, Object>() {{
+            put(PARAM_ENTITY_GUID, entityGuid);
+            put(PARAM_CLASSIFICATION_VERTEX_ID, classificationVertexId);
+            put(PARAM_RELATIONSHIP_GUID, relationshipGuid);
+            put(PARAM_CLASSIFICATION_PROPAGATION_MODE, propagationMode);
+        }};
     }
 
     public static Map<String, Object> toParameters(String entityGuid, String classificationVertexId, String relationshipGuid) {

--- a/repository/src/test/java/org/apache/atlas/repository/tagpropagation/ClassificationPropagationWithTasksTest.java
+++ b/repository/src/test/java/org/apache/atlas/repository/tagpropagation/ClassificationPropagationWithTasksTest.java
@@ -122,22 +122,22 @@ public class ClassificationPropagationWithTasksTest extends AtlasTestBase {
     @Test
     public void parameterValidation() throws AtlasBaseException {
         try {
-            entityGraphMapper.propagateClassification(null, null, null);
-            entityGraphMapper.propagateClassification("unknown", "abcd", "xyz");
+            entityGraphMapper.propagateClassification(null, null, null, null);
+            entityGraphMapper.propagateClassification("unknown", "abcd", "xyz", null);
         }
         catch (AtlasBaseException e) {
             assertNotNull(e.getCause());
             assertTrue(e.getCause() instanceof EntityNotFoundException);
         }
 
-        List<String> ret = entityGraphMapper.propagateClassification(HDFS_PATH_EMPLOYEES, StringUtils.EMPTY, StringUtils.EMPTY);
+        List<String> ret = entityGraphMapper.propagateClassification(HDFS_PATH_EMPLOYEES, StringUtils.EMPTY, StringUtils.EMPTY, null);
         assertNull(ret);
 
         ret = entityGraphMapper.deleteClassificationPropagation(StringUtils.EMPTY, StringUtils.EMPTY);
         assertNull(ret);
 
         AtlasEntity hdfs_employees = getEntity(HDFS_PATH_EMPLOYEES);
-        ret = entityGraphMapper.propagateClassification(hdfs_employees.getGuid(), StringUtils.EMPTY, StringUtils.EMPTY);
+        ret = entityGraphMapper.propagateClassification(hdfs_employees.getGuid(), StringUtils.EMPTY, StringUtils.EMPTY, null);
         assertNull(ret);
     }
 
@@ -167,7 +167,7 @@ public class ClassificationPropagationWithTasksTest extends AtlasTestBase {
 
         AtlasEntity entityUpdated = getEntity(HDFS_PATH_EMPLOYEES);
         assertNotNull(entityUpdated.getPendingTasks());
-        List<String> impactedEntities = entityGraphMapper.propagateClassification(hdfs_employees.getGuid(), classificationVertex.getId().toString(), StringUtils.EMPTY);
+        List<String> impactedEntities = entityGraphMapper.propagateClassification(hdfs_employees.getGuid(), classificationVertex.getId().toString(), StringUtils.EMPTY, null);
         assertNotNull(impactedEntities);
     }
 
@@ -197,7 +197,7 @@ public class ClassificationPropagationWithTasksTest extends AtlasTestBase {
         final String TAG_NAME = "tagX";
 
         AtlasEntity hdfs_employees = getEntity(HDFS_PATH_EMPLOYEES);
-        entityGraphMapper.propagateClassification(hdfs_employees.getGuid(), StringUtils.EMPTY, StringUtils.EMPTY);
+        entityGraphMapper.propagateClassification(hdfs_employees.getGuid(), StringUtils.EMPTY, StringUtils.EMPTY, null);
 
         AtlasClassification tagX = new AtlasClassification(TAG_NAME);
         tagX.setEntityGuid(hdfs_employees.getGuid());


### PR DESCRIPTION
## Restrict classification propagation only to asset hierarchy

> When we attach a classification to an asset and set `propagate:true` → The classification is propagated along the asset hierarchy (Example → From database to schemas to table to columns as defined in the relationshipDefs) and it is also propagated along the downstream lineage of that asset.

We need to add support to allow the API user to decide if they want to propagate the classification only along the asset hierarchy (and not lineage )or only along the lineage (and not along the asset hierarchy) or both.

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] Enhancement (adds functionality)
