### PR TITLE
ATLAN-2367 children ignored processes fixed

### DIFF
--- a/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
@@ -611,7 +611,7 @@ public class EntityLineageService implements AtlasLineageService {
 
     private void processLastLevel(AtlasVertex currentVertex, boolean isInput, AtlasLineageInfo ret, AtlasLineageContext lineageContext) {
         List<AtlasEdge> processEdges = vertexEdgeCache.getEdges(currentVertex, IN, isInput ? PROCESS_OUTPUTS_EDGE : PROCESS_INPUTS_EDGE);
-        processEdges = lineageContext.getIgnoredProcesses() != null ? eliminateIgnoredProcesses(processEdges, isInput, lineageContext) : processEdges;
+        processEdges = CollectionUtils.isNotEmpty(lineageContext.getIgnoredProcesses()) ? eliminateIgnoredProcesses(processEdges, isInput, lineageContext) : processEdges;
         ret.setHasChildrenForDirection(getGuid(currentVertex), new LineageChildrenInfo(isInput ? INPUT : OUTPUT, hasMoreChildren(processEdges)));
     }
 

--- a/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
@@ -394,7 +394,7 @@ public class EntityLineageService implements AtlasLineageService {
         if (depth != 0) {
             processIntermediateLevel(currentVertex, isInput, depth, visitedVertices, ret, lineageContext);
         } else {
-            processLastLevel(currentVertex, isInput, ret);
+            processLastLevel(currentVertex, isInput, ret, lineageContext);
         }
         RequestContext.get().endMetricRecord(metric);
     }
@@ -609,9 +609,29 @@ public class EntityLineageService implements AtlasLineageService {
         }
     }
 
-    private void processLastLevel(AtlasVertex currentVertex, boolean isInput, AtlasLineageInfo ret) {
+    private void processLastLevel(AtlasVertex currentVertex, boolean isInput, AtlasLineageInfo ret, AtlasLineageContext lineageContext) {
         List<AtlasEdge> processEdges = vertexEdgeCache.getEdges(currentVertex, IN, isInput ? PROCESS_OUTPUTS_EDGE : PROCESS_INPUTS_EDGE);
+        processEdges = lineageContext.getIgnoredProcesses() != null ? eliminateIgnoredProcesses(processEdges, isInput, lineageContext) : processEdges;
         ret.setHasChildrenForDirection(getGuid(currentVertex), new LineageChildrenInfo(isInput ? INPUT : OUTPUT, hasMoreChildren(processEdges)));
+    }
+
+    private List<AtlasEdge> eliminateIgnoredProcesses(List<AtlasEdge> processEdges, boolean isInput, AtlasLineageContext lineageContext) {
+        List<AtlasEdge> edges = new ArrayList<>();
+        for (AtlasEdge processEdge : processEdges) {
+            AtlasVertex processVertex;
+            if (isInput) {
+                processVertex = processEdge.getOutVertex();
+            }
+            else {
+                processVertex = processEdge.getInVertex();
+            }
+            if (processVertex != null) {
+                if (!lineageContext.getIgnoredProcesses().contains(processVertex.getProperty(Constants.ENTITY_TYPE_PROPERTY_KEY, String.class))) {
+                    edges.add(processEdge);
+                }
+            }
+        }
+        return edges;
     }
 
     private List<AtlasEdge> getEdgesOfProcess(boolean isInput, AtlasLineageContext lineageContext, AtlasVertex processVertex) {


### PR DESCRIPTION
## Change description

> The issue we had with ATLAN-2367 was that when we ignore some type of processes for example ColumnProcesses we were handling it within relations in the response. But, from this ignore attribute, vertex children info was also getting affected from it. Since we were not handling this ignore for vertex children info, we would return INPUT true for some assets which have column processes linked for example. So, this fixes this problem so that we are also handling ignore operation for vertex children info attribute as well.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
