### PR TITLE
4.8 Benchmark Fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,10 +74,10 @@ RUN cd /opt/apache-atlas/bin \
 RUN cd /opt/apache-atlas/bin \
     && ./atlas_start.py -setup || true
 
+RUN find / -perm /6000 -type f -exec chmod a-s {} \; || true 
+
 RUN groupadd -r user && useradd -r -g user user
 
 USER user
-
-RUN find / -perm /6000 -type f -exec chmod a-s {} \; || true 
 
 VOLUME ["/opt/apache-atlas/conf", "/opt/apache-atlas/logs"]


### PR DESCRIPTION
4.8 Benchmark Fix
Removing setuid and setgid permissions in the images can prevent privilege escalation attacks within containers.