### PR TITLE
Revert "fix: classification type property skipDisplayNameUniquenessCheck isn't stored in graph store"

### DIFF
--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -75,7 +75,6 @@ public final class Constants {
     public static final String TYPEVERSION_PROPERTY_KEY     = getEncodedTypePropertyKey(INTERNAL_PROPERTY_KEY_PREFIX + "type.version");
     public static final String TYPEOPTIONS_PROPERTY_KEY     = getEncodedTypePropertyKey(INTERNAL_PROPERTY_KEY_PREFIX + "type.options");
     public static final String TYPESERVICETYPE_PROPERTY_KEY = getEncodedTypePropertyKey(INTERNAL_PROPERTY_KEY_PREFIX + "type.servicetype");
-    public static final String TYPE_ALLOW_DUPLICATE_DISPLAY_NAME = getEncodedTypePropertyKey(INTERNAL_PROPERTY_KEY_PREFIX + "type.allowDuplicateDisplayName");
 
     // relationship def constants
     public static final String RELATIONSHIPTYPE_END1_KEY                               = "endDef1";

--- a/intg/src/main/java/org/apache/atlas/model/typedef/AtlasClassificationDef.java
+++ b/intg/src/main/java/org/apache/atlas/model/typedef/AtlasClassificationDef.java
@@ -52,7 +52,7 @@ public class AtlasClassificationDef extends AtlasStructDef implements AtlasNamed
     private Set<String> entityTypes;
 
     private String displayName;
-    private boolean allowDuplicateDisplayName;
+    private boolean skipDisplayNameUniquenessCheck;
     // subTypes field below is derived from 'superTypes' specified in all AtlasClassificationDef
     // this value is ignored during create & update operations
     private Set<String> subTypes;
@@ -104,10 +104,10 @@ public class AtlasClassificationDef extends AtlasStructDef implements AtlasNamed
 
     public AtlasClassificationDef(String name, String displayName, String description, String typeVersion,
                                   List<AtlasAttributeDef> attributeDefs, Set<String> superTypes,
-                                  Set<String> entityTypes, Map<String, String> options, boolean allowDuplicateDisplayName) {
+                                  Set<String> entityTypes, Map<String, String> options, boolean skipDisplayNameUniquenessCheck) {
         super(TypeCategory.CLASSIFICATION, name, description, typeVersion, attributeDefs, options);
         this.setDisplayName(displayName);
-        this.setAllowDuplicateDisplayName(allowDuplicateDisplayName);
+        this.setSkipDisplayNameUniquenessCheck(skipDisplayNameUniquenessCheck);
         setSuperTypes(superTypes);
         setEntityTypes(entityTypes);
     }
@@ -119,7 +119,7 @@ public class AtlasClassificationDef extends AtlasStructDef implements AtlasNamed
             setDisplayName(other.getDisplayName());
             setEntityTypes(other.getEntityTypes());
             setSubTypes(other.getSubTypes());
-            setAllowDuplicateDisplayName(other.getAllowDuplicateDisplayName());
+            setSkipDisplayNameUniquenessCheck(other.getSkipDisplayNameUniquenessCheck());
         }
     }
 
@@ -267,20 +267,20 @@ public class AtlasClassificationDef extends AtlasStructDef implements AtlasNamed
 
         return Objects.equals(superTypes, that.superTypes) &&
                 Objects.equals(displayName, that.displayName) &&
-                Objects.equals(allowDuplicateDisplayName, that.allowDuplicateDisplayName) &&
+                Objects.equals(skipDisplayNameUniquenessCheck, that.skipDisplayNameUniquenessCheck) &&
                 Objects.equals(entityTypes,that.entityTypes);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), superTypes, this.displayName, this.allowDuplicateDisplayName);
+        return Objects.hash(super.hashCode(), superTypes, this.displayName, this.skipDisplayNameUniquenessCheck);
     }
 
     @Override
     protected void appendExtraBaseTypeDefToString(StringBuilder sb) {
         super.appendExtraBaseTypeDefToString(sb);
         sb.append(", displayName='").append(this.displayName).append('\'');
-        sb.append(", allowDuplicateDisplayName='").append(this.allowDuplicateDisplayName).append('\'');
+        sb.append(", skipDisplayNameUniquenessCheck='").append(this.skipDisplayNameUniquenessCheck).append('\'');
     }
 
     @Override
@@ -298,12 +298,12 @@ public class AtlasClassificationDef extends AtlasStructDef implements AtlasNamed
         this.displayName = displayName;
     }
 
-    public boolean getAllowDuplicateDisplayName() {
-        return allowDuplicateDisplayName;
+    public boolean getSkipDisplayNameUniquenessCheck() {
+        return skipDisplayNameUniquenessCheck;
     }
 
-    public void setAllowDuplicateDisplayName(boolean allowDuplicateDisplayName) {
-        this.allowDuplicateDisplayName = allowDuplicateDisplayName;
+    public void setSkipDisplayNameUniquenessCheck(boolean skipDisplayNameUniquenessCheck) {
+        this.skipDisplayNameUniquenessCheck = skipDisplayNameUniquenessCheck;
     }
 
     @Override

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasClassificationDefStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasClassificationDefStoreV2.java
@@ -80,14 +80,13 @@ class AtlasClassificationDefStoreV2 extends AtlasAbstractDefStoreV2<AtlasClassif
         if (ret != null) {
             throw new AtlasBaseException(AtlasErrorCode.TYPE_ALREADY_EXISTS, classificationDef.getName());
         }
-        if(!classificationDef.getAllowDuplicateDisplayName()) {
-            ret = typeDefStore.findTypeVertexByDisplayName(
-                    classificationDef.getDisplayName(), TypeCategory.TRAIT);
-            if (ret != null) {
-                throw new AtlasBaseException(AtlasErrorCode.TYPE_WITH_DISPLAY_NAME_ALREADY_EXISTS, classificationDef.getDisplayName());
-            }
+        ret = typeDefStore.findTypeVertexByDisplayName(
+                classificationDef.getDisplayName(), TypeCategory.TRAIT);
+        if (ret != null && !classificationDef.getSkipDisplayNameUniquenessCheck()) {
+            throw new AtlasBaseException(AtlasErrorCode.TYPE_WITH_DISPLAY_NAME_ALREADY_EXISTS, classificationDef.getDisplayName());
         }
-            ret = typeDefStore.createTypeVertex(classificationDef);
+
+        ret = typeDefStore.createTypeVertex(classificationDef);
 
         updateVertexPreCreate(classificationDef, (AtlasClassificationType)type, ret);
 
@@ -109,7 +108,7 @@ class AtlasClassificationDefStoreV2 extends AtlasAbstractDefStoreV2<AtlasClassif
         updateVertexAddReferences(classificationDef, vertex);
 
         AtlasClassificationDef ret = toClassificationDef(vertex);
-
+        ret.setSkipDisplayNameUniquenessCheck(classificationDef.getSkipDisplayNameUniquenessCheck());
         if (LOG.isDebugEnabled()) {
             LOG.debug("<== AtlasClassificationDefStoreV1.create({}, {}): {}", classificationDef, preCreateResult, ret);
         }
@@ -190,12 +189,13 @@ class AtlasClassificationDefStoreV2 extends AtlasAbstractDefStoreV2<AtlasClassif
             throw new AtlasBaseException(AtlasErrorCode.MISSING_CLASSIFICATION_DISPLAY_NAME);
         }
 
-        if(!classifiDef.getAllowDuplicateDisplayName()){
-            AtlasVertex ret = typeDefStore.findTypeVertexByDisplayName(
-                    classifiDef.getDisplayName(), DataTypes.TypeCategory.TRAIT);
-            if (ret != null && (classifiDef.getGuid() == null || !classifiDef.getGuid().equals(ret.getProperty(Constants.GUID_PROPERTY_KEY, String.class)))){
-                throw new AtlasBaseException(AtlasErrorCode.TYPE_WITH_DISPLAY_NAME_ALREADY_EXISTS, classifiDef.getDisplayName());
-            }
+        //validate uniqueness of display name
+        AtlasVertex ret = typeDefStore.findTypeVertexByDisplayName(
+                classifiDef.getDisplayName(), DataTypes.TypeCategory.TRAIT);
+        if (ret != null && (
+                classifiDef.getGuid() == null || !classifiDef.getGuid().equals(ret.getProperty(Constants.GUID_PROPERTY_KEY, String.class)))
+                 && (!classifiDef.getSkipDisplayNameUniquenessCheck())) {
+            throw new AtlasBaseException(AtlasErrorCode.TYPE_WITH_DISPLAY_NAME_ALREADY_EXISTS, classifiDef.getDisplayName());
         }
     }
 
@@ -213,6 +213,7 @@ class AtlasClassificationDefStoreV2 extends AtlasAbstractDefStoreV2<AtlasClassif
         AtlasClassificationDef ret = StringUtils.isNotBlank(classifiDef.getGuid())
                   ? updateByGuid(classifiDef.getGuid(), classifiDef) : updateByName(classifiDef.getName(), classifiDef);
 
+        ret.setSkipDisplayNameUniquenessCheck(classifiDef.getSkipDisplayNameUniquenessCheck());
         if (LOG.isDebugEnabled()) {
             LOG.debug("<== AtlasClassificationDefStoreV1.update({}): {}", classifiDef, ret);
         }
@@ -391,7 +392,6 @@ class AtlasClassificationDefStoreV2 extends AtlasAbstractDefStoreV2<AtlasClassif
 
             ret.setSuperTypes(typeDefStore.getSuperTypeNames(vertex));
             ret.setEntityTypes(typeDefStore.getEntityTypeNames(vertex));
-            ret.setAllowDuplicateDisplayName(typeDefStore.getAllowDuplicateDisplayNameProperty(vertex));
         }
 
         return ret;

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasStructDefStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasStructDefStoreV2.java
@@ -24,7 +24,6 @@ import org.apache.atlas.authorize.AtlasPrivilege;
 import org.apache.atlas.authorize.AtlasTypeAccessRequest;
 import org.apache.atlas.authorize.AtlasAuthorizationUtils;
 import org.apache.atlas.exception.AtlasBaseException;
-import org.apache.atlas.model.typedef.AtlasClassificationDef;
 import org.apache.atlas.model.typedef.AtlasStructDef;
 import org.apache.atlas.model.typedef.AtlasStructDef.AtlasAttributeDef;
 import org.apache.atlas.model.typedef.AtlasStructDef.AtlasConstraintDef;
@@ -50,7 +49,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.apache.atlas.repository.Constants.TYPE_ALLOW_DUPLICATE_DISPLAY_NAME;
 import static org.apache.atlas.type.AtlasStructType.AtlasAttribute.encodePropertyKey;
 
 /**
@@ -374,9 +372,6 @@ public class AtlasStructDefStoreV2 extends AtlasAbstractDefStoreV2<AtlasStructDe
         String encodedtypeNamePropertyKey = AtlasGraphUtilsV2.encodePropertyKey(typeNamePropertyKey);
 
         vertex.setProperty(encodedtypeNamePropertyKey, attrNames);
-        if(structDef instanceof AtlasClassificationDef) {
-            vertex.setProperty(TYPE_ALLOW_DUPLICATE_DISPLAY_NAME, ((AtlasClassificationDef) structDef).getAllowDuplicateDisplayName());
-        }
     }
 
     public static void updateVertexPreUpdate(AtlasStructDef structDef, AtlasStructType structType,
@@ -472,9 +467,7 @@ public class AtlasStructDefStoreV2 extends AtlasAbstractDefStoreV2<AtlasStructDe
                 AtlasGraphUtilsV2.setProperty(vertex, propertyKey, toJsonFromAttribute(structType.getAttribute(attributeDef.getName())));
             }
         }
-        if(structDef instanceof AtlasClassificationDef) {
-            vertex.setProperty(TYPE_ALLOW_DUPLICATE_DISPLAY_NAME, ((AtlasClassificationDef) structDef).getAllowDuplicateDisplayName());
-        }
+
         AtlasGraphUtilsV2.setEncodedProperty(vertex, encodedStructDefPropertyKey, attrNames);
     }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasTypeDefGraphStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasTypeDefGraphStoreV2.java
@@ -495,11 +495,6 @@ public class AtlasTypeDefGraphStoreV2 extends AtlasTypeDefGraphStore {
         return getTypeNamesFromEdges(vertex, AtlasGraphUtilsV2.ENTITYTYPE_EDGE_LABEL);
     }
 
-    boolean getAllowDuplicateDisplayNameProperty(AtlasVertex vertex) {
-        Boolean allowDuplicateDisplayNameProperty =  vertex.getProperty(Constants.TYPE_ALLOW_DUPLICATE_DISPLAY_NAME, Boolean.class);
-        return allowDuplicateDisplayNameProperty != null ? allowDuplicateDisplayNameProperty : false;
-    }
-
     /**
      * Get the typename properties from the edges, that are associated with the vertex and have the supplied edge label.
      * @param vertex


### PR DESCRIPTION
Reverts atlanhq/atlas-metastore#1528