### PR TITLE
Enhance/meta 3141 - CLASSIFICATION_ONLY_PROPAGATION_DELETE task traversal optimization

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -33,7 +33,6 @@ import org.apache.atlas.model.instance.AtlasEntity.Status;
 import org.apache.atlas.model.instance.AtlasEntityHeader;
 import org.apache.atlas.model.instance.AtlasObjectId;
 import org.apache.atlas.model.instance.AtlasRelationship;
-import org.apache.atlas.repository.graphdb.AtlasVertexQuery;
 import org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2;
 import org.apache.atlas.type.AtlasArrayType;
 import org.apache.atlas.type.AtlasMapType;
@@ -51,6 +50,7 @@ import org.apache.atlas.repository.graphdb.AtlasElement;
 import org.apache.atlas.repository.graphdb.AtlasGraph;
 import org.apache.atlas.repository.graphdb.AtlasGraphQuery;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
+import org.apache.atlas.repository.graphdb.AtlasVertexQuery;
 import org.apache.atlas.type.AtlasEntityType;
 import org.apache.atlas.type.AtlasType;
 import org.apache.atlas.exception.EntityNotFoundException;
@@ -453,6 +453,24 @@ public final class GraphHelper {
         }
 
         return ret;
+    }
+
+    public static Iterator<AtlasEdge> getPropagatedEdgesIterator (AtlasVertex classificationVertex) {
+        AtlasVertexQuery      edges = classificationVertex.query().direction(AtlasEdgeDirection.IN).label(CLASSIFICATION_LABEL)
+                .has(CLASSIFICATION_EDGE_IS_PROPAGATED_PROPERTY_KEY, true)
+                .has(CLASSIFICATION_EDGE_NAME_PROPERTY_KEY, getTypeName(classificationVertex));
+
+        LOG.info("Traversed via iterator {} vertices for classification {}", edges.count(), classificationVertex.getId());
+
+        return edges.edges().iterator();
+    }
+
+    public static Iterator<AtlasVertex> getPropagatedEdgesVerticesIterator (AtlasVertex classificationVertex) {
+        Iterator<AtlasVertex>      vertices = classificationVertex.query().direction(AtlasEdgeDirection.IN).label(CLASSIFICATION_LABEL)
+                .has(CLASSIFICATION_EDGE_IS_PROPAGATED_PROPERTY_KEY, true)
+                .has(CLASSIFICATION_EDGE_NAME_PROPERTY_KEY, getTypeName(classificationVertex)).vertices().iterator();
+
+        return vertices;
     }
 
     public static boolean hasEntityReferences(AtlasVertex classificationVertex) {

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -455,23 +455,16 @@ public final class GraphHelper {
         return ret;
     }
 
-    public static Iterator<AtlasEdge> getPropagatedEdgesIterator (AtlasVertex classificationVertex) {
-        AtlasVertexQuery      edges = classificationVertex.query().direction(AtlasEdgeDirection.IN).label(CLASSIFICATION_LABEL)
-                .has(CLASSIFICATION_EDGE_IS_PROPAGATED_PROPERTY_KEY, true)
-                .has(CLASSIFICATION_EDGE_NAME_PROPERTY_KEY, getTypeName(classificationVertex));
-
-        LOG.info("Traversed via iterator {} vertices for classification {}", edges.count(), classificationVertex.getId());
-
-        return edges.edges().iterator();
-    }
-
     public static List<AtlasVertex> getPropagatedVertices (AtlasVertex classificationVertex) {
-        List<AtlasVertex> ret   = new ArrayList<>();
-        Iterable        vertices = classificationVertex.query().direction(AtlasEdgeDirection.IN).label(CLASSIFICATION_LABEL)
-                .has(CLASSIFICATION_EDGE_IS_PROPAGATED_PROPERTY_KEY, true)
-                .has(CLASSIFICATION_EDGE_NAME_PROPERTY_KEY, getTypeName(classificationVertex)).vertices();
+        List<AtlasVertex>   ret      =  new ArrayList<>();
+        Iterable            vertices =  classificationVertex.query().direction(AtlasEdgeDirection.IN).label(CLASSIFICATION_LABEL)
+                                                            .has(CLASSIFICATION_EDGE_IS_PROPAGATED_PROPERTY_KEY, true)
+                                                            .has(CLASSIFICATION_EDGE_NAME_PROPERTY_KEY, getTypeName(classificationVertex))
+                                                            .vertices();
+
         if (vertices != null) {
             Iterator<AtlasVertex> iterator = vertices.iterator();
+
             while (iterator.hasNext()) {
                 AtlasVertex vertex = iterator.next();
 

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -456,20 +456,14 @@ public final class GraphHelper {
     }
 
     public static List<AtlasVertex> getPropagatedVertices (AtlasVertex classificationVertex) {
-        List<AtlasVertex>   ret      =  new ArrayList<>();
-        Iterable            vertices =  classificationVertex.query().direction(AtlasEdgeDirection.IN).label(CLASSIFICATION_LABEL)
+        List<AtlasVertex>   ret      =  new ArrayList<AtlasVertex>();
+        Iterator<AtlasVertex>            vertices =  classificationVertex.query().direction(AtlasEdgeDirection.IN).label(CLASSIFICATION_LABEL)
                                                             .has(CLASSIFICATION_EDGE_IS_PROPAGATED_PROPERTY_KEY, true)
                                                             .has(CLASSIFICATION_EDGE_NAME_PROPERTY_KEY, getTypeName(classificationVertex))
-                                                            .vertices();
+                                                            .vertices().iterator();
 
         if (vertices != null) {
-            Iterator<AtlasVertex> iterator = vertices.iterator();
-
-            while (iterator.hasNext()) {
-                AtlasVertex vertex = iterator.next();
-
-                ret.add(vertex);
-            }
+           ret = IteratorUtils.toList(vertices);
         }
 
         return ret;

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -465,12 +465,21 @@ public final class GraphHelper {
         return edges.edges().iterator();
     }
 
-    public static Iterator<AtlasVertex> getPropagatedEdgesVerticesIterator (AtlasVertex classificationVertex) {
-        Iterator<AtlasVertex>      vertices = classificationVertex.query().direction(AtlasEdgeDirection.IN).label(CLASSIFICATION_LABEL)
+    public static List<AtlasVertex> getPropagatedVertices (AtlasVertex classificationVertex) {
+        List<AtlasVertex> ret   = new ArrayList<>();
+        Iterable        vertices = classificationVertex.query().direction(AtlasEdgeDirection.IN).label(CLASSIFICATION_LABEL)
                 .has(CLASSIFICATION_EDGE_IS_PROPAGATED_PROPERTY_KEY, true)
-                .has(CLASSIFICATION_EDGE_NAME_PROPERTY_KEY, getTypeName(classificationVertex)).vertices().iterator();
+                .has(CLASSIFICATION_EDGE_NAME_PROPERTY_KEY, getTypeName(classificationVertex)).vertices();
+        if (vertices != null) {
+            Iterator<AtlasVertex> iterator = vertices.iterator();
+            while (iterator.hasNext()) {
+                AtlasVertex vertex = iterator.next();
 
-        return vertices;
+                ret.add(vertex);
+            }
+        }
+
+        return ret;
     }
 
     public static boolean hasEntityReferences(AtlasVertex classificationVertex) {


### PR DESCRIPTION
## CLASSIFICATION_ONLY_PROPAGATION_DELETE task traversal optimization
> The traversal part of the CLASSIFICATION_ONLY_PROPAGATION_DELETE task has many scopes of optimization. I will try to find out those and solve. Consider scenario propagation from a->b -> c -> … -> z a has tag tag_0  which is propagated to all up to z, say we removed deleted c  & now we need to remove propagations from c -> z , Currently, it is diff based between complete lineage & lineage between a -> c . Instead of this, see if we can directly get c -> z

## Type of change
- [x] Enhancement
