### PR TITLE
Meta 3154 - CLASSIFICATION_ONLY_PROPAGATION_DELETE task traversal optimization(Part 2)

### DIFF
--- a/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
@@ -87,7 +87,8 @@ public enum AtlasConfiguration {
     SESSION_TIMEOUT_SECS("atlas.session.timeout.secs", -1),
     UPDATE_COMPOSITE_INDEX_STATUS("atlas.update.composite.index.status", true),
     TASKS_GRAPH_COMMIT_CHUNK_SIZE("atlas.tasks.graph.commit.chunk.size", 1000),
-    MAX_NUMBER_OF_RETRIES("atlas.tasks.graph.retry.count", 3);
+    MAX_NUMBER_OF_RETRIES("atlas.tasks.graph.retry.count", 3),
+    GRAPH_TRAVERSE_LEVEL_BUCKET_SIZE("atlas.graph.traverse.bucket.size",100);
 
 
     private static final Configuration APPLICATION_PROPERTIES;

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -455,15 +455,19 @@ public final class GraphHelper {
         return ret;
     }
 
-    public static List<AtlasVertex> getPropagatedVertices (AtlasVertex classificationVertex) {
-        List<AtlasVertex>   ret      =  new ArrayList<AtlasVertex>();
-        Iterator<AtlasVertex>            vertices =  classificationVertex.query().direction(AtlasEdgeDirection.IN).label(CLASSIFICATION_LABEL)
+    public static List<String> getPropagatedVerticesIds (AtlasVertex classificationVertex) {
+        List<String>            ret      =  new ArrayList<>();
+        Iterator<AtlasVertex>   vertices =  classificationVertex.query().direction(AtlasEdgeDirection.IN).label(CLASSIFICATION_LABEL)
                                                             .has(CLASSIFICATION_EDGE_IS_PROPAGATED_PROPERTY_KEY, true)
                                                             .has(CLASSIFICATION_EDGE_NAME_PROPERTY_KEY, getTypeName(classificationVertex))
                                                             .vertices().iterator();
 
         if (vertices != null) {
-           ret = IteratorUtils.toList(vertices);
+            while(vertices.hasNext()){
+                String vertexId = vertices.next().getIdForDisplay();
+                ret.add(vertexId);
+            }
+
         }
 
         return ret;

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -2749,7 +2749,7 @@ public class EntityGraphMapper {
 
             List<String> edgeLabelsToExclude = CLASSIFICATION_PROPAGATION_EXCLUSION_MAP.get(propagationMode);
 
-            List<AtlasVertex> impactedVertices = entityRetriever.getIncludedImpactedVerticesV2(entityVertex, relationshipGuid, classificationVertexId, edgeLabelsToExclude);
+            List<AtlasVertex> impactedVertices = entityRetriever.getIncludedImpactedVerticesV3(entityVertex, relationshipGuid, classificationVertexId, edgeLabelsToExclude);
 
             if (CollectionUtils.isEmpty(impactedVertices)) {
                 LOG.debug("propagateClassification(entityGuid={}, classificationVertexId={}): found no entities to propagate the classification", entityGuid, classificationVertexId);
@@ -3370,18 +3370,20 @@ public class EntityGraphMapper {
                     propagationMode = CLASSIFICATION_PROPAGATION_MODE_RESTRICT_LINEAGE;
                 }
 
-                List<AtlasVertex> propagatedVertices = GraphHelper.getPropagatedVertices(currentClassificationVertex);
-                LOG.info("Traversed {} vertices with edge {} for classification vertex {}", propagatedVertices.size(), edge.getId(), classificationId);
+                List<String> propagatedVerticesIds = GraphHelper.getPropagatedVerticesIds(currentClassificationVertex);
+                LOG.info("Traversed {} vertices with edge {} for classification vertex {}", propagatedVerticesIds.size(), edge.getId(), classificationId);
 
-                List<AtlasVertex> propagatedEntitiesWithoutEdge = entityRetriever.getImpactedVerticesV2(sourceEntityVertex, GraphHelper.getRelationshipGuid(edge), classificationId,
+                List<String> propagatedVerticesIdsWithoutEdge = entityRetriever.getImpactedVerticesIds(sourceEntityVertex, GraphHelper.getRelationshipGuid(edge), classificationId,
                         CLASSIFICATION_PROPAGATION_EXCLUSION_MAP.get(propagationMode));
 
-                LOG.info("Traversed {} vertices except edge {} for classification vertex {}", propagatedEntitiesWithoutEdge.size(), edge.getId(), classificationId);
+                LOG.info("Traversed {} vertices except edge {} for classification vertex {}", propagatedVerticesIdsWithoutEdge.size(), edge.getId(), classificationId);
 
-                List<AtlasVertex>   verticesToRemove = (List<AtlasVertex>)CollectionUtils.subtract(propagatedVertices, propagatedEntitiesWithoutEdge);
+                List<String>   verticesIdsToRemove = (List<String>)CollectionUtils.subtract(propagatedVerticesIds, propagatedVerticesIdsWithoutEdge);
 
-                propagatedEntitiesWithoutEdge.clear();
-                propagatedVertices.clear();
+                propagatedVerticesIdsWithoutEdge.clear();
+                propagatedVerticesIds.clear();
+
+                List<AtlasVertex> verticesToRemove = verticesIdsToRemove.stream().map(x -> graph.getVertex(x)).collect(Collectors.toList());
 
                 LOG.info("To delete classification from {} vertices for deletion of edge {} and classification {}", verticesToRemove.size(), edge.getId(), classificationId);
 
@@ -3413,15 +3415,6 @@ public class EntityGraphMapper {
         List<AtlasEntity> updatedEntities = updateClassificationText(classification, updatedVertices);
 
         entityChangeNotifier.onClassificationsDeletedFromEntities(updatedEntities, Collections.singletonList(classification));
-    }
-
-    private AtlasEntity getEntity(AtlasVertex vertex) {
-        try {
-            return entityRetriever.toAtlasEntity(vertex);
-        } catch (AtlasBaseException e) {
-            LOG.error("Failed to get entity vertex for vertex id {}", vertex.getId());
-        }
-        return null;
     }
 
     List<String> processClassificationEdgeDeletionInChunk(AtlasClassification classification, List<AtlasEdge> propagatedEdges) throws AtlasBaseException {


### PR DESCRIPTION
## CLASSIFICATION_ONLY_PROPAGATION_DELETE task traversal optimization(Part 2)

>We release the first iteration of optimization in CLASSIFICATION_ONLY_PROPAGATION_DELETE now we need to work on optimizing it more. We will update rest of the work in this ticket

## Type of change
- [x] Enhancement