### PR TITLE
Enhance/meta 4314 - XSS Protection for Atlas API endpoints, fix and launchdarkly enabled

### DIFF
--- a/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
@@ -95,7 +95,7 @@ public enum AtlasConfiguration {
     LINEAGE_ON_DEMAND_DEFAULT_NODE_COUNT("atlas.lineage.on.demand.default.node.count", 3),
     LINEAGE_MAX_NODE_COUNT("atlas.lineage.max.node.count", 9000),
     SUPPORTED_RELATIONSHIP_EVENTS("atlas.notification.relationships.filter", "asset_readme"),
-    REST_API_XSS_FILTER_MASK_STRING("atlas.rest.xss.filter.mask.string", "map<[a-zA-Z _,:<>0-9\\x60]*>|struct<[a-zA-Z _,:<>0-9\\x60]*>|array<[a-zA-Z _,:<>0-9\\x60]*>|\\{\\{[a-zA-Z _,-:0-9\\x60]*\\}\\}"),
+    REST_API_XSS_FILTER_MASK_STRING("atlas.rest.xss.filter.mask.string", "map<[a-zA-Z _,:<>0-9\\x60]*>|struct<[a-zA-Z _,:<>0-9\\x60]*>|array<[a-zA-Z _,:<>0-9\\x60]*>|\\{\\{[a-zA-Z _,-:0-9\\x60\\{\\}]*\\}\\}"),
     REST_API_XSS_FILTER_EXLUDE_SERVER_NAME("atlas.rest.xss.filter.exclude.server.name", "atlas-service-atlas.atlas.svc.cluster.local");
 
 

--- a/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
@@ -95,7 +95,7 @@ public enum AtlasConfiguration {
     LINEAGE_ON_DEMAND_DEFAULT_NODE_COUNT("atlas.lineage.on.demand.default.node.count", 3),
     LINEAGE_MAX_NODE_COUNT("atlas.lineage.max.node.count", 9000),
     SUPPORTED_RELATIONSHIP_EVENTS("atlas.notification.relationships.filter", "asset_readme"),
-    REST_API_XSS_FILTER_MASK_STRING("atlas.rest.xss.filter.mask.string", "map<[a-zA-Z _,:<>0-9\\x60]*>|struct<[a-zA-Z _,:<>0-9\\x60]*>|array<[a-zA-Z _,:<>0-9\\x60]*>"),
+    REST_API_XSS_FILTER_MASK_STRING("atlas.rest.xss.filter.mask.string", "map<[a-zA-Z _,:<>0-9\\x60]*>|struct<[a-zA-Z _,:<>0-9\\x60]*>|array<[a-zA-Z _,:<>0-9\\x60]*>|\\{\\{[a-zA-Z _,-:0-9\\x60]*\\}\\}"),
     REST_API_XSS_FILTER_EXLUDE_SERVER_NAME("atlas.rest.xss.filter.exclude.server.name", "atlas-service-atlas.atlas.svc.cluster.local");
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -734,6 +734,7 @@
         <kafka.version>2.8.1</kafka.version>
         <keycloak.version>15.0.2.1</keycloak.version>
         <owasp-html-sanitizer.version>20220608.1</owasp-html-sanitizer.version>
+        <launch-darkly.version>6.0.5</launch-darkly.version>
         <reload4j.version>1.2.19</reload4j.version>
         <log4j2.version>2.17.1</log4j2.version>
         <lucene-solr.version>8.6.3</lucene-solr.version>
@@ -891,7 +892,7 @@
             <dependency>
                 <groupId>com.launchdarkly</groupId>
                 <artifactId>launchdarkly-java-server-sdk</artifactId>
-                <version>6.0.5</version>
+                <version>${launch-darkly.version}</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -887,6 +887,13 @@
                 <version>${owasp-html-sanitizer.version}</version>
             </dependency>
 
+            <!-- https://mvnrepository.com/artifact/com.launchdarkly/launchdarkly-java-server-sdk -->
+            <dependency>
+                <groupId>com.launchdarkly</groupId>
+                <artifactId>launchdarkly-java-server-sdk</artifactId>
+                <version>6.0.5</version>
+            </dependency>
+
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -128,6 +128,13 @@
             <version>${owasp-html-sanitizer.version}</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/com.launchdarkly/launchdarkly-java-server-sdk -->
+        <dependency>
+            <groupId>com.launchdarkly</groupId>
+            <artifactId>launchdarkly-java-server-sdk</artifactId>
+            <version>6.0.5</version>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.atlas</groupId>
             <artifactId>atlas-authorization</artifactId>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -132,7 +132,7 @@
         <dependency>
             <groupId>com.launchdarkly</groupId>
             <artifactId>launchdarkly-java-server-sdk</artifactId>
-            <version>6.0.5</version>
+            <version>${launch-darkly.version}</version>
         </dependency>
 
         <dependency>

--- a/webapp/src/main/java/org/apache/atlas/web/security/AtlasSecurityConfig.java
+++ b/webapp/src/main/java/org/apache/atlas/web/security/AtlasSecurityConfig.java
@@ -333,8 +333,4 @@ public class AtlasSecurityConfig extends WebSecurityConfigurerAdapter {
         filter.setSessionAuthenticationStrategy(sessionAuthenticationStrategy());
         return filter;
     }
-
-    public boolean isProduction() {
-        return configuration.getBoolean("atlas.isproduction", false);
-    }
 }

--- a/webapp/src/main/java/org/apache/atlas/web/security/AtlasSecurityConfig.java
+++ b/webapp/src/main/java/org/apache/atlas/web/security/AtlasSecurityConfig.java
@@ -133,9 +133,9 @@ public class AtlasSecurityConfig extends WebSecurityConfigurerAdapter {
         this.staleTransactionCleanupFilter = staleTransactionCleanupFilter;
         this.activeServerFilter = activeServerFilter;
         this.launchDarklyConfig = launchDarklyConfig;
-        String serverURL = System.getenv("AUTH_SERVER_URL");
-        if(StringUtils.isNotEmpty(serverURL)) {
-            this.launchDarklyConfig.initContext("context-atlas", "Atlas","instance", serverURL);
+        String serverDomain = System.getenv("DOMAIN_NAME");
+        if(StringUtils.isNotEmpty(serverDomain)) {
+            this.launchDarklyConfig.initContext("context-atlas", "Atlas","instance", serverDomain);
         }
 
         this.keycloakEnabled = configuration.getBoolean(AtlasAuthenticationProvider.KEYCLOAK_AUTH_METHOD, false);
@@ -244,11 +244,11 @@ public class AtlasSecurityConfig extends WebSecurityConfigurerAdapter {
         }
 
         //XSS filter at first
-        if(launchDarklyConfig.evaluate("xss-protection-and-route-alb")) {
-            LOG.info("XSS filter is enabled");
+        if(launchDarklyConfig.evaluate("metastore-enable-xss-protection")) {
             httpSecurity.addFilterBefore(atlasXSSPreventionFilter, BasicAuthenticationFilter.class);
+            LOG.info("XSS filter is enabled from Atlas");
         } else {
-            LOG.info("XSS filter is disabled");
+            LOG.info("XSS filter is disabled from Atlas");
         }
         httpSecurity.addFilterAfter(atlasXSSPreventionFilter, BasicAuthenticationFilter.class);
         //Enable activeServerFilter regardless of HA or HS
@@ -335,5 +335,9 @@ public class AtlasSecurityConfig extends WebSecurityConfigurerAdapter {
         KeycloakAuthenticationProcessingFilter filter = new KeycloakAuthenticationProcessingFilter(authenticationManagerBean(), KEYCLOAK_REQUEST_MATCHER);
         filter.setSessionAuthenticationStrategy(sessionAuthenticationStrategy());
         return filter;
+    }
+
+    public boolean isProduction() {
+        return configuration.getBoolean("atlas.isproduction", false);
     }
 }

--- a/webapp/src/main/java/org/apache/atlas/web/security/AtlasSecurityConfig.java
+++ b/webapp/src/main/java/org/apache/atlas/web/security/AtlasSecurityConfig.java
@@ -72,6 +72,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static org.apache.atlas.AtlasConstants.ATLAS_MIGRATION_MODE_FILENAME;
 import static org.apache.atlas.web.filters.HeadersUtil.SERVER_KEY;
@@ -96,8 +97,8 @@ public class AtlasSecurityConfig extends WebSecurityConfigurerAdapter {
     private final StaleTransactionCleanupFilter staleTransactionCleanupFilter;
     private final ActiveServerFilter activeServerFilter;
     private final LaunchDarklyConfig launchDarklyConfig;
-    private final static String LAUNCH_DARKLY_SDK_KEY       = System.getenv("USER_LAUNCH_DARKLY_SDK_KEY");
-    private final static String INSTANCE_DOMAIN_NAME        = System.getenv("DOMAIN_NAME");
+    private final static String LAUNCH_DARKLY_SDK_KEY       = Objects.toString(System.getenv("USER_LAUNCH_DARKLY_SDK_KEY"), "");
+    private final static String INSTANCE_DOMAIN_NAME        = Objects.toString(System.getenv("DOMAIN_NAME"), "");
     private final static String LAUNCH_DARKLY_CONTEXT       = "context-atlas";
     private final static String LAUNCH_DARKLY_CONTEXT_NAME  = "Atlas";
     private final static String LAUNCH_DARKLY_FEATURE_FLAG_ENABLE_XSS_KEY  = "instance";
@@ -138,8 +139,6 @@ public class AtlasSecurityConfig extends WebSecurityConfigurerAdapter {
         this.launchDarklyConfig = new LaunchDarklyConfig(LAUNCH_DARKLY_SDK_KEY);
         this.launchDarklyConfig.initContext(LAUNCH_DARKLY_CONTEXT, LAUNCH_DARKLY_CONTEXT_NAME,
                 LAUNCH_DARKLY_FEATURE_FLAG_ENABLE_XSS_KEY, INSTANCE_DOMAIN_NAME );
-
-
         this.keycloakEnabled = configuration.getBoolean(AtlasAuthenticationProvider.KEYCLOAK_AUTH_METHOD, false);
     }
 

--- a/webapp/src/main/java/org/apache/atlas/web/security/AtlasSecurityConfig.java
+++ b/webapp/src/main/java/org/apache/atlas/web/security/AtlasSecurityConfig.java
@@ -244,7 +244,7 @@ public class AtlasSecurityConfig extends WebSecurityConfigurerAdapter {
         }
 
         //XSS filter at first
-        if(launchDarklyConfig.evaluate("xss-protection-with-alb")) {
+        if(launchDarklyConfig.evaluate("xss-protection-and-route-alb")) {
             LOG.info("XSS filter is enabled");
             httpSecurity.addFilterBefore(atlasXSSPreventionFilter, BasicAuthenticationFilter.class);
         } else {

--- a/webapp/src/main/java/org/apache/atlas/web/security/AtlasSecurityConfig.java
+++ b/webapp/src/main/java/org/apache/atlas/web/security/AtlasSecurityConfig.java
@@ -244,7 +244,6 @@ public class AtlasSecurityConfig extends WebSecurityConfigurerAdapter {
         } else {
             LOG.info("Atlas is in HA or HS Mode, enabling ActiveServerFilter");
         }
-        LOG.error("Dekho dekho ");
 
         //XSS filter at first
         if(launchDarklyConfig.evaluate(LAUNCH_DARKLY_METASTORE_ENABLE_XSS_FILTER)) {

--- a/webapp/src/main/java/org/apache/atlas/web/security/AtlasSecurityConfig.java
+++ b/webapp/src/main/java/org/apache/atlas/web/security/AtlasSecurityConfig.java
@@ -17,9 +17,6 @@
  */
 package org.apache.atlas.web.security;
 
-import com.launchdarkly.sdk.LDContext;
-import com.launchdarkly.sdk.server.LDClient;
-import org.apache.atlas.AtlasConfiguration;
 import org.apache.atlas.web.filters.*;
 import org.apache.atlas.web.service.LaunchDarklyConfig;
 import org.apache.commons.configuration.Configuration;

--- a/webapp/src/main/java/org/apache/atlas/web/service/LaunchDarklyConfig.java
+++ b/webapp/src/main/java/org/apache/atlas/web/service/LaunchDarklyConfig.java
@@ -3,9 +3,11 @@ package org.apache.atlas.web.service;
 import com.launchdarkly.sdk.LDContext;
 import com.launchdarkly.sdk.server.LDClient;
 import org.apache.commons.lang.StringUtils;
-import org.apache.tinkerpop.shaded.minlog.Log;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class LaunchDarklyConfig {
+    private static final Logger LOG = LoggerFactory.getLogger(LaunchDarklyConfig.class);
     private String sdkKey;
     private LDContext ldContext;
     private LDClient client;
@@ -20,7 +22,7 @@ public class LaunchDarklyConfig {
             try {
                 client = new LDClient(sdkKey);
             } catch (Exception e) {
-                Log.error("Error while initializing LaunchDarkly client", e);
+                LOG.error("Error while initializing LaunchDarkly client", e);
             }
         }
     }
@@ -37,7 +39,7 @@ public class LaunchDarklyConfig {
                         .set(key, value)
                         .build();
             } catch (Exception e) {
-                Log.error("Error while initializing LaunchDarkly context", e);
+                LOG.error("Error while initializing LaunchDarkly context", e);
             }
         }
     }

--- a/webapp/src/main/java/org/apache/atlas/web/service/LaunchDarklyConfig.java
+++ b/webapp/src/main/java/org/apache/atlas/web/service/LaunchDarklyConfig.java
@@ -47,9 +47,9 @@ public class LaunchDarklyConfig {
     public boolean evaluate(String featureKey) {
         boolean ret;
         try{
-            ret = client !=null ? client.boolVariation(featureKey, ldContext, false): false;
+            ret = client != null ? client.boolVariation(featureKey, ldContext, false) : false;
         } catch (Exception e) {
-           ret = false;
+           return false;
         }
         return ret;
     }

--- a/webapp/src/main/java/org/apache/atlas/web/service/LaunchDarklyConfig.java
+++ b/webapp/src/main/java/org/apache/atlas/web/service/LaunchDarklyConfig.java
@@ -3,44 +3,57 @@ package org.apache.atlas.web.service;
 import com.launchdarkly.sdk.LDContext;
 import com.launchdarkly.sdk.server.LDClient;
 import org.apache.commons.lang.StringUtils;
-import org.springframework.stereotype.Component;
+import org.apache.tinkerpop.shaded.minlog.Log;
 
-import javax.inject.Inject;
-
-@Component
 public class LaunchDarklyConfig {
     private String sdkKey;
     private LDContext ldContext;
     private LDClient client;
 
-    @Inject
-    public LaunchDarklyConfig() {
-        sdkKey              = System.getenv("USER_LAUNCH_DARKLY_SDK_KEY");
+    public LaunchDarklyConfig(String sdkKey) {
+        this.sdkKey = sdkKey;
         initClient();
     }
 
     private void initClient() {
         if(StringUtils.isNotEmpty(sdkKey)) {
-            client      = new LDClient(sdkKey);
+            try {
+                client = new LDClient(sdkKey);
+            } catch (Exception e) {
+                Log.error("Error while initializing LaunchDarkly client", e);
+            }
         }
     }
 
     public void initContext(String context, String name, String key, String value) {
-       ldContext =  LDContext.builder(context)
-                .name(name)
-                .set(key, value)
-                .build();
+        if (client == null) {
+            return;
+        }
+
+        if(StringUtils.isNotEmpty(context) && StringUtils.isNotEmpty(name) && StringUtils.isNotEmpty(key) && StringUtils.isNotEmpty(value)) {
+            try {
+                ldContext = LDContext.builder(context)
+                        .name(name)
+                        .set(key, value)
+                        .build();
+            } catch (Exception e) {
+                Log.error("Error while initializing LaunchDarkly context", e);
+            }
+        }
     }
 
     public boolean evaluate(String featureKey) {
-        return client !=null ? client.boolVariation(featureKey, ldContext, false): false;
+        boolean ret;
+        try{
+            ret = client !=null ? client.boolVariation(featureKey, ldContext, false): false;
+        } catch (Exception e) {
+           ret = false;
+        }
+        return ret;
     }
 
     public LDClient getClient() {
         return client;
     }
 
-    public LDContext getLdContext() {
-        return ldContext;
-    }
 }

--- a/webapp/src/main/java/org/apache/atlas/web/service/LaunchDarklyConfig.java
+++ b/webapp/src/main/java/org/apache/atlas/web/service/LaunchDarklyConfig.java
@@ -1,0 +1,46 @@
+package org.apache.atlas.web.service;
+
+import com.launchdarkly.sdk.LDContext;
+import com.launchdarkly.sdk.server.LDClient;
+import org.apache.commons.lang.StringUtils;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+
+@Component
+public class LaunchDarklyConfig {
+    private String sdkKey;
+    private LDContext ldContext;
+    private LDClient client;
+
+    @Inject
+    public LaunchDarklyConfig() {
+        sdkKey              = System.getenv("USER_LAUNCH_DARKLY_SDK_KEY");
+        initClient();
+    }
+
+    private void initClient() {
+        if(StringUtils.isNotEmpty(sdkKey)) {
+            client      = new LDClient(sdkKey);
+        }
+    }
+
+    public void initContext(String context, String name, String key, String value) {
+       ldContext =  LDContext.builder(context)
+                .name(name)
+                .set(key, value)
+                .build();
+    }
+
+    public boolean evaluate(String featureKey) {
+        return client !=null ? client.boolVariation(featureKey, ldContext, false): false;
+    }
+
+    public LDClient getClient() {
+        return client;
+    }
+
+    public LDContext getLdContext() {
+        return ldContext;
+    }
+}


### PR DESCRIPTION
## Enhance/meta 4314 - XSS Protection for Atlas API endpoints, fix and launchdarkly enabled

> Few pointers were raised on deploying XSS protection, fixed those and created new release plans.
