### PR TITLE
added Launchdarkly framework and enabled lineage events

### DIFF
--- a/intg/pom.xml
+++ b/intg/pom.xml
@@ -112,6 +112,13 @@
             <version>${guava.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- https://mvnrepository.com/artifact/com.launchdarkly/launchdarkly-java-server-sdk -->
+        <dependency>
+            <groupId>com.launchdarkly</groupId>
+            <artifactId>launchdarkly-java-server-sdk</artifactId>
+            <version>${launch-darkly.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
@@ -95,6 +95,7 @@ public enum AtlasConfiguration {
     LINEAGE_ON_DEMAND_DEFAULT_NODE_COUNT("atlas.lineage.on.demand.default.node.count", 3),
     LINEAGE_MAX_NODE_COUNT("atlas.lineage.max.node.count", 9000),
     SUPPORTED_RELATIONSHIP_EVENTS("atlas.notification.relationships.filter", "asset_readme,asset_links"),
+    SUPPORTED_LINEAGE_RELATIONSHIP_EVENTS_VIA_FEATURE_FLAG("atlas.notification.lineage.events.feature.flag.enabled.filter", "catalog_process_inputs,process_catalog_outputs,column_lineage"),
     REST_API_XSS_FILTER_MASK_STRING("atlas.rest.xss.filter.mask.string", "map<[a-zA-Z _,:<>0-9\\x60]*>|struct<[a-zA-Z _,:<>0-9\\x60]*>|array<[a-zA-Z _,:<>0-9\\x60]*>|\\{\\{[a-zA-Z _,-:0-9\\x60\\{\\}]*\\}\\}"),
     REST_API_XSS_FILTER_EXLUDE_SERVER_NAME("atlas.rest.xss.filter.exclude.server.name", "atlas-service-atlas.atlas.svc.cluster.local");
 

--- a/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
@@ -94,8 +94,10 @@ public enum AtlasConfiguration {
     LINEAGE_ON_DEMAND_ENABLED("atlas.lineage.on.demand.enabled", true),
     LINEAGE_ON_DEMAND_DEFAULT_NODE_COUNT("atlas.lineage.on.demand.default.node.count", 3),
     LINEAGE_MAX_NODE_COUNT("atlas.lineage.max.node.count", 9000),
+
     SUPPORTED_RELATIONSHIP_EVENTS("atlas.notification.relationships.filter", "asset_readme,asset_links"),
     SUPPORTED_LINEAGE_RELATIONSHIP_EVENTS_VIA_FEATURE_FLAG("atlas.notification.lineage.events.feature.flag.enabled.filter", "catalog_process_inputs,process_catalog_outputs,column_lineage"),
+
     REST_API_XSS_FILTER_MASK_STRING("atlas.rest.xss.filter.mask.string", "map<[a-zA-Z _,:<>0-9\\x60]*>|struct<[a-zA-Z _,:<>0-9\\x60]*>|array<[a-zA-Z _,:<>0-9\\x60]*>|\\{\\{[a-zA-Z _,-:0-9\\x60\\{\\}]*\\}\\}"),
     REST_API_XSS_FILTER_EXLUDE_SERVER_NAME("atlas.rest.xss.filter.exclude.server.name", "atlas-service-atlas.atlas.svc.cluster.local");
 

--- a/intg/src/main/java/org/apache/atlas/featureflag/AtlasFeatureFlagConfig.java
+++ b/intg/src/main/java/org/apache/atlas/featureflag/AtlasFeatureFlagConfig.java
@@ -1,0 +1,38 @@
+package org.apache.atlas.featureflag;
+import com.launchdarkly.sdk.server.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.annotation.PreDestroy;
+import java.io.IOException;
+import java.util.Objects;
+
+@Configuration
+public class AtlasFeatureFlagConfig {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AtlasFeatureFlagConfig.class);
+    private final static String LAUNCH_DARKLY_SDK_KEY       = Objects.toString(System.getenv("USER_LAUNCH_DARKLY_SDK_KEY"), "");
+    public final static String INSTANCE_DOMAIN_NAME         = Objects.toString(System.getenv("DOMAIN_NAME"), "");
+    public final static String UNQ_CONTEXT_KEY              = "context-atlas";
+    public final static String CONTEXT_NAME                 = "Atlas";
+    private LDClient launchDarklyClient;
+
+    @Bean
+    public LDClient launchDarklyClient() {
+        try {
+            this.launchDarklyClient = new LDClient(LAUNCH_DARKLY_SDK_KEY);
+        } catch (Exception e) {
+            LOG.error("Error while initializing LaunchDarkly client", e);
+            throw e;
+        }
+        return this.launchDarklyClient;
+    }
+
+    @PreDestroy
+    public void destroy() throws IOException {
+        this.launchDarklyClient.close();
+    }
+
+}

--- a/intg/src/main/java/org/apache/atlas/featureflag/FeatureFlagStore.java
+++ b/intg/src/main/java/org/apache/atlas/featureflag/FeatureFlagStore.java
@@ -1,0 +1,5 @@
+package org.apache.atlas.featureflag;
+
+public interface FeatureFlagStore {
+    boolean evaluate(String featureFlagKey, String featureFlagValue);
+}

--- a/intg/src/main/java/org/apache/atlas/featureflag/FeatureFlagStoreLaunchDarklyImpl.java
+++ b/intg/src/main/java/org/apache/atlas/featureflag/FeatureFlagStoreLaunchDarklyImpl.java
@@ -1,0 +1,36 @@
+package org.apache.atlas.featureflag;
+
+import com.launchdarkly.sdk.LDContext;
+import com.launchdarkly.sdk.server.LDClient;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FeatureFlagStoreLaunchDarklyImpl implements FeatureFlagStore {
+
+    private final LDClient client;
+
+    public FeatureFlagStoreLaunchDarklyImpl(LDClient ldClient) {
+        this.client = ldClient;
+    }
+
+    @Override
+    public boolean evaluate(String featureFlagKey, String featureFlagValue) {
+        boolean ret;
+        try {
+            LDContext ldContext = initContext(featureFlagKey, featureFlagValue);
+            ret = client.boolVariation(featureFlagKey, ldContext, false);
+        } catch (Exception e) {
+            return false;
+        }
+        return ret;
+    }
+
+    private static LDContext initContext(String key, String value) {
+        LDContext ldContext = LDContext.builder(AtlasFeatureFlagConfig.UNQ_CONTEXT_KEY)
+                .name(AtlasFeatureFlagConfig.CONTEXT_NAME)
+                .set(key, value)
+                .build();
+        return ldContext;
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -734,6 +734,7 @@
         <kafka.version>2.8.1</kafka.version>
         <keycloak.version>15.0.2.1</keycloak.version>
         <owasp-html-sanitizer.version>20220608.1</owasp-html-sanitizer.version>
+        <launch-darkly.version>6.0.5</launch-darkly.version>
         <reload4j.version>1.2.19</reload4j.version>
         <log4j2.version>2.17.1</log4j2.version>
         <lucene-solr.version>8.6.3</lucene-solr.version>

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityChangeNotifier.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityChangeNotifier.java
@@ -80,6 +80,7 @@ public class AtlasEntityChangeNotifier implements IAtlasEntityChangeNotifier {
     private static final List<String> ALLOWED_RELATIONSHIP_TYPES = Arrays.asList(AtlasConfiguration.SUPPORTED_RELATIONSHIP_EVENTS.getStringArray());
     private static final List<String> ALLOWED_LINEAGE_RELATIONSHIP_TYPES_VIA_FEATURE_FLAG = Arrays.asList(AtlasConfiguration.SUPPORTED_LINEAGE_RELATIONSHIP_EVENTS_VIA_FEATURE_FLAG.getStringArray());
     private final static String LINEAGE_EVENTS_FEATURE_FLAG_KEY =  "metastore-enable-lineage-events-for-pipeline";
+
     @Inject
     public AtlasEntityChangeNotifier(Set<EntityChangeListener> entityChangeListeners,
                                      Set<EntityChangeListenerV2> entityChangeListenersV2,
@@ -131,7 +132,7 @@ public class AtlasEntityChangeNotifier implements IAtlasEntityChangeNotifier {
         }
 
         List<AtlasRelationship> featureFlagBasedEvents = new ArrayList<>();
-        if (isLineageBasedEventsEnabled())
+        if (isLineageBasedEventsEnabled())      //TODO: Remove feature flag once tested on few prod tenants
             featureFlagBasedEvents.addAll(relationships.stream().filter(r -> ALLOWED_LINEAGE_RELATIONSHIP_TYPES_VIA_FEATURE_FLAG.contains(r.getTypeName())).collect(Collectors.toList()));
 
         relationships = relationships.stream().filter(r -> ALLOWED_RELATIONSHIP_TYPES.contains(r.getTypeName())).collect(Collectors.toList());


### PR DESCRIPTION
## Added feature flag based events for lineage CUD operations

Enabled feature flag based events for lineage CUD operations. Events to be consumed by existing dataflow pipeline es-relationships-sync-rt. Added relationship types: catalog_process_inputs,process_catalog_outputs,column_lineage. Events to be consumed by existing dataflow pipeline es-relationships-sync-rt.

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)


### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
