### PR TITLE
Meta-4202: Add validation for Enum creation with reserved keywords

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEnumDefStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEnumDefStoreV2.java
@@ -41,7 +41,22 @@ import java.util.List;
  */
 class AtlasEnumDefStoreV2 extends AtlasAbstractDefStoreV2<AtlasEnumDef> {
     private static final Logger LOG = LoggerFactory.getLogger(AtlasEnumDefStoreV2.class);
-
+    private static final List<String> KEYWORDS_INVALID_FOR_ENUM = new ArrayList() {
+        {
+            add("boolean");
+            add("byte");
+            add("short");
+            add("int");
+            add("long");
+            add("float");
+            add("double");
+            add("biginteger");
+            add("bigdecimal");
+            add("string");
+            add("date");
+            add("objectid");
+        }
+    };
     public AtlasEnumDefStoreV2(AtlasTypeDefGraphStoreV2 typeDefStore, AtlasTypeRegistry typeRegistry) {
         super(typeDefStore, typeRegistry);
     }
@@ -53,6 +68,10 @@ class AtlasEnumDefStoreV2 extends AtlasAbstractDefStoreV2<AtlasEnumDef> {
         }
 
         validateType(enumDef);
+
+        if(KEYWORDS_INVALID_FOR_ENUM.contains(enumDef.getName())){
+            throw new AtlasBaseException(AtlasErrorCode.UNKNOWN_TYPENAME, enumDef.getName());
+        }
 
         AtlasAuthorizationUtils.verifyAccess(new AtlasTypeAccessRequest(AtlasPrivilege.TYPE_CREATE, enumDef), "create enum-def ", enumDef.getName());
 


### PR DESCRIPTION
restrict end user from creating enum with reserved keywords.

Linear: https://linear.app/atlanproduct/issue/META-4202

![image](https://user-images.githubusercontent.com/121708100/218696465-bcf15b5d-6184-4e65-8c17-51bd17ddc956.png)
