### PR TITLE
Enhance/meta 3315 - Hard delete soft deleted Asset

### DIFF
--- a/intg/src/main/java/org/apache/atlas/DeleteType.java
+++ b/intg/src/main/java/org/apache/atlas/DeleteType.java
@@ -23,7 +23,8 @@ import org.apache.commons.lang.StringUtils;
 public enum DeleteType {
     DEFAULT,
     SOFT,
-    HARD;
+    HARD,
+    PURGE;
 
     public static DeleteType from(String s) {
         if(StringUtils.isEmpty(s)) {
@@ -36,6 +37,9 @@ public enum DeleteType {
 
             case "hard":
                 return HARD;
+
+            case "purge":
+                return  PURGE;
 
             default:
                 return DEFAULT;

--- a/pom.xml
+++ b/pom.xml
@@ -732,7 +732,7 @@
         <junit.version>4.13.1</junit.version>
         <kafka.scala.binary.version>2.12</kafka.scala.binary.version>
         <kafka.version>2.8.1</kafka.version>
-        <keycloak.version>15.0.2</keycloak.version>
+        <keycloak.version>15.0.2.1</keycloak.version>
         <reload4j.version>1.2.19</reload4j.version>
         <log4j2.version>2.17.1</log4j2.version>
         <lucene-solr.version>8.6.3</lucene-solr.version>

--- a/pom.xml
+++ b/pom.xml
@@ -732,7 +732,7 @@
         <junit.version>4.13.1</junit.version>
         <kafka.scala.binary.version>2.12</kafka.scala.binary.version>
         <kafka.version>2.8.1</kafka.version>
-        <keycloak.version>15.0.2.1</keycloak.version>
+        <keycloak.version>15.0.2</keycloak.version>
         <reload4j.version>1.2.19</reload4j.version>
         <log4j2.version>2.17.1</log4j2.version>
         <lucene-solr.version>8.6.3</lucene-solr.version>

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerDelegate.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerDelegate.java
@@ -56,6 +56,7 @@ public class DeleteHandlerDelegate {
     }
 
     public DeleteHandlerV1 getHandler(DeleteType deleteType) {
+        RequestContext requestContext = RequestContext.get();
         if (deleteType == null) {
             deleteType = DeleteType.DEFAULT;
         }
@@ -65,6 +66,10 @@ public class DeleteHandlerDelegate {
                 return softDeleteHandler;
 
             case HARD:
+                return hardDeleteHandler;
+
+            case PURGE:
+                requestContext.setPurgeRequested(true);
                 return hardDeleteHandler;
 
             default:

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerDelegate.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerDelegate.java
@@ -56,7 +56,6 @@ public class DeleteHandlerDelegate {
     }
 
     public DeleteHandlerV1 getHandler(DeleteType deleteType) {
-        RequestContext requestContext = RequestContext.get();
         if (deleteType == null) {
             deleteType = DeleteType.DEFAULT;
         }
@@ -69,7 +68,6 @@ public class DeleteHandlerDelegate {
                 return hardDeleteHandler;
 
             case PURGE:
-                requestContext.setPurgeRequested(true);
                 return hardDeleteHandler;
 
             default:

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -1092,6 +1092,10 @@ public abstract class DeleteHandlerV1 {
      * @throws AtlasException
      */
     private void deleteAllClassifications(AtlasVertex instanceVertex) throws AtlasBaseException {
+        // If instance is deleted no need to operate classification deleted
+        if (getState(instanceVertex).equals(DELETED))
+            return;
+
         List<AtlasEdge> classificationEdges = getAllClassificationEdges(instanceVertex);
 
         for (AtlasEdge edge : classificationEdges) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -259,7 +259,7 @@ public abstract class DeleteHandlerV1 {
                     } else {
                         AtlasEdge edge = graphHelper.getEdgeForLabel(vertex, edgeLabel);
 
-                        if (edge == null || (getState(edge) == (isPurgeRequested ? ACTIVE : DELETED))) {
+                        if (edge == null || (!isPurgeRequested && DELETED.equals(getState(edge)))) {
                             continue;
                         }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -177,15 +177,11 @@ public abstract class DeleteHandlerV1 {
 
         for (AtlasEdge edge : edges) {
             boolean isInternal = isInternalType(edge.getInVertex()) && isInternalType(edge.getOutVertex());
-            boolean needToSkip = !isInternal && (getState(edge) == (isPurgeRequested ? ACTIVE : DELETED));
+            boolean needToSkip = !isInternal && (!isPurgeRequested && DELETED.equals(getState(edge)));
 
             if (needToSkip) {
                 if (LOG.isDebugEnabled()) {
-                    if(isPurgeRequested) {
-                        LOG.debug("Skipping purging of edge={} as it is active or already purged", getIdFromEdge(edge));
-                    } else{
-                        LOG.debug("Skipping deletion of edge={} as it is already deleted", getIdFromEdge(edge));
-                    }
+                    LOG.debug("Skipping deletion of edge={} as it is already deleted", getIdFromEdge(edge));
                 }
 
                 continue;

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -212,6 +212,12 @@ public abstract class DeleteHandlerV1 {
 
         while (vertices.size() > 0) {
             AtlasVertex        vertex = vertices.pop();
+            AtlasEntity.Status state  = getState(vertex);
+
+            //If the vertex marked for deletion, if we are not purging, skip it
+            if (!isPurgeRequested && DELETED.equals(state)) {
+                continue;
+            }
 
             String guid = GraphHelper.getGuid(vertex);
 
@@ -311,7 +317,7 @@ public abstract class DeleteHandlerV1 {
 
                         if (CollectionUtils.isNotEmpty(edges)) {
                             for (AtlasEdge edge : edges) {
-                                if (edge == null || (getState(edge) == (isPurgeRequested ? ACTIVE : DELETED))) {
+                                if (edge == null || (!isPurgeRequested && DELETED.equals(getState(edge)))) {
                                     continue;
                                 }
 
@@ -1097,7 +1103,7 @@ public abstract class DeleteHandlerV1 {
             return;
 
         List<AtlasEdge> classificationEdges = getAllClassificationEdges(instanceVertex);
-    
+
         for (AtlasEdge edge : classificationEdges) {
             AtlasVertex classificationVertex = edge.getInVertex();
             boolean     isClassificationEdge = isClassificationEdge(edge);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -1093,11 +1093,11 @@ public abstract class DeleteHandlerV1 {
      */
     private void deleteAllClassifications(AtlasVertex instanceVertex) throws AtlasBaseException {
         // If instance is deleted no need to operate classification deleted
-        if (getState(instanceVertex).equals(DELETED))
+        if (!ACTIVE.equals(getState(instanceVertex)))
             return;
 
         List<AtlasEdge> classificationEdges = getAllClassificationEdges(instanceVertex);
-
+    
         for (AtlasEdge edge : classificationEdges) {
             AtlasVertex classificationVertex = edge.getInVertex();
             boolean     isClassificationEdge = isClassificationEdge(edge);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -683,6 +683,7 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
             throw new AtlasBaseException(AtlasErrorCode.INVALID_PARAMETERS, "Guid(s) not specified");
         }
 
+        AtlasAuthorizationUtils.verifyAccess(new AtlasAdminAccessRequest(AtlasPrivilege.ADMIN_PURGE), "purge entity: guids=", guids);
         Collection<AtlasVertex> purgeCandidates = new ArrayList<>();
 
         for (String guid : guids) {
@@ -695,10 +696,6 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
 
                 continue;
             }
-
-            AtlasEntityHeader entityHeader = entityRetriever.toAtlasEntityHeaderWithClassifications(vertex);
-
-            AtlasAuthorizationUtils.verifyAccess(new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_DELETE, entityHeader), "delete entity: guid=", guid);
 
             purgeCandidates.add(vertex);
         }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -627,7 +627,7 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
 
         EntityMutationResponse ret = deleteVertices(deletionCandidates);
 
-        if(ret.getDeletedEntities()!=null)
+        if(ret.getDeletedEntities() != null)
             processTermEntityDeletion(ret.getDeletedEntities());
 
         // Notify the change listeners
@@ -1708,7 +1708,8 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
         for (AtlasEntityHeader entity : req.getDeletedEntities()) {
             String handler;
             if (ATLAS_GLOSSARY_CATEGORY_ENTITY_TYPE.equals(entity.getTypeName())) {
-                handler = "HARD";
+                handler  = req.getDeleteType().equals(DeleteType.PURGE) ?
+                        DeleteType.PURGE.name() : DeleteType.HARD.name();
             } else {
                 handler = RequestContext.get().getDeleteType().name();
             }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -683,7 +683,6 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
             throw new AtlasBaseException(AtlasErrorCode.INVALID_PARAMETERS, "Guid(s) not specified");
         }
 
-        AtlasAuthorizationUtils.verifyAccess(new AtlasAdminAccessRequest(AtlasPrivilege.ADMIN_PURGE), "purge entity: guids=", guids);
         Collection<AtlasVertex> purgeCandidates = new ArrayList<>();
 
         for (String guid : guids) {
@@ -696,6 +695,10 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
 
                 continue;
             }
+
+            AtlasEntityHeader entityHeader = entityRetriever.toAtlasEntityHeaderWithClassifications(vertex);
+
+            AtlasAuthorizationUtils.verifyAccess(new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_DELETE, entityHeader), "delete entity: guid=", guid);
 
             purgeCandidates.add(vertex);
         }

--- a/webapp/src/main/java/org/apache/atlas/web/filters/AuditFilter.java
+++ b/webapp/src/main/java/org/apache/atlas/web/filters/AuditFilter.java
@@ -97,11 +97,10 @@ public class AuditFilter implements Filter {
 
             if (StringUtils.isNotEmpty(deleteType)) {
                 if (deleteTypeOverrideEnabled) {
-                    DeleteType deleteType1 = DeleteType.from(deleteType);
-                    if(DeleteType.PURGE.equals(deleteType1)) {
+                    if(DeleteType.PURGE.name().equals(deleteType)) {
                         requestContext.setPurgeRequested(true);
                     }
-                    requestContext.setDeleteType(deleteType1);
+                    requestContext.setDeleteType(DeleteType.from(deleteType));
                 } else {
                     LOG.warn("Override of deleteType is not enabled. Ignoring parameter deleteType={}, in request from user={}", deleteType, user);
                 }

--- a/webapp/src/main/java/org/apache/atlas/web/filters/AuditFilter.java
+++ b/webapp/src/main/java/org/apache/atlas/web/filters/AuditFilter.java
@@ -83,7 +83,6 @@ public class AuditFilter implements Filter {
         final Set<String>         userGroups         = AtlasAuthorizationUtils.getCurrentUserGroups();
         final String              deleteType         = httpRequest.getParameter("deleteType");
         final boolean             skipFailedEntities = Boolean.parseBoolean(httpRequest.getParameter("skipFailedEntities"));
-        final boolean             isPurgeRequested = Boolean.parseBoolean(httpRequest.getParameter("isPurgeRequested"));
 
         try {
             currentThread.setName(formatName(oldName, requestId));
@@ -95,7 +94,6 @@ public class AuditFilter implements Filter {
             requestContext.setCreateShellEntityForNonExistingReference(createShellEntityForNonExistingReference);
             requestContext.setForwardedAddresses(AtlasAuthorizationUtils.getForwardedAddressesFromRequest(httpRequest));
             requestContext.setSkipFailedEntities(skipFailedEntities);
-            requestContext.setPurgeRequested(isPurgeRequested);
 
             if (StringUtils.isNotEmpty(deleteType)) {
                 if (deleteTypeOverrideEnabled) {

--- a/webapp/src/main/java/org/apache/atlas/web/filters/AuditFilter.java
+++ b/webapp/src/main/java/org/apache/atlas/web/filters/AuditFilter.java
@@ -97,7 +97,11 @@ public class AuditFilter implements Filter {
 
             if (StringUtils.isNotEmpty(deleteType)) {
                 if (deleteTypeOverrideEnabled) {
-                    requestContext.setDeleteType(DeleteType.from(deleteType));
+                    DeleteType deleteType1 = DeleteType.from(deleteType);
+                    if(DeleteType.PURGE.equals(deleteType1)) {
+                        requestContext.setPurgeRequested(true);
+                    }
+                    requestContext.setDeleteType(deleteType1);
                 } else {
                     LOG.warn("Override of deleteType is not enabled. Ignoring parameter deleteType={}, in request from user={}", deleteType, user);
                 }

--- a/webapp/src/main/java/org/apache/atlas/web/filters/AuditFilter.java
+++ b/webapp/src/main/java/org/apache/atlas/web/filters/AuditFilter.java
@@ -83,6 +83,7 @@ public class AuditFilter implements Filter {
         final Set<String>         userGroups         = AtlasAuthorizationUtils.getCurrentUserGroups();
         final String              deleteType         = httpRequest.getParameter("deleteType");
         final boolean             skipFailedEntities = Boolean.parseBoolean(httpRequest.getParameter("skipFailedEntities"));
+        final boolean             isPurgeRequested = Boolean.parseBoolean(httpRequest.getParameter("isPurgeRequested"));
 
         try {
             currentThread.setName(formatName(oldName, requestId));
@@ -94,6 +95,7 @@ public class AuditFilter implements Filter {
             requestContext.setCreateShellEntityForNonExistingReference(createShellEntityForNonExistingReference);
             requestContext.setForwardedAddresses(AtlasAuthorizationUtils.getForwardedAddressesFromRequest(httpRequest));
             requestContext.setSkipFailedEntities(skipFailedEntities);
+            requestContext.setPurgeRequested(isPurgeRequested);
 
             if (StringUtils.isNotEmpty(deleteType)) {
                 if (deleteTypeOverrideEnabled) {


### PR DESCRIPTION
##  Hard delete soft deleted Asset

> Via API we don't had the ability to remove soft deleted assets, we had the but only restricted to Atlas Admin which was inconvenient for normal users. So we decided to implement this inside existing delete API. We implemented new type of deleteType is which is PURGE. If we set deleteType as PURGE it will delete all the asset regardless of its state.  Follow the implementation details in https://linear.app/atlanproduct/issue/META-3315

## Type of change
- [x] Enhancement 
