### PR TITLE
Meta-4227: Generate qualifiedName for ReadMe entity at server side

### DIFF
--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -199,6 +199,7 @@ public final class Constants {
 
     public static final String NAME                                    = "name";
     public static final String QUALIFIED_NAME                          = "qualifiedName";
+    public static final String ASSET                                   = "asset";
     public static final String TYPE_NAME_PROPERTY_KEY                  = INTERNAL_PROPERTY_KEY_PREFIX + "typeName";
     public static final String INDEX_SEARCH_MAX_RESULT_SET_SIZE        = "atlas.graph.index.search.max-result-set-size";
     public static final String INDEX_SEARCH_TYPES_MAX_QUERY_STR_LENGTH = "atlas.graph.index.search.types.max-query-str-length";

--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -127,6 +127,7 @@ public final class Constants {
      */
     public static final String CONNECTION_ENTITY_TYPE       = "Connection";
     public static final String QUERY_ENTITY_TYPE            = "Query";
+    public static final String README_ENTITY_TYPE           = "Readme";
     public static final String QUERY_FOLDER_ENTITY_TYPE     = "Folder";
     public static final String QUERY_COLLECTION_ENTITY_TYPE = "Collection";
 

--- a/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
@@ -183,6 +183,7 @@ public enum AtlasErrorCode {
     PAGINATION_CAN_ONLY_BE_USED_WITH_DEPTH_ONE(400, "ATLAS-400-00-103", "Pagination can be used only when depth is 1"),
     CANT_CALCULATE_VERTEX_COUNTS_WITHOUT_PAGINATION(400, "ATLAS-400-00-104", "Vertex counts can't be calculated without pagination"),
     FORBIDDEN_TYPENAME(400,"ATLAS-400-00-107", "Forbidden type: Can not pass builtin type {0}"),
+    README_FAILED(400,"ATLAS-400-00-108", "Asset is required for readme creation"),
 
     // All Not found enums go here
     TYPE_NAME_NOT_FOUND(404, "ATLAS-404-00-001", "Given typename {0} was invalid"),

--- a/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
@@ -184,7 +184,7 @@ public enum AtlasErrorCode {
     CANT_CALCULATE_VERTEX_COUNTS_WITHOUT_PAGINATION(400, "ATLAS-400-00-104", "Vertex counts can't be calculated without pagination"),
     FORBIDDEN_TYPENAME(400,"ATLAS-400-00-107", "Forbidden type: Can not pass builtin type {0}"),
     README_FAILED(400,"ATLAS-400-00-108", "Readme creation failed for {0}: Asset is required"),
-    README_ALREADY_PRESENT(400,"ATLAS-400-00-109", "Readme already exists for the entity"),
+    README_ALREADY_PRESENT(400,"ATLAS-400-00-109", "Readme of guid {0} already exists for the entity"),
 
     // All Not found enums go here
     TYPE_NAME_NOT_FOUND(404, "ATLAS-404-00-001", "Given typename {0} was invalid"),

--- a/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
@@ -184,6 +184,7 @@ public enum AtlasErrorCode {
     CANT_CALCULATE_VERTEX_COUNTS_WITHOUT_PAGINATION(400, "ATLAS-400-00-104", "Vertex counts can't be calculated without pagination"),
     FORBIDDEN_TYPENAME(400,"ATLAS-400-00-107", "Forbidden type: Can not pass builtin type {0}"),
     README_FAILED(400,"ATLAS-400-00-108", "Readme creation failed for {0}: Asset is required"),
+    README_ALREADY_PRESENT(400,"ATLAS-400-00-109", "Readme already exists for the entity"),
 
     // All Not found enums go here
     TYPE_NAME_NOT_FOUND(404, "ATLAS-404-00-001", "Given typename {0} was invalid"),

--- a/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
@@ -183,7 +183,7 @@ public enum AtlasErrorCode {
     PAGINATION_CAN_ONLY_BE_USED_WITH_DEPTH_ONE(400, "ATLAS-400-00-103", "Pagination can be used only when depth is 1"),
     CANT_CALCULATE_VERTEX_COUNTS_WITHOUT_PAGINATION(400, "ATLAS-400-00-104", "Vertex counts can't be calculated without pagination"),
     FORBIDDEN_TYPENAME(400,"ATLAS-400-00-107", "Forbidden type: Can not pass builtin type {0}"),
-    README_FAILED(400,"ATLAS-400-00-108", "Asset is required for readme creation"),
+    README_FAILED(400,"ATLAS-400-00-108", "Readme creation failed for {0}: Asset is required"),
 
     // All Not found enums go here
     TYPE_NAME_NOT_FOUND(404, "ATLAS-404-00-001", "Given typename {0} was invalid"),

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -59,6 +59,7 @@ import org.apache.atlas.repository.store.graph.v2.preprocessor.glossary.Category
 import org.apache.atlas.repository.store.graph.v2.preprocessor.glossary.GlossaryPreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.glossary.TermPreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessor;
+import org.apache.atlas.repository.store.graph.v2.preprocessor.readme.ReadmePreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.sql.QueryCollectionPreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.sql.QueryFolderPreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.sql.QueryPreProcessor;
@@ -369,13 +370,15 @@ public class EntityGraphMapper {
                     reqContext.getDeletedEdgesIds().clear();
 
                     String guid = createdEntity.getGuid();
-                    AtlasVertex vertex = context.getVertex(guid);
                     AtlasEntityType entityType = context.getType(guid);
 
                     PreProcessor preProcessor = getPreProcessor(entityType.getTypeName());
                     if (preProcessor != null) {
                         preProcessor.processAttributes(createdEntity, context, CREATE);
+                        if(entityType.getTypeName().equals(README_ENTITY_TYPE))
+                            guid = createdEntity.getGuid();
                     }
+                    AtlasVertex vertex = context.getVertex(guid);
 
                     mapAttributes(createdEntity, entityType, vertex, CREATE, context);
                     mapRelationshipAttributes(createdEntity, entityType, vertex, CREATE, context);
@@ -578,6 +581,10 @@ public class EntityGraphMapper {
 
             case QUERY_COLLECTION_ENTITY_TYPE:
                 preProcessor = new QueryCollectionPreProcessor(typeRegistry, entityRetriever);
+                break;
+
+            case README_ENTITY_TYPE:
+                preProcessor = new ReadmePreProcessor(typeRegistry, entityRetriever, graph, restoreHandlerV1);
                 break;
 
         }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -585,7 +585,7 @@ public class EntityGraphMapper {
                 break;
 
             case README_ENTITY_TYPE:
-                preProcessor = new ReadmePreProcessor(typeRegistry, entityRetriever, graph, restoreHandlerV1);
+                preProcessor = new ReadmePreProcessor(typeRegistry, entityRetriever, graph);
                 break;
 
         }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -375,8 +375,9 @@ public class EntityGraphMapper {
                     PreProcessor preProcessor = getPreProcessor(entityType.getTypeName());
                     if (preProcessor != null) {
                         preProcessor.processAttributes(createdEntity, context, CREATE);
-                        if(entityType.getTypeName().equals(README_ENTITY_TYPE))
+                        if(entityType.getTypeName().equals(README_ENTITY_TYPE)) {
                             guid = createdEntity.getGuid();
+                        }
                     }
                     AtlasVertex vertex = context.getVertex(guid);
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityMutationContext.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityMutationContext.java
@@ -56,6 +56,15 @@ public class EntityMutationContext {
             entityVsVertex.put(internalGuid, atlasVertex);
         }
     }
+    public void updateEntityReferences(String internalGuid, AtlasEntity entity, AtlasEntityType type, AtlasVertex atlasVertex) {
+        entityVsType.put(entity.getGuid(), type);
+        entityVsVertex.put(entity.getGuid(), atlasVertex);
+
+        if (!StringUtils.equals(internalGuid, entity.getGuid())) {
+            guidAssignments.put(internalGuid, entity.getGuid());
+            entityVsVertex.put(internalGuid, atlasVertex);
+        }
+    }
 
     public void addUpdated(String internalGuid, AtlasEntity entity, AtlasEntityType type, AtlasVertex atlasVertex) {
         if (!entityVsVertex.containsKey(internalGuid)) { // if the entity was already created/updated

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/readme/ReadmePreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/readme/ReadmePreProcessor.java
@@ -3,9 +3,9 @@ package org.apache.atlas.repository.store.graph.v2.preprocessor.readme;
 import org.apache.atlas.RequestContext;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.instance.*;
+import org.apache.atlas.repository.graph.GraphHelper;
 import org.apache.atlas.repository.graphdb.AtlasGraph;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
-import org.apache.atlas.repository.store.graph.v1.RestoreHandlerV1;
 import org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2;
 import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
 import org.apache.atlas.repository.store.graph.v2.EntityMutationContext;
@@ -71,7 +71,7 @@ public class ReadmePreProcessor implements PreProcessor {
                 AtlasEntityType entityType = typeRegistry.getEntityTypeByName(entity.getTypeName());
                 AtlasVertex vertex = AtlasGraphUtilsV2.findByUniqueAttributes(graph, entityType, entity.getAttributes());
                 if (vertex != null) {
-                    LOG.error("Readme already exists for the asset.");
+                    LOG.error("Readme of guid {} already exists for the asset.", GraphHelper.getGuid(vertex));
                     throw new AtlasBaseException(README_ALREADY_PRESENT);
                 }
                 requestContext.cacheDifferentialEntity(entity);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/readme/ReadmePreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/readme/ReadmePreProcessor.java
@@ -71,8 +71,9 @@ public class ReadmePreProcessor implements PreProcessor {
                 AtlasEntityType entityType = typeRegistry.getEntityTypeByName(entity.getTypeName());
                 AtlasVertex vertex = AtlasGraphUtilsV2.findByUniqueAttributes(graph, entityType, entity.getAttributes());
                 if (vertex != null) {
-                    LOG.error("Readme of guid {} already exists for the asset.", GraphHelper.getGuid(vertex));
-                    throw new AtlasBaseException(README_ALREADY_PRESENT);
+                    String guidOfReadme = GraphHelper.getGuid(vertex);
+                    LOG.error("Readme of guid {} already exists for the asset.", guidOfReadme);
+                    throw new AtlasBaseException(README_ALREADY_PRESENT, guidOfReadme);
                 }
                 requestContext.cacheDifferentialEntity(entity);
             } else {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/readme/ReadmePreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/readme/ReadmePreProcessor.java
@@ -1,0 +1,99 @@
+package org.apache.atlas.repository.store.graph.v2.preprocessor.readme;
+
+import org.apache.atlas.GraphTransactionInterceptor;
+import org.apache.atlas.RequestContext;
+import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.model.instance.*;
+import org.apache.atlas.repository.graphdb.AtlasGraph;
+import org.apache.atlas.repository.graphdb.AtlasVertex;
+import org.apache.atlas.repository.store.graph.v1.RestoreHandlerV1;
+import org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2;
+import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
+import org.apache.atlas.repository.store.graph.v2.EntityMutationContext;
+import org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessor;
+import org.apache.atlas.type.AtlasEntityType;
+import org.apache.atlas.type.AtlasTypeRegistry;
+import org.apache.atlas.utils.AtlasPerfMetrics;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.util.Collections;
+
+import static org.apache.atlas.model.instance.AtlasEntity.Status.DELETED;
+import static org.apache.atlas.repository.Constants.QUALIFIED_NAME;
+import static org.apache.atlas.repository.Constants.STATE_PROPERTY_KEY;
+
+public class ReadmePreProcessor implements PreProcessor {
+    private static final Logger LOG = LoggerFactory.getLogger(ReadmePreProcessor.class);
+
+    private final AtlasTypeRegistry    typeRegistry;
+    private final EntityGraphRetriever entityRetriever;
+    private final AtlasGraph           graph;
+    private final RestoreHandlerV1     restoreHandlerV1;
+
+    public ReadmePreProcessor(AtlasTypeRegistry typeRegistry, EntityGraphRetriever entityRetriever, AtlasGraph graph, RestoreHandlerV1 restoreHandlerV1) {
+        this.entityRetriever = entityRetriever;
+        this.typeRegistry = typeRegistry;
+        this.graph = graph;
+        this.restoreHandlerV1 = restoreHandlerV1;
+    }
+
+    @Override
+    public void processAttributes(AtlasStruct entityStruct, EntityMutationContext context,
+                                  EntityMutations.EntityOperation operation) throws AtlasBaseException {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("ReadmePreProcessor.processAttributes: pre processing {}, {}", entityStruct.getAttribute(QUALIFIED_NAME), operation);
+        }
+
+        AtlasEntity entity = (AtlasEntity) entityStruct;
+
+        switch (operation) {
+            case CREATE:
+                processCreateReadme(entity, context);
+                break;
+            case UPDATE:
+                processUpdateReadme(entity, context.getVertex(entity.getGuid()));
+                break;
+        }
+    }
+
+    private void processCreateReadme(AtlasEntity entity, EntityMutationContext context) throws AtlasBaseException {
+        RequestContext requestContext = RequestContext.get();
+        AtlasPerfMetrics.MetricRecorder metricRecorder = requestContext.startMetricRecord("processCreateReadme");
+        String entityQualifiedName = createQualifiedName(entity);
+
+        entity.setAttribute(QUALIFIED_NAME, entityQualifiedName);
+
+        AtlasEntityType entityType = typeRegistry.getEntityTypeByName(entity.getTypeName());
+        AtlasVertex vertex = AtlasGraphUtilsV2.findByUniqueAttributes(graph, entityType, entity.getAttributes());
+        if(vertex != null){
+            if(vertex.getProperty(STATE_PROPERTY_KEY, String.class).equals(DELETED.name())){
+                GraphTransactionInterceptor.addToVertexStateCache(vertex.getId(), AtlasEntity.Status.ACTIVE);
+                restoreHandlerV1.restoreEntities(Collections.singletonList(vertex));
+            }
+            context.cacheEntity(entity.getGuid(), vertex, entityType);
+        }
+        requestContext.recordEntityUpdate(entityRetriever.toAtlasEntityHeader(vertex, entity.getAttributes().keySet()));
+        requestContext.cacheDifferentialEntity(entity);
+        requestContext.endMetricRecord(metricRecorder);
+    }
+    private void processUpdateReadme(AtlasEntity entity, AtlasVertex vertex) throws AtlasBaseException {
+        RequestContext requestContext = RequestContext.get();
+        AtlasPerfMetrics.MetricRecorder metricRecorder = requestContext.startMetricRecord("processUpdateReadme");
+        String vertexQnName = vertex.getProperty(QUALIFIED_NAME, String.class);
+
+        entity.setAttribute(QUALIFIED_NAME, vertexQnName);
+        requestContext.recordEntityUpdate(entityRetriever.toAtlasEntityHeader(vertex, entity.getAttributes().keySet()));
+        requestContext.cacheDifferentialEntity(entity);
+        requestContext.endMetricRecord(metricRecorder);
+    }
+
+    public String createQualifiedName(AtlasEntity entity) throws AtlasBaseException {
+        AtlasObjectId asset = (AtlasObjectId) entity.getRelationshipAttribute("asset");
+        String guid = asset.getGuid();
+        if(StringUtils.isEmpty(guid))
+            guid = AtlasGraphUtilsV2.getGuidByUniqueAttributes(graph, typeRegistry.getEntityTypeByName(asset.getTypeName()), asset.getUniqueAttributes());
+
+        return guid + "/readme";
+    }
+}

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/readme/ReadmePreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/readme/ReadmePreProcessor.java
@@ -20,11 +20,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.util.Collections;
 
+import static org.apache.atlas.AtlasErrorCode.BAD_REQUEST;
 import static org.apache.atlas.AtlasErrorCode.README_FAILED;
 import static org.apache.atlas.model.instance.AtlasEntity.Status.DELETED;
 import static org.apache.atlas.repository.Constants.QUALIFIED_NAME;
 import static org.apache.atlas.repository.Constants.STATE_PROPERTY_KEY;
 import static org.apache.atlas.repository.Constants.ASSET;
+import static org.apache.atlas.repository.Constants.NAME;
 
 public class ReadmePreProcessor implements PreProcessor {
     private static final Logger LOG = LoggerFactory.getLogger(ReadmePreProcessor.class);
@@ -57,52 +59,56 @@ public class ReadmePreProcessor implements PreProcessor {
             case UPDATE:
                 processUpdateReadme(entity, context.getVertex(entity.getGuid()));
                 break;
+            default:
+                throw new AtlasBaseException(BAD_REQUEST, "Invalid Request");
         }
     }
 
     private void processCreateReadme(AtlasEntity entity, EntityMutationContext context) throws AtlasBaseException {
         AtlasObjectId asset = (AtlasObjectId) entity.getRelationshipAttribute(ASSET);
-        if (asset != null) {
-            RequestContext requestContext = RequestContext.get();
-            AtlasPerfMetrics.MetricRecorder metricRecorder = requestContext.startMetricRecord("processCreateReadme");
-            String entityQualifiedName = createQualifiedName(asset);
+        RequestContext requestContext = RequestContext.get();
+        AtlasPerfMetrics.MetricRecorder metricRecorder = requestContext.startMetricRecord("processCreateReadme");
+        try {
+            if (asset != null) {
+                String entityQualifiedName = createQualifiedName(asset);
 
-            entity.setAttribute(QUALIFIED_NAME, entityQualifiedName);
+                entity.setAttribute(QUALIFIED_NAME, entityQualifiedName);
 
-            AtlasEntityType entityType = typeRegistry.getEntityTypeByName(entity.getTypeName());
-            AtlasVertex vertex = AtlasGraphUtilsV2.findByUniqueAttributes(graph, entityType, entity.getAttributes());
-            if (vertex != null) {
-                if (vertex.getProperty(STATE_PROPERTY_KEY, String.class).equals(DELETED.name())) {
-                    GraphTransactionInterceptor.addToVertexStateCache(vertex.getId(), AtlasEntity.Status.ACTIVE);
-                    restoreHandlerV1.restoreEntities(Collections.singletonList(vertex));
+                AtlasEntityType entityType = typeRegistry.getEntityTypeByName(entity.getTypeName());
+                AtlasVertex vertex = AtlasGraphUtilsV2.findByUniqueAttributes(graph, entityType, entity.getAttributes());
+                if (vertex != null) {
+                    if (vertex.getProperty(STATE_PROPERTY_KEY, String.class).equals(DELETED.name())) {
+                        GraphTransactionInterceptor.addToVertexStateCache(vertex.getId(), AtlasEntity.Status.ACTIVE);
+                        restoreHandlerV1.restoreEntities(Collections.singletonList(vertex));
+                    }
+                    String internalGuidOfReadme = context.getDiscoveryContext().getReferencedGuids().get(asset.getGuid());
+                    entity.setGuid(GraphHelper.getGuid(vertex));
+                    context.updateEntityReferences(internalGuidOfReadme, entity, entityType, vertex);
                 }
-                String internalGuidOfReadme = context.getDiscoveryContext().getReferencedGuids().get(asset.getGuid());
-                entity.setGuid(GraphHelper.getGuid(vertex));
-                context.updateEntityReferences(internalGuidOfReadme, entity, entityType, vertex);
+                requestContext.recordEntityUpdate(entityRetriever.toAtlasEntityHeader(vertex, entity.getAttributes().keySet()));
+                requestContext.cacheDifferentialEntity(entity);
+            } else {
+                LOG.error("Asset is required for readme creation");
+                throw new AtlasBaseException(README_FAILED, (String) entity.getAttribute(NAME));
             }
-            requestContext.recordEntityUpdate(entityRetriever.toAtlasEntityHeader(vertex, entity.getAttributes().keySet()));
-            requestContext.cacheDifferentialEntity(entity);
+        } finally{
             requestContext.endMetricRecord(metricRecorder);
-        }
-        else{
-            throw new AtlasBaseException(README_FAILED);
         }
     }
     private void processUpdateReadme(AtlasEntity entity, AtlasVertex vertex) throws AtlasBaseException {
         RequestContext requestContext = RequestContext.get();
         AtlasPerfMetrics.MetricRecorder metricRecorder = requestContext.startMetricRecord("processUpdateReadme");
-        String vertexQnName = vertex.getProperty(QUALIFIED_NAME, String.class);
 
-        entity.setAttribute(QUALIFIED_NAME, vertexQnName);
+        entity.setAttribute(QUALIFIED_NAME, vertex.getProperty(QUALIFIED_NAME, String.class));
         requestContext.recordEntityUpdate(entityRetriever.toAtlasEntityHeader(vertex, entity.getAttributes().keySet()));
         requestContext.cacheDifferentialEntity(entity);
         requestContext.endMetricRecord(metricRecorder);
     }
 
-    public String createQualifiedName(AtlasObjectId asset) throws AtlasBaseException {
-        String guid = asset.getGuid();
+    private String createQualifiedName(AtlasObjectId atlasObjectId) throws AtlasBaseException {
+        String guid = atlasObjectId.getGuid();
         if(StringUtils.isEmpty(guid))
-            guid = AtlasGraphUtilsV2.getGuidByUniqueAttributes(graph, typeRegistry.getEntityTypeByName(asset.getTypeName()), asset.getUniqueAttributes());
+            guid = AtlasGraphUtilsV2.getGuidByUniqueAttributes(graph, typeRegistry.getEntityTypeByName(atlasObjectId.getTypeName()), atlasObjectId.getUniqueAttributes());
 
         return guid + "/readme";
     }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/readme/ReadmePreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/readme/ReadmePreProcessor.java
@@ -1,5 +1,6 @@
 package org.apache.atlas.repository.store.graph.v2.preprocessor.readme;
 
+import org.apache.atlas.GraphTransactionInterceptor;
 import org.apache.atlas.RequestContext;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.instance.*;
@@ -72,7 +73,7 @@ public class ReadmePreProcessor implements PreProcessor {
             AtlasVertex vertex = AtlasGraphUtilsV2.findByUniqueAttributes(graph, entityType, entity.getAttributes());
             if (vertex != null) {
                 if (vertex.getProperty(STATE_PROPERTY_KEY, String.class).equals(DELETED.name())) {
-                    vertex.setProperty(STATE_PROPERTY_KEY, ACTIVE.name());
+                    GraphTransactionInterceptor.addToVertexStateCache(vertex.getId(), AtlasEntity.Status.ACTIVE);
                     restoreHandlerV1.restoreEntities(Collections.singletonList(vertex));
                 }
                 String internalGuidOfReadme = context.getDiscoveryContext().getReferencedGuids().get(asset.getGuid());

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/readme/ReadmePreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/readme/ReadmePreProcessor.java
@@ -30,13 +30,11 @@ public class ReadmePreProcessor implements PreProcessor {
     private final AtlasTypeRegistry    typeRegistry;
     private final EntityGraphRetriever entityRetriever;
     private final AtlasGraph           graph;
-    private final RestoreHandlerV1     restoreHandlerV1;
 
-    public ReadmePreProcessor(AtlasTypeRegistry typeRegistry, EntityGraphRetriever entityRetriever, AtlasGraph graph, RestoreHandlerV1 restoreHandlerV1) {
+    public ReadmePreProcessor(AtlasTypeRegistry typeRegistry, EntityGraphRetriever entityRetriever, AtlasGraph graph) {
         this.entityRetriever = entityRetriever;
         this.typeRegistry = typeRegistry;
         this.graph = graph;
-        this.restoreHandlerV1 = restoreHandlerV1;
     }
 
     @Override
@@ -50,7 +48,7 @@ public class ReadmePreProcessor implements PreProcessor {
 
         switch (operation) {
             case CREATE:
-                processCreateReadme(entity, context);
+                processCreateReadme(entity);
                 break;
             case UPDATE:
                 processUpdateReadme(entity, context.getVertex(entity.getGuid()));
@@ -60,7 +58,7 @@ public class ReadmePreProcessor implements PreProcessor {
         }
     }
 
-    private void processCreateReadme(AtlasEntity entity, EntityMutationContext context) throws AtlasBaseException {
+    private void processCreateReadme(AtlasEntity entity) throws AtlasBaseException {
         AtlasObjectId asset = (AtlasObjectId) entity.getRelationshipAttribute(ASSET);
         RequestContext requestContext = RequestContext.get();
         AtlasPerfMetrics.MetricRecorder metricRecorder = requestContext.startMetricRecord("processCreateReadme");
@@ -76,7 +74,6 @@ public class ReadmePreProcessor implements PreProcessor {
                     LOG.error("Readme already exists for the asset.");
                     throw new AtlasBaseException(README_ALREADY_PRESENT);
                 }
-                requestContext.recordEntityUpdate(entityRetriever.toAtlasEntityHeader(vertex, entity.getAttributes().keySet()));
                 requestContext.cacheDifferentialEntity(entity);
             } else {
                 LOG.error("Asset is required for readme creation");

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/readme/ReadmePreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/readme/ReadmePreProcessor.java
@@ -1,10 +1,8 @@
 package org.apache.atlas.repository.store.graph.v2.preprocessor.readme;
 
-import org.apache.atlas.GraphTransactionInterceptor;
 import org.apache.atlas.RequestContext;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.instance.*;
-import org.apache.atlas.repository.graph.GraphHelper;
 import org.apache.atlas.repository.graphdb.AtlasGraph;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
 import org.apache.atlas.repository.store.graph.v1.RestoreHandlerV1;
@@ -18,13 +16,11 @@ import org.apache.atlas.utils.AtlasPerfMetrics;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.util.Collections;
 
 import static org.apache.atlas.AtlasErrorCode.BAD_REQUEST;
 import static org.apache.atlas.AtlasErrorCode.README_FAILED;
-import static org.apache.atlas.model.instance.AtlasEntity.Status.DELETED;
+import static org.apache.atlas.AtlasErrorCode.README_ALREADY_PRESENT;
 import static org.apache.atlas.repository.Constants.QUALIFIED_NAME;
-import static org.apache.atlas.repository.Constants.STATE_PROPERTY_KEY;
 import static org.apache.atlas.repository.Constants.ASSET;
 import static org.apache.atlas.repository.Constants.NAME;
 
@@ -77,13 +73,8 @@ public class ReadmePreProcessor implements PreProcessor {
                 AtlasEntityType entityType = typeRegistry.getEntityTypeByName(entity.getTypeName());
                 AtlasVertex vertex = AtlasGraphUtilsV2.findByUniqueAttributes(graph, entityType, entity.getAttributes());
                 if (vertex != null) {
-                    if (vertex.getProperty(STATE_PROPERTY_KEY, String.class).equals(DELETED.name())) {
-                        GraphTransactionInterceptor.addToVertexStateCache(vertex.getId(), AtlasEntity.Status.ACTIVE);
-                        restoreHandlerV1.restoreEntities(Collections.singletonList(vertex));
-                    }
-                    String internalGuidOfReadme = context.getDiscoveryContext().getReferencedGuids().get(asset.getGuid());
-                    entity.setGuid(GraphHelper.getGuid(vertex));
-                    context.updateEntityReferences(internalGuidOfReadme, entity, entityType, vertex);
+                    LOG.error("Readme already exists for the asset.");
+                    throw new AtlasBaseException(README_ALREADY_PRESENT);
                 }
                 requestContext.recordEntityUpdate(entityRetriever.toAtlasEntityHeader(vertex, entity.getAttributes().keySet()));
                 requestContext.cacheDifferentialEntity(entity);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/readme/ReadmePreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/readme/ReadmePreProcessor.java
@@ -20,7 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.util.Collections;
 
-import static org.apache.atlas.model.instance.AtlasEntity.Status.ACTIVE;
+import static org.apache.atlas.AtlasErrorCode.README_FAILED;
 import static org.apache.atlas.model.instance.AtlasEntity.Status.DELETED;
 import static org.apache.atlas.repository.Constants.QUALIFIED_NAME;
 import static org.apache.atlas.repository.Constants.STATE_PROPERTY_KEY;
@@ -83,6 +83,9 @@ public class ReadmePreProcessor implements PreProcessor {
             requestContext.recordEntityUpdate(entityRetriever.toAtlasEntityHeader(vertex, entity.getAttributes().keySet()));
             requestContext.cacheDifferentialEntity(entity);
             requestContext.endMetricRecord(metricRecorder);
+        }
+        else{
+            throw new AtlasBaseException(README_FAILED);
         }
     }
     private void processUpdateReadme(AtlasEntity entity, AtlasVertex vertex) throws AtlasBaseException {


### PR DESCRIPTION
There was ambiguity when ReadMe to asset were generated by user via API using their own qualifiedName pattern.

In order to have constituency in qualifiedName is generated at server side.

Linear: https://linear.app/atlanproduct/issue/META-4227