### PR TITLE
Logging/meta 3138 - Added log to track vertices count visibility 

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -532,6 +532,8 @@ public class EntityGraphRetriever {
                 List<AtlasVertex> entitiesPropagatingTo = getImpactedVerticesV2(sourceEntityVertex, relationshipGuidToExclude,
                         classificationId, CLASSIFICATION_PROPAGATION_EXCLUSION_MAP.get(propagationMode));
 
+                LOG.info("Traversed {} vertices for Classification vertex id {} excluding RelationShip GUID {}", entitiesPropagatingTo.size(), classificationId, relationshipGuidToExclude);
+
                 ret.put(classificationVertex, entitiesPropagatingTo);
             }
         }


### PR DESCRIPTION
## Added log to track vertices count visibility in CLASSIFICATION_ONLY_PROPAGATION_DELETE task

> Added log to track vertices count visibility in CLASSIFICATION_ONLY_PROPAGATION_DELETE task


## Type of change
- [x] Added log