### PR TITLE
Meta-4227: Generate qualifiedName for ReadMe entity at server side

### DIFF
--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -199,6 +199,7 @@ public final class Constants {
 
     public static final String NAME                                    = "name";
     public static final String QUALIFIED_NAME                          = "qualifiedName";
+    public static final String ASSET                                   = "asset";
     public static final String TYPE_NAME_PROPERTY_KEY                  = INTERNAL_PROPERTY_KEY_PREFIX + "typeName";
     public static final String INDEX_SEARCH_MAX_RESULT_SET_SIZE        = "atlas.graph.index.search.max-result-set-size";
     public static final String INDEX_SEARCH_TYPES_MAX_QUERY_STR_LENGTH = "atlas.graph.index.search.types.max-query-str-length";

--- a/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
@@ -183,6 +183,7 @@ public enum AtlasErrorCode {
     PAGINATION_CAN_ONLY_BE_USED_WITH_DEPTH_ONE(400, "ATLAS-400-00-103", "Pagination can be used only when depth is 1"),
     CANT_CALCULATE_VERTEX_COUNTS_WITHOUT_PAGINATION(400, "ATLAS-400-00-104", "Vertex counts can't be calculated without pagination"),
     FORBIDDEN_TYPENAME(400,"ATLAS-400-00-107", "Forbidden type: Can not pass builtin type {0}"),
+    README_FAILED(400,"ATLAS-400-00-108", "Asset is required for readme creation"),
 
     // All Not found enums go here
     TYPE_NAME_NOT_FOUND(404, "ATLAS-404-00-001", "Given typename {0} was invalid"),

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -375,8 +375,9 @@ public class EntityGraphMapper {
                     PreProcessor preProcessor = getPreProcessor(entityType.getTypeName());
                     if (preProcessor != null) {
                         preProcessor.processAttributes(createdEntity, context, CREATE);
-                        if(entityType.getTypeName().equals(README_ENTITY_TYPE))
+                        if(entityType.getTypeName().equals(README_ENTITY_TYPE)) {
                             guid = createdEntity.getGuid();
+                        }
                     }
                     AtlasVertex vertex = context.getVertex(guid);
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityMutationContext.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityMutationContext.java
@@ -56,6 +56,15 @@ public class EntityMutationContext {
             entityVsVertex.put(internalGuid, atlasVertex);
         }
     }
+    public void updateEntityReferences(String internalGuid, AtlasEntity entity, AtlasEntityType type, AtlasVertex atlasVertex) {
+        entityVsType.put(entity.getGuid(), type);
+        entityVsVertex.put(entity.getGuid(), atlasVertex);
+
+        if (!StringUtils.equals(internalGuid, entity.getGuid())) {
+            guidAssignments.put(internalGuid, entity.getGuid());
+            entityVsVertex.put(internalGuid, atlasVertex);
+        }
+    }
 
     public void addUpdated(String internalGuid, AtlasEntity entity, AtlasEntityType type, AtlasVertex atlasVertex) {
         if (!entityVsVertex.containsKey(internalGuid)) { // if the entity was already created/updated

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/readme/ReadmePreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/readme/ReadmePreProcessor.java
@@ -1,5 +1,6 @@
 package org.apache.atlas.repository.store.graph.v2.preprocessor.readme;
 
+import org.apache.atlas.GraphTransactionInterceptor;
 import org.apache.atlas.RequestContext;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.instance.*;
@@ -72,7 +73,7 @@ public class ReadmePreProcessor implements PreProcessor {
             AtlasVertex vertex = AtlasGraphUtilsV2.findByUniqueAttributes(graph, entityType, entity.getAttributes());
             if (vertex != null) {
                 if (vertex.getProperty(STATE_PROPERTY_KEY, String.class).equals(DELETED.name())) {
-                    vertex.setProperty(STATE_PROPERTY_KEY, ACTIVE.name());
+                    GraphTransactionInterceptor.addToVertexStateCache(vertex.getId(), AtlasEntity.Status.ACTIVE);
                     restoreHandlerV1.restoreEntities(Collections.singletonList(vertex));
                 }
                 String internalGuidOfReadme = context.getDiscoveryContext().getReferencedGuids().get(asset.getGuid());

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/readme/ReadmePreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/readme/ReadmePreProcessor.java
@@ -20,7 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.util.Collections;
 
-import static org.apache.atlas.model.instance.AtlasEntity.Status.ACTIVE;
+import static org.apache.atlas.AtlasErrorCode.README_FAILED;
 import static org.apache.atlas.model.instance.AtlasEntity.Status.DELETED;
 import static org.apache.atlas.repository.Constants.QUALIFIED_NAME;
 import static org.apache.atlas.repository.Constants.STATE_PROPERTY_KEY;
@@ -83,6 +83,9 @@ public class ReadmePreProcessor implements PreProcessor {
             requestContext.recordEntityUpdate(entityRetriever.toAtlasEntityHeader(vertex, entity.getAttributes().keySet()));
             requestContext.cacheDifferentialEntity(entity);
             requestContext.endMetricRecord(metricRecorder);
+        }
+        else{
+            throw new AtlasBaseException(README_FAILED);
         }
     }
     private void processUpdateReadme(AtlasEntity entity, AtlasVertex vertex) throws AtlasBaseException {


### PR DESCRIPTION
There was ambiguity when ReadMe to asset were generated by user via API using their own qualifiedName pattern.

In order to have constituency in qualifiedName is generated at server side.

Linear: https://linear.app/atlanproduct/issue/META-4227