### PR TITLE
META-3939 :-  Fix CVE : Apache Cassandra vulnerable to Code Injection due to unsafe configuration

### DIFF
--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -113,8 +113,16 @@
                     <groupId>io.netty</groupId>
                     <artifactId>netty-handler</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>log4j-over-slf4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.dropwizard.metrics</groupId>
+                    <artifactId>metrics-core</artifactId>
+                </exclusion>
             </exclusions>
-            <version>2.1.8</version>
+            <version>3.11.12</version>
         </dependency>
 
 
@@ -234,6 +242,13 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+            <version>3.2.6</version>
+        </dependency>
+
         <dependency>
             <groupId>org.cassandraunit</groupId>
             <artifactId>cassandra-unit</artifactId>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -130,6 +130,12 @@
         <dependency>
             <groupId>org.apache.atlas</groupId>
             <artifactId>atlas-notification</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.yammer.metrics</groupId>
+                    <artifactId>metrics-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION

CVE https://github.com/atlanhq/atlas-metastore/security/dependabot/66

### Recommendation :- 
Upgrade org.apache.cassandra:cassandra-all to version 3.0.26 or later. For example:

```
<dependency>
  <groupId>org.apache.cassandra</groupId>
  <artifactId>cassandra-all</artifactId>
  <version>[3.0.26,)</version>
</dependency>
```

Linear - https://linear.app/atlanproduct/issue/META-3939