### PR TITLE
META-4025- revert testng and revert dependency-review skip CVE

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,6 +9,5 @@ jobs:
       - name: 'Checkout Repository'
         uses: actions/checkout@v3
       - name: Dependency Review
-        uses: actions/dependency-review-action@v3
-        with:
-         allow-ghsas: GHSA-mjmj-j48q-9wg2
+        uses: actions/dependency-review-action@v2
+

--- a/graphdb/common/pom.xml
+++ b/graphdb/common/pom.xml
@@ -42,7 +42,7 @@ under the License. -->
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.7.1</version>
+            <version>6.9.4</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
## Change description
Reverting testng version back to 6.9.4, so that java 8 is supported by default.
https://atlanhq.slack.com/archives/C02S3N4LVNX/p1674585548264699

Also reverting dependency-review skip CVE option
> Description here

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
