### PR TITLE
Meta-4202: Add validation for EntityDef/StructDef/EnumDef creation with reserved keywords.

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasAbstractDefStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasAbstractDefStoreV2.java
@@ -41,6 +41,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.ArrayList;
 import java.util.regex.Pattern;
 
 /**
@@ -58,6 +59,22 @@ import java.util.regex.Pattern;
     private static final Pattern INTERNAL_NAME_PATTERN = Pattern.compile(INTERNAL_NAME_REGEX);
 
     public static final String ALLOW_RESERVED_KEYWORDS = "atlas.types.allowReservedKeywords";
+    public static final List<String> KEYWORDS_INVALID_FOR_TYPE_CREATION = new ArrayList() {
+        {
+            add("boolean");
+            add("byte");
+            add("short");
+            add("int");
+            add("long");
+            add("float");
+            add("double");
+            add("biginteger");
+            add("bigdecimal");
+            add("string");
+            add("date");
+            add("objectid");
+        }
+    };
 
     public AtlasAbstractDefStoreV2(AtlasTypeDefGraphStoreV2 typeDefStore, AtlasTypeRegistry typeRegistry) {
         this.typeDefStore = typeDefStore;

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityDefStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityDefStoreV2.java
@@ -57,6 +57,10 @@ public class AtlasEntityDefStoreV2 extends AtlasAbstractDefStoreV2<AtlasEntityDe
 
         validateType(entityDef);
 
+        if(AtlasAbstractDefStoreV2.KEYWORDS_INVALID_FOR_TYPE_CREATION.contains(entityDef.getName())){
+            throw new AtlasBaseException(AtlasErrorCode.UNKNOWN_TYPENAME, entityDef.getName());
+        }
+
         AtlasType type = typeRegistry.getType(entityDef.getName());
 
         if (type.getTypeCategory() != org.apache.atlas.model.TypeCategory.ENTITY) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEnumDefStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEnumDefStoreV2.java
@@ -41,22 +41,7 @@ import java.util.List;
  */
 class AtlasEnumDefStoreV2 extends AtlasAbstractDefStoreV2<AtlasEnumDef> {
     private static final Logger LOG = LoggerFactory.getLogger(AtlasEnumDefStoreV2.class);
-    private static final List<String> KEYWORDS_INVALID_FOR_ENUM = new ArrayList() {
-        {
-            add("boolean");
-            add("byte");
-            add("short");
-            add("int");
-            add("long");
-            add("float");
-            add("double");
-            add("biginteger");
-            add("bigdecimal");
-            add("string");
-            add("date");
-            add("objectid");
-        }
-    };
+
     public AtlasEnumDefStoreV2(AtlasTypeDefGraphStoreV2 typeDefStore, AtlasTypeRegistry typeRegistry) {
         super(typeDefStore, typeRegistry);
     }
@@ -69,7 +54,7 @@ class AtlasEnumDefStoreV2 extends AtlasAbstractDefStoreV2<AtlasEnumDef> {
 
         validateType(enumDef);
 
-        if(KEYWORDS_INVALID_FOR_ENUM.contains(enumDef.getName())){
+        if(AtlasAbstractDefStoreV2.KEYWORDS_INVALID_FOR_TYPE_CREATION.contains(enumDef.getName())){
             throw new AtlasBaseException(AtlasErrorCode.UNKNOWN_TYPENAME, enumDef.getName());
         }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasStructDefStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasStructDefStoreV2.java
@@ -69,6 +69,10 @@ public class AtlasStructDefStoreV2 extends AtlasAbstractDefStoreV2<AtlasStructDe
 
         validateType(structDef);
 
+        if(AtlasAbstractDefStoreV2.KEYWORDS_INVALID_FOR_TYPE_CREATION.contains(structDef.getName())){
+            throw new AtlasBaseException(AtlasErrorCode.UNKNOWN_TYPENAME, structDef.getName());
+        }
+
         AtlasType type = typeRegistry.getType(structDef.getName());
 
         if (type.getTypeCategory() != org.apache.atlas.model.TypeCategory.STRUCT) {


### PR DESCRIPTION
restrict end user from creating EnumDef/EntityDef/StructDef with reserved keywords.

Linear: https://linear.app/atlanproduct/issue/META-4202

![image](https://user-images.githubusercontent.com/121708100/218696465-bcf15b5d-6184-4e65-8c17-51bd17ddc956.png)
