### PR TITLE
Meta 4227: Generate qualifiedName for ReadMe entity at server side

### DIFF
--- a/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
@@ -184,7 +184,7 @@ public enum AtlasErrorCode {
     CANT_CALCULATE_VERTEX_COUNTS_WITHOUT_PAGINATION(400, "ATLAS-400-00-104", "Vertex counts can't be calculated without pagination"),
     FORBIDDEN_TYPENAME(400,"ATLAS-400-00-107", "Forbidden type: Can not pass builtin type {0}"),
     README_FAILED(400,"ATLAS-400-00-108", "Readme creation failed for {0}: Asset is required"),
-    README_ALREADY_PRESENT(400,"ATLAS-400-00-109", "Readme already exists for the entity"),
+    README_ALREADY_PRESENT(400,"ATLAS-400-00-109", "Readme of guid {0} already exists for the entity"),
 
     // All Not found enums go here
     TYPE_NAME_NOT_FOUND(404, "ATLAS-404-00-001", "Given typename {0} was invalid"),

--- a/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
@@ -184,6 +184,7 @@ public enum AtlasErrorCode {
     CANT_CALCULATE_VERTEX_COUNTS_WITHOUT_PAGINATION(400, "ATLAS-400-00-104", "Vertex counts can't be calculated without pagination"),
     FORBIDDEN_TYPENAME(400,"ATLAS-400-00-107", "Forbidden type: Can not pass builtin type {0}"),
     README_FAILED(400,"ATLAS-400-00-108", "Readme creation failed for {0}: Asset is required"),
+    README_ALREADY_PRESENT(400,"ATLAS-400-00-109", "Readme already exists for the entity"),
 
     // All Not found enums go here
     TYPE_NAME_NOT_FOUND(404, "ATLAS-404-00-001", "Given typename {0} was invalid"),

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -585,7 +585,7 @@ public class EntityGraphMapper {
                 break;
 
             case README_ENTITY_TYPE:
-                preProcessor = new ReadmePreProcessor(typeRegistry, entityRetriever, graph, restoreHandlerV1);
+                preProcessor = new ReadmePreProcessor(typeRegistry, entityRetriever, graph);
                 break;
 
         }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/readme/ReadmePreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/readme/ReadmePreProcessor.java
@@ -3,9 +3,9 @@ package org.apache.atlas.repository.store.graph.v2.preprocessor.readme;
 import org.apache.atlas.RequestContext;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.instance.*;
+import org.apache.atlas.repository.graph.GraphHelper;
 import org.apache.atlas.repository.graphdb.AtlasGraph;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
-import org.apache.atlas.repository.store.graph.v1.RestoreHandlerV1;
 import org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2;
 import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
 import org.apache.atlas.repository.store.graph.v2.EntityMutationContext;
@@ -71,7 +71,7 @@ public class ReadmePreProcessor implements PreProcessor {
                 AtlasEntityType entityType = typeRegistry.getEntityTypeByName(entity.getTypeName());
                 AtlasVertex vertex = AtlasGraphUtilsV2.findByUniqueAttributes(graph, entityType, entity.getAttributes());
                 if (vertex != null) {
-                    LOG.error("Readme already exists for the asset.");
+                    LOG.error("Readme of guid {} already exists for the asset.", GraphHelper.getGuid(vertex));
                     throw new AtlasBaseException(README_ALREADY_PRESENT);
                 }
                 requestContext.cacheDifferentialEntity(entity);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/readme/ReadmePreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/readme/ReadmePreProcessor.java
@@ -71,8 +71,9 @@ public class ReadmePreProcessor implements PreProcessor {
                 AtlasEntityType entityType = typeRegistry.getEntityTypeByName(entity.getTypeName());
                 AtlasVertex vertex = AtlasGraphUtilsV2.findByUniqueAttributes(graph, entityType, entity.getAttributes());
                 if (vertex != null) {
-                    LOG.error("Readme of guid {} already exists for the asset.", GraphHelper.getGuid(vertex));
-                    throw new AtlasBaseException(README_ALREADY_PRESENT);
+                    String guidOfReadme = GraphHelper.getGuid(vertex);
+                    LOG.error("Readme of guid {} already exists for the asset.", guidOfReadme);
+                    throw new AtlasBaseException(README_ALREADY_PRESENT, guidOfReadme);
                 }
                 requestContext.cacheDifferentialEntity(entity);
             } else {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/readme/ReadmePreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/readme/ReadmePreProcessor.java
@@ -30,13 +30,11 @@ public class ReadmePreProcessor implements PreProcessor {
     private final AtlasTypeRegistry    typeRegistry;
     private final EntityGraphRetriever entityRetriever;
     private final AtlasGraph           graph;
-    private final RestoreHandlerV1     restoreHandlerV1;
 
-    public ReadmePreProcessor(AtlasTypeRegistry typeRegistry, EntityGraphRetriever entityRetriever, AtlasGraph graph, RestoreHandlerV1 restoreHandlerV1) {
+    public ReadmePreProcessor(AtlasTypeRegistry typeRegistry, EntityGraphRetriever entityRetriever, AtlasGraph graph) {
         this.entityRetriever = entityRetriever;
         this.typeRegistry = typeRegistry;
         this.graph = graph;
-        this.restoreHandlerV1 = restoreHandlerV1;
     }
 
     @Override
@@ -50,7 +48,7 @@ public class ReadmePreProcessor implements PreProcessor {
 
         switch (operation) {
             case CREATE:
-                processCreateReadme(entity, context);
+                processCreateReadme(entity);
                 break;
             case UPDATE:
                 processUpdateReadme(entity, context.getVertex(entity.getGuid()));
@@ -60,7 +58,7 @@ public class ReadmePreProcessor implements PreProcessor {
         }
     }
 
-    private void processCreateReadme(AtlasEntity entity, EntityMutationContext context) throws AtlasBaseException {
+    private void processCreateReadme(AtlasEntity entity) throws AtlasBaseException {
         AtlasObjectId asset = (AtlasObjectId) entity.getRelationshipAttribute(ASSET);
         RequestContext requestContext = RequestContext.get();
         AtlasPerfMetrics.MetricRecorder metricRecorder = requestContext.startMetricRecord("processCreateReadme");
@@ -76,7 +74,6 @@ public class ReadmePreProcessor implements PreProcessor {
                     LOG.error("Readme already exists for the asset.");
                     throw new AtlasBaseException(README_ALREADY_PRESENT);
                 }
-                requestContext.recordEntityUpdate(entityRetriever.toAtlasEntityHeader(vertex, entity.getAttributes().keySet()));
                 requestContext.cacheDifferentialEntity(entity);
             } else {
                 LOG.error("Asset is required for readme creation");

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/readme/ReadmePreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/readme/ReadmePreProcessor.java
@@ -1,10 +1,8 @@
 package org.apache.atlas.repository.store.graph.v2.preprocessor.readme;
 
-import org.apache.atlas.GraphTransactionInterceptor;
 import org.apache.atlas.RequestContext;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.instance.*;
-import org.apache.atlas.repository.graph.GraphHelper;
 import org.apache.atlas.repository.graphdb.AtlasGraph;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
 import org.apache.atlas.repository.store.graph.v1.RestoreHandlerV1;
@@ -18,13 +16,11 @@ import org.apache.atlas.utils.AtlasPerfMetrics;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.util.Collections;
 
 import static org.apache.atlas.AtlasErrorCode.BAD_REQUEST;
 import static org.apache.atlas.AtlasErrorCode.README_FAILED;
-import static org.apache.atlas.model.instance.AtlasEntity.Status.DELETED;
+import static org.apache.atlas.AtlasErrorCode.README_ALREADY_PRESENT;
 import static org.apache.atlas.repository.Constants.QUALIFIED_NAME;
-import static org.apache.atlas.repository.Constants.STATE_PROPERTY_KEY;
 import static org.apache.atlas.repository.Constants.ASSET;
 import static org.apache.atlas.repository.Constants.NAME;
 
@@ -77,13 +73,8 @@ public class ReadmePreProcessor implements PreProcessor {
                 AtlasEntityType entityType = typeRegistry.getEntityTypeByName(entity.getTypeName());
                 AtlasVertex vertex = AtlasGraphUtilsV2.findByUniqueAttributes(graph, entityType, entity.getAttributes());
                 if (vertex != null) {
-                    if (vertex.getProperty(STATE_PROPERTY_KEY, String.class).equals(DELETED.name())) {
-                        GraphTransactionInterceptor.addToVertexStateCache(vertex.getId(), AtlasEntity.Status.ACTIVE);
-                        restoreHandlerV1.restoreEntities(Collections.singletonList(vertex));
-                    }
-                    String internalGuidOfReadme = context.getDiscoveryContext().getReferencedGuids().get(asset.getGuid());
-                    entity.setGuid(GraphHelper.getGuid(vertex));
-                    context.updateEntityReferences(internalGuidOfReadme, entity, entityType, vertex);
+                    LOG.error("Readme already exists for the asset.");
+                    throw new AtlasBaseException(README_ALREADY_PRESENT);
                 }
                 requestContext.recordEntityUpdate(entityRetriever.toAtlasEntityHeader(vertex, entity.getAttributes().keySet()));
                 requestContext.cacheDifferentialEntity(entity);


### PR DESCRIPTION
There was ambiguity when ReadMe to asset were generated by user via API using their own qualifiedName pattern.

In order to have constituency in qualifiedName is generated at server side.

Linear: https://linear.app/atlanproduct/issue/META-4227