### PR TITLE
fix/META-4267 - Fix IllegalStateException while removing classification propagation

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/HardDeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/HardDeleteHandlerV1.java
@@ -54,6 +54,7 @@ public class HardDeleteHandlerV1 extends DeleteHandlerV1 {
         if (LOG.isDebugEnabled()) {
             LOG.debug("==> HardDeleteHandlerV1.deleteEdge({}, {})", GraphHelper.string(edge), force);
         }
+        boolean isRelationshipEdge = isRelationshipEdge(edge);
 
         authorizeRemoveRelation(edge);
 
@@ -64,7 +65,7 @@ public class HardDeleteHandlerV1 extends DeleteHandlerV1 {
         }
 
         graphHelper.removeEdge(edge);
-        if (isRelationshipEdge(edge))
+        if (isRelationshipEdge)
             AtlasRelationshipStoreV2.recordRelationshipMutation(AtlasRelationshipStoreV2.RelationshipMutation.RELATIONSHIP_HARD_DELETE, edge, entityRetriever);
     }
 }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/SoftDeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/SoftDeleteHandlerV1.java
@@ -70,6 +70,7 @@ public class SoftDeleteHandlerV1 extends DeleteHandlerV1 {
         if (LOG.isDebugEnabled()) {
             LOG.debug("==> SoftDeleteHandlerV1.deleteEdge({}, {})",GraphHelper.string(edge), force);
         }
+        boolean isRelationshipEdge = isRelationshipEdge(edge);
 
         authorizeRemoveRelation(edge);
 
@@ -92,7 +93,7 @@ public class SoftDeleteHandlerV1 extends DeleteHandlerV1 {
                 AtlasGraphUtilsV2.setEncodedProperty(edge, MODIFIED_BY_KEY, RequestContext.get().getUser());
             }
         }
-        if (isRelationshipEdge(edge))
+        if (isRelationshipEdge)
             AtlasRelationshipStoreV2.recordRelationshipMutation(AtlasRelationshipStoreV2.RelationshipMutation.RELATIONSHIP_SOFT_DELETE, edge, entityRetriever);
     }
 }


### PR DESCRIPTION
## fix/META-4267 - Fix IllegalStateException while removing classification propagation

> Classification Propagation Deletion task was failing with IllegalStateException, due to some changes in edge deletion part. Made fix and working fine

## Type of change
- [x] Bug fix (fixes an issue)