### PR TITLE
Meta4194: Added a query param to create a classificationDef of same Display Name

### DIFF
--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -78,7 +78,6 @@ public final class Constants {
     public static final String TYPEVERSION_PROPERTY_KEY     = getEncodedTypePropertyKey(INTERNAL_PROPERTY_KEY_PREFIX + "type.version");
     public static final String TYPEOPTIONS_PROPERTY_KEY     = getEncodedTypePropertyKey(INTERNAL_PROPERTY_KEY_PREFIX + "type.options");
     public static final String TYPESERVICETYPE_PROPERTY_KEY = getEncodedTypePropertyKey(INTERNAL_PROPERTY_KEY_PREFIX + "type.servicetype");
-    public static final String TYPE_ALLOW_DUPLICATE_DISPLAY_NAME = getEncodedTypePropertyKey(INTERNAL_PROPERTY_KEY_PREFIX + "type.allowDuplicateDisplayName");
 
     // relationship def constants
     public static final String RELATIONSHIPTYPE_END1_KEY                               = "endDef1";

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasStructDefStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasStructDefStoreV2.java
@@ -24,7 +24,6 @@ import org.apache.atlas.authorize.AtlasPrivilege;
 import org.apache.atlas.authorize.AtlasTypeAccessRequest;
 import org.apache.atlas.authorize.AtlasAuthorizationUtils;
 import org.apache.atlas.exception.AtlasBaseException;
-import org.apache.atlas.model.typedef.AtlasClassificationDef;
 import org.apache.atlas.model.typedef.AtlasStructDef;
 import org.apache.atlas.model.typedef.AtlasStructDef.AtlasAttributeDef;
 import org.apache.atlas.model.typedef.AtlasStructDef.AtlasConstraintDef;
@@ -50,7 +49,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.apache.atlas.repository.Constants.TYPE_ALLOW_DUPLICATE_DISPLAY_NAME;
 import static org.apache.atlas.type.AtlasStructType.AtlasAttribute.encodePropertyKey;
 
 /**
@@ -374,9 +372,6 @@ public class AtlasStructDefStoreV2 extends AtlasAbstractDefStoreV2<AtlasStructDe
         String encodedtypeNamePropertyKey = AtlasGraphUtilsV2.encodePropertyKey(typeNamePropertyKey);
 
         vertex.setProperty(encodedtypeNamePropertyKey, attrNames);
-        if(structDef instanceof AtlasClassificationDef) {
-            vertex.setProperty(TYPE_ALLOW_DUPLICATE_DISPLAY_NAME, ((AtlasClassificationDef) structDef).getAllowDuplicateDisplayName());
-        }
     }
 
     public static void updateVertexPreUpdate(AtlasStructDef structDef, AtlasStructType structType,
@@ -471,9 +466,6 @@ public class AtlasStructDefStoreV2 extends AtlasAbstractDefStoreV2<AtlasStructDe
 
                 AtlasGraphUtilsV2.setProperty(vertex, propertyKey, toJsonFromAttribute(structType.getAttribute(attributeDef.getName())));
             }
-        }
-        if(structDef instanceof AtlasClassificationDef) {
-            vertex.setProperty(TYPE_ALLOW_DUPLICATE_DISPLAY_NAME, ((AtlasClassificationDef) structDef).getAllowDuplicateDisplayName());
         }
         AtlasGraphUtilsV2.setEncodedProperty(vertex, encodedStructDefPropertyKey, attrNames);
     }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasTypeDefGraphStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasTypeDefGraphStoreV2.java
@@ -495,11 +495,6 @@ public class AtlasTypeDefGraphStoreV2 extends AtlasTypeDefGraphStore {
         return getTypeNamesFromEdges(vertex, AtlasGraphUtilsV2.ENTITYTYPE_EDGE_LABEL);
     }
 
-    boolean getAllowDuplicateDisplayNameProperty(AtlasVertex vertex) {
-        Boolean allowDuplicateDisplayNameProperty =  vertex.getProperty(Constants.TYPE_ALLOW_DUPLICATE_DISPLAY_NAME, Boolean.class);
-        return allowDuplicateDisplayNameProperty != null ? allowDuplicateDisplayNameProperty : false;
-    }
-
     /**
      * Get the typename properties from the edges, that are associated with the vertex and have the supplied edge label.
      * @param vertex


### PR DESCRIPTION
Query Parameter is allowDuplicateDisplayName. A classificationDef of same displayName having query param allowDuplicateDisplayName = true will create it.

Linear: https://linear.app/atlanproduct/issue/META-4194