### PR TITLE
Revert META-4130: Ubuntu OS base image version to 22.04 for atlas-metastore …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 #
 
 FROM scratch
-FROM ubuntu:22.04
+FROM ubuntu:18.04
 LABEL maintainer="engineering@atlan.com"
 ARG VERSION=3.0.0-SNAPSHOT
 
@@ -28,10 +28,10 @@ RUN apt-get update \
     && apt-get -y install apt-utils \
     && apt-get -y install \
         wget \
-        python3 \
+        python \
         openjdk-8-jdk-headless \
         patch \
-        netcat-traditional \
+        netcat \
         curl \
     && cd / \
     && mkdir /opt/ranger-atlas-plugin \
@@ -49,9 +49,6 @@ RUN cd / \
     && mkdir /opt/apache-atlas/libext \
     && mv /atlas-index-repair-tool-${VERSION}.jar /opt/apache-atlas/libext/ \
     && rm -rf /atlas-index-repair-tool-${VERSION}.tar.gz
-
-RUN ln -s /usr/bin/python3 /usr/bin/python & \
-    ln -s /usr/bin/pip3 /usr/bin/pip \
 
 COPY atlas-hub/repair_index.py /opt/apache-atlas/bin/
 


### PR DESCRIPTION
Reverts atlanhq/atlas-metastore#1569