### PR TITLE
Adding 4.7 check

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -78,6 +78,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          no-cache: true
           push: true
           tags: |
             ghcr.io/atlanhq/${{ github.event.repository.name }}-${{ steps.get_branch.outputs.branch }}:latest


### PR DESCRIPTION
Adding update instructions in a single line on the Dockerfile will cause the update layer to be cached. Adding a -no-cache check
