### PR TITLE
Meta 4202: Add validation for EntityDef/ StructDef/ EnumDef creation with reserved keywords

### DIFF
--- a/intg/src/main/java/org/apache/atlas/model/typedef/AtlasEnumDef.java
+++ b/intg/src/main/java/org/apache/atlas/model/typedef/AtlasEnumDef.java
@@ -29,6 +29,8 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlSeeAlso;
 
+import org.apache.atlas.AtlasErrorCode;
+import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.PList;
 import org.apache.atlas.model.SearchFilter.SortType;
 import org.apache.atlas.model.TypeCategory;
@@ -209,6 +211,13 @@ public class AtlasEnumDef extends AtlasBaseTypeDef implements Serializable {
         }
 
         return ret;
+    }
+
+    public static void validateTypeName(AtlasEnumDef type) throws AtlasBaseException{
+        for(String builtinTypeName: ATLAS_BUILTIN_TYPES){
+            if(builtinTypeName.equals(type.getName()))
+                throw new AtlasBaseException(AtlasErrorCode.FORBIDDEN_TYPENAME, builtinTypeName);
+        }
     }
 
     @Override

--- a/intg/src/main/java/org/apache/atlas/model/typedef/AtlasStructDef.java
+++ b/intg/src/main/java/org/apache/atlas/model/typedef/AtlasStructDef.java
@@ -39,6 +39,8 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlSeeAlso;
 
+import org.apache.atlas.AtlasErrorCode;
+import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.PList;
 import org.apache.atlas.model.SearchFilter.SortType;
 import org.apache.atlas.model.TypeCategory;
@@ -107,6 +109,12 @@ public class AtlasStructDef extends AtlasBaseTypeDef implements Serializable {
 
     public List<AtlasAttributeDef> getAttributeDefs() {
         return attributeDefs;
+    }
+
+    public static void validateTypeName(AtlasStructDef type) throws AtlasBaseException {
+        for(String builtinTypeName: ATLAS_BUILTIN_TYPES)
+            if (builtinTypeName.equals(type.getName()))
+                throw new AtlasBaseException(AtlasErrorCode.FORBIDDEN_TYPENAME, builtinTypeName);
     }
 
     public void setAttributeDefs(List<AtlasAttributeDef> attributeDefs) {

--- a/intg/src/main/java/org/apache/atlas/type/AtlasTypeRegistry.java
+++ b/intg/src/main/java/org/apache/atlas/type/AtlasTypeRegistry.java
@@ -757,20 +757,12 @@ public class AtlasTypeRegistry {
 
         public List<AtlasBaseTypeDef> getDeleteedTypes() { return deletedTypes; }
 
-        void validateTypeCreation(AtlasBaseTypeDef typeDef) throws AtlasBaseException{
-            if(this.isRegisteredType(typeDef.getName()) && (this.getType(typeDef.getName()).getTypeCategory().equals(TypeCategory.PRIMITIVE)||(this.getType(typeDef.getName()).getTypeCategory().equals(TypeCategory.OBJECT_ID_TYPE)))){
-                throw new AtlasBaseException(AtlasErrorCode.FORBIDDEN_TYPENAME, typeDef.getName());
-            }
-        }
-
         private void addTypeWithNoRefResolve(AtlasBaseTypeDef typeDef) throws AtlasBaseException{
             if (LOG.isDebugEnabled()) {
                 LOG.debug("==> AtlasTypeRegistry.addTypeWithNoRefResolve({})", typeDef);
             }
 
             if (typeDef != null) {
-                if(typeDef.getClass().equals(AtlasEnumDef.class) || typeDef.getClass().equals(AtlasStructDef.class) || typeDef.getClass().equals(AtlasEntityDef.class))
-                    validateTypeCreation(typeDef);
 
                 if (typeDef.getClass().equals(AtlasEnumDef.class)) {
                     AtlasEnumDef enumDef = (AtlasEnumDef) typeDef;
@@ -848,8 +840,6 @@ public class AtlasTypeRegistry {
             }
 
             if (guid != null && typeDef != null) {
-                if(typeDef.getClass().equals(AtlasEnumDef.class) || typeDef.getClass().equals(AtlasStructDef.class) || typeDef.getClass().equals(AtlasEntityDef.class))
-                    validateTypeCreation(typeDef);
 
                 // ignore
                 if (typeDef.getClass().equals(AtlasEnumDef.class)) {
@@ -899,8 +889,6 @@ public class AtlasTypeRegistry {
             }
 
             if (name != null && typeDef != null) {
-                if(typeDef.getClass().equals(AtlasEnumDef.class) || typeDef.getClass().equals(AtlasStructDef.class) || typeDef.getClass().equals(AtlasEntityDef.class))
-                    validateTypeCreation(typeDef);
 
                 if (typeDef.getClass().equals(AtlasEnumDef.class)) {
                     AtlasEnumDef enumDef = (AtlasEnumDef) typeDef;


### PR DESCRIPTION
restrict end user from creating enumdef/entitydef/structdef with reserved keywords.

Linear: https://linear.app/atlanproduct/issue/META-4202

![image](https://user-images.githubusercontent.com/121708100/218696465-bcf15b5d-6184-4e65-8c17-51bd17ddc956.png)
