### PR TITLE
META-4129: Add multi query support to vertex requests

### DIFF
--- a/graphdb/api/src/main/java/org/apache/atlas/repository/graphdb/AtlasGraph.java
+++ b/graphdb/api/src/main/java/org/apache/atlas/repository/graphdb/AtlasGraph.java
@@ -28,6 +28,7 @@ import javax.script.ScriptEngine;
 import javax.script.ScriptException;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -116,6 +117,9 @@ public interface AtlasGraph<V, E> {
      * @return
      */
     AtlasVertex<V, E> getVertex(String vertexId);
+
+
+    List<AtlasVertex<V, E>> getVertices(String... vertexIds);
 
     /**
      * Gets the names of the indexes on edges

--- a/graphdb/api/src/main/java/org/apache/atlas/repository/graphdb/AtlasIndexQuery.java
+++ b/graphdb/api/src/main/java/org/apache/atlas/repository/graphdb/AtlasIndexQuery.java
@@ -84,8 +84,12 @@ public interface AtlasIndexQuery<V, E> {
         AtlasVertex<V, E> getVertex();
 
         /**
+         * Gets the vertex Id
+         */
+        String getVertexId();
+
+        /**
          * Gets the score for this result.
-         *
          */
         double getScore();
 

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchQuery.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchQuery.java
@@ -33,12 +33,7 @@ import org.apache.http.util.EntityUtils;
 import org.apache.tinkerpop.gremlin.process.traversal.Order;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.client.HttpAsyncResponseConsumerFactory;
-import org.elasticsearch.client.RequestOptions;
-import org.elasticsearch.client.RestClient;
-import org.elasticsearch.client.Request;
-import org.elasticsearch.client.Response;
-import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.*;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.janusgraph.util.encoding.LongEncoding;
@@ -208,6 +203,11 @@ public class AtlasElasticsearchQuery implements AtlasIndexQuery<AtlasJanusVertex
         }
 
         @Override
+        public String getVertexId() {
+            return String.valueOf(LongEncoding.decode(hit.getId()));
+        }
+
+        @Override
         public double getScore() {
             return hit.getScore();
         }
@@ -239,6 +239,11 @@ public class AtlasElasticsearchQuery implements AtlasIndexQuery<AtlasJanusVertex
         public AtlasVertex<AtlasJanusVertex, AtlasJanusEdge> getVertex() {
             long vertexId = LongEncoding.decode(String.valueOf(hit.get("_id")));
             return graph.getVertex(String.valueOf(vertexId));
+        }
+
+        @Override
+        public String getVertexId() {
+            return String.valueOf(LongEncoding.decode(String.valueOf(hit.get("_id"))));
         }
 
         @Override

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusGraph.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusGraph.java
@@ -28,19 +28,7 @@ import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.groovy.GroovyExpression;
 import org.apache.atlas.model.discovery.SearchParams;
 import org.apache.atlas.model.instance.AtlasEntity;
-import org.apache.atlas.repository.graphdb.AtlasEdge;
-import org.apache.atlas.repository.graphdb.AtlasGraph;
-import org.apache.atlas.repository.graphdb.AtlasGraphIndexClient;
-import org.apache.atlas.repository.graphdb.AtlasGraphManagement;
-import org.apache.atlas.repository.graphdb.AtlasGraphQuery;
-import org.apache.atlas.repository.graphdb.AtlasGraphTraversal;
-import org.apache.atlas.repository.graphdb.AtlasIndexQuery;
-import org.apache.atlas.repository.graphdb.AtlasIndexQueryParameter;
-import org.apache.atlas.repository.graphdb.AtlasPropertyKey;
-import org.apache.atlas.repository.graphdb.AtlasSchemaViolationException;
-import org.apache.atlas.repository.graphdb.AtlasVertex;
-import org.apache.atlas.repository.graphdb.GraphIndexQueryParameters;
-import org.apache.atlas.repository.graphdb.GremlinVersion;
+import org.apache.atlas.repository.graphdb.*;
 import org.apache.atlas.repository.graphdb.janus.query.AtlasJanusGraphQuery;
 import org.apache.atlas.repository.graphdb.utils.IteratorToIterableAdapter;
 import org.apache.atlas.type.AtlasType;
@@ -61,12 +49,7 @@ import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONWriter;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
-import org.janusgraph.core.Cardinality;
-import org.janusgraph.core.JanusGraph;
-import org.janusgraph.core.JanusGraphFactory;
-import org.janusgraph.core.JanusGraphIndexQuery;
-import org.janusgraph.core.PropertyKey;
-import org.janusgraph.core.SchemaViolationException;
+import org.janusgraph.core.*;
 import org.janusgraph.core.schema.JanusGraphIndex;
 import org.janusgraph.core.schema.JanusGraphManagement;
 import org.janusgraph.core.schema.Parameter;
@@ -80,12 +63,9 @@ import javax.script.ScriptEngine;
 import javax.script.ScriptException;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import static org.apache.atlas.AtlasErrorCode.RELATIONSHIP_CREATE_INVALID_PARAMS;
 import static org.apache.atlas.repository.Constants.*;
@@ -398,6 +378,13 @@ public class AtlasJanusGraph implements AtlasGraph<AtlasJanusVertex, AtlasJanusE
     }
 
     @Override
+    public List<AtlasVertex<AtlasJanusVertex, AtlasJanusEdge>> getVertices(String... vertexIds) {
+        Iterator<Vertex> it = getGraph().vertices(vertexIds);
+        List<Vertex> vertices = getElements(it);
+        return GraphDbObjectFactory.createVertices(this, vertices);
+    }
+
+    @Override
     public void releaseGremlinScriptEngine(ScriptEngine scriptEngine) {
         if (scriptEngine instanceof GremlinGroovyScriptEngine) {
             try {
@@ -486,12 +473,19 @@ public class AtlasJanusGraph implements AtlasGraph<AtlasJanusVertex, AtlasJanusE
     }
 
 
-    String getIndexFieldName(AtlasPropertyKey propertyKey, JanusGraphIndex graphIndex, Parameter ... parameters) {
+    String getIndexFieldName(AtlasPropertyKey propertyKey, JanusGraphIndex graphIndex, Parameter... parameters) {
         PropertyKey janusKey = AtlasJanusObjectFactory.createPropertyKey(propertyKey);
-        if(parameters == null) {
+        if (parameters == null) {
             parameters = EMPTY_PARAMETER_ARRAY;
         }
         return janusGraph.getIndexSerializer().getDefaultFieldName(janusKey, parameters, graphIndex.getBackingIndex());
+    }
+
+    private static <T> List<T> getElements(Iterator<T> it) {
+        if (!it.hasNext()) {
+            return Collections.EMPTY_LIST;
+        }
+        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(it, Spliterator.ORDERED), true).collect(Collectors.toList());
     }
 
 

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusIndexQuery.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusIndexQuery.java
@@ -17,21 +17,20 @@
  */
 package org.apache.atlas.repository.graphdb.janus;
 
-import java.util.Iterator;
-import java.util.Set;
-
+import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Iterators;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.discovery.SearchParams;
 import org.apache.atlas.repository.graphdb.AtlasIndexQuery;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
-
-import com.google.common.base.Function;
-import com.google.common.collect.Iterators;
 import org.apache.atlas.repository.graphdb.DirectIndexQueryResult;
 import org.apache.tinkerpop.gremlin.process.traversal.Order;
 import org.janusgraph.core.JanusGraphIndexQuery;
 import org.janusgraph.core.JanusGraphVertex;
+
+import java.util.Iterator;
+import java.util.Set;
 
 /**
  * Janus implementation of AtlasIndexQuery.
@@ -128,6 +127,11 @@ public class AtlasJanusIndexQuery implements AtlasIndexQuery<AtlasJanusVertex, A
         @Override
         public AtlasVertex<AtlasJanusVertex, AtlasJanusEdge> getVertex() {
             return GraphDbObjectFactory.createVertex(graph, source.getElement());
+        }
+
+        @Override
+        public String getVertexId() {
+            return String.valueOf(source.getElement().id());
         }
 
         @Override

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/GraphDbObjectFactory.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/GraphDbObjectFactory.java
@@ -18,16 +18,21 @@
 
 package org.apache.atlas.repository.graphdb.janus;
 
-import org.janusgraph.core.EdgeLabel;
 import org.apache.atlas.repository.graphdb.AtlasCardinality;
 import org.apache.atlas.repository.graphdb.AtlasGraphIndex;
+import org.apache.atlas.repository.graphdb.AtlasVertex;
 import org.apache.atlas.repository.graphdb.janus.query.AtlasJanusGraphQuery;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
-
 import org.janusgraph.core.Cardinality;
+import org.janusgraph.core.EdgeLabel;
 import org.janusgraph.core.PropertyKey;
 import org.janusgraph.core.schema.JanusGraphIndex;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
 
 /**
@@ -79,8 +84,21 @@ public final class GraphDbObjectFactory {
     }
 
     /**
-     * @param propertyKey The Gremlin propertyKey.
+     * Creates an AtlasJanusVertex that corresponds for each Gremlin Vertex.
      *
+     * @param graph   The graph that contains all the vertices
+     * @param sources the Gremlin vertices
+     * @return
+     */
+    public static List<AtlasVertex<AtlasJanusVertex, AtlasJanusEdge>> createVertices(AtlasJanusGraph graph, List<Vertex> sources) {
+        if (CollectionUtils.isEmpty(sources)) {
+            return Collections.EMPTY_LIST;
+        }
+        return sources.stream().map(v -> new AtlasJanusVertex(graph, v)).collect(Collectors.toList());
+    }
+
+    /**
+     * @param propertyKey The Gremlin propertyKey.
      */
     public static AtlasJanusPropertyKey createPropertyKey(PropertyKey propertyKey) {
         if (propertyKey == null) {

--- a/repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java
@@ -18,6 +18,7 @@
 package org.apache.atlas.discovery;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
 import org.apache.atlas.*;
 import org.apache.atlas.annotation.GraphTransaction;
 import org.apache.atlas.authorize.AtlasAuthorizationUtils;
@@ -65,6 +66,8 @@ import javax.inject.Inject;
 import javax.script.ScriptEngine;
 import javax.script.ScriptException;
 import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.apache.atlas.AtlasErrorCode.*;
 import static org.apache.atlas.SortOrder.ASCENDING;
@@ -1004,15 +1007,18 @@ public class EntityDiscoveryService implements AtlasDiscoveryService {
     private void prepareSearchResult(AtlasSearchResult ret, DirectIndexQueryResult indexQueryResult, Set<String> resultAttributes, boolean fetchCollapsedResults) throws AtlasBaseException {
         SearchParams searchParams = ret.getSearchParameters();
         try {
-            if(LOG.isDebugEnabled()){
+            if (LOG.isDebugEnabled()) {
                 LOG.debug("Preparing search results for ({})", ret.getSearchParameters());
             }
-            Iterator<Result> iterator = indexQueryResult.getIterator();
+            List<Result> indexResults = Lists.newArrayList(indexQueryResult.getIterator());
             boolean showSearchScore = searchParams.getShowSearchScore();
 
-            while (iterator.hasNext()) {
-                Result result = iterator.next();
-                AtlasVertex vertex = result.getVertex();
+            Map<String, AtlasVertex> verticesMap = getVerticesMap(indexResults);
+            Iterator<Result> indexResultsIterator = indexResults.iterator();
+
+            while (indexResultsIterator.hasNext()) {
+                Result result = indexResultsIterator.next();
+                AtlasVertex vertex = verticesMap.getOrDefault(result.getVertexId(), result.getVertex());
 
                 if (vertex == null) {
                     LOG.warn("vertex in null");
@@ -1059,9 +1065,14 @@ public class EntityDiscoveryService implements AtlasDiscoveryService {
                 ret.addEntity(header);
             }
         } catch (Exception e) {
-                throw e;
+            throw e;
         }
         scrubSearchResults(ret, searchParams.getSuppressLogs());
+    }
+
+    private Map<String, AtlasVertex> getVerticesMap(List<Result> results) {
+        String[] vertexIds = results.stream().map(r -> r.getVertexId()).collect(Collectors.toList()).toArray(new String[0]);
+        return (Map<String, AtlasVertex>) graph.getVertices(vertexIds).stream().collect(Collectors.toMap(v -> ((AtlasVertex) v).getId(), Function.identity()));
     }
 
     private Map<String, Object> getMap(String key, Object value) {
@@ -1071,11 +1082,11 @@ public class EntityDiscoveryService implements AtlasDiscoveryService {
     }
 
     public List<AtlasEntityHeader> searchUsingTermQualifiedName(int from, int size, String termQName,
-                                                        Set<String> attributes, Set<String>relationAttributes) throws AtlasBaseException {
+                                                                Set<String> attributes, Set<String> relationAttributes) throws AtlasBaseException {
         IndexSearchParams indexSearchParams = new IndexSearchParams();
         Map<String, Object> dsl = getMap("from", from);
         dsl.put("size", size);
-        dsl.put("query", getMap("term", getMap("__meanings", getMap("value",termQName))));
+        dsl.put("query", getMap("term", getMap("__meanings", getMap("value", termQName))));
 
         indexSearchParams.setDsl(dsl);
         indexSearchParams.setAttributes(attributes);

--- a/server-api/src/main/java/org/apache/atlas/RequestContext.java
+++ b/server-api/src/main/java/org/apache/atlas/RequestContext.java
@@ -28,6 +28,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import java.util.*;
 
@@ -119,6 +120,7 @@ public class RequestContext {
         }
 
         CURRENT_CONTEXT.remove();
+        MDC.clear();
     }
 
     public void clearCache() {


### PR DESCRIPTION
## Change description
Batch query vertex id's flow as part of indexsearch API.

> Description here
- As part of the indexSearch requests, vertex Id's details are pulled from cassandra through series of `edgeQuery` operations. The current change will perform a batch query making using of `multiedgequery` API which JG provides.
- Added MDC and traceIds to trace the indexsearch API calls.

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
