### PR TITLE
Fix/meta 2570

### DIFF
--- a/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
@@ -482,8 +482,8 @@ public class EntityLineageService implements AtlasLineageService {
             if (edgesOfProcess.size() > currentOffset) {
                 isFirstValidProcessReached = true;
                 ret.setHasChildrenForDirection(getGuid(processVertex), new LineageChildrenInfo(isInput ? INPUT : OUTPUT, hasMoreChildren(edgesOfProcess)));
-                boolean graphTerminated = executeCurrentProcessVertex(isInput, depth, visitedVertices, ret, lineageContext, currentVertexEdges, inputVertexCount, currentOffset, i, edge, edgesOfProcess);
-                if (graphTerminated)
+                boolean isLimitReached = executeCurrentProcessVertex(isInput, depth, visitedVertices, ret, lineageContext, currentVertexEdges, inputVertexCount, currentOffset, i, edge, edgesOfProcess);
+                if (isLimitReached)
                     return;
             } else
                 currentOffset -= edgesOfProcess.size();
@@ -559,10 +559,12 @@ public class EntityLineageService implements AtlasLineageService {
                             int processEdgeIndex) {
         if (lineageContext.getDirection() == BOTH) {
             if (isInput && nonProcessEntityCount(ret) == lineageContext.getLimit()) {
-                ret.setHasMoreUpstreamVertices(hasMoreVertices(currentVertexEdges, currentVertexEdgeIndex, edgesOfProcess, processEdgeIndex));
+                //ret.setHasMoreUpstreamVertices(hasMoreVertices(currentVertexEdges, currentVertexEdgeIndex, edgesOfProcess, processEdgeIndex));
+                ret.setHasMoreUpstreamVertices(true);
                 return true;
             } else if (!isInput && nonProcessEntityCount(ret) - inputVertexCount == lineageContext.getLimit()) {
-                ret.setHasMoreDownstreamVertices(hasMoreVertices(currentVertexEdges, currentVertexEdgeIndex, edgesOfProcess, processEdgeIndex));
+                //ret.setHasMoreDownstreamVertices(hasMoreVertices(currentVertexEdges, currentVertexEdgeIndex, edgesOfProcess, processEdgeIndex));
+                ret.setHasMoreDownstreamVertices(true);
                 return true;
             }
         } else if (nonProcessEntityCount(ret) == lineageContext.getLimit()) {

--- a/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
@@ -572,23 +572,11 @@ public class EntityLineageService implements AtlasLineageService {
     }
 
     private void setVertexCountsForOneDirection(boolean isInput, AtlasLineageInfo ret, List<AtlasEdge> currentVertexEdges, int currentVertexEdgeIndex, List<AtlasEdge> edgesOfProcess, int processEdgeIndex) {
-        if (hasMoreVertices(currentVertexEdges, currentVertexEdgeIndex, edgesOfProcess, processEdgeIndex)) {
-            if (isInput) {
-                ret.setHasMoreUpstreamVertices(true);
-            } else {
-                ret.setHasMoreDownstreamVertices(true);
-            }
+        if (isInput) {
+            ret.setHasMoreUpstreamVertices(true);
         } else {
-            if (isInput) {
-                ret.setHasMoreUpstreamVertices(false);
-            } else {
-                ret.setHasMoreDownstreamVertices(false);
-            }
+            ret.setHasMoreDownstreamVertices(true);
         }
-    }
-
-    private boolean hasMoreVertices(List<AtlasEdge> currentVertexEdges, int currentVertexEdgeIndex, List<AtlasEdge> edgesOfProcess, int currentProcessEdgeIndex) {
-        return currentProcessEdgeIndex < edgesOfProcess.size() || currentVertexEdgeIndex < currentVertexEdges.size();
     }
 
     private long nonProcessEntityCount(AtlasLineageInfo ret) {

--- a/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
@@ -493,11 +493,10 @@ public class EntityLineageService implements AtlasLineageService {
     private List<AtlasEdge> getEdgesOfProcess(boolean isInput, AtlasLineageContext lineageContext, Set<String> paginationCalculatedVertices, AtlasVertex processVertex) {
         List<Pair<AtlasEdge, String>> processEdgeOutputVertexIdPairs = getUnvisitedProcessEdgesWithOutputVertexIds(isInput, lineageContext, paginationCalculatedVertices, processVertex);
         processEdgeOutputVertexIdPairs.forEach(pair -> paginationCalculatedVertices.add(pair.getRight()));
-        List<AtlasEdge> edgesOfProcess = processEdgeOutputVertexIdPairs
+        return processEdgeOutputVertexIdPairs
                 .stream()
                 .map(Pair::getLeft)
                 .collect(Collectors.toList());
-        return edgesOfProcess;
     }
 
     private boolean executeCurrentProcessVertex(boolean isInput,
@@ -559,11 +558,9 @@ public class EntityLineageService implements AtlasLineageService {
                             int processEdgeIndex) {
         if (lineageContext.getDirection() == BOTH) {
             if (isInput && nonProcessEntityCount(ret) == lineageContext.getLimit()) {
-                //ret.setHasMoreUpstreamVertices(hasMoreVertices(currentVertexEdges, currentVertexEdgeIndex, edgesOfProcess, processEdgeIndex));
                 ret.setHasMoreUpstreamVertices(true);
                 return true;
             } else if (!isInput && nonProcessEntityCount(ret) - inputVertexCount == lineageContext.getLimit()) {
-                //ret.setHasMoreDownstreamVertices(hasMoreVertices(currentVertexEdges, currentVertexEdgeIndex, edgesOfProcess, processEdgeIndex));
                 ret.setHasMoreDownstreamVertices(true);
                 return true;
             }


### PR DESCRIPTION
## Lineage bug fix release

> Fixed issue: When there is just one more asset than the page size in upstream or downstream, we do not return hasUpstream as true

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)


### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [x] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
