### PR TITLE
ATLAN-2570 fixed the hasMoreVertices condition for terminating graph c…

### DIFF
--- a/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
@@ -569,8 +569,7 @@ public class EntityLineageService implements AtlasLineageService {
     }
 
     private boolean hasMoreVertices(List<AtlasEdge> currentVertexEdges, int currentVertexEdgeIndex, List<AtlasEdge> edgesOfProcess, int currentProcessEdgeIndex) {
-        return (currentProcessEdgeIndex < edgesOfProcess.size() - 1 || currentVertexEdgeIndex < currentVertexEdges.size() - 1) &&
-                !(currentProcessEdgeIndex == edgesOfProcess.size() - 1 && currentVertexEdgeIndex == currentVertexEdges.size() - 1);
+        return currentProcessEdgeIndex < edgesOfProcess.size() || currentVertexEdgeIndex < currentVertexEdges.size();
     }
 
     private long nonProcessEntityCount(AtlasLineageInfo ret) {


### PR DESCRIPTION
## Lineage Bug fix
Ticket: ATLAN-2570
https://linear.app/atlanproduct/issue/ATLAN-2570/find-hotel-20-or-[snowflake-lineage]-lineage-graph-not-showing-all

> fixed the hasMoreVertices condition for terminating graph correctly

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
