### PR TITLE
Revert META-3939 :- [beta] Fix CVE : Apache Cassandra vulnerable to Code Injection due to unsafe configuration

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,7 +12,6 @@
 name: "CodeQL"
 
 on: 
-  pull_request:
   schedule:
       - cron: '0 1 * * *'
 

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -113,12 +113,8 @@
                     <groupId>io.netty</groupId>
                     <artifactId>netty-handler</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>log4j-over-slf4j</artifactId>
-                </exclusion>
             </exclusions>
-            <version>3.0.26</version>
+            <version>2.1.8</version>
         </dependency>
 
 


### PR DESCRIPTION
Reverts atlanhq/atlas-metastore#1198