### PR TITLE
META-3051 :- Remove struct type attribute when set to null

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -987,7 +987,7 @@ public abstract class DeleteHandlerV1 {
         }
     }
 
-    protected void deleteVertex(AtlasVertex instanceVertex, boolean force) throws AtlasBaseException {
+    public void deleteVertex(AtlasVertex instanceVertex, boolean force) throws AtlasBaseException {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Setting the external references to {} to null(removing edges)", string(instanceVertex));
         }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -1011,17 +1011,26 @@ public class EntityGraphMapper {
                         Object attrOldValue = null;
                         boolean isArrayOfPrimitiveType = false;
                         boolean isArrayOfEnum = false;
+
+                        boolean isStruct = (TypeCategory.STRUCT == attribute.getDefinedInType().getTypeCategory()
+                                || TypeCategory.STRUCT == attribute.getAttributeType().getTypeCategory());
+
                         if (attribute.getAttributeType().getTypeCategory().equals(ARRAY)) {
                             AtlasArrayType attributeType = (AtlasArrayType) attribute.getAttributeType();
                             AtlasType elementType = attributeType.getElementType();
                             isArrayOfPrimitiveType = elementType.getTypeCategory().equals(TypeCategory.PRIMITIVE);
                             isArrayOfEnum = elementType.getTypeCategory().equals(TypeCategory.ENUM);
                         }
+
                         if (isArrayOfPrimitiveType || isArrayOfEnum) {
-                            attrOldValue = vertex.getPropertyValues(attribute.getVertexPropertyName(),attribute.getClass());
+                            attrOldValue = vertex.getPropertyValues(attribute.getVertexPropertyName(), attribute.getClass());
+                        } else if (isStruct) {
+                            String edgeLabel = AtlasGraphUtilsV2.getEdgeLabel(attribute.getName());
+                            attrOldValue = getCollectionElementsUsingRelationship(vertex, attribute, edgeLabel);
                         } else {
-                            attrOldValue = vertex.getProperty(attribute.getVertexPropertyName(),attribute.getClass());
+                            attrOldValue = vertex.getProperty(attribute.getVertexPropertyName(), attribute.getClass());
                         }
+
                         if (attrValue != null && !attrValue.equals(attrOldValue)) {
                             addValuesToAutoUpdateAttributesList(attribute, userAutoUpdateAttributes, timestampAutoUpdateAttributes);
                         }
@@ -1146,7 +1155,7 @@ public class EntityGraphMapper {
 
                 AtlasEdge newEdge = mapStructValue(ctx, context);
 
-                if (currentEdge != null && !currentEdge.equals(newEdge)) {
+                if (currentEdge != null && newEdge!= null && !currentEdge.equals(newEdge)) {
                     deleteDelegate.getHandler().deleteEdgeReference(currentEdge, ctx.getAttrType().getTypeCategory(), false, true, ctx.getReferringVertex());
                 }
 
@@ -1490,9 +1499,12 @@ public class EntityGraphMapper {
 
             if (structVal != null) {
                 updateVertex(structVal, ctx.getCurrentEdge().getInVertex(), context);
+                ret = ctx.getCurrentEdge();
+            } else {
+                deleteDelegate.getHandler().deleteVertex(ctx.getCurrentEdge().getInVertex(),true);
+                ret = null;
             }
 
-            ret = ctx.getCurrentEdge();
         } else if (ctx.getValue() != null) {
             String edgeLabel = AtlasGraphUtilsV2.getEdgeLabel(ctx.getVertexProperty());
 


### PR DESCRIPTION
Linear Ticket
https://linear.app/atlanproduct/issue/META-3051/cannot-remove-struct-type-attribute-when-set-to-null