### PR TITLE
Fix/meta 4037 self cycle

### DIFF
--- a/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
@@ -900,23 +900,22 @@ public class EntityLineageService implements AtlasLineageService {
 
     private void processLastLevel(AtlasVertex currentVertex, boolean isInput, AtlasLineageInfo ret, AtlasLineageContext lineageContext) {
         List<AtlasEdge> processEdges = vertexEdgeCache.getEdges(currentVertex, IN, isInput ? PROCESS_OUTPUTS_EDGE : PROCESS_INPUTS_EDGE);
-        processEdges = CollectionUtils.isNotEmpty(lineageContext.getIgnoredProcesses()) ? eliminateIgnoredProcesses(processEdges, isInput, lineageContext, currentVertex) : processEdges;
-        ret.setHasChildrenForDirection(getGuid(currentVertex), new LineageChildrenInfo(isInput ? INPUT : OUTPUT, hasMoreChildren(processEdges)));
-    }
 
-    private List<AtlasEdge> eliminateIgnoredProcesses(List<AtlasEdge> processEdges, boolean isInput, AtlasLineageContext lineageContext, AtlasVertex currentVertex) {
-        List<AtlasEdge> edges = new ArrayList<>();
-        for (AtlasEdge processEdge : processEdges) {
-            AtlasVertex processVertex;
-            processVertex = processEdge.getOutVertex();
-            if (processVertex != null) {
-                if (!childHasOnlySelfCycle(processVertex, currentVertex, isInput) &&
-                        !lineageContext.getIgnoredProcesses().contains(processVertex.getProperty(Constants.ENTITY_TYPE_PROPERTY_KEY, String.class))) {
-                    edges.add(processEdge);
-                }
-            }
-        }
-        return edges;
+        // Filter lineages based on ignored process types
+        processEdges = CollectionUtils.isNotEmpty(lineageContext.getIgnoredProcesses()) ?
+                processEdges.stream()
+                        .filter(processEdge -> processEdge.getOutVertex() != null)
+                        .filter(processEdge -> !lineageContext.getIgnoredProcesses().contains(processEdge.getOutVertex().getProperty(Constants.ENTITY_TYPE_PROPERTY_KEY, String.class)))
+                        .collect(Collectors.toList())
+                : processEdges;
+
+        // Filter lineages if child has only self-cyclic relation
+        processEdges = processEdges.stream()
+                .filter(processEdge -> processEdge.getOutVertex() != null)
+                .filter(processEdge -> !childHasOnlySelfCycle(processEdge.getOutVertex(), currentVertex, isInput))
+                .collect(Collectors.toList());
+
+        ret.setHasChildrenForDirection(getGuid(currentVertex), new LineageChildrenInfo(isInput ? INPUT : OUTPUT, hasMoreChildren(processEdges)));
     }
 
     private boolean childHasOnlySelfCycle(AtlasVertex processVertex, AtlasVertex currentVertex, boolean isInput) {


### PR DESCRIPTION
## Change description

> Fixes [ATLAN-3060](https://linear.app/atlanproduct/issue/ATLAN-3060/newsuk-20-reg-lineage-issue-in-upstream-for-the-object). 
- The issue is with self-cyclic cyclic check. If there are more lineages apart from self-cycle, then we count the relation as no more children.
- The fix is, if there is only one lineage and it is a self-cycle, then count that as no more children.
- And make sure that ignored processes do not interfere self-cyclic check

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
