### PR TITLE
Meta-4615: __hasLineage property not recorded in audit Log

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -4083,8 +4083,10 @@ public class EntityGraphMapper {
                         AtlasGraphUtilsV2.setEncodedProperty(assetVertex, HAS_LINEAGE, true);
                         AtlasGraphUtilsV2.setEncodedProperty(processVertex, HAS_LINEAGE, true);
                         AtlasEntity diffEntity = RequestContext.get().getDifferentialEntity(guid);
-                        diffEntity.setAttribute(HAS_LINEAGE, true);
-                        RequestContext.get().cacheDifferentialEntity(diffEntity);
+                        if(diffEntity != null) {
+                            diffEntity.setAttribute(HAS_LINEAGE, true);
+                            RequestContext.get().cacheDifferentialEntity(diffEntity);
+                        }
                         isHasLineageSet = true;
                     }
 


### PR DESCRIPTION
When entity is updated with inputs and outputs , the __hasLineage property is set to true after calculation but same is not recorded in audit Log.

Expectations :- __hasLineage property for entity created / updated must be recorded.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)