### PR TITLE
META-3039 Restrict classification propagation only to asset hierarch

### DIFF
--- a/intg/src/main/java/org/apache/atlas/model/instance/AtlasClassification.java
+++ b/intg/src/main/java/org/apache/atlas/model/instance/AtlasClassification.java
@@ -181,6 +181,19 @@ public class AtlasClassification extends AtlasStruct implements Serializable {
                Objects.equals(validityPeriods, that.validityPeriods) && Objects.equals(restrictPropagationThroughLineage, that.restrictPropagationThroughLineage);
     }
 
+    public boolean checkForUpdate(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+        if (!super.equals(o)) { return false; }
+        AtlasClassification that = (AtlasClassification) o;
+        return Objects.equals(entityGuid, that.entityGuid) &&
+                entityStatus == that.entityStatus &&
+                Objects.equals(validityPeriods, that.validityPeriods) &&
+                (Objects.equals(propagate, that.propagate) || (propagate == null)) &&
+                (Objects.equals(removePropagationsOnEntityDelete, that.removePropagationsOnEntityDelete) || (removePropagationsOnEntityDelete == null)) &&
+                (Objects.equals(restrictPropagationThroughLineage, that.restrictPropagationThroughLineage) || (restrictPropagationThroughLineage == null));
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), entityGuid, entityStatus, propagate, removePropagationsOnEntityDelete, restrictPropagationThroughLineage);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/ClassificationAssociator.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/ClassificationAssociator.java
@@ -346,7 +346,7 @@ public class ClassificationAssociator {
 
         private V findObjectFrom(List<V> reference, V check) {
             return (V) CollectionUtils.find(reference, ox ->
-                    ((V) ox).equals(check));
+                    ((V) ox).checkForUpdate(check));
         }
 
         private V findFrom(List<V> reference, V check) {


### PR DESCRIPTION
## Restrict classification propagation only to asset hierarchy

> When we attach a classification to an asset and set `propagate:true` → The classification is propagated along the asset hierarchy (Example → From database to schemas to table to columns as defined in the relationshipDefs) and it is also propagated along the downstream lineage of that asset.

## Type of change
- [x] Enhancement
