### PR TITLE
Meta-4227: Generate qualifiedName for ReadMe entity at server side

### DIFF
--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -129,6 +129,7 @@ public final class Constants {
     public static final String QUERY_ENTITY_TYPE            = "Query";
     public static final String QUERY_FOLDER_ENTITY_TYPE     = "QueryFolder";
     public static final String QUERY_COLLECTION_ENTITY_TYPE = "QueryCollection";
+    public static final String README_ENTITY_TYPE = "Readme";
 
 
     /**

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -370,7 +370,6 @@ public class EntityGraphMapper {
                     reqContext.getDeletedEdgesIds().clear();
 
                     String guid = createdEntity.getGuid();
-                    AtlasVertex vertex = context.getVertex(guid);
                     AtlasEntityType entityType = context.getType(guid);
 
                     PreProcessor preProcessor = getPreProcessor(entityType.getTypeName());
@@ -378,9 +377,9 @@ public class EntityGraphMapper {
                         preProcessor.processAttributes(createdEntity, context, CREATE);
                         if(entityType.getTypeName().equals(README_ENTITY_TYPE))
                             guid = createdEntity.getGuid();
-                            vertex = AtlasGraphUtilsV2.findByUniqueAttributes(this.graph, entityType, createdEntity.getAttributes());
                     }
 
+                    AtlasVertex vertex = context.getVertex(guid);
                     mapAttributes(createdEntity, entityType, vertex, CREATE, context);
                     mapRelationshipAttributes(createdEntity, entityType, vertex, CREATE, context);
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -59,6 +59,7 @@ import org.apache.atlas.repository.store.graph.v2.preprocessor.glossary.Category
 import org.apache.atlas.repository.store.graph.v2.preprocessor.glossary.GlossaryPreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.glossary.TermPreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessor;
+import org.apache.atlas.repository.store.graph.v2.preprocessor.readme.ReadmePreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.sql.QueryCollectionPreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.sql.QueryFolderPreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.sql.QueryPreProcessor;
@@ -578,6 +579,10 @@ public class EntityGraphMapper {
 
             case QUERY_COLLECTION_ENTITY_TYPE:
                 preProcessor = new QueryCollectionPreProcessor(typeRegistry, entityRetriever);
+                break;
+
+            case README_ENTITY_TYPE:
+                preProcessor = new ReadmePreProcessor(typeRegistry, entityRetriever, graph);
                 break;
 
         }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -582,7 +582,7 @@ public class EntityGraphMapper {
                 break;
 
             case README_ENTITY_TYPE:
-                preProcessor = new ReadmePreProcessor(typeRegistry, entityRetriever, graph);
+                preProcessor = new ReadmePreProcessor(typeRegistry, entityRetriever, graph, taskManagement);
                 break;
 
         }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -376,6 +376,9 @@ public class EntityGraphMapper {
                     PreProcessor preProcessor = getPreProcessor(entityType.getTypeName());
                     if (preProcessor != null) {
                         preProcessor.processAttributes(createdEntity, context, CREATE);
+                        if(entityType.getTypeName().equals(README_ENTITY_TYPE))
+                            guid = createdEntity.getGuid();
+                            vertex = AtlasGraphUtilsV2.findByUniqueAttributes(this.graph, entityType, createdEntity.getAttributes());
                     }
 
                     mapAttributes(createdEntity, entityType, vertex, CREATE, context);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/IDBasedEntityResolver.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/IDBasedEntityResolver.java
@@ -32,15 +32,11 @@ import org.apache.atlas.type.AtlasTypeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 
 public class IDBasedEntityResolver implements EntityResolver {
     private static final Logger LOG = LoggerFactory.getLogger(IDBasedEntityResolver.class);
-    public static final String README_ENTITY_TYPE    = "Readme";
-    public static final String QUALIFIED_NAME        = "qualifiedName";
-    public static final String GUID                  = "guid";
 
     private final AtlasGraph        graph;
     private final AtlasTypeRegistry typeRegistry;
@@ -72,10 +68,7 @@ public class IDBasedEntityResolver implements EntityResolver {
                     if (entityType == null) {
                         throw new AtlasBaseException(element.getValue(), AtlasErrorCode.TYPE_NAME_INVALID, TypeCategory.ENTITY.name(), entity.getTypeName());
                     }
-                    if(entity.getTypeName().equals(README_ENTITY_TYPE)){
-                        Object asset = entity.getRelationshipAttribute("asset");
-                        if(asset != null) entity.setAttribute(QUALIFIED_NAME, ((LinkedHashMap)asset).get(GUID) + "/readme");
-                    }
+
                     vertex = AtlasGraphUtilsV2.findByUniqueAttributes(this.graph, entityType, entity.getAttributes());
                 } else if (!isAssignedGuid) { // for local-guids, entity must be in the stream
                     throw new AtlasBaseException(element.getValue(), AtlasErrorCode.REFERENCED_ENTITY_NOT_FOUND, guid);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/IDBasedEntityResolver.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/IDBasedEntityResolver.java
@@ -32,11 +32,15 @@ import org.apache.atlas.type.AtlasTypeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 
 public class IDBasedEntityResolver implements EntityResolver {
     private static final Logger LOG = LoggerFactory.getLogger(IDBasedEntityResolver.class);
+    public static final String README_ENTITY_TYPE    = "Readme";
+    public static final String QUALIFIED_NAME        = "qualifiedName";
+    public static final String GUID                  = "guid";
 
     private final AtlasGraph        graph;
     private final AtlasTypeRegistry typeRegistry;
@@ -68,7 +72,10 @@ public class IDBasedEntityResolver implements EntityResolver {
                     if (entityType == null) {
                         throw new AtlasBaseException(element.getValue(), AtlasErrorCode.TYPE_NAME_INVALID, TypeCategory.ENTITY.name(), entity.getTypeName());
                     }
-
+                    if(entity.getTypeName().equals(README_ENTITY_TYPE)){
+                        Object asset = entity.getRelationshipAttribute("asset");
+                        if(asset != null) entity.setAttribute(QUALIFIED_NAME, ((LinkedHashMap)asset).get(GUID) + "/readme");
+                    }
                     vertex = AtlasGraphUtilsV2.findByUniqueAttributes(this.graph, entityType, entity.getAttributes());
                 } else if (!isAssignedGuid) { // for local-guids, entity must be in the stream
                     throw new AtlasBaseException(element.getValue(), AtlasErrorCode.REFERENCED_ENTITY_NOT_FOUND, guid);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/readme/ReadmePreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/readme/ReadmePreProcessor.java
@@ -49,7 +49,7 @@ public class ReadmePreProcessor implements PreProcessor {
 
         switch (operation) {
             case CREATE:
-                processCreateReadme(entity);
+                processCreateReadme(entity, context);
                 break;
             case UPDATE:
                 processUpdateReadme(entity, context.getVertex(entity.getGuid()));
@@ -57,7 +57,7 @@ public class ReadmePreProcessor implements PreProcessor {
         }
     }
 
-    private void processCreateReadme(AtlasEntity entity) throws AtlasBaseException {
+    private void processCreateReadme(AtlasEntity entity, EntityMutationContext context) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("processCreateReadme");
         String entityQualifiedName = createQualifiedName(entity);
 
@@ -68,6 +68,7 @@ public class ReadmePreProcessor implements PreProcessor {
         if(vertex != null){
             String guidOfReadme = GraphHelper.getGuid(vertex);
             entity.setGuid(guidOfReadme);
+            context.cacheEntity(guidOfReadme, vertex, entityType);
         }
 
         RequestContext.get().endMetricRecord(metricRecorder);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/readme/ReadmePreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/readme/ReadmePreProcessor.java
@@ -1,0 +1,90 @@
+package org.apache.atlas.repository.store.graph.v2.preprocessor.readme;
+
+import org.apache.atlas.RequestContext;
+import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.model.instance.AtlasEntity;
+import org.apache.atlas.model.instance.AtlasObjectId;
+import org.apache.atlas.model.instance.AtlasStruct;
+import org.apache.atlas.model.instance.EntityMutations;
+import org.apache.atlas.repository.graphdb.AtlasGraph;
+import org.apache.atlas.repository.graphdb.AtlasVertex;
+import org.apache.atlas.repository.store.graph.v1.HardDeleteHandlerV1;
+import org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2;
+import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
+import org.apache.atlas.repository.store.graph.v2.EntityMutationContext;
+import org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessor;
+import org.apache.atlas.repository.store.graph.v2.preprocessor.glossary.GlossaryPreProcessor;
+import org.apache.atlas.type.AtlasEntityType;
+import org.apache.atlas.type.AtlasTypeRegistry;
+import org.apache.atlas.utils.AtlasPerfMetrics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import static org.apache.atlas.repository.Constants.QUALIFIED_NAME;
+
+public class ReadmePreProcessor implements PreProcessor {
+    private static final Logger LOG = LoggerFactory.getLogger(GlossaryPreProcessor.class);
+
+    private final AtlasTypeRegistry typeRegistry;
+    private final EntityGraphRetriever entityRetriever;
+    private final AtlasGraph graph;
+
+    public ReadmePreProcessor(AtlasTypeRegistry typeRegistry, EntityGraphRetriever entityRetriever, AtlasGraph graph) {
+        this.entityRetriever = entityRetriever;
+        this.typeRegistry = typeRegistry;
+        this.graph = graph;
+    }
+
+    @Override
+    public void processAttributes(AtlasStruct entityStruct, EntityMutationContext context,
+                                  EntityMutations.EntityOperation operation) throws AtlasBaseException {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("GlossaryPreProcessor.processAttributes: pre processing {}, {}", entityStruct.getAttribute(QUALIFIED_NAME), operation);
+        }
+
+        AtlasEntity entity = (AtlasEntity) entityStruct;
+
+        switch (operation) {
+            case CREATE:
+                processCreateReadme(entity);
+                break;
+            case UPDATE:
+                processUpdateReadme(entity, context.getVertex(entity.getGuid()));
+                break;
+        }
+    }
+
+    private void processCreateReadme(AtlasStruct entity) throws AtlasBaseException {
+        AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("processCreateReadme");
+        String entityQualifiedName = createQualifiedName((AtlasEntity) entity);
+
+        entity.setAttribute(QUALIFIED_NAME, entityQualifiedName);
+
+        AtlasEntityType entityType = typeRegistry.getEntityTypeByName(entity.getTypeName());
+        AtlasVertex vertex = AtlasGraphUtilsV2.findByUniqueAttributes(this.graph, entityType, entity.getAttributes());
+        if(vertex != null){
+            HardDeleteHandlerV1 hardDeleteHandlerV1 = new HardDeleteHandlerV1(graph, typeRegistry, null);
+            Collection<AtlasVertex> vertices = new ArrayList<>();
+            vertices.add(vertex);
+            hardDeleteHandlerV1.deleteEntities(vertices);
+        }
+
+        RequestContext.get().endMetricRecord(metricRecorder);
+    }
+    private void processUpdateReadme(AtlasStruct entity, AtlasVertex vertex){
+
+        AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("processUpdateReadme");
+        String vertexQnName = vertex.getProperty(QUALIFIED_NAME, String.class);
+
+        entity.setAttribute(QUALIFIED_NAME, vertexQnName);
+        RequestContext.get().endMetricRecord(metricRecorder);
+    }
+
+    public static String createQualifiedName(AtlasEntity entity) {
+        AtlasObjectId asset = (AtlasObjectId) entity.getRelationshipAttribute("asset");
+        return asset.getGuid() + "/readme" ;
+    }
+}

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/readme/ReadmePreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/readme/ReadmePreProcessor.java
@@ -14,6 +14,7 @@ import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
 import org.apache.atlas.repository.store.graph.v2.EntityMutationContext;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.glossary.GlossaryPreProcessor;
+import org.apache.atlas.tasks.TaskManagement;
 import org.apache.atlas.type.AtlasEntityType;
 import org.apache.atlas.type.AtlasTypeRegistry;
 import org.apache.atlas.utils.AtlasPerfMetrics;
@@ -31,11 +32,13 @@ public class ReadmePreProcessor implements PreProcessor {
     private final AtlasTypeRegistry typeRegistry;
     private final EntityGraphRetriever entityRetriever;
     private final AtlasGraph graph;
+    private final TaskManagement taskManagement;
 
-    public ReadmePreProcessor(AtlasTypeRegistry typeRegistry, EntityGraphRetriever entityRetriever, AtlasGraph graph) {
+    public ReadmePreProcessor(AtlasTypeRegistry typeRegistry, EntityGraphRetriever entityRetriever, AtlasGraph graph, TaskManagement taskManagement) {
         this.entityRetriever = entityRetriever;
         this.typeRegistry = typeRegistry;
         this.graph = graph;
+        this.taskManagement = taskManagement;
     }
 
     @Override
@@ -66,7 +69,7 @@ public class ReadmePreProcessor implements PreProcessor {
         AtlasEntityType entityType = typeRegistry.getEntityTypeByName(entity.getTypeName());
         AtlasVertex vertex = AtlasGraphUtilsV2.findByUniqueAttributes(this.graph, entityType, entity.getAttributes());
         if(vertex != null){
-            HardDeleteHandlerV1 hardDeleteHandlerV1 = new HardDeleteHandlerV1(graph, typeRegistry, null);
+            HardDeleteHandlerV1 hardDeleteHandlerV1 = new HardDeleteHandlerV1(graph, typeRegistry, taskManagement);
             Collection<AtlasVertex> vertices = new ArrayList<>();
             vertices.add(vertex);
             hardDeleteHandlerV1.deleteEntities(vertices);


### PR DESCRIPTION
There was ambiguity when ReadMe to asset were generated by user via API using their own qualifiedName pattern.

In order to have constituency in qualifiedName is generated at server side.

Linear: https://linear.app/atlanproduct/issue/META-4227

