### PR TITLE
Fix Atlas API to support /api/meta to access Atlas API (entity/bulk, indexsearch etc)

### DIFF
--- a/webapp/src/main/java/org/apache/atlas/web/resources/DataSetLineageResource.java
+++ b/webapp/src/main/java/org/apache/atlas/web/resources/DataSetLineageResource.java
@@ -56,7 +56,7 @@ import static org.apache.atlas.v1.model.lineage.SchemaResponse.SchemaDetails;
 /**
  * Jersey Resource for Hive Table Lineage.
  */
-@Path("lineage/hive")
+@Path("v1/lineage/hive")
 @Singleton
 @Service
 @Deprecated

--- a/webapp/src/main/java/org/apache/atlas/web/resources/EntityResource.java
+++ b/webapp/src/main/java/org/apache/atlas/web/resources/EntityResource.java
@@ -83,7 +83,7 @@ import java.util.Map;
  * of the Type they correspond with.
  */
 @Singleton
-@Path("entities")
+@Path("v1/entities")
 @Service
 @Deprecated
 public class EntityResource {

--- a/webapp/src/main/java/org/apache/atlas/web/resources/LineageResource.java
+++ b/webapp/src/main/java/org/apache/atlas/web/resources/LineageResource.java
@@ -42,7 +42,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
-@Path("lineage")
+@Path("v1/lineage")
 @Singleton
 @Service
 @Deprecated

--- a/webapp/src/main/java/org/apache/atlas/web/resources/MetadataDiscoveryResource.java
+++ b/webapp/src/main/java/org/apache/atlas/web/resources/MetadataDiscoveryResource.java
@@ -54,7 +54,7 @@ import java.util.List;
 /**
  * Jersey Resource for metadata operations.
  */
-@Path("discovery")
+@Path("v1/discovery")
 @Singleton
 @Service
 @Deprecated

--- a/webapp/src/main/java/org/apache/atlas/web/resources/TypesResource.java
+++ b/webapp/src/main/java/org/apache/atlas/web/resources/TypesResource.java
@@ -64,7 +64,7 @@ import java.util.Map;
  *
  * You could represent any meta model representing any domain using these types.
  */
-@Path("types")
+@Path("v1/types")
 @Singleton
 @Service
 @Deprecated

--- a/webapp/src/main/java/org/apache/atlas/web/rest/DiscoveryREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/DiscoveryREST.java
@@ -62,7 +62,7 @@ import java.util.Set;
 /**
  * REST interface for data discovery using dsl or full text search
  */
-@Path("v2/search")
+@Path("search")
 @Singleton
 @Service
 @Consumes({Servlets.JSON_MEDIA_TYPE, MediaType.APPLICATION_JSON})

--- a/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
@@ -79,7 +79,7 @@ import static org.apache.atlas.authorize.AtlasPrivilege.*;
 /**
  * REST for a single entity
  */
-@Path("v2/entity")
+@Path("entity")
 @Singleton
 @Service
 @Consumes({Servlets.JSON_MEDIA_TYPE, MediaType.APPLICATION_JSON})

--- a/webapp/src/main/java/org/apache/atlas/web/rest/GlossaryREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/GlossaryREST.java
@@ -54,7 +54,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-@Path("v2/glossary")
+@Path("glossary")
 @Service
 @Consumes({Servlets.JSON_MEDIA_TYPE, MediaType.APPLICATION_JSON})
 @Produces({Servlets.JSON_MEDIA_TYPE, MediaType.APPLICATION_JSON})

--- a/webapp/src/main/java/org/apache/atlas/web/rest/LineageREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/LineageREST.java
@@ -52,7 +52,7 @@ import java.util.Map;
 /**
  * REST interface for an entity's lineage information
  */
-@Path("v2/lineage")
+@Path("lineage")
 @Singleton
 @Service
 @Consumes({Servlets.JSON_MEDIA_TYPE, MediaType.APPLICATION_JSON})

--- a/webapp/src/main/java/org/apache/atlas/web/rest/RelationshipREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/RelationshipREST.java
@@ -39,7 +39,7 @@ import java.util.List;
 /**
  * REST interface for entity relationships.
  */
-@Path("v2/relationship")
+@Path("relationship")
 @Singleton
 @Service
 @Consumes({Servlets.JSON_MEDIA_TYPE, MediaType.APPLICATION_JSON})

--- a/webapp/src/main/java/org/apache/atlas/web/rest/TaskREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/TaskREST.java
@@ -37,7 +37,7 @@ import javax.ws.rs.core.MediaType;
 /**
  * REST interface for CRUD operations on tasks
  */
-@Path("v2/task")
+@Path("task")
 @Singleton
 @Service
 @Consumes({Servlets.JSON_MEDIA_TYPE, MediaType.APPLICATION_JSON})

--- a/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
@@ -53,7 +53,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * REST interface for CRUD operations on type definitions
  */
-@Path("v2/types")
+@Path("types")
 @Singleton
 @Service
 @Consumes({Servlets.JSON_MEDIA_TYPE, MediaType.APPLICATION_JSON})

--- a/webapp/src/main/webapp/WEB-INF/web.xml
+++ b/webapp/src/main/webapp/WEB-INF/web.xml
@@ -60,6 +60,8 @@
     <servlet-mapping>
         <servlet-name>jersey-servlet</servlet-name>
         <url-pattern>/api/atlas/*</url-pattern>
+        <url-pattern>/api/atlas/v2/*</url-pattern>
+        <url-pattern>/api/meta/*</url-pattern>
     </servlet-mapping>
 
     <filter>


### PR DESCRIPTION
Problem statement - we receive /api/meta  in the API request going to metastore, and then kong rewrite the path to /api/atlas/v2/ before forwarding it to ALB.
ALB currently doesn't support path rewrite, checking if we can change the subpath on Atlas to accept request on /api/meta itself.