### PR TITLE
Meta-4202: Add validation for Enumdef/entitydef/structdef creation with reserved keywords

### DIFF
--- a/intg/src/main/java/org/apache/atlas/type/AtlasTypeRegistry.java
+++ b/intg/src/main/java/org/apache/atlas/type/AtlasTypeRegistry.java
@@ -893,12 +893,15 @@ public class AtlasTypeRegistry {
             }
         }
 
-        private void updateTypeByNameWithNoRefResolve(String name, AtlasBaseTypeDef typeDef) {
+        private void updateTypeByNameWithNoRefResolve(String name, AtlasBaseTypeDef typeDef) throws AtlasBaseException{
             if (LOG.isDebugEnabled()) {
                 LOG.debug("==> AtlasTypeRegistry.updateTypeByNameWithNoRefResolve({})", name);
             }
 
             if (name != null && typeDef != null) {
+                if(typeDef.getClass().equals(AtlasEnumDef.class) || typeDef.getClass().equals(AtlasStructDef.class) || typeDef.getClass().equals(AtlasEntityDef.class))
+                    validateTypeCreation(typeDef);
+
                 if (typeDef.getClass().equals(AtlasEnumDef.class)) {
                     AtlasEnumDef enumDef = (AtlasEnumDef) typeDef;
 


### PR DESCRIPTION
restrict end user from creating enumdef/entitydef/structdef with reserved keywords.

Linear: https://linear.app/atlanproduct/issue/META-4202