### PR TITLE
META-4265: Include flags for meanings and classifications

### DIFF
--- a/intg/src/main/java/org/apache/atlas/model/discovery/SearchParameters.java
+++ b/intg/src/main/java/org/apache/atlas/model/discovery/SearchParameters.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.PUBLIC_ONLY;

--- a/intg/src/main/java/org/apache/atlas/model/discovery/SearchParameters.java
+++ b/intg/src/main/java/org/apache/atlas/model/discovery/SearchParameters.java
@@ -47,6 +47,7 @@ public class SearchParameters extends SearchParams implements Serializable {
     private String  termName;
     private String  sortBy;
     private boolean excludeDeletedEntities;
+    private boolean includeClassificationAttributes;
     private boolean includeSubTypes                 = true;
     private boolean includeSubClassifications       = true;
     private int     limit;
@@ -154,6 +155,21 @@ public class SearchParameters extends SearchParams implements Serializable {
      */
     public void setExcludeDeletedEntities(boolean excludeDeletedEntities) {
         this.excludeDeletedEntities = excludeDeletedEntities;
+    }
+
+    /**
+     * @return True if classification attributes are included in search result.
+     */
+    public boolean getIncludeClassificationAttributes() {
+        return includeClassificationAttributes;
+    }
+
+    /**
+     * Include classificatio attributes in search result.
+     * @param includeClassificationAttributes boolean flag
+     */
+    public void setIncludeClassificationAttributes(boolean includeClassificationAttributes) {
+        this.includeClassificationAttributes = includeClassificationAttributes;
     }
 
     /**
@@ -290,7 +306,7 @@ public class SearchParameters extends SearchParams implements Serializable {
         if (o == null || getClass() != o.getClass()) return false;
         SearchParameters that = (SearchParameters) o;
         return excludeDeletedEntities == that.excludeDeletedEntities &&
-                excludeClassificationAttributes == that.excludeClassificationAttributes &&
+                includeClassificationAttributes == that.includeClassificationAttributes &&
                 includeSubTypes == that.includeSubTypes &&
                 includeSubClassifications == that.includeSubClassifications &&
                 limit == that.limit &&
@@ -310,7 +326,7 @@ public class SearchParameters extends SearchParams implements Serializable {
     @Override
     public int hashCode() {
         return Objects.hash(query, queryFields, typeName, classification, termName, includeSubTypes, includeSubClassifications,
-                            excludeDeletedEntities, excludeClassificationAttributes, limit, offset, entityFilters,
+                            excludeDeletedEntities, includeClassificationAttributes, limit, offset, entityFilters,
                             tagFilters, attributes, sortBy, sortOrder);
     }
 
@@ -328,7 +344,7 @@ public class SearchParameters extends SearchParams implements Serializable {
         sb.append(", includeSubTypes='").append(includeSubTypes).append('\'');
         sb.append(", includeSubClassifications='").append(includeSubClassifications).append('\'');
         sb.append(", excludeDeletedEntities=").append(excludeDeletedEntities);
-        sb.append(", includeClassificationAttributes=").append(excludeClassificationAttributes);
+        sb.append(", includeClassificationAttributes=").append(includeClassificationAttributes);
         sb.append(", limit=").append(limit);
         sb.append(", offset=").append(offset);
         sb.append(", entityFilters=").append(entityFilters);

--- a/intg/src/main/java/org/apache/atlas/model/discovery/SearchParameters.java
+++ b/intg/src/main/java/org/apache/atlas/model/discovery/SearchParameters.java
@@ -48,6 +48,7 @@ public class SearchParameters extends SearchParams implements Serializable {
     private String  termName;
     private String  sortBy;
     private boolean excludeDeletedEntities;
+    private boolean includeClassificationAttributes;
     private boolean includeSubTypes                 = true;
     private boolean includeSubClassifications       = true;
     private int     limit;
@@ -155,6 +156,21 @@ public class SearchParameters extends SearchParams implements Serializable {
      */
     public void setExcludeDeletedEntities(boolean excludeDeletedEntities) {
         this.excludeDeletedEntities = excludeDeletedEntities;
+    }
+
+    /**
+     * @return True if classification attributes are included in search result.
+     */
+    public boolean getIncludeClassificationAttributes() {
+        return includeClassificationAttributes;
+    }
+
+    /**
+     * Include classificatio attributes in search result.
+     * @param includeClassificationAttributes boolean flag
+     */
+    public void setIncludeClassificationAttributes(boolean includeClassificationAttributes) {
+        this.includeClassificationAttributes = includeClassificationAttributes;
     }
 
     /**
@@ -291,6 +307,7 @@ public class SearchParameters extends SearchParams implements Serializable {
         if (o == null || getClass() != o.getClass()) return false;
         SearchParameters that = (SearchParameters) o;
         return excludeDeletedEntities == that.excludeDeletedEntities &&
+                includeClassificationAttributes == that.includeClassificationAttributes &&
                 includeSubTypes == that.includeSubTypes &&
                 includeSubClassifications == that.includeSubClassifications &&
                 limit == that.limit &&
@@ -310,7 +327,7 @@ public class SearchParameters extends SearchParams implements Serializable {
     @Override
     public int hashCode() {
         return Objects.hash(query, queryFields, typeName, classification, termName, includeSubTypes, includeSubClassifications,
-                            excludeDeletedEntities, limit, offset, entityFilters,
+                            excludeDeletedEntities, includeClassificationAttributes, limit, offset, entityFilters,
                             tagFilters, attributes, sortBy, sortOrder);
     }
 
@@ -328,6 +345,7 @@ public class SearchParameters extends SearchParams implements Serializable {
         sb.append(", includeSubTypes='").append(includeSubTypes).append('\'');
         sb.append(", includeSubClassifications='").append(includeSubClassifications).append('\'');
         sb.append(", excludeDeletedEntities=").append(excludeDeletedEntities);
+        sb.append(", includeClassificationAttributes=").append(includeClassificationAttributes);
         sb.append(", limit=").append(limit);
         sb.append(", offset=").append(offset);
         sb.append(", entityFilters=").append(entityFilters);

--- a/intg/src/main/java/org/apache/atlas/model/discovery/SearchParameters.java
+++ b/intg/src/main/java/org/apache/atlas/model/discovery/SearchParameters.java
@@ -30,7 +30,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.PUBLIC_ONLY;
@@ -48,7 +47,6 @@ public class SearchParameters extends SearchParams implements Serializable {
     private String  termName;
     private String  sortBy;
     private boolean excludeDeletedEntities;
-    private boolean includeClassificationAttributes;
     private boolean includeSubTypes                 = true;
     private boolean includeSubClassifications       = true;
     private int     limit;
@@ -156,21 +154,6 @@ public class SearchParameters extends SearchParams implements Serializable {
      */
     public void setExcludeDeletedEntities(boolean excludeDeletedEntities) {
         this.excludeDeletedEntities = excludeDeletedEntities;
-    }
-
-    /**
-     * @return True if classification attributes are included in search result.
-     */
-    public boolean getIncludeClassificationAttributes() {
-        return includeClassificationAttributes;
-    }
-
-    /**
-     * Include classificatio attributes in search result.
-     * @param includeClassificationAttributes boolean flag
-     */
-    public void setIncludeClassificationAttributes(boolean includeClassificationAttributes) {
-        this.includeClassificationAttributes = includeClassificationAttributes;
     }
 
     /**
@@ -307,7 +290,7 @@ public class SearchParameters extends SearchParams implements Serializable {
         if (o == null || getClass() != o.getClass()) return false;
         SearchParameters that = (SearchParameters) o;
         return excludeDeletedEntities == that.excludeDeletedEntities &&
-                includeClassificationAttributes == that.includeClassificationAttributes &&
+                excludeClassificationAttributes == that.excludeClassificationAttributes &&
                 includeSubTypes == that.includeSubTypes &&
                 includeSubClassifications == that.includeSubClassifications &&
                 limit == that.limit &&
@@ -327,7 +310,7 @@ public class SearchParameters extends SearchParams implements Serializable {
     @Override
     public int hashCode() {
         return Objects.hash(query, queryFields, typeName, classification, termName, includeSubTypes, includeSubClassifications,
-                            excludeDeletedEntities, includeClassificationAttributes, limit, offset, entityFilters,
+                            excludeDeletedEntities, excludeClassificationAttributes, limit, offset, entityFilters,
                             tagFilters, attributes, sortBy, sortOrder);
     }
 
@@ -345,7 +328,7 @@ public class SearchParameters extends SearchParams implements Serializable {
         sb.append(", includeSubTypes='").append(includeSubTypes).append('\'');
         sb.append(", includeSubClassifications='").append(includeSubClassifications).append('\'');
         sb.append(", excludeDeletedEntities=").append(excludeDeletedEntities);
-        sb.append(", includeClassificationAttributes=").append(includeClassificationAttributes);
+        sb.append(", includeClassificationAttributes=").append(excludeClassificationAttributes);
         sb.append(", limit=").append(limit);
         sb.append(", offset=").append(offset);
         sb.append(", entityFilters=").append(entityFilters);

--- a/intg/src/main/java/org/apache/atlas/model/discovery/SearchParameters.java
+++ b/intg/src/main/java/org/apache/atlas/model/discovery/SearchParameters.java
@@ -48,7 +48,6 @@ public class SearchParameters extends SearchParams implements Serializable {
     private String  termName;
     private String  sortBy;
     private boolean excludeDeletedEntities;
-    private boolean includeClassificationAttributes;
     private boolean includeSubTypes                 = true;
     private boolean includeSubClassifications       = true;
     private int     limit;
@@ -156,21 +155,6 @@ public class SearchParameters extends SearchParams implements Serializable {
      */
     public void setExcludeDeletedEntities(boolean excludeDeletedEntities) {
         this.excludeDeletedEntities = excludeDeletedEntities;
-    }
-
-    /**
-     * @return True if classification attributes are included in search result.
-     */
-    public boolean getIncludeClassificationAttributes() {
-        return includeClassificationAttributes;
-    }
-
-    /**
-     * Include classificatio attributes in search result.
-     * @param includeClassificationAttributes boolean flag
-     */
-    public void setIncludeClassificationAttributes(boolean includeClassificationAttributes) {
-        this.includeClassificationAttributes = includeClassificationAttributes;
     }
 
     /**
@@ -307,7 +291,6 @@ public class SearchParameters extends SearchParams implements Serializable {
         if (o == null || getClass() != o.getClass()) return false;
         SearchParameters that = (SearchParameters) o;
         return excludeDeletedEntities == that.excludeDeletedEntities &&
-                includeClassificationAttributes == that.includeClassificationAttributes &&
                 includeSubTypes == that.includeSubTypes &&
                 includeSubClassifications == that.includeSubClassifications &&
                 limit == that.limit &&
@@ -327,7 +310,7 @@ public class SearchParameters extends SearchParams implements Serializable {
     @Override
     public int hashCode() {
         return Objects.hash(query, queryFields, typeName, classification, termName, includeSubTypes, includeSubClassifications,
-                            excludeDeletedEntities, includeClassificationAttributes, limit, offset, entityFilters,
+                            excludeDeletedEntities, limit, offset, entityFilters,
                             tagFilters, attributes, sortBy, sortOrder);
     }
 
@@ -345,7 +328,6 @@ public class SearchParameters extends SearchParams implements Serializable {
         sb.append(", includeSubTypes='").append(includeSubTypes).append('\'');
         sb.append(", includeSubClassifications='").append(includeSubClassifications).append('\'');
         sb.append(", excludeDeletedEntities=").append(excludeDeletedEntities);
-        sb.append(", includeClassificationAttributes=").append(includeClassificationAttributes);
         sb.append(", limit=").append(limit);
         sb.append(", offset=").append(offset);
         sb.append(", entityFilters=").append(entityFilters);

--- a/intg/src/main/java/org/apache/atlas/model/discovery/SearchParams.java
+++ b/intg/src/main/java/org/apache/atlas/model/discovery/SearchParams.java
@@ -10,8 +10,8 @@ public abstract class SearchParams {
     Set<String> collapseRelationAttributes;
     boolean showSearchScore;
     boolean suppressLogs;
-    boolean includeMeanings;
-    boolean includeClassifications;
+    boolean excludeMeanings;
+    boolean excludeClassificationAttributes;
 
     public abstract String getQuery();
 
@@ -63,19 +63,19 @@ public abstract class SearchParams {
         this.suppressLogs = suppressLogs;
     }
 
-    public boolean isIncludeClassifications() {
-        return includeClassifications;
+    public boolean isExcludeClassificationAttributes() {
+        return excludeClassificationAttributes;
     }
 
-    public void setIncludeClassifications(boolean includeClassifications) {
-        this.includeClassifications = includeClassifications;
+    public void setExcludeClassificationAttributes(boolean excludeClassificationAttributes) {
+        this.excludeClassificationAttributes = excludeClassificationAttributes;
     }
 
-    public boolean isIncludeMeanings() {
-        return includeMeanings;
+    public boolean isExcludeMeanings() {
+        return excludeMeanings;
     }
 
-    public void setIncludeMeanings(boolean includeMeanings) {
-        this.includeMeanings = includeMeanings;
+    public void setExcludeMeanings(boolean excludeMeanings) {
+        this.excludeMeanings = excludeMeanings;
     }
 }

--- a/intg/src/main/java/org/apache/atlas/model/discovery/SearchParams.java
+++ b/intg/src/main/java/org/apache/atlas/model/discovery/SearchParams.java
@@ -11,7 +11,7 @@ public abstract class SearchParams {
     boolean showSearchScore;
     boolean suppressLogs;
     boolean excludeMeanings;
-    boolean excludeClassification;
+    boolean excludeClassifications;
 
     public abstract String getQuery();
 
@@ -63,12 +63,12 @@ public abstract class SearchParams {
         this.suppressLogs = suppressLogs;
     }
 
-    public boolean isExcludeClassification() {
-        return excludeClassification;
+    public boolean isExcludeClassifications() {
+        return excludeClassifications;
     }
 
-    public void setExcludeClassification(boolean excludeClassification) {
-        this.excludeClassification = excludeClassification;
+    public void setExcludeClassifications(boolean excludeClassifications) {
+        this.excludeClassifications = excludeClassifications;
     }
 
     public boolean isExcludeMeanings() {

--- a/intg/src/main/java/org/apache/atlas/model/discovery/SearchParams.java
+++ b/intg/src/main/java/org/apache/atlas/model/discovery/SearchParams.java
@@ -10,6 +10,8 @@ public abstract class SearchParams {
     Set<String> collapseRelationAttributes;
     boolean showSearchScore;
     boolean suppressLogs;
+    boolean includeMeanings;
+    boolean includeClassifications;
 
     public abstract String getQuery();
 
@@ -59,5 +61,21 @@ public abstract class SearchParams {
 
     public void setSuppressLogs(boolean suppressLogs) {
         this.suppressLogs = suppressLogs;
+    }
+
+    public boolean isIncludeClassifications() {
+        return includeClassifications;
+    }
+
+    public void setIncludeClassifications(boolean includeClassifications) {
+        this.includeClassifications = includeClassifications;
+    }
+
+    public boolean isIncludeMeanings() {
+        return includeMeanings;
+    }
+
+    public void setIncludeMeanings(boolean includeMeanings) {
+        this.includeMeanings = includeMeanings;
     }
 }

--- a/intg/src/main/java/org/apache/atlas/model/discovery/SearchParams.java
+++ b/intg/src/main/java/org/apache/atlas/model/discovery/SearchParams.java
@@ -11,7 +11,7 @@ public abstract class SearchParams {
     boolean showSearchScore;
     boolean suppressLogs;
     boolean excludeMeanings;
-    boolean excludeClassificationAttributes;
+    boolean excludeClassification;
 
     public abstract String getQuery();
 
@@ -63,12 +63,12 @@ public abstract class SearchParams {
         this.suppressLogs = suppressLogs;
     }
 
-    public boolean isExcludeClassificationAttributes() {
-        return excludeClassificationAttributes;
+    public boolean isExcludeClassification() {
+        return excludeClassification;
     }
 
-    public void setExcludeClassificationAttributes(boolean excludeClassificationAttributes) {
-        this.excludeClassificationAttributes = excludeClassificationAttributes;
+    public void setExcludeClassification(boolean excludeClassification) {
+        this.excludeClassification = excludeClassification;
     }
 
     public boolean isExcludeMeanings() {

--- a/repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java
@@ -489,7 +489,7 @@ public class EntityDiscoveryService implements AtlasDiscoveryService {
             for (AtlasVertex atlasVertex : resultList) {
                 AtlasEntityHeader entity = entityRetriever.toAtlasEntityHeader(atlasVertex, resultAttributes);
 
-                if(searchParameters.getIncludeClassificationAttributes()) {
+                if(RequestContext.get().includeClassifications()) {
                     entity.setClassifications(entityRetriever.getAllClassifications(atlasVertex));
                 }
 
@@ -645,7 +645,7 @@ public class EntityDiscoveryService implements AtlasDiscoveryService {
                 AtlasVertex vertex       = entityRetriever.getEntityVertex(endVertexGuid);
                 AtlasEntityHeader entity = entityRetriever.toAtlasEntityHeader(vertex, searchParameters.getAttributes());
 
-                if (searchParameters.getIncludeClassificationAttributes()) {
+                if (RequestContext.get().includeClassifications()) {
                     entity.setClassifications(entityRetriever.getAllClassifications(vertex));
                 }
                 resultList.add(entity);
@@ -1020,7 +1020,9 @@ public class EntityDiscoveryService implements AtlasDiscoveryService {
                 }
 
                 AtlasEntityHeader header = entityRetriever.toAtlasEntityHeader(vertex, resultAttributes);
-                header.setClassifications(entityRetriever.getAllClassifications(vertex));
+                if(RequestContext.get().includeClassifications()){
+                    header.setClassifications(entityRetriever.getAllClassifications(vertex));
+                }
                 if (showSearchScore) {
                     ret.addEntityScore(header.getGuid(), result.getScore());
                 }

--- a/repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java
@@ -489,7 +489,7 @@ public class EntityDiscoveryService implements AtlasDiscoveryService {
             for (AtlasVertex atlasVertex : resultList) {
                 AtlasEntityHeader entity = entityRetriever.toAtlasEntityHeader(atlasVertex, resultAttributes);
 
-                if(searchParameters.isExcludeClassificationAttributes()) {
+                if(searchParameters.getIncludeClassificationAttributes()) {
                     entity.setClassifications(entityRetriever.getAllClassifications(atlasVertex));
                 }
 
@@ -645,7 +645,7 @@ public class EntityDiscoveryService implements AtlasDiscoveryService {
                 AtlasVertex vertex       = entityRetriever.getEntityVertex(endVertexGuid);
                 AtlasEntityHeader entity = entityRetriever.toAtlasEntityHeader(vertex, searchParameters.getAttributes());
 
-                if (searchParameters.isExcludeClassificationAttributes()) {
+                if (searchParameters.getIncludeClassificationAttributes()) {
                     entity.setClassifications(entityRetriever.getAllClassifications(vertex));
                 }
                 resultList.add(entity);

--- a/repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java
@@ -489,7 +489,7 @@ public class EntityDiscoveryService implements AtlasDiscoveryService {
             for (AtlasVertex atlasVertex : resultList) {
                 AtlasEntityHeader entity = entityRetriever.toAtlasEntityHeader(atlasVertex, resultAttributes);
 
-                if(RequestContext.get().includeClassifications()) {
+                if(searchParameters.getIncludeClassificationAttributes()) {
                     entity.setClassifications(entityRetriever.getAllClassifications(atlasVertex));
                 }
 
@@ -645,7 +645,7 @@ public class EntityDiscoveryService implements AtlasDiscoveryService {
                 AtlasVertex vertex       = entityRetriever.getEntityVertex(endVertexGuid);
                 AtlasEntityHeader entity = entityRetriever.toAtlasEntityHeader(vertex, searchParameters.getAttributes());
 
-                if (RequestContext.get().includeClassifications()) {
+                if (searchParameters.getIncludeClassificationAttributes()) {
                     entity.setClassifications(entityRetriever.getAllClassifications(vertex));
                 }
                 resultList.add(entity);

--- a/repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java
@@ -489,7 +489,7 @@ public class EntityDiscoveryService implements AtlasDiscoveryService {
             for (AtlasVertex atlasVertex : resultList) {
                 AtlasEntityHeader entity = entityRetriever.toAtlasEntityHeader(atlasVertex, resultAttributes);
 
-                if(searchParameters.getIncludeClassificationAttributes()) {
+                if(searchParameters.isExcludeClassificationAttributes()) {
                     entity.setClassifications(entityRetriever.getAllClassifications(atlasVertex));
                 }
 
@@ -645,7 +645,7 @@ public class EntityDiscoveryService implements AtlasDiscoveryService {
                 AtlasVertex vertex       = entityRetriever.getEntityVertex(endVertexGuid);
                 AtlasEntityHeader entity = entityRetriever.toAtlasEntityHeader(vertex, searchParameters.getAttributes());
 
-                if (searchParameters.getIncludeClassificationAttributes()) {
+                if (searchParameters.isExcludeClassificationAttributes()) {
                     entity.setClassifications(entityRetriever.getAllClassifications(vertex));
                 }
                 resultList.add(entity);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -987,10 +987,13 @@ public class EntityGraphRetriever {
         ret.setCreateTime(new Date(GraphHelper.getCreatedTime(entityVertex)));
         ret.setUpdateTime(new Date(GraphHelper.getModifiedTime(entityVertex)));
 
-        List<AtlasTermAssignmentHeader> termAssignmentHeaders = mapAssignedTerms(entityVertex);
-        ret.setMeanings(termAssignmentHeaders);
-        ret.setMeaningNames(termAssignmentHeaders.stream().map(AtlasTermAssignmentHeader::getDisplayText).collect(Collectors.toList()));
-
+        if(RequestContext.get().includeMeanings()) {
+            List<AtlasTermAssignmentHeader> termAssignmentHeaders = mapAssignedTerms(entityVertex);
+            ret.setMeanings(termAssignmentHeaders);
+            ret.setMeaningNames(
+                termAssignmentHeaders.stream().map(AtlasTermAssignmentHeader::getDisplayText)
+                    .collect(Collectors.toList()));
+        }
         AtlasEntityType entityType = typeRegistry.getEntityTypeByName(typeName);
 
         if (entityType != null) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -121,7 +121,6 @@ import static org.apache.atlas.repository.Constants.*;
 import static org.apache.atlas.repository.graph.GraphHelper.*;
 import static org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2.getIdFromVertex;
 import static org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2.isReference;
-import static org.apache.atlas.repository.store.graph.v2.tasks.ClassificationPropagateTaskFactory.CLASSIFICATION_ONLY_PROPAGATION_DELETE;
 import static org.apache.atlas.type.AtlasStructType.AtlasAttribute.AtlasRelationshipEdgeDirection;
 import static org.apache.atlas.type.AtlasStructType.AtlasAttribute.AtlasRelationshipEdgeDirection.BOTH;
 import static org.apache.atlas.type.AtlasStructType.AtlasAttribute.AtlasRelationshipEdgeDirection.IN;

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -978,7 +978,9 @@ public class EntityGraphRetriever {
         ret.setTypeName(typeName);
         ret.setGuid(guid);
         ret.setStatus(GraphHelper.getStatus(entityVertex));
-        ret.setClassificationNames(getAllTraitNames(entityVertex));
+        if(RequestContext.get().includeClassifications()){
+            ret.setClassificationNames(getAllTraitNames(entityVertex));
+        }
         ret.setIsIncomplete(isIncomplete);
         ret.setLabels(getLabels(entityVertex));
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -121,6 +121,7 @@ import static org.apache.atlas.repository.Constants.*;
 import static org.apache.atlas.repository.graph.GraphHelper.*;
 import static org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2.getIdFromVertex;
 import static org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2.isReference;
+import static org.apache.atlas.repository.store.graph.v2.tasks.ClassificationPropagateTaskFactory.CLASSIFICATION_ONLY_PROPAGATION_DELETE;
 import static org.apache.atlas.type.AtlasStructType.AtlasAttribute.AtlasRelationshipEdgeDirection;
 import static org.apache.atlas.type.AtlasStructType.AtlasAttribute.AtlasRelationshipEdgeDirection.BOTH;
 import static org.apache.atlas.type.AtlasStructType.AtlasAttribute.AtlasRelationshipEdgeDirection.IN;

--- a/server-api/src/main/java/org/apache/atlas/RequestContext.java
+++ b/server-api/src/main/java/org/apache/atlas/RequestContext.java
@@ -82,6 +82,8 @@ public class RequestContext {
     private boolean     createShellEntityForNonExistingReference = false;
     private boolean     skipFailedEntities = false;
     private boolean     allowDeletedRelationsIndexsearch = false;
+    private boolean     includeMeanings = false;
+    private boolean     includeClassifications = false;
     private String      currentTypePatchAction = "";
     private AtlasTask   currentTask;
     private String traceId;
@@ -573,6 +575,22 @@ public class RequestContext {
 
     public void setTraceId(String traceId) {
         this.traceId = traceId;
+    }
+
+    public void setIncludeMeanings(boolean includeMeanings) {
+        this.includeMeanings = includeMeanings;
+    }
+
+    public boolean includeMeanings() {
+        return this.includeMeanings;
+    }
+
+    public void setIncludeClassifications(boolean includeClassifications) {
+        this.includeClassifications = includeClassifications;
+    }
+
+    public boolean includeClassifications() {
+        return this.includeClassifications;
     }
 
     public class EntityGuidPair {

--- a/server-api/src/main/java/org/apache/atlas/RequestContext.java
+++ b/server-api/src/main/java/org/apache/atlas/RequestContext.java
@@ -82,8 +82,8 @@ public class RequestContext {
     private boolean     createShellEntityForNonExistingReference = false;
     private boolean     skipFailedEntities = false;
     private boolean     allowDeletedRelationsIndexsearch = false;
-    private boolean     includeMeanings = false;
-    private boolean     includeClassifications = false;
+    private boolean     includeMeanings = true;
+    private boolean     includeClassifications = true;
     private String      currentTypePatchAction = "";
     private AtlasTask   currentTask;
     private String traceId;

--- a/webapp/src/main/java/org/apache/atlas/web/rest/DiscoveryREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/DiscoveryREST.java
@@ -371,7 +371,7 @@ public class DiscoveryREST {
     public AtlasSearchResult indexSearch(IndexSearchParams parameters) throws AtlasBaseException {
         AtlasPerfTracer perf = null;
         RequestContext.get().setIncludeMeanings(!parameters.isExcludeMeanings());
-        RequestContext.get().setIncludeClassifications(!parameters.isExcludeClassificationAttributes());
+        RequestContext.get().setIncludeClassifications(!parameters.isExcludeClassification());
         try {
             if (AtlasPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
                 perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "DiscoveryREST.indexSearch(" + parameters + ")");
@@ -438,7 +438,8 @@ public class DiscoveryREST {
             parameters.setExcludeDeletedEntities(excludeDeletedEntities);
             parameters.setLimit(limit);
             parameters.setOffset(offset);
-            parameters.setExcludeClassificationAttributes(!includeClassificationAttributes);
+            parameters.setIncludeClassificationAttributes(includeClassificationAttributes);
+            parameters.setExcludeClassification(!includeClassificationAttributes);
             parameters.setExcludeMeanings(excludeMeaningsAttributes);
             RequestContext.get().setIncludeClassifications(includeClassificationAttributes);
             RequestContext.get().setIncludeMeanings(!excludeMeaningsAttributes);

--- a/webapp/src/main/java/org/apache/atlas/web/rest/DiscoveryREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/DiscoveryREST.java
@@ -371,7 +371,7 @@ public class DiscoveryREST {
     public AtlasSearchResult indexSearch(IndexSearchParams parameters) throws AtlasBaseException {
         AtlasPerfTracer perf = null;
         RequestContext.get().setIncludeMeanings(!parameters.isExcludeMeanings());
-        RequestContext.get().setIncludeClassifications(!parameters.isExcludeClassification());
+        RequestContext.get().setIncludeClassifications(!parameters.isExcludeClassifications());
         try {
             if (AtlasPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
                 perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "DiscoveryREST.indexSearch(" + parameters + ")");
@@ -439,7 +439,7 @@ public class DiscoveryREST {
             parameters.setLimit(limit);
             parameters.setOffset(offset);
             parameters.setIncludeClassificationAttributes(includeClassificationAttributes);
-            parameters.setExcludeClassification(!includeClassificationAttributes);
+            parameters.setExcludeClassifications(!includeClassificationAttributes);
             parameters.setExcludeMeanings(excludeMeaningsAttributes);
             RequestContext.get().setIncludeClassifications(includeClassificationAttributes);
             RequestContext.get().setIncludeMeanings(!excludeMeaningsAttributes);

--- a/webapp/src/main/java/org/apache/atlas/web/rest/DiscoveryREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/DiscoveryREST.java
@@ -368,12 +368,10 @@ public class DiscoveryREST {
     @Path("indexsearch")
     @POST
     @Timed
-    public AtlasSearchResult indexSearch(IndexSearchParams parameters,
-        @QueryParam("includeClassificationAttributes") boolean includeClassificationAttributes,
-        @QueryParam("includeMeaningsAttributes") boolean includeMeaningsAttributes) throws AtlasBaseException {
+    public AtlasSearchResult indexSearch(IndexSearchParams parameters) throws AtlasBaseException {
         AtlasPerfTracer perf = null;
-        RequestContext.get().setIncludeMeanings(includeMeaningsAttributes);
-        RequestContext.get().setIncludeClassifications(includeClassificationAttributes);
+        RequestContext.get().setIncludeMeanings(parameters.isIncludeMeanings());
+        RequestContext.get().setIncludeClassifications(parameters.isIncludeClassifications());
         try {
             if (AtlasPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
                 perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "DiscoveryREST.indexSearch(" + parameters + ")");
@@ -440,6 +438,8 @@ public class DiscoveryREST {
             parameters.setExcludeDeletedEntities(excludeDeletedEntities);
             parameters.setLimit(limit);
             parameters.setOffset(offset);
+            parameters.setIncludeClassifications(includeClassificationAttributes);
+            parameters.setIncludeMeanings(includeMeaningsAttributes);
             RequestContext.get().setIncludeClassifications(includeClassificationAttributes);
             RequestContext.get().setIncludeMeanings(includeMeaningsAttributes);
             return discoveryService.searchRelatedEntities(guid, relation, getApproximateCount, parameters);

--- a/webapp/src/main/java/org/apache/atlas/web/rest/DiscoveryREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/DiscoveryREST.java
@@ -19,6 +19,7 @@ package org.apache.atlas.web.rest;
 
 import org.apache.atlas.AtlasClient;
 import org.apache.atlas.AtlasErrorCode;
+import org.apache.atlas.RequestContext;
 import org.apache.atlas.SortOrder;
 import org.apache.atlas.annotation.Timed;
 import org.apache.atlas.authorize.AtlasAuthorizationUtils;
@@ -367,9 +368,12 @@ public class DiscoveryREST {
     @Path("indexsearch")
     @POST
     @Timed
-    public AtlasSearchResult indexSearch(IndexSearchParams parameters) throws AtlasBaseException {
+    public AtlasSearchResult indexSearch(IndexSearchParams parameters,
+        @QueryParam("includeClassificationAttributes") boolean includeClassificationAttributes,
+        @QueryParam("includeMeaningsAttributes") boolean includeMeaningsAttributes) throws AtlasBaseException {
         AtlasPerfTracer perf = null;
-
+        RequestContext.get().setIncludeMeanings(includeMeaningsAttributes);
+        RequestContext.get().setIncludeClassifications(includeClassificationAttributes);
         try {
             if (AtlasPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
                 perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "DiscoveryREST.indexSearch(" + parameters + ")");
@@ -413,6 +417,7 @@ public class DiscoveryREST {
                                                    @QueryParam("sortOrder")                       SortOrder   sortOrder,
                                                    @QueryParam("excludeDeletedEntities")          boolean     excludeDeletedEntities,
                                                    @QueryParam("includeClassificationAttributes") boolean     includeClassificationAttributes,
+                                                   @QueryParam("includeMeaningsAttributes")       boolean     includeMeaningsAttributes,
                                                    @QueryParam("getApproximateCount")             boolean     getApproximateCount,
                                                    @QueryParam("limit")                           int         limit,
                                                    @QueryParam("offset")                          int         offset) throws AtlasBaseException {
@@ -435,7 +440,8 @@ public class DiscoveryREST {
             parameters.setExcludeDeletedEntities(excludeDeletedEntities);
             parameters.setLimit(limit);
             parameters.setOffset(offset);
-            parameters.setIncludeClassificationAttributes(includeClassificationAttributes);
+            RequestContext.get().setIncludeClassifications(includeClassificationAttributes);
+            RequestContext.get().setIncludeMeanings(includeMeaningsAttributes);
             return discoveryService.searchRelatedEntities(guid, relation, getApproximateCount, parameters);
 
         } finally {

--- a/webapp/src/main/java/org/apache/atlas/web/rest/DiscoveryREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/DiscoveryREST.java
@@ -370,8 +370,8 @@ public class DiscoveryREST {
     @Timed
     public AtlasSearchResult indexSearch(IndexSearchParams parameters) throws AtlasBaseException {
         AtlasPerfTracer perf = null;
-        RequestContext.get().setIncludeMeanings(parameters.isIncludeMeanings());
-        RequestContext.get().setIncludeClassifications(parameters.isIncludeClassifications());
+        RequestContext.get().setIncludeMeanings(!parameters.isExcludeMeanings());
+        RequestContext.get().setIncludeClassifications(!parameters.isExcludeClassificationAttributes());
         try {
             if (AtlasPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
                 perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "DiscoveryREST.indexSearch(" + parameters + ")");
@@ -415,7 +415,7 @@ public class DiscoveryREST {
                                                    @QueryParam("sortOrder")                       SortOrder   sortOrder,
                                                    @QueryParam("excludeDeletedEntities")          boolean     excludeDeletedEntities,
                                                    @QueryParam("includeClassificationAttributes") boolean     includeClassificationAttributes,
-                                                   @QueryParam("includeMeaningsAttributes")       boolean     includeMeaningsAttributes,
+                                                   @QueryParam("excludeMeaningsAttributes")       boolean     excludeMeaningsAttributes,
                                                    @QueryParam("getApproximateCount")             boolean     getApproximateCount,
                                                    @QueryParam("limit")                           int         limit,
                                                    @QueryParam("offset")                          int         offset) throws AtlasBaseException {
@@ -438,10 +438,10 @@ public class DiscoveryREST {
             parameters.setExcludeDeletedEntities(excludeDeletedEntities);
             parameters.setLimit(limit);
             parameters.setOffset(offset);
-            parameters.setIncludeClassifications(includeClassificationAttributes);
-            parameters.setIncludeMeanings(includeMeaningsAttributes);
+            parameters.setExcludeClassificationAttributes(!includeClassificationAttributes);
+            parameters.setExcludeMeanings(excludeMeaningsAttributes);
             RequestContext.get().setIncludeClassifications(includeClassificationAttributes);
-            RequestContext.get().setIncludeMeanings(includeMeaningsAttributes);
+            RequestContext.get().setIncludeMeanings(!excludeMeaningsAttributes);
             return discoveryService.searchRelatedEntities(guid, relation, getApproximateCount, parameters);
 
         } finally {


### PR DESCRIPTION
## Change description
Included query param flags, to include/exclude meanings and classifications as part of the search results. 


> Description here
FrontEnd can now add query params as shown below:

```
http://localhost:21000/api/atlas/v2/search/indexsearch?includeClassificationAttributes=true&includeMeaningsAttributes=true
```


## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Checklists
- Atlas already have support for `includeClassificationAttributes` for `relationship` search API, additionally we have also included `includeMeaningsAttributes` in this PR
