### PR TITLE
META-3939 :- [beta] Fix CVE : Apache Cassandra vulnerable to Code Injection due to unsafe configuration

### DIFF
--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -113,8 +113,12 @@
                     <groupId>io.netty</groupId>
                     <artifactId>netty-handler</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>log4j-over-slf4j</artifactId>
+                </exclusion>
             </exclusions>
-            <version>2.1.8</version>
+            <version>3.0.26</version>
         </dependency>
 
 


### PR DESCRIPTION
Fix for CVE to ugprade cassandra-all to 3.0.26
Linear
https://linear.app/atlanproduct/issue/META-3939