### PR TITLE
Adding 4.1 & 4.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,4 +74,10 @@ RUN cd /opt/apache-atlas/bin \
 RUN cd /opt/apache-atlas/bin \
     && ./atlas_start.py -setup || true
 
+RUN groupadd -r user && useradd -r -g user user
+
+USER user
+
+RUN find / -perm /6000 -type f -exec chmod a-s {} \; || true 
+
 VOLUME ["/opt/apache-atlas/conf", "/opt/apache-atlas/logs"]


### PR DESCRIPTION
Adding 4.1 and 4.8 CIS Benchmark control

4.1
Adding a user for the container.

4.8
Removing setuid and setgid permissions in the images can prevent privilege escalation attacks within containers.