### PR TITLE
META-3067 :- Add classification displayName in validation msg

### DIFF
--- a/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
@@ -212,6 +212,7 @@ public enum AtlasErrorCode {
     // All data conflict errors go here
     TYPE_ALREADY_EXISTS(409, "ATLAS-409-00-001", "Given type {0} already exists"),
     TYPE_HAS_REFERENCES(409, "ATLAS-409-00-002", "Given type {0} has references"),
+    CLASSIFICATION_TYPE_HAS_REFERENCES(409, "ATLAS-409-00-002", "Given classification {0} [{1}] has references"),
     INSTANCE_ALREADY_EXISTS(409, "ATLAS-409-00-003", "failed to update entity: {0}"),
     RELATIONSHIP_ALREADY_EXISTS(409, "ATLAS-409-00-004", "relationship {0} already exists between entities {1} and {2}"),
     TYPE_HAS_RELATIONSHIPS(409, "ATLAS-409-00-005", "Given type {0} has associated relationshipDefs"),

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasClassificationDefStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasClassificationDefStoreV2.java
@@ -305,7 +305,8 @@ class AtlasClassificationDefStoreV2 extends AtlasAbstractDefStoreV2<AtlasClassif
         AtlasVertex ret = typeDefStore.findTypeVertexByNameAndCategory(name, TypeCategory.TRAIT);
 
         if (AtlasGraphUtilsV2.typeHasInstanceVertex(name)) {
-            throw new AtlasBaseException(AtlasErrorCode.TYPE_HAS_REFERENCES, name);
+            String displayName = existingDef.getDisplayName() != null ? existingDef.getDisplayName() : "";
+            throw new AtlasBaseException(AtlasErrorCode.CLASSIFICATION_TYPE_HAS_REFERENCES, displayName,  name);
         }
 
         if (ret == null) {
@@ -336,7 +337,8 @@ class AtlasClassificationDefStoreV2 extends AtlasAbstractDefStoreV2<AtlasClassif
         String typeName = AtlasGraphUtilsV2.getEncodedProperty(ret, TYPENAME_PROPERTY_KEY, String.class);
 
         if (AtlasGraphUtilsV2.typeHasInstanceVertex(typeName)) {
-            throw new AtlasBaseException(AtlasErrorCode.TYPE_HAS_REFERENCES, typeName);
+            String displayName = existingDef.getDisplayName() != null ? existingDef.getDisplayName() : "";
+            throw new AtlasBaseException(AtlasErrorCode.CLASSIFICATION_TYPE_HAS_REFERENCES, displayName, typeName);
         }
 
         if (ret == null) {


### PR DESCRIPTION
## Change description
Delete a Classification having assets associated with it. The validation message that is displayed at the top has incorrect text.
[Linear](https://linear.app/atlanproduct/issue/META-3067/classification-the-validation-message-isnt-correct-when-we-try) 
> Description here

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
