### PR TITLE
META-4130: Ubuntu OS base image version to 22.04 for atlas-metastore image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 #
 
 FROM scratch
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 LABEL maintainer="engineering@atlan.com"
 ARG VERSION=3.0.0-SNAPSHOT
 
@@ -28,10 +28,10 @@ RUN apt-get update \
     && apt-get -y install apt-utils \
     && apt-get -y install \
         wget \
-        python \
+        python3 \
         openjdk-8-jdk-headless \
         patch \
-        netcat \
+        netcat-traditional \
         curl \
     && cd / \
     && mkdir /opt/ranger-atlas-plugin \
@@ -49,6 +49,9 @@ RUN cd / \
     && mkdir /opt/apache-atlas/libext \
     && mv /atlas-index-repair-tool-${VERSION}.jar /opt/apache-atlas/libext/ \
     && rm -rf /atlas-index-repair-tool-${VERSION}.tar.gz
+
+RUN ln -s /usr/bin/python3 /usr/bin/python & \
+    ln -s /usr/bin/pip3 /usr/bin/pip
 
 COPY atlas-hub/repair_index.py /opt/apache-atlas/bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,10 @@ RUN apt-get update \
     && apt-get -y install apt-utils \
     && apt-get -y install \
         wget \
-        python3 \
+        python2 \
         openjdk-8-jdk-headless \
         patch \
-        netcat-traditional \
+        netcat \
         curl \
     && cd / \
     && mkdir /opt/ranger-atlas-plugin \
@@ -50,8 +50,7 @@ RUN cd / \
     && mv /atlas-index-repair-tool-${VERSION}.jar /opt/apache-atlas/libext/ \
     && rm -rf /atlas-index-repair-tool-${VERSION}.tar.gz
 
-RUN ln -s /usr/bin/python3 /usr/bin/python & \
-    ln -s /usr/bin/pip3 /usr/bin/pip
+RUN ln -s /usr/bin/python2 /usr/bin/python
 
 COPY atlas-hub/repair_index.py /opt/apache-atlas/bin/
 


### PR DESCRIPTION
## Change description
META-4130: Ubuntu OS base image version to 22.04 for atlas-metastore image

linear - https://linear.app/atlanproduct/issue/META-4130

> Description here

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
