### PR TITLE
META-3091 - Paginate commit on classification propagation delete task

### DIFF
--- a/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
@@ -86,7 +86,7 @@ public enum AtlasConfiguration {
     TASKS_QUEUE_SIZE("atlas.tasks.queue.size", 1000),
     SESSION_TIMEOUT_SECS("atlas.session.timeout.secs", -1),
     UPDATE_COMPOSITE_INDEX_STATUS("atlas.update.composite.index.status", true),
-    TASKS_GRAPH_COMMIT_CHUNK_SIZE("atlas.tasks.graph.commit.chunk.size", 100),
+    TASKS_GRAPH_COMMIT_CHUNK_SIZE("atlas.tasks.graph.commit.chunk.size", 1500),
     MAX_NUMBER_OF_RETRIES("atlas.tasks.graph.retry.count", 3);
 
 

--- a/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
@@ -86,7 +86,7 @@ public enum AtlasConfiguration {
     TASKS_QUEUE_SIZE("atlas.tasks.queue.size", 1000),
     SESSION_TIMEOUT_SECS("atlas.session.timeout.secs", -1),
     UPDATE_COMPOSITE_INDEX_STATUS("atlas.update.composite.index.status", true),
-    TASKS_GRAPH_COMMIT_CHUNK_SIZE("atlas.tasks.graph.commit.chunk.size", 30),
+    TASKS_GRAPH_COMMIT_CHUNK_SIZE("atlas.tasks.graph.commit.chunk.size", 100),
     MAX_NUMBER_OF_RETRIES("atlas.tasks.graph.retry.count", 3);
 
 

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -455,11 +455,11 @@ public final class GraphHelper {
         return ret;
     }
 
-    public static List<AtlasEdge> getNPropagatedEdges(AtlasVertex classificationVertex, int N) {
+    public static List<AtlasEdge> getPropagatedEdges(AtlasVertex classificationVertex, int limit) {
         List<AtlasEdge> ret   = new ArrayList<>();
         Iterable        edges = classificationVertex.query().direction(AtlasEdgeDirection.IN).label(CLASSIFICATION_LABEL)
                 .has(CLASSIFICATION_EDGE_IS_PROPAGATED_PROPERTY_KEY, true)
-                .has(CLASSIFICATION_EDGE_NAME_PROPERTY_KEY, getTypeName(classificationVertex)).edges();
+                .has(CLASSIFICATION_EDGE_NAME_PROPERTY_KEY, getTypeName(classificationVertex)).edges(limit);
         if (edges != null) {
             Iterator<AtlasEdge> iterator = edges.iterator();
 
@@ -467,10 +467,6 @@ public final class GraphHelper {
                 AtlasEdge edge = iterator.next();
 
                 ret.add(edge);
-
-                if (ret.size() == N) {
-                    break;
-                }
             }
         }
 

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -455,6 +455,28 @@ public final class GraphHelper {
         return ret;
     }
 
+    public static List<AtlasEdge> getNPropagatedEdges(AtlasVertex classificationVertex, int N) {
+        List<AtlasEdge> ret   = new ArrayList<>();
+        Iterable        edges = classificationVertex.query().direction(AtlasEdgeDirection.IN).label(CLASSIFICATION_LABEL)
+                .has(CLASSIFICATION_EDGE_IS_PROPAGATED_PROPERTY_KEY, true)
+                .has(CLASSIFICATION_EDGE_NAME_PROPERTY_KEY, getTypeName(classificationVertex)).edges();
+        if (edges != null) {
+            Iterator<AtlasEdge> iterator = edges.iterator();
+
+            while (iterator.hasNext()) {
+                AtlasEdge edge = iterator.next();
+
+                ret.add(edge);
+
+                if (ret.size() == N) {
+                    break;
+                }
+            }
+        }
+
+        return ret;
+    }
+
     public static boolean hasEntityReferences(AtlasVertex classificationVertex) {
         return classificationVertex.hasEdges(AtlasEdgeDirection.IN, CLASSIFICATION_LABEL);
     }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -603,6 +603,32 @@ public abstract class DeleteHandlerV1 {
         return ret;
     }
 
+    public List<AtlasVertex> removeTagPropagation(AtlasVertex classificationVertex, int N) throws AtlasBaseException {
+        AtlasPerfMetrics.MetricRecorder metric = RequestContext.get().startMetricRecord("removeTagPropagationVertex");
+        List<AtlasVertex> ret = new ArrayList<>();
+
+        if (classificationVertex != null) {
+            List<AtlasEdge> propagatedEdges = getNPropagatedEdges(classificationVertex, N);
+
+            if (CollectionUtils.isNotEmpty(propagatedEdges)) {
+                AtlasClassification classification = entityRetriever.toAtlasClassification(classificationVertex);
+
+                for (AtlasEdge propagatedEdge : propagatedEdges) {
+                    AtlasVertex entityVertex = propagatedEdge.getOutVertex();
+
+                    ret.add(entityVertex);
+
+                    // record remove propagation details to send notifications at the end
+                    RequestContext.get().recordRemovedPropagation(getGuid(entityVertex), classification);
+
+                    deletePropagatedEdge(propagatedEdge);
+                }
+            }
+        }
+        RequestContext.get().endMetricRecord(metric);
+        return ret;
+    }
+
     public void removeTagPropagation(AtlasVertex classificationVertex, List<AtlasVertex> entityVertices) throws AtlasBaseException {
         if (classificationVertex != null && CollectionUtils.isNotEmpty(entityVertices)) {
             AtlasPerfMetrics.MetricRecorder metric = RequestContext.get().startMetricRecord("removeTagPropagationVertices");

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -608,7 +608,7 @@ public abstract class DeleteHandlerV1 {
         List<AtlasVertex> ret = new ArrayList<>();
 
         if (classificationVertex != null) {
-            List<AtlasEdge> propagatedEdges = getNPropagatedEdges(classificationVertex, N);
+            List<AtlasEdge> propagatedEdges = getPropagatedEdges(classificationVertex, N);
 
             if (CollectionUtils.isNotEmpty(propagatedEdges)) {
                 AtlasClassification classification = entityRetriever.toAtlasClassification(classificationVertex);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -3281,7 +3281,6 @@ public class EntityGraphMapper {
         }
     }
 
-    @GraphTransaction
     public List<String> deleteClassificationPropagation(String entityGuid, String classificationVertexId) throws AtlasBaseException {
         try {
             if (StringUtils.isEmpty(classificationVertexId)) {
@@ -3313,17 +3312,17 @@ public class EntityGraphMapper {
                 List<AtlasEntity>   chunkedPropagatedEntities = updateClassificationText(classification, entityVertices);
                 propagatedEntities.addAll(chunkedPropagatedEntities);
 
-                graph.commit();
-
                 entityChangeNotifier.onClassificationsDeletedFromEntities(chunkedPropagatedEntities, Collections.singletonList(classification));
 
                 verticesCount = entityVertices.size();
 
-                GraphTransactionInterceptor.clearCache();
+                transactionInterceptHelper.intercept();
 
             } while (verticesCount >= CHUNK_SIZE);
 
             deleteDelegate.getHandler().deleteClassificationVertex(classificationVertex, true);
+
+            transactionInterceptHelper.intercept();
 
             return propagatedEntities.stream().map(x -> x.getGuid()).collect(Collectors.toList());
         } catch (Exception e) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -3298,18 +3298,32 @@ public class EntityGraphMapper {
             }
 
             AtlasClassification classification = entityRetriever.toAtlasClassification(classificationVertex);
-            List<AtlasVertex> entityVertices = deleteDelegate.getHandler().removeTagPropagation(classificationVertex);
+
+            int verticesCount = 0;
+
+            List<AtlasEntity> propagatedEntities = new ArrayList<>();
+
+            do {
+                List<AtlasVertex> entityVertices = deleteDelegate.getHandler().removeTagPropagation(classificationVertex, CHUNK_SIZE);
+                if (CollectionUtils.isEmpty(entityVertices)) {
+                    continue;
+                }
+                List<String> impactedGuids = entityVertices.stream().map(x -> GraphHelper.getGuid(x)).collect(Collectors.toList());
+                GraphTransactionInterceptor.lockObjectAndReleasePostCommit(impactedGuids);
+                List<AtlasEntity>   chunkedPropagatedEntities = updateClassificationText(classification, entityVertices);
+                propagatedEntities.addAll(chunkedPropagatedEntities);
+
+                graph.commit();
+
+                entityChangeNotifier.onClassificationsDeletedFromEntities(chunkedPropagatedEntities, Collections.singletonList(classification));
+
+                verticesCount = entityVertices.size();
+
+                GraphTransactionInterceptor.clearCache();
+
+            } while (verticesCount >= CHUNK_SIZE);
+
             deleteDelegate.getHandler().deleteClassificationVertex(classificationVertex, true);
-            if (CollectionUtils.isEmpty(entityVertices)) {
-                return null;
-            }
-
-            List<String> impactedGuids = entityVertices.stream().map(x -> GraphHelper.getGuid(x)).collect(Collectors.toList());
-            GraphTransactionInterceptor.lockObjectAndReleasePostCommit(impactedGuids);
-
-            List<AtlasEntity>   propagatedEntities = updateClassificationText(classification, entityVertices);
-
-            entityChangeNotifier.onClassificationsDeletedFromEntities(propagatedEntities, Collections.singletonList(classification));
 
             return propagatedEntities.stream().map(x -> x.getGuid()).collect(Collectors.toList());
         } catch (Exception e) {


### PR DESCRIPTION
## Paginate commit on classification propagation delete task

> With [META-3047](https://linear.app/atlanproduct/issue/META-3047/optimize-classification-propagation-addremoval-task-to-reduce-time), graph commit is called in chunks and this affected performance, heap usage, success of the ADD task drastically.  So, the same logic has to be applied to the delete task as well.

## Type of change
- [x] Enhancement
