### PR TITLE
Roll back typedef when typedef is not created in ES but in cassandra.

### DIFF
--- a/graphdb/api/src/main/java/org/apache/atlas/repository/graphdb/AtlasGraphManagement.java
+++ b/graphdb/api/src/main/java/org/apache/atlas/repository/graphdb/AtlasGraphManagement.java
@@ -18,6 +18,8 @@
 
 package org.apache.atlas.repository.graphdb;
 
+import org.apache.atlas.model.typedef.AtlasBaseTypeDef;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -27,6 +29,13 @@ import java.util.List;
  *
  */
 public interface AtlasGraphManagement {
+
+    /**
+     * Removes type vertex
+     *
+     * @param typeDef
+     */
+    void removeTypeVertex(AtlasBaseTypeDef typeDef);
 
     /**
      * Checks whether a property with the given key has been defined in the graph schema.

--- a/intg/src/main/java/org/apache/atlas/model/typedef/AtlasBaseTypeDef.java
+++ b/intg/src/main/java/org/apache/atlas/model/typedef/AtlasBaseTypeDef.java
@@ -161,6 +161,7 @@ public abstract class AtlasBaseTypeDef implements java.io.Serializable {
     private String  typeVersion;
     private String  serviceType;
     private Map<String, String> options;
+    private String  vertexId;
 
     protected AtlasBaseTypeDef(TypeCategory category, String name, String description, String typeVersion,
                                String serviceType, Map<String, String> options) {
@@ -211,6 +212,14 @@ public abstract class AtlasBaseTypeDef implements java.io.Serializable {
             setTypeVersion(null);
             setOptions(null);
         }
+    }
+
+    public String getVertexId() {
+        return vertexId;
+    }
+
+    public void setVertexId(String vertexId) {
+        this.vertexId = vertexId;
     }
 
     public TypeCategory getCategory() { return category; }

--- a/intg/src/main/java/org/apache/atlas/model/typedef/AtlasStructDef.java
+++ b/intg/src/main/java/org/apache/atlas/model/typedef/AtlasStructDef.java
@@ -280,6 +280,8 @@ public class AtlasStructDef extends AtlasBaseTypeDef implements Serializable {
         public static final String    ATTRDEF_OPTION_APPEND_ON_PARTIAL_UPDATE = "isAppendOnPartialUpdate";
         private final String          STRING_TRUE                             = "true";
         private final String          MULTIFIELDS                             = "multifields";
+        private Boolean               isIndexCreated                          = false;
+        private Boolean               isIndexPresent                          = false;
 
         /**
          * single-valued attribute or multi-valued attribute.
@@ -398,6 +400,14 @@ public class AtlasStructDef extends AtlasBaseTypeDef implements Serializable {
                 setSkipScrubbing(other.getSkipScrubbing());
             }
         }
+
+        public void setIsIndexCreated(Boolean isIndexCreated){this.isIndexCreated = isIndexCreated;}
+
+        public Boolean getIsIndexCreated(){return isIndexCreated;}
+
+        public void setIndexPresent(Boolean isIndexPresent){this.isIndexPresent = isIndexPresent;}
+
+        public Boolean getIndexPresent(){return isIndexPresent;}
 
         public void setDisplayName(String displayName) {
             this.displayName = displayName;

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphBackedSearchIndexer.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphBackedSearchIndexer.java
@@ -664,7 +664,7 @@ public class GraphBackedSearchIndexer implements SearchIndexer, ActiveStateChang
                     createVertexIndex(attributeDef, management, propertyName, UniqueKind.NONE, primitiveClassType, cardinality, isIndexable, false, isStringField, indexTypeESConfig, indexTypeESFields);
 
                     if (uniqPropName != null) {
-                        createVertexIndex(attributeDef, management, propertyName, UniqueKind.NONE, primitiveClassType, cardinality, isIndexable, false, isStringField, indexTypeESConfig, indexTypeESFields);
+                        createVertexIndex(attributeDef, management, uniqPropName, UniqueKind.PER_TYPE_UNIQUE, primitiveClassType, cardinality, isIndexable, true, isStringField);
                     }
 
                 }

--- a/repository/src/main/java/org/apache/atlas/repository/patches/UniqueAttributePatch.java
+++ b/repository/src/main/java/org/apache/atlas/repository/patches/UniqueAttributePatch.java
@@ -142,7 +142,8 @@ public class UniqueAttributePatch extends AtlasPatchHandler {
                     Class             propertyClass  = getIndexer().getPrimitiveClass(attribTypeName);
                     AtlasCardinality  cardinality    = getIndexer().toAtlasCardinality(attributeDef.getCardinality());
 
-                    getIndexer().createVertexIndex(management,
+                    getIndexer().createVertexIndex(attributeDef,
+                                                   management,
                                                    uniquePropertyName,
                                                    UniqueKind.PER_TYPE_UNIQUE,
                                                    propertyClass,


### PR DESCRIPTION
Rollback of a typedef when it is stored in cassandra and not in ES. 
Summarise your Changes
A typedef is created when it is stored in cassandra and not in ES.

Link for the issue: https://linear.app/atlanproduct/issue/META-4043

When Mixed Index is not created then typedef should rollback: delete propertykey and typevertex.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)