### PR TITLE
Meta 4194: Classificationdef Schema param: Create classificationDef of same displayName

### DIFF
--- a/intg/src/main/java/org/apache/atlas/model/typedef/AtlasClassificationDef.java
+++ b/intg/src/main/java/org/apache/atlas/model/typedef/AtlasClassificationDef.java
@@ -52,7 +52,7 @@ public class AtlasClassificationDef extends AtlasStructDef implements AtlasNamed
     private Set<String> entityTypes;
 
     private String displayName;
-    private boolean isUniqueDisplayNameCheck;
+    private boolean skipDisplayNameUniquenessCheck;
     // subTypes field below is derived from 'superTypes' specified in all AtlasClassificationDef
     // this value is ignored during create & update operations
     private Set<String> subTypes;
@@ -99,15 +99,15 @@ public class AtlasClassificationDef extends AtlasStructDef implements AtlasNamed
     public AtlasClassificationDef(String name, String displayName, String description, String typeVersion,
                                   List<AtlasAttributeDef> attributeDefs, Set<String> superTypes,
                                   Set<String> entityTypes, Map<String, String> options) {
-        this(name, displayName, description, typeVersion, attributeDefs, superTypes, entityTypes, options, true);
+        this(name, displayName, description, typeVersion, attributeDefs, superTypes, entityTypes, options, false);
     }
 
     public AtlasClassificationDef(String name, String displayName, String description, String typeVersion,
                                   List<AtlasAttributeDef> attributeDefs, Set<String> superTypes,
-                                  Set<String> entityTypes, Map<String, String> options, boolean isUniquenessCheck) {
+                                  Set<String> entityTypes, Map<String, String> options, boolean skipDisplayNameUniquenessCheck) {
         super(TypeCategory.CLASSIFICATION, name, description, typeVersion, attributeDefs, options);
         this.setDisplayName(displayName);
-        this.setUniqueDisplayNameCheck(isUniquenessCheck);
+        this.setSkipDisplayNameUniquenessCheck(skipDisplayNameUniquenessCheck);
         setSuperTypes(superTypes);
         setEntityTypes(entityTypes);
     }
@@ -119,7 +119,7 @@ public class AtlasClassificationDef extends AtlasStructDef implements AtlasNamed
             setDisplayName(other.getDisplayName());
             setEntityTypes(other.getEntityTypes());
             setSubTypes(other.getSubTypes());
-            setUniqueDisplayNameCheck(other.getisUniqueDisplayNameCheck());
+            setSkipDisplayNameUniquenessCheck(other.getSkipDisplayNameUniquenessCheck());
         }
     }
 
@@ -267,20 +267,20 @@ public class AtlasClassificationDef extends AtlasStructDef implements AtlasNamed
 
         return Objects.equals(superTypes, that.superTypes) &&
                 Objects.equals(displayName, that.displayName) &&
-                Objects.equals(isUniqueDisplayNameCheck, that.isUniqueDisplayNameCheck) &&
+                Objects.equals(skipDisplayNameUniquenessCheck, that.skipDisplayNameUniquenessCheck) &&
                 Objects.equals(entityTypes,that.entityTypes);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), superTypes, this.displayName, this.isUniqueDisplayNameCheck);
+        return Objects.hash(super.hashCode(), superTypes, this.displayName, this.skipDisplayNameUniquenessCheck);
     }
 
     @Override
     protected void appendExtraBaseTypeDefToString(StringBuilder sb) {
         super.appendExtraBaseTypeDefToString(sb);
         sb.append(", displayName='").append(this.displayName).append('\'');
-        sb.append(", isUniquenessCheck='").append(this.isUniqueDisplayNameCheck).append('\'');
+        sb.append(", skipDisplayNameUniquenessCheck='").append(this.skipDisplayNameUniquenessCheck).append('\'');
     }
 
     @Override
@@ -298,12 +298,12 @@ public class AtlasClassificationDef extends AtlasStructDef implements AtlasNamed
         this.displayName = displayName;
     }
 
-    public boolean getisUniqueDisplayNameCheck() {
-        return isUniqueDisplayNameCheck;
+    public boolean getSkipDisplayNameUniquenessCheck() {
+        return skipDisplayNameUniquenessCheck;
     }
 
-    public void setUniqueDisplayNameCheck(boolean isUniqueDisplayNameCheck) {
-        this.isUniqueDisplayNameCheck = isUniqueDisplayNameCheck;
+    public void setSkipDisplayNameUniquenessCheck(boolean skipDisplayNameUniquenessCheck) {
+        this.skipDisplayNameUniquenessCheck = skipDisplayNameUniquenessCheck;
     }
 
     @Override

--- a/intg/src/main/java/org/apache/atlas/model/typedef/AtlasClassificationDef.java
+++ b/intg/src/main/java/org/apache/atlas/model/typedef/AtlasClassificationDef.java
@@ -52,7 +52,7 @@ public class AtlasClassificationDef extends AtlasStructDef implements AtlasNamed
     private Set<String> entityTypes;
 
     private String displayName;
-
+    private boolean isUniqueDisplayNameCheck;
     // subTypes field below is derived from 'superTypes' specified in all AtlasClassificationDef
     // this value is ignored during create & update operations
     private Set<String> subTypes;
@@ -99,9 +99,15 @@ public class AtlasClassificationDef extends AtlasStructDef implements AtlasNamed
     public AtlasClassificationDef(String name, String displayName, String description, String typeVersion,
                                   List<AtlasAttributeDef> attributeDefs, Set<String> superTypes,
                                   Set<String> entityTypes, Map<String, String> options) {
+        this(name, displayName, description, typeVersion, attributeDefs, superTypes, entityTypes, options, true);
+    }
+
+    public AtlasClassificationDef(String name, String displayName, String description, String typeVersion,
+                                  List<AtlasAttributeDef> attributeDefs, Set<String> superTypes,
+                                  Set<String> entityTypes, Map<String, String> options, boolean isUniquenessCheck) {
         super(TypeCategory.CLASSIFICATION, name, description, typeVersion, attributeDefs, options);
         this.setDisplayName(displayName);
-
+        this.setUniqueDisplayNameCheck(isUniquenessCheck);
         setSuperTypes(superTypes);
         setEntityTypes(entityTypes);
     }
@@ -113,6 +119,7 @@ public class AtlasClassificationDef extends AtlasStructDef implements AtlasNamed
             setDisplayName(other.getDisplayName());
             setEntityTypes(other.getEntityTypes());
             setSubTypes(other.getSubTypes());
+            setUniqueDisplayNameCheck(other.getisUniqueDisplayNameCheck());
         }
     }
 
@@ -260,18 +267,20 @@ public class AtlasClassificationDef extends AtlasStructDef implements AtlasNamed
 
         return Objects.equals(superTypes, that.superTypes) &&
                 Objects.equals(displayName, that.displayName) &&
+                Objects.equals(isUniqueDisplayNameCheck, that.isUniqueDisplayNameCheck) &&
                 Objects.equals(entityTypes,that.entityTypes);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), superTypes, this.displayName);
+        return Objects.hash(super.hashCode(), superTypes, this.displayName, this.isUniqueDisplayNameCheck);
     }
 
     @Override
     protected void appendExtraBaseTypeDefToString(StringBuilder sb) {
         super.appendExtraBaseTypeDefToString(sb);
         sb.append(", displayName='").append(this.displayName).append('\'');
+        sb.append(", isUniquenessCheck='").append(this.isUniqueDisplayNameCheck).append('\'');
     }
 
     @Override
@@ -287,6 +296,14 @@ public class AtlasClassificationDef extends AtlasStructDef implements AtlasNamed
     @Override
     public void setDisplayName(String displayName) {
         this.displayName = displayName;
+    }
+
+    public boolean getisUniqueDisplayNameCheck() {
+        return isUniqueDisplayNameCheck;
+    }
+
+    public void setUniqueDisplayNameCheck(boolean isUniqueDisplayNameCheck) {
+        this.isUniqueDisplayNameCheck = isUniqueDisplayNameCheck;
     }
 
     @Override

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasClassificationDefStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasClassificationDefStoreV2.java
@@ -82,7 +82,7 @@ class AtlasClassificationDefStoreV2 extends AtlasAbstractDefStoreV2<AtlasClassif
         }
         ret = typeDefStore.findTypeVertexByDisplayName(
                 classificationDef.getDisplayName(), TypeCategory.TRAIT);
-        if (ret != null && classificationDef.getisUniqueDisplayNameCheck()) {
+        if (ret != null && !classificationDef.getSkipDisplayNameUniquenessCheck()) {
             throw new AtlasBaseException(AtlasErrorCode.TYPE_WITH_DISPLAY_NAME_ALREADY_EXISTS, classificationDef.getDisplayName());
         }
 
@@ -108,7 +108,7 @@ class AtlasClassificationDefStoreV2 extends AtlasAbstractDefStoreV2<AtlasClassif
         updateVertexAddReferences(classificationDef, vertex);
 
         AtlasClassificationDef ret = toClassificationDef(vertex);
-        ret.setUniqueDisplayNameCheck(classificationDef.getisUniqueDisplayNameCheck());
+        ret.setSkipDisplayNameUniquenessCheck(classificationDef.getSkipDisplayNameUniquenessCheck());
         if (LOG.isDebugEnabled()) {
             LOG.debug("<== AtlasClassificationDefStoreV1.create({}, {}): {}", classificationDef, preCreateResult, ret);
         }
@@ -194,7 +194,7 @@ class AtlasClassificationDefStoreV2 extends AtlasAbstractDefStoreV2<AtlasClassif
                 classifiDef.getDisplayName(), DataTypes.TypeCategory.TRAIT);
         if (ret != null && (
                 classifiDef.getGuid() == null || !classifiDef.getGuid().equals(ret.getProperty(Constants.GUID_PROPERTY_KEY, String.class)))
-                 && (classifiDef.getisUniqueDisplayNameCheck())) {
+                 && (!classifiDef.getSkipDisplayNameUniquenessCheck())) {
             throw new AtlasBaseException(AtlasErrorCode.TYPE_WITH_DISPLAY_NAME_ALREADY_EXISTS, classifiDef.getDisplayName());
         }
     }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasClassificationDefStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasClassificationDefStoreV2.java
@@ -82,7 +82,7 @@ class AtlasClassificationDefStoreV2 extends AtlasAbstractDefStoreV2<AtlasClassif
         }
         ret = typeDefStore.findTypeVertexByDisplayName(
                 classificationDef.getDisplayName(), TypeCategory.TRAIT);
-        if (ret != null) {
+        if (ret != null && classificationDef.getisUniqueDisplayNameCheck()) {
             throw new AtlasBaseException(AtlasErrorCode.TYPE_WITH_DISPLAY_NAME_ALREADY_EXISTS, classificationDef.getDisplayName());
         }
 
@@ -108,7 +108,7 @@ class AtlasClassificationDefStoreV2 extends AtlasAbstractDefStoreV2<AtlasClassif
         updateVertexAddReferences(classificationDef, vertex);
 
         AtlasClassificationDef ret = toClassificationDef(vertex);
-
+        ret.setUniqueDisplayNameCheck(classificationDef.getisUniqueDisplayNameCheck());
         if (LOG.isDebugEnabled()) {
             LOG.debug("<== AtlasClassificationDefStoreV1.create({}, {}): {}", classificationDef, preCreateResult, ret);
         }
@@ -193,7 +193,8 @@ class AtlasClassificationDefStoreV2 extends AtlasAbstractDefStoreV2<AtlasClassif
         AtlasVertex ret = typeDefStore.findTypeVertexByDisplayName(
                 classifiDef.getDisplayName(), DataTypes.TypeCategory.TRAIT);
         if (ret != null && (
-                classifiDef.getGuid() == null || !classifiDef.getGuid().equals(ret.getProperty(Constants.GUID_PROPERTY_KEY, String.class)))) {
+                classifiDef.getGuid() == null || !classifiDef.getGuid().equals(ret.getProperty(Constants.GUID_PROPERTY_KEY, String.class)))
+                 && (classifiDef.getisUniqueDisplayNameCheck())) {
             throw new AtlasBaseException(AtlasErrorCode.TYPE_WITH_DISPLAY_NAME_ALREADY_EXISTS, classifiDef.getDisplayName());
         }
     }


### PR DESCRIPTION
Introduced a new param in ClassificationDef (`skipDisplayNameUniquenessCheck`).
When set true, classificationDef of same displayName will be allowed to create.

Linear: https://linear.app/atlanproduct/issue/META-4194

<img width="370" alt="image" src="https://user-images.githubusercontent.com/121708100/217840634-5facde21-35a8-42ee-b08f-b0fdbf3c8e4f.png">
