### PR TITLE
qualifiedName of the process to be added in the relation array of the get_lineage api

### DIFF
--- a/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
@@ -538,6 +538,7 @@ public class EntityLineageService implements AtlasLineageService {
         AtlasVertex processVertex = outgoingEdge.getOutVertex();
         String      inGuid        = AtlasGraphUtilsV2.getIdFromVertex(inVertex);
         String      outGuid       = AtlasGraphUtilsV2.getIdFromVertex(outVertex);
+        String      processGuid   = AtlasGraphUtilsV2.getIdFromVertex(processVertex);
         String      relationGuid  = null;
         boolean     isInputEdge   = incomingEdge.getLabel().equalsIgnoreCase(PROCESS_INPUTS_EDGE);
 
@@ -549,6 +550,11 @@ public class EntityLineageService implements AtlasLineageService {
         if (!entities.containsKey(outGuid)) {
             AtlasEntityHeader entityHeader = entityRetriever.toAtlasEntityHeaderWithClassifications(outVertex, lineageContext.getAttributes());
             entities.put(outGuid, entityHeader);
+        }
+
+        if (!entities.containsKey(processGuid)) {
+            AtlasEntityHeader entityHeader = entityRetriever.toAtlasEntityHeaderWithClassifications(processVertex, lineageContext.getAttributes());
+            entities.put(processGuid, entityHeader);    
         }
 
         if (isInputEdge) {


### PR DESCRIPTION
## Need process entity details in the getlineage API

> ant to show a different colored line on the graph if the process is from DBT vs snowflake.To tell if it's from DBT or snowflake, we can look at the qualified name of the process.The getLineage API does not have a way to get attributes of the process when hideProcess is true 

## Type of change
- [x] Enhancement