### PR TITLE
chore: convert branch names to lowercase

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -51,7 +51,7 @@ jobs:
         run: chmod +x ./build.sh && ./build.sh
 
       - name: Get branch name
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/,,})"
         id: get_branch
 
       - run:   echo "REPOSITORY_NAME=`echo "$GITHUB_REPOSITORY" | awk -F / '{print $2}' | sed -e "s/:refs//"`" >> $GITHUB_ENV


### PR DESCRIPTION
## Change description
This PR intends to a small fix maven ci. since the repository name [can't be in uppercase](https://github.com/atlanhq/atlas-metastore/runs/8160740052?check_suite_focus=true#step:11:108) in the Docker/GitHub registry.

## Type of change
- [x] CI pipeline fix


## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [x] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
