### PR TITLE
Atlan 3636 - Enable JWT online token validation from Atlas

### DIFF
--- a/client-keycloak/pom.xml
+++ b/client-keycloak/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>apache-atlas</artifactId>
+        <groupId>org.apache.atlas</groupId>
+        <version>3.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>client-keycloak</artifactId>
+    <description>Apache Atlas Common</description>
+    <name>Apache Atlas Keycloak client</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-admin-client</artifactId>
+            <version>15.0.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>jsr311-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.atlas</groupId>
+            <artifactId>atlas-common</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/client-keycloak/src/main/java/org/apache/atlas/keycloak/client/KeycloakClient.java
+++ b/client-keycloak/src/main/java/org/apache/atlas/keycloak/client/KeycloakClient.java
@@ -1,4 +1,22 @@
-package org.apache.atlas.web.security.client;
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.atlas.keycloak.client;
 
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.commons.collections.CollectionUtils;
@@ -83,7 +101,7 @@ public class KeycloakClient {
                 JSONObject object = new JSONObject(keyConf);
 
                 REALM_ID = object.getString("realm");
-                AUTH_SERVER_URL = "https://beta.atlan.dev/auth";
+                AUTH_SERVER_URL = "http://keycloak-http.keycloak.svc.cluster.local/auth";
                 CLIENT_ID = object.getString("resource");
                 GRANT_TYPE = "client_credentials";
                 CLIENT_SECRET = object.getJSONObject("credentials").getString("secret");
@@ -116,13 +134,6 @@ public class KeycloakClient {
 
     public RealmResource getRealm() {
         return keycloak.realm(REALM_ID);
-    }
-
-    public boolean isClient(String clientId) {
-      //List clientList =   keycloak.realm(REALM_ID).clients().findByClientId("apikey-04772573-d9ce-4212-a304-c24073b5875e");
-
-      LOG.info(" client List" + keycloak.realm(REALM_ID));
-      return false;
     }
 
     public List<UserRepresentation> getAllUsers() {

--- a/client-keycloak/src/main/java/org/apache/atlas/keycloak/client/KeycloakClient.java
+++ b/client-keycloak/src/main/java/org/apache/atlas/keycloak/client/KeycloakClient.java
@@ -101,13 +101,13 @@ public class KeycloakClient {
                 JSONObject object = new JSONObject(keyConf);
 
                 REALM_ID = object.getString("realm");
-                AUTH_SERVER_URL = "http://keycloak-http.keycloak.svc.cluster.local/auth";
+                AUTH_SERVER_URL = object.getString("auth-server-url");
                 CLIENT_ID = object.getString("resource");
                 GRANT_TYPE = "client_credentials";
                 CLIENT_SECRET = object.getJSONObject("credentials").getString("secret");
 
-                LOG.info("Keycloak conf: REALM_ID:{}, AUTH_SERVER_URL:{}, CLIENT_ID:{}, CLIENT_SECRET:{}",
-                        REALM_ID, AUTH_SERVER_URL, CLIENT_ID, CLIENT_SECRET);
+                LOG.info("Keycloak conf: REALM_ID:{}, AUTH_SERVER_URL:{}, CLIENT_ID:{}",
+                        REALM_ID, AUTH_SERVER_URL, CLIENT_ID);
             } else {
                 throw new AtlasBaseException("Keycloak configuration file not found in location " + confLocation);
             }

--- a/pom.xml
+++ b/pom.xml
@@ -784,6 +784,7 @@
         <module>server-api</module>
         <module>notification</module>
         <module>client</module>
+        <module>client-keycloak</module>
         <module>graphdb</module>
         <module>repository</module>
         <module>authorization</module>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -294,6 +294,18 @@
         <dependency>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>jsr311-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.spec.javax.ws.rs</groupId>
+            <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
+            <version>2.0.1.Final</version>
         </dependency>
 
         <dependency>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -525,6 +525,20 @@
             </exclusions>
         </dependency>
 
+
+
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-admin-client</artifactId>
+            <version>15.0.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>jsr311-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
         <!-- sentry.io dependency in webapp/pom.xml -->
         <dependency>
             <groupId>io.sentry</groupId>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -525,20 +525,6 @@
             </exclusions>
         </dependency>
 
-
-
-        <dependency>
-            <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-admin-client</artifactId>
-            <version>15.0.2</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.ws.rs</groupId>
-                    <artifactId>jsr311-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
         <!-- sentry.io dependency in webapp/pom.xml -->
         <dependency>
             <groupId>io.sentry</groupId>
@@ -584,6 +570,17 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.atlas</groupId>
+            <artifactId>client-keycloak</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>jsr311-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/webapp/src/main/java/org/apache/atlas/web/security/AtlasKeycloakAuthenticationProvider.java
+++ b/webapp/src/main/java/org/apache/atlas/web/security/AtlasKeycloakAuthenticationProvider.java
@@ -17,9 +17,12 @@
 package org.apache.atlas.web.security;
 
 import org.apache.atlas.ApplicationProperties;
+import org.apache.atlas.web.security.client.KeycloakClient;
 import org.apache.commons.configuration.Configuration;
 import org.keycloak.adapters.springsecurity.authentication.KeycloakAuthenticationProvider;
 import org.keycloak.adapters.springsecurity.token.KeycloakAuthenticationToken;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -31,14 +34,17 @@ import java.util.Map;
 
 @Component
 public class AtlasKeycloakAuthenticationProvider extends AtlasAbstractAuthenticationProvider {
+  private static final Logger LOG1 = LoggerFactory.getLogger(AtlasKeycloakAuthenticationProvider.class);
+
   private final boolean groupsFromUGI;
   private final String groupsClaim;
 
   private final KeycloakAuthenticationProvider keycloakAuthenticationProvider;
+  private final KeycloakClient keycloakClient;
 
   public AtlasKeycloakAuthenticationProvider() throws Exception {
     this.keycloakAuthenticationProvider = new KeycloakAuthenticationProvider();
-
+    this.keycloakClient = KeycloakClient.getKeycloakClient();
     Configuration configuration = ApplicationProperties.get();
     this.groupsFromUGI = configuration.getBoolean("atlas.authentication.method.keycloak.ugi-groups", true);
     this.groupsClaim = configuration.getString("atlas.authentication.method.keycloak.groups_claim");
@@ -65,6 +71,9 @@ public class AtlasKeycloakAuthenticationProvider extends AtlasAbstractAuthentica
         authentication = new KeycloakAuthenticationToken(token.getAccount(), token.isInteractive(), grantedAuthorities);
       }
     }
+
+    LOG1.info(" logged in with principal {}", authentication.getPrincipal());
+    keycloakClient.isClient(authentication.getName());
 
     return authentication;
   }


### PR DESCRIPTION
## Atlan 3636 - Enable JWT online token validation from Atlas

> API Token is still enabled after deletion, need to invalidate those token