### PR TITLE
META-3287:  AuditSearch result returning scrubbed attributes

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/audit/AbstractStorageBasedAuditRepository.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/AbstractStorageBasedAuditRepository.java
@@ -160,5 +160,5 @@ public abstract class AbstractStorageBasedAuditRepository implements Service, En
     return Bytes.toBytes(keyStr);
   }
 
-  public abstract EntityAuditSearchResult searchEvents(String queryString, Set<String> attributes) throws AtlasBaseException;
+  public abstract EntityAuditSearchResult searchEvents(String queryString) throws AtlasBaseException;
 }

--- a/repository/src/main/java/org/apache/atlas/repository/audit/CassandraBasedAuditRepository.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/CassandraBasedAuditRepository.java
@@ -25,7 +25,6 @@ import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Lists;
 import org.apache.atlas.AtlasException;
 import org.apache.atlas.EntityAuditEvent;
 import org.apache.atlas.annotation.ConditionalOnAtlasProperty;
@@ -259,10 +258,5 @@ public class CassandraBasedAuditRepository extends AbstractStorageBasedAuditRepo
   @Override
   public void stop() throws AtlasException {
     cassSession.close();
-  }
-
-  @Override
-  public EntityAuditSearchResult searchEvents(String queryString, Set<String> attributes) throws AtlasBaseException {
-    return null;
   }
 }

--- a/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
@@ -24,14 +24,10 @@ import org.apache.atlas.ApplicationProperties;
 import org.apache.atlas.AtlasException;
 import org.apache.atlas.EntityAuditEvent;
 import org.apache.atlas.RequestContext;
-import org.apache.atlas.AtlasErrorCode;
 import org.apache.atlas.annotation.ConditionalOnAtlasProperty;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.audit.EntityAuditEventV2;
 import org.apache.atlas.model.audit.EntityAuditSearchResult;
-import org.apache.atlas.model.instance.AtlasEntity;
-import org.apache.atlas.model.instance.AtlasEntityHeader;
-import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
 import org.apache.atlas.type.AtlasType;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.configuration.Configuration;
@@ -63,9 +59,6 @@ import java.util.*;
 
 import static java.nio.charset.Charset.defaultCharset;
 import static org.springframework.util.StreamUtils.copyToString;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
 
 /**
  * This class provides cassandra support as the backend for audit storage support.

--- a/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
@@ -97,12 +97,10 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
     * */
 
     private RestClient lowLevelClient;
-    private final EntityGraphRetriever entityGraphRetriever;
     private final Configuration configuration;
 
     @Inject
-    public ESBasedAuditRepository(EntityGraphRetriever entityGraphRetriever, Configuration configuration) {
-        this.entityGraphRetriever = entityGraphRetriever;
+    public ESBasedAuditRepository(Configuration configuration) {
         this.configuration = configuration;
     }
 
@@ -212,26 +210,21 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
 
     @Override
     public EntityAuditSearchResult searchEvents(String queryString) throws AtlasBaseException {
-        return searchEvents(queryString, null);
-    }
-
-    public EntityAuditSearchResult searchEvents(String queryString, Set<String> attributes) throws AtlasBaseException {
         LOG.info("Hitting ES query to fetch audits: {}", queryString);
         try {
             String response = performSearchOnIndex(queryString);
-            return getResultFromResponse(response, attributes);
+            return getResultFromResponse(response);
         } catch (IOException e) {
             throw new AtlasBaseException(e);
         }
     }
 
-    private EntityAuditSearchResult getResultFromResponse(String responseString, Set<String> attributes) throws AtlasBaseException {
+    private EntityAuditSearchResult getResultFromResponse(String responseString) throws AtlasBaseException {
         List<EntityAuditEventV2> entityAudits = new ArrayList<>();
         EntityAuditSearchResult searchResult = new EntityAuditSearchResult();
         Map<String, Object> responseMap = AtlasType.fromJson(responseString, Map.class);
         Map<String, Object> hits_0 = (Map<String, Object>) responseMap.get("hits");
         List<LinkedHashMap> hits_1 = (List<LinkedHashMap>) hits_0.get("hits");
-        RequestContext requestContext = RequestContext.get();
         for (LinkedHashMap hit : hits_1) {
             Map source = (Map) hit.get("_source");
             String entityGuid = (String) source.get(ENTITYID);
@@ -241,24 +234,6 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
             event.setDetail((Map<String, Object>) source.get(DETAIL));
             event.setUser((String) source.get(USER));
             event.setCreated((long) source.get(CREATED));
-            if (requestContext.getCachedEntityHeader(entityGuid) != null) {
-                event.setEntityDetail(requestContext.getCachedEntityHeader(entityGuid));
-            } else {
-                AtlasEntityHeader entityHeader = null;
-
-                try {
-                    entityHeader = entityGraphRetriever.toAtlasEntityHeader(entityGuid, attributes);
-                }catch (AtlasBaseException exception){
-                    if (exception.getAtlasErrorCode() != AtlasErrorCode.INSTANCE_GUID_NOT_FOUND){
-                        throw exception;
-                    }
-                }
-
-                if (entityHeader != null) {
-                    requestContext.setEntityHeaderCache(entityHeader);
-                    event.setEntityDetail(entityHeader);
-                }
-            }
             if (source.get(TIMESTAMP) != null) {
                 event.setTimestamp((long) source.get(TIMESTAMP));
             }

--- a/repository/src/main/java/org/apache/atlas/repository/audit/HBaseBasedAuditRepository.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/HBaseBasedAuditRepository.java
@@ -582,10 +582,6 @@ public class HBaseBasedAuditRepository extends AbstractStorageBasedAuditReposito
         return ret;
     }
 
-    @Override
-    public EntityAuditSearchResult searchEvents(String queryString, Set<String> attributes) throws AtlasBaseException {
-        return null;
-    }
 
     private String getResultString(Result result, byte[] columnName) {
         byte[] rawValue = result.getValue(COLUMN_FAMILY, columnName);

--- a/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
@@ -1179,13 +1179,18 @@ public class EntityREST {
         for (EntityAuditEventV2 event : result.getEntityAudits()) {
             try {
                 AtlasSearchResult ret = new AtlasSearchResult();
-                AtlasEntityHeader entityHeader = entityGraphRetriever.toAtlasEntityHeader(event.getEntityId(), attributes);
+                AtlasEntityWithExtInfo entityWithExtInfo = entitiesStore.getByIdWithoutAuthorization(event.getEntityId());
+                AtlasEntityHeader entityHeader = new AtlasEntityHeader(entityWithExtInfo.getEntity());
                 ret.addEntity(entityHeader);
                 AtlasSearchResultScrubRequest request = new AtlasSearchResultScrubRequest(typeRegistry, ret);
                 AtlasAuthorizationUtils.scrubSearchResults(request, suppressLogs);
                 if(entityHeader.getScrubbed()!= null && entityHeader.getScrubbed()){
                     event.setDetail(null);
                 }
+                Map<String, Object> entityAttrs = entityHeader.getAttributes();
+                if(attributes ==null) entityAttrs.clear();
+                else entityAttrs.keySet().retainAll(attributes);
+
                 event.setEntityDetail(entityHeader);
 
             } catch (AtlasBaseException e) {

--- a/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
@@ -37,11 +37,9 @@ import org.apache.atlas.model.instance.AtlasEntity.AtlasEntitiesWithExtInfo;
 import org.apache.atlas.model.instance.AtlasEntity.AtlasEntityWithExtInfo;
 import org.apache.atlas.model.typedef.AtlasStructDef.AtlasAttributeDef;
 import org.apache.atlas.repository.audit.ESBasedAuditRepository;
-import org.apache.atlas.repository.converters.AtlasInstanceConverter;
 import org.apache.atlas.repository.store.graph.AtlasEntityStore;
 import org.apache.atlas.repository.store.graph.v2.AtlasEntityStream;
 import org.apache.atlas.repository.store.graph.v2.ClassificationAssociator;
-import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
 import org.apache.atlas.repository.store.graph.v2.EntityStream;
 import org.apache.atlas.type.AtlasClassificationType;
 import org.apache.atlas.type.AtlasEntityType;
@@ -99,17 +97,12 @@ public class EntityREST {
     private final AtlasTypeRegistry      typeRegistry;
     private final AtlasEntityStore       entitiesStore;
     private final ESBasedAuditRepository  esBasedAuditRepository;
-    private final AtlasInstanceConverter instanceConverter;
-    private final EntityGraphRetriever entityGraphRetriever;
 
     @Inject
-    public EntityREST(AtlasTypeRegistry typeRegistry, AtlasEntityStore entitiesStore, ESBasedAuditRepository  esBasedAuditRepository,
-                      AtlasInstanceConverter instanceConverter, EntityGraphRetriever entityGraphRetriever) {
+    public EntityREST(AtlasTypeRegistry typeRegistry, AtlasEntityStore entitiesStore, ESBasedAuditRepository  esBasedAuditRepository) {
         this.typeRegistry      = typeRegistry;
         this.entitiesStore     = entitiesStore;
         this.esBasedAuditRepository = esBasedAuditRepository;
-        this.instanceConverter = instanceConverter;
-        this.entityGraphRetriever = entityGraphRetriever;
     }
 
     /**
@@ -1188,7 +1181,7 @@ public class EntityREST {
                     event.setDetail(null);
                 }
                 Map<String, Object> entityAttrs = entityHeader.getAttributes();
-                if(attributes ==null) entityAttrs.clear();
+                if(attributes == null) entityAttrs.clear();
                 else entityAttrs.keySet().retainAll(attributes);
 
                 event.setEntityDetail(entityHeader);


### PR DESCRIPTION
## Change description

> Description hereWith the release of [META-3008](https://linear.app/atlanproduct/issue/META-3008) we added a feature to get the entity along with audit logs. Found out it is returning scrubbed attributes even if scrub logic is there.

## Type of change
- [x] Bug fix (fixes an issue)

## Related issues
- META-3008

> Fix [#1](Fixed scrubbing mechanism for entity detail) 