### PR TITLE
Fix/meta 3919 - Check for status of task from Graph store also(Master PR)

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -393,25 +393,28 @@ public final class GraphHelper {
     public static boolean isClassificationAttached(AtlasVertex entityVertex, AtlasVertex classificationVertex) {
         AtlasPerfMetrics.MetricRecorder isClassificationAttachedMetricRecorder  = RequestContext.get().startMetricRecord("isClassificationAttached");
         String                          classificationId                        = classificationVertex.getIdForDisplay();
-        Iterator<AtlasVertex> vertices = entityVertex.query()
-                .direction(AtlasEdgeDirection.OUT)
-                .label(CLASSIFICATION_LABEL)
-                .has(CLASSIFICATION_EDGE_NAME_PROPERTY_KEY, getTypeName(classificationVertex))
-                .vertices().iterator();
+        try {
+            Iterator<AtlasVertex> vertices = entityVertex.query()
+                    .direction(AtlasEdgeDirection.OUT)
+                    .label(CLASSIFICATION_LABEL)
+                    .has(CLASSIFICATION_EDGE_NAME_PROPERTY_KEY, getTypeName(classificationVertex))
+                    .vertices().iterator();
 
-        if (vertices != null) {
-            while (vertices.hasNext()) {
-                AtlasVertex vertex = vertices.next();
-                if (vertex != null) {
-                    if (vertex.getIdForDisplay().equals(classificationId)) {
-                        return true;
+            if (vertices != null) {
+                while (vertices.hasNext()) {
+                    AtlasVertex vertex = vertices.next();
+                    if (vertex != null) {
+                        if (vertex.getIdForDisplay().equals(classificationId)) {
+                            return true;
+                        }
                     }
                 }
             }
+        } catch (Exception e) {
+            LOG.error("Error while checking if classification is attached to entity", e);
+        } finally {
+            RequestContext.get().endMetricRecord(isClassificationAttachedMetricRecorder);
         }
-
-        RequestContext.get().endMetricRecord(isClassificationAttachedMetricRecorder);
-
         return false;
     }
 

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -410,8 +410,8 @@ public final class GraphHelper {
                     }
                 }
             }
-        } catch (Exception e) {
-            LOG.error("Error while checking if classification is attached to entity", e);
+        } catch (Exception err) {
+            throw err;
         } finally {
             RequestContext.get().endMetricRecord(isClassificationAttachedMetricRecorder);
         }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -81,9 +81,10 @@ import static org.apache.atlas.type.Constants.HAS_LINEAGE;
 import static org.apache.atlas.type.Constants.PENDING_TASKS_PROPERTY_KEY;
 
 public abstract class DeleteHandlerV1 {
-    public static final Logger LOG = LoggerFactory.getLogger(DeleteHandlerV1.class);
+    public static final Logger  LOG = LoggerFactory.getLogger(DeleteHandlerV1.class);
 
-    static final boolean DEFERRED_ACTION_ENABLED = AtlasConfiguration.TASKS_USE_ENABLED.getBoolean();
+    static final boolean        DEFERRED_ACTION_ENABLED        = AtlasConfiguration.TASKS_USE_ENABLED.getBoolean();
+    static final     int        PENDING_TASK_QUERY_SIZE_LIMIT  = 20;
 
     protected final GraphHelper          graphHelper;
     private   final AtlasTypeRegistry    typeRegistry;
@@ -92,7 +93,7 @@ public abstract class DeleteHandlerV1 {
     private   final boolean              softDelete;
     private   final TaskManagement       taskManagement;
     private   final AtlasGraph           graph;
-    private   final TaskUtil            taskUtil;
+    private   final TaskUtil             taskUtil;
 
 
     public DeleteHandlerV1(AtlasGraph graph, AtlasTypeRegistry typeRegistry, boolean shouldUpdateInverseReference, boolean softDelete, TaskManagement taskManagement) {
@@ -1376,34 +1377,37 @@ public abstract class DeleteHandlerV1 {
     }
 
     private boolean skipClassificationTaskCreation(String classificationId) throws AtlasBaseException {
+        AtlasPerfMetrics.MetricRecorder metric = RequestContext.get().startMetricRecord("skipClassificationTaskCreation");
         /*
         If any of,
         1. CLASSIFICATION_PROPAGATION_DELETE
         2. CLASSIFICATION_REFRESH_PROPAGATION task scheduled already
         skip classification task creation
          */
+        try {
 
-        List<AtlasTask> queuedTasks  = RequestContext.get().getQueuedTasks();
-        for(AtlasTask queuedTask : queuedTasks) {
-            if(queuedTask.getClassificationId().equals(classificationId)) {
-                String queuedTaskType = queuedTask.getType();
-                if(queuedTaskType.equals(CLASSIFICATION_REFRESH_PROPAGATION)
-                        || queuedTaskType.equals(CLASSIFICATION_PROPAGATION_DELETE)) {
-                    return true;
-                }
+            List<String> taskTypes = Arrays.asList(CLASSIFICATION_REFRESH_PROPAGATION, CLASSIFICATION_PROPAGATION_DELETE);
+            if (RequestContext.get().getQueuedTasks().stream().anyMatch(task -> task.getClassificationId().equals(classificationId)
+                    && taskTypes.contains(task.getType()))) {
+                return true;
             }
+
+            TaskSearchResult taskSearchResult = taskUtil.findPendingTasksByClassificationId(0, PENDING_TASK_QUERY_SIZE_LIMIT,
+                    classificationId, taskTypes , new ArrayList<>());
+
+            // if any task have status as PENDING, then skip task creation
+            if (taskSearchResult.getTasks().stream().anyMatch(task -> task.getClassificationId().equals(classificationId)
+                    && taskTypes.contains(task.getType()) && task.getStatus().equals(AtlasTask.Status.PENDING))) {
+                return true;
+            } else {
+                LOG.info("There is inconsistency in task queue, there are no pending tasks for classification id {} but there are tasks in queue", classificationId);
+            }
+        } catch (AtlasBaseException e) {
+            LOG.error("Error while checking if classification task creation is required for classification id {}", classificationId, e);
+            throw e;
+        } finally {
+            RequestContext.get().endMetricRecord(metric);
         }
-
-        //Search in ES to get the tasks
-        TaskSearchResult taskSearchResult = taskUtil.findPendingTasksByClassificationId(0, 1, classificationId, new ArrayList<String>(){{
-            add(CLASSIFICATION_PROPAGATION_DELETE);
-            add(CLASSIFICATION_REFRESH_PROPAGATION);
-        }}, new ArrayList<>());
-
-        if (!taskSearchResult.getTasks().isEmpty()) {
-            return true;
-        }
-
 
         return false;
     }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -1387,9 +1387,10 @@ public abstract class DeleteHandlerV1 {
         try {
 
             List<String> taskTypes = Arrays.asList(CLASSIFICATION_REFRESH_PROPAGATION, CLASSIFICATION_PROPAGATION_DELETE);
+            List<AtlasTask> tasksInRequestContext = RequestContext.get().getQueuedTasks();
             if (
-                    RequestContext.get().getQueuedTasks().stream()
-                    .filter(Objects::nonNull)
+                    tasksInRequestContext != null &&
+                    tasksInRequestContext.stream().filter(Objects::nonNull)
                     .anyMatch(task -> task.getClassificationId().equals(classificationId)
                             && taskTypes.contains(task.getType()) && task.getStatus().equals(AtlasTask.Status.PENDING))
             ) {


### PR DESCRIPTION
## Add check for status of task from Graph store also

> Recently, we released new code into production. However, we identified an issue where a certain part of the code needed improvement. Specifically, we were checking for the existence of pending tasks of a certain classification id and, if found, not scheduling the task. However, this was being done by fetching information from Elasticsearch (ES), which can lead to inconsistencies.o address this, we added a fix to also check the status of the task in Graph store, ensuring accuracy and consistency.