### PR TITLE
Gov 700: Add a new multi-field mapping for __classificationText attribute

### DIFF
--- a/addons/elasticsearch/es-mappings.json
+++ b/addons/elasticsearch/es-mappings.json
@@ -49,6 +49,18 @@
           "type": "long"
         }
       }
+    },
+    "__classificationsText": {
+      "type": "text",
+      "fields": {
+        "text": {
+          "type": "text",
+          "analyzer": "atlan_space_analyzer"
+        }
+      },
+      "copy_to" : [
+        "all"
+      ]
     }
   }
 }

--- a/addons/elasticsearch/es-settings.json
+++ b/addons/elasticsearch/es-settings.json
@@ -41,6 +41,13 @@
           "lowercase"
         ]
       },
+      "atlan_space_analyzer": {
+        "type": "custom",
+        "tokenizer": "whitespace",
+        "filter": [
+          "apostrophe", "lowercase"
+        ]
+      },
       "atlan_text_stemmer": {
         "type": "custom",
         "tokenizer": "atlan_tokenizer",


### PR DESCRIPTION
Since, Source tag attachment metadata are saved in classification attributes that are not indexed in ES.
We use __classificationText which contents entire classification as string.

`__classificationsText": "Sog1oWyAxs21iGWFL0h3l0 SHO7M5ZTA3BBOnGFrOwGDN tagSyncTimestamp Thu Jan 01 00:00:00 GMT 1970 tagSyncError null tagQualifiedName default/snowflake/1679648643/ANALYTICS/WIDE_WORLD_IMPORTERS/CONFIDENTIAL tagGuid a32fefea-1947-4849-84e1-2437115eb0b5 tagValue tagAttachmentValue Highly Restricted tagAttachmentKey null isTagSynced false tagName CONFIDENTIAL tagSource snowflake`

__classificationText has a standard analyzer (-) we will also need a space based analyzer because this may cause false hits while search by GUID.