### PR TITLE
META-4039: updated typedef PUT api with patch query params

### DIFF
--- a/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
@@ -471,7 +471,7 @@ public class TypesREST {
     @Path("/typedefs")
     @Experimental
     @Timed
-    public AtlasTypesDef updateAtlasTypeDefs(final AtlasTypesDef typesDef) throws AtlasBaseException {
+    public AtlasTypesDef updateAtlasTypeDefs(final AtlasTypesDef typesDef, @QueryParam("patch") final boolean patch) throws AtlasBaseException {
         AtlasPerfTracer perf = null;
         InterProcessMutex lock = null;
         RequestContext.get().setTraceId(UUID.randomUUID().toString());
@@ -503,6 +503,8 @@ public class TypesREST {
                 }
                 classificationDef.setRandomNameForNewAttributeDefs(existingClassificationDef);
             }
+            RequestContext.get().setInTypePatching(patch);
+            LOG.info("TypesRest.updateAtlasTypeDefs:: Typedef patch enabled:" + patch);
             AtlasTypesDef atlasTypesDef = typeDefStore.updateTypesDef(typesDef);
             typeCacheRefresher.refreshAllHostCache();
             return atlasTypesDef;
@@ -513,6 +515,7 @@ public class TypesREST {
             LOG.error("TypesREST.updateAtlasTypeDefs:: " + e.getMessage(), e);
             throw new AtlasBaseException("Error while updating a type definition");
         } finally {
+            RequestContext.clear();
             releaseLock(lock);
             AtlasPerfTracer.log(perf);
         }


### PR DESCRIPTION
## Change description
Support patching behavior for Typedef update API
> Description here
Currently, typedefs update process involves, adding a patch file with modified attributes and relationships. To make the process more simple, we are enabling typedef update API to support patching with means of a query params.

**Current API:**
```
PUT /typedefs
```
**Updated API:**
```
PUT /typedefs?patch=<true|false>
```

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
