### PR TITLE
META-4265: Added includeFilters for additional filtering

### DIFF
--- a/intg/src/main/java/org/apache/atlas/model/discovery/IndexSearchParams.java
+++ b/intg/src/main/java/org/apache/atlas/model/discovery/IndexSearchParams.java
@@ -3,6 +3,8 @@ package org.apache.atlas.model.discovery;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.atlas.type.AtlasType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,6 +29,7 @@ public class IndexSearchParams extends SearchParams {
 
     private Map dsl;
     private String queryString;
+    private List<String> includeFilters = new ArrayList<String>(0);
 
     /*
     * Indexsearch includes all relations (if requested with param attributes) even if relationshipStatus is DELETED
@@ -62,10 +65,15 @@ public class IndexSearchParams extends SearchParams {
     @Override
     public String toString() {
         return "IndexSearchParams{" +
-                "dsl='" + dsl + '\'' +
-                ", queryString='" + queryString + '\'' +
-                ", attributes=" + attributes +
-                ", relationAttributes=" + relationAttributes +
-                '}';
+            "dsl='" + dsl + '\'' +
+            ", queryString='" + queryString + '\'' +
+            ", attributes=" + attributes +
+            ", relationAttributes=" + relationAttributes +
+            ", includeFilters=" + includeFilters +
+            '}';
+    }
+
+    public List<String> getIncludeFilters() {
+        return this.includeFilters;
     }
 }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -121,7 +121,6 @@ import static org.apache.atlas.repository.Constants.*;
 import static org.apache.atlas.repository.graph.GraphHelper.*;
 import static org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2.getIdFromVertex;
 import static org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2.isReference;
-import static org.apache.atlas.repository.store.graph.v2.tasks.ClassificationPropagateTaskFactory.CLASSIFICATION_ONLY_PROPAGATION_DELETE;
 import static org.apache.atlas.type.AtlasStructType.AtlasAttribute.AtlasRelationshipEdgeDirection;
 import static org.apache.atlas.type.AtlasStructType.AtlasAttribute.AtlasRelationshipEdgeDirection.BOTH;
 import static org.apache.atlas.type.AtlasStructType.AtlasAttribute.AtlasRelationshipEdgeDirection.IN;
@@ -986,10 +985,6 @@ public class EntityGraphRetriever {
         ret.setUpdatedBy(GraphHelper.getModifiedByAsString(entityVertex));
         ret.setCreateTime(new Date(GraphHelper.getCreatedTime(entityVertex)));
         ret.setUpdateTime(new Date(GraphHelper.getModifiedTime(entityVertex)));
-
-        List<AtlasTermAssignmentHeader> termAssignmentHeaders = mapAssignedTerms(entityVertex);
-        ret.setMeanings(termAssignmentHeaders);
-        ret.setMeaningNames(termAssignmentHeaders.stream().map(AtlasTermAssignmentHeader::getDisplayText).collect(Collectors.toList()));
 
         AtlasEntityType entityType = typeRegistry.getEntityTypeByName(typeName);
 


### PR DESCRIPTION
## Change description
Changed `indexSearch` API to support `includeFilters` as part of the payload. `includeFilters` is a list, which takes the values `meanings and classifications`

<img width="400" alt="Screenshot 2023-03-06 at 3 08 05 PM" src="https://user-images.githubusercontent.com/119731738/223072684-7c5b69c2-a328-4f2f-8574-8342602cbc8a.png">

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
