### PR TITLE
fix: classification type property skipDisplayNameUniquenessCheck isn't stored in graph store

### DIFF
--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -75,6 +75,7 @@ public final class Constants {
     public static final String TYPEVERSION_PROPERTY_KEY     = getEncodedTypePropertyKey(INTERNAL_PROPERTY_KEY_PREFIX + "type.version");
     public static final String TYPEOPTIONS_PROPERTY_KEY     = getEncodedTypePropertyKey(INTERNAL_PROPERTY_KEY_PREFIX + "type.options");
     public static final String TYPESERVICETYPE_PROPERTY_KEY = getEncodedTypePropertyKey(INTERNAL_PROPERTY_KEY_PREFIX + "type.servicetype");
+    public static final String TYPE_SKIP_DISPLAYNAME_UNIQUENESS_CHECK = getEncodedTypePropertyKey(INTERNAL_PROPERTY_KEY_PREFIX + "type.skipDisplayNameUniquenessCheck");
 
     // relationship def constants
     public static final String RELATIONSHIPTYPE_END1_KEY                               = "endDef1";

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasClassificationDefStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasClassificationDefStoreV2.java
@@ -41,6 +41,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.apache.atlas.repository.Constants.TYPENAME_PROPERTY_KEY;
+import static org.apache.atlas.repository.Constants.TYPE_SKIP_DISPLAYNAME_UNIQUENESS_CHECK;
 
 /**
  * ClassificationDef store in v1 format.
@@ -366,12 +367,14 @@ class AtlasClassificationDefStoreV2 extends AtlasAbstractDefStoreV2<AtlasClassif
                                        AtlasClassificationType classificationType,
                                        AtlasVertex             vertex) throws AtlasBaseException {
         AtlasStructDefStoreV2.updateVertexPreCreate(classificationDef, classificationType, vertex, typeDefStore);
+        vertex.setProperty(TYPE_SKIP_DISPLAYNAME_UNIQUENESS_CHECK, classificationDef.getSkipDisplayNameUniquenessCheck());
     }
 
     private void updateVertexPreUpdate(AtlasClassificationDef  classificationDef,
                                        AtlasClassificationType classificationType,
                                        AtlasVertex             vertex) throws AtlasBaseException {
         AtlasStructDefStoreV2.updateVertexPreUpdate(classificationDef, classificationType, vertex, typeDefStore);
+        vertex.setProperty(TYPE_SKIP_DISPLAYNAME_UNIQUENESS_CHECK, classificationDef.getSkipDisplayNameUniquenessCheck());
     }
 
     private void updateVertexAddReferences(AtlasClassificationDef classificationDef, AtlasVertex vertex) throws AtlasBaseException {
@@ -392,6 +395,7 @@ class AtlasClassificationDefStoreV2 extends AtlasAbstractDefStoreV2<AtlasClassif
 
             ret.setSuperTypes(typeDefStore.getSuperTypeNames(vertex));
             ret.setEntityTypes(typeDefStore.getEntityTypeNames(vertex));
+            ret.setSkipDisplayNameUniquenessCheck(typeDefStore.getSkipDisplayNameUniquenessCheckProperty(vertex));
         }
 
         return ret;

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasTypeDefGraphStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasTypeDefGraphStoreV2.java
@@ -495,6 +495,11 @@ public class AtlasTypeDefGraphStoreV2 extends AtlasTypeDefGraphStore {
         return getTypeNamesFromEdges(vertex, AtlasGraphUtilsV2.ENTITYTYPE_EDGE_LABEL);
     }
 
+    boolean getSkipDisplayNameUniquenessCheckProperty(AtlasVertex vertex) {
+        Boolean skipDisplayNameUniquenessCheckProperty =  vertex.getProperty(Constants.TYPE_SKIP_DISPLAYNAME_UNIQUENESS_CHECK, Boolean.class);
+        return skipDisplayNameUniquenessCheckProperty != null ? skipDisplayNameUniquenessCheckProperty : false;
+    }
+
     /**
      * Get the typename properties from the edges, that are associated with the vertex and have the supplied edge label.
      * @param vertex


### PR DESCRIPTION
## fix: classification type property skipDisplayNameUniquenessCheck isn't stored in graph store