### PR TITLE
updated field limit to 1500

### DIFF
--- a/addons/elasticsearch/es-settings.json
+++ b/addons/elasticsearch/es-settings.json
@@ -1,4 +1,9 @@
 {
+  "mapping" : {
+    "total_fields" : {
+    "limit" : "1500"
+    }
+  },
   "analysis": {
     "analyzer": {
       "atlan_text_analyzer": {


### PR DESCRIPTION
field limit increased in ElasticSearch for janusgraph vertex index.
Summarise your Changes

Increased the limit to 1500 in ElasticSearch for janusgraph vertex index.
Link for the issue:

a https://linear.app/atlanproduct/issue/META-3987
Docs and Polishing Checklist
Added field limit in the settings.json file in elasticsearch directory.