### PR TITLE
Meta-4227: Generate qualifiedName for ReadMe entity at server side

### DIFF
--- a/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
@@ -183,7 +183,7 @@ public enum AtlasErrorCode {
     PAGINATION_CAN_ONLY_BE_USED_WITH_DEPTH_ONE(400, "ATLAS-400-00-103", "Pagination can be used only when depth is 1"),
     CANT_CALCULATE_VERTEX_COUNTS_WITHOUT_PAGINATION(400, "ATLAS-400-00-104", "Vertex counts can't be calculated without pagination"),
     FORBIDDEN_TYPENAME(400,"ATLAS-400-00-107", "Forbidden type: Can not pass builtin type {0}"),
-    README_FAILED(400,"ATLAS-400-00-108", "Asset is required for readme creation"),
+    README_FAILED(400,"ATLAS-400-00-108", "Readme creation failed for {0}: Asset is required"),
 
     // All Not found enums go here
     TYPE_NAME_NOT_FOUND(404, "ATLAS-404-00-001", "Given typename {0} was invalid"),

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/readme/ReadmePreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/readme/ReadmePreProcessor.java
@@ -20,11 +20,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.util.Collections;
 
+import static org.apache.atlas.AtlasErrorCode.BAD_REQUEST;
 import static org.apache.atlas.AtlasErrorCode.README_FAILED;
 import static org.apache.atlas.model.instance.AtlasEntity.Status.DELETED;
 import static org.apache.atlas.repository.Constants.QUALIFIED_NAME;
 import static org.apache.atlas.repository.Constants.STATE_PROPERTY_KEY;
 import static org.apache.atlas.repository.Constants.ASSET;
+import static org.apache.atlas.repository.Constants.NAME;
 
 public class ReadmePreProcessor implements PreProcessor {
     private static final Logger LOG = LoggerFactory.getLogger(ReadmePreProcessor.class);
@@ -57,52 +59,56 @@ public class ReadmePreProcessor implements PreProcessor {
             case UPDATE:
                 processUpdateReadme(entity, context.getVertex(entity.getGuid()));
                 break;
+            default:
+                throw new AtlasBaseException(BAD_REQUEST, "Invalid Request");
         }
     }
 
     private void processCreateReadme(AtlasEntity entity, EntityMutationContext context) throws AtlasBaseException {
         AtlasObjectId asset = (AtlasObjectId) entity.getRelationshipAttribute(ASSET);
-        if (asset != null) {
-            RequestContext requestContext = RequestContext.get();
-            AtlasPerfMetrics.MetricRecorder metricRecorder = requestContext.startMetricRecord("processCreateReadme");
-            String entityQualifiedName = createQualifiedName(asset);
+        RequestContext requestContext = RequestContext.get();
+        AtlasPerfMetrics.MetricRecorder metricRecorder = requestContext.startMetricRecord("processCreateReadme");
+        try {
+            if (asset != null) {
+                String entityQualifiedName = createQualifiedName(asset);
 
-            entity.setAttribute(QUALIFIED_NAME, entityQualifiedName);
+                entity.setAttribute(QUALIFIED_NAME, entityQualifiedName);
 
-            AtlasEntityType entityType = typeRegistry.getEntityTypeByName(entity.getTypeName());
-            AtlasVertex vertex = AtlasGraphUtilsV2.findByUniqueAttributes(graph, entityType, entity.getAttributes());
-            if (vertex != null) {
-                if (vertex.getProperty(STATE_PROPERTY_KEY, String.class).equals(DELETED.name())) {
-                    GraphTransactionInterceptor.addToVertexStateCache(vertex.getId(), AtlasEntity.Status.ACTIVE);
-                    restoreHandlerV1.restoreEntities(Collections.singletonList(vertex));
+                AtlasEntityType entityType = typeRegistry.getEntityTypeByName(entity.getTypeName());
+                AtlasVertex vertex = AtlasGraphUtilsV2.findByUniqueAttributes(graph, entityType, entity.getAttributes());
+                if (vertex != null) {
+                    if (vertex.getProperty(STATE_PROPERTY_KEY, String.class).equals(DELETED.name())) {
+                        GraphTransactionInterceptor.addToVertexStateCache(vertex.getId(), AtlasEntity.Status.ACTIVE);
+                        restoreHandlerV1.restoreEntities(Collections.singletonList(vertex));
+                    }
+                    String internalGuidOfReadme = context.getDiscoveryContext().getReferencedGuids().get(asset.getGuid());
+                    entity.setGuid(GraphHelper.getGuid(vertex));
+                    context.updateEntityReferences(internalGuidOfReadme, entity, entityType, vertex);
                 }
-                String internalGuidOfReadme = context.getDiscoveryContext().getReferencedGuids().get(asset.getGuid());
-                entity.setGuid(GraphHelper.getGuid(vertex));
-                context.updateEntityReferences(internalGuidOfReadme, entity, entityType, vertex);
+                requestContext.recordEntityUpdate(entityRetriever.toAtlasEntityHeader(vertex, entity.getAttributes().keySet()));
+                requestContext.cacheDifferentialEntity(entity);
+            } else {
+                LOG.error("Asset is required for readme creation");
+                throw new AtlasBaseException(README_FAILED, (String) entity.getAttribute(NAME));
             }
-            requestContext.recordEntityUpdate(entityRetriever.toAtlasEntityHeader(vertex, entity.getAttributes().keySet()));
-            requestContext.cacheDifferentialEntity(entity);
+        } finally{
             requestContext.endMetricRecord(metricRecorder);
-        }
-        else{
-            throw new AtlasBaseException(README_FAILED);
         }
     }
     private void processUpdateReadme(AtlasEntity entity, AtlasVertex vertex) throws AtlasBaseException {
         RequestContext requestContext = RequestContext.get();
         AtlasPerfMetrics.MetricRecorder metricRecorder = requestContext.startMetricRecord("processUpdateReadme");
-        String vertexQnName = vertex.getProperty(QUALIFIED_NAME, String.class);
 
-        entity.setAttribute(QUALIFIED_NAME, vertexQnName);
+        entity.setAttribute(QUALIFIED_NAME, vertex.getProperty(QUALIFIED_NAME, String.class));
         requestContext.recordEntityUpdate(entityRetriever.toAtlasEntityHeader(vertex, entity.getAttributes().keySet()));
         requestContext.cacheDifferentialEntity(entity);
         requestContext.endMetricRecord(metricRecorder);
     }
 
-    public String createQualifiedName(AtlasObjectId asset) throws AtlasBaseException {
-        String guid = asset.getGuid();
+    private String createQualifiedName(AtlasObjectId atlasObjectId) throws AtlasBaseException {
+        String guid = atlasObjectId.getGuid();
         if(StringUtils.isEmpty(guid))
-            guid = AtlasGraphUtilsV2.getGuidByUniqueAttributes(graph, typeRegistry.getEntityTypeByName(asset.getTypeName()), asset.getUniqueAttributes());
+            guid = AtlasGraphUtilsV2.getGuidByUniqueAttributes(graph, typeRegistry.getEntityTypeByName(atlasObjectId.getTypeName()), atlasObjectId.getUniqueAttributes());
 
         return guid + "/readme";
     }


### PR DESCRIPTION
There was ambiguity when ReadMe to asset were generated by user via API using their own qualifiedName pattern.

In order to have constituency in qualifiedName is generated at server side.

Linear: https://linear.app/atlanproduct/issue/META-4227