### PR TITLE
META-3039 Restrict classification propagation only to asset hierarchy

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -345,9 +345,9 @@ public final class GraphHelper {
         boolean ret = false;
 
         if (classificationVertex != null) {
-            Boolean enabled = AtlasGraphUtilsV2.getEncodedProperty(classificationVertex, CLASSIFICATION_VERTEX_RESTRICT_PROPAGATE_THROUGH_LINEAGE, Boolean.class);
+            Boolean restrictPropagationThroughLineage = AtlasGraphUtilsV2.getEncodedProperty(classificationVertex, CLASSIFICATION_VERTEX_RESTRICT_PROPAGATE_THROUGH_LINEAGE, Boolean.class);
 
-            ret = (enabled == null) ? true : enabled;
+            ret = (restrictPropagationThroughLineage == null) ? false : restrictPropagationThroughLineage;
         }
 
         return ret;

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -2720,15 +2720,12 @@ public class EntityGraphMapper {
              */
             Boolean updatedRestrictPropagationThroughLineage = entityRetriever.toAtlasClassification(classificationVertex).getRestrictPropagationThroughLineage();
 
-            if(currentRestrictPropagationThroughLineage!=null &&
-                    updatedRestrictPropagationThroughLineage != currentRestrictPropagationThroughLineage){
-                if(updatedRestrictPropagationThroughLineage){
+            if (currentRestrictPropagationThroughLineage!=null && !currentRestrictPropagationThroughLineage && updatedRestrictPropagationThroughLineage) {
                     deleteDelegate.getHandler().removeTagPropagation(classificationVertex);
-                }
             }
 
             String propagationMode = CLASSIFICATION_PROPAGATION_MODE_DEFAULT;
-            if(updatedRestrictPropagationThroughLineage){
+            if (updatedRestrictPropagationThroughLineage) {
                 propagationMode = CLASSIFICATION_PROPAGATION_MODE_RESTRICT_LINEAGE;
             }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -523,7 +523,7 @@ public class EntityGraphRetriever {
                 AtlasVertex       sourceEntityVertex    = AtlasGraphUtilsV2.findByGuid(this.graph, sourceEntityId);
                 String propagationMode = CLASSIFICATION_PROPAGATION_MODE_DEFAULT;
 
-                if(toAtlasClassification(classificationVertex).getRestrictPropagationThroughLineage()){
+                if (toAtlasClassification(classificationVertex).getRestrictPropagationThroughLineage()) {
                     propagationMode = CLASSIFICATION_PROPAGATION_MODE_RESTRICT_LINEAGE;
                 }
 
@@ -615,13 +615,13 @@ public class EntityGraphRetriever {
             if (tagPropagationEdges == null) {
                 continue;
             }
-            if(edgeLabelsToExclude != null) {
-                if (!edgeLabelsToExclude.isEmpty()) {
-                    tagPropagationEdges = Arrays.stream(tagPropagationEdges).filter(x -> !edgeLabelsToExclude.contains(x)).collect(Collectors.toList()).toArray(new String[0]);
-                }
+
+            if (edgeLabelsToExclude != null && !edgeLabelsToExclude.isEmpty()) {
+                tagPropagationEdges = Arrays.stream(tagPropagationEdges)
+                        .filter(x -> !edgeLabelsToExclude.contains(x))
+                        .collect(Collectors.toList())
+                        .toArray(new String[0]);
             }
-
-
 
             Iterator<AtlasEdge> propagationEdges = entityVertex.getEdges(AtlasEdgeDirection.BOTH, tagPropagationEdges).iterator();
 


### PR DESCRIPTION
## Restrict classification propagation only to asset hierarchy

> When we attach a classification to an asset and set `propagate:true` → The classification is propagated along the asset hierarchy (Example → From database to schemas to table to columns as defined in the relationshipDefs) and it is also propagated along the downstream lineage of that asset.

## Type of change
- [x] Enhancement
