### PR TITLE
PLT-314: Zookeper deprecation with redis - Staging

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -128,6 +128,12 @@
             <version>${kafka.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.redisson</groupId>
+            <artifactId>redisson</artifactId>
+            <version>${redis.client.version}</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/common/src/main/java/org/apache/atlas/service/redis/AbstractRedisService.java
+++ b/common/src/main/java/org/apache/atlas/service/redis/AbstractRedisService.java
@@ -44,12 +44,12 @@ public abstract class AbstractRedisService implements RedisService {
             isLockAcquired = lock.tryLock(waitTimeInMS, leaseTimeInMS, TimeUnit.MILLISECONDS);
             if (isLockAcquired) {
                 keyLockMap.put(key, lock);
-                getLogger().info("Acquired distributed lock on task for {}, host:{}", key, getHostAddress());
+                getLogger().info("Acquired distributed lock for {}, host:{}", key, getHostAddress());
             } else {
                 getLogger().info("Attempt failed as lock {} is already acquired, host: {}.", key, getHostAddress());
             }
         } catch (InterruptedException e) {
-            getLogger().error("Failed to acquire distributed lock, host: {}", getHostAddress(), e);
+            getLogger().error("Failed to acquire distributed lock for {}, host: {}", key, getHostAddress(), e);
             throw new AtlasException(e);
         }
         return isLockAcquired;

--- a/common/src/main/java/org/apache/atlas/service/redis/AbstractRedisService.java
+++ b/common/src/main/java/org/apache/atlas/service/redis/AbstractRedisService.java
@@ -1,0 +1,122 @@
+package org.apache.atlas.service.redis;
+
+import org.apache.atlas.ApplicationProperties;
+import org.apache.atlas.AtlasException;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.lang.ArrayUtils;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.redisson.config.ReadMode;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+public abstract class AbstractRedisService implements RedisService {
+
+    private static final String REDIS_URL_PREFIX = "redis://";
+    private static final String ATLAS_REDIS_URL = "atlas.redis.url";
+    private static final String ATLAS_REDIS_SENTINEL_URLS = "atlas.redis.sentinel.urls";
+    private static final String ATLAS_REDIS_USERNAME = "atlas.redis.username";
+    private static final String ATLAS_REDIS_PASSWORD = "atlas.redis.password";
+    private static final String ATLAS_REDIS_MASTER_NAME = "atlas.redis.master_name";
+    private static final String ATLAS_REDIS_LOCK_WAIT_TIME_MS = "atlas.redis.lock.wait_time.ms";
+    private static final String ATLAS_REDIS_LEASE_TIME_MS = "atlas.redis.lock.lease_time.ms";
+    private static final int DEFAULT_REDIS_WAIT_TIME_MS = 15000;
+    private static final int DEFAULT_REDIS_LEASE_TIME_MS = 60000;
+
+    RedissonClient redisClient;
+    Map<String, RLock> keyLockMap;
+    Configuration atlasConfig;
+    long waitTimeInMS;
+    long leaseTimeInMS;
+
+    @Override
+    public boolean acquireDistributedLock(String key) throws Exception {
+        getLogger().info("Attempting to acquire distributed lock for {}, host:{}", key, getHostAddress());
+        boolean isLockAcquired;
+        try {
+            RLock lock = redisClient.getFairLock(key);
+            isLockAcquired = lock.tryLock(waitTimeInMS, leaseTimeInMS, TimeUnit.MILLISECONDS);
+            if (isLockAcquired) {
+                keyLockMap.put(key, lock);
+                getLogger().info("Acquired distributed lock on task for {}, host:{}", key, getHostAddress());
+            } else {
+                getLogger().info("Attempt failed as lock {} is already acquired, host: {}.", key, getHostAddress());
+            }
+        } catch (InterruptedException e) {
+            getLogger().error("Failed to acquire distributed lock, host: {}", getHostAddress(), e);
+            throw new AtlasException(e);
+        }
+        return isLockAcquired;
+    }
+
+    @Override
+    public void releaseDistributedLock(String key) {
+        if (!keyLockMap.containsKey(key)) {
+            return;
+        }
+        try {
+            RLock lock = keyLockMap.get(key);
+            if (lock.isHeldByCurrentThread()) {
+                getLogger().info("Attempt to release distributed lock for {}, host: {}", key, getHostAddress());
+                lock.unlock();
+                getLogger().info("successfully released distributed lock for {}, host: {}", key, getHostAddress());
+            }
+        } catch (Exception e) {
+            getLogger().error("Failed to release distributed lock for {}", key, e);
+        }
+    }
+
+    private String getHostAddress() throws UnknownHostException {
+        return InetAddress.getLocalHost().getHostAddress();
+    }
+
+    private void initAtlasConfig() throws AtlasException {
+        keyLockMap = new ConcurrentHashMap<>();
+        atlasConfig = ApplicationProperties.get();
+        waitTimeInMS = atlasConfig.getLong(ATLAS_REDIS_LOCK_WAIT_TIME_MS, DEFAULT_REDIS_WAIT_TIME_MS);
+        leaseTimeInMS = atlasConfig.getLong(ATLAS_REDIS_LEASE_TIME_MS, DEFAULT_REDIS_LEASE_TIME_MS);
+    }
+
+    Config getLocalConfig() throws AtlasException {
+        initAtlasConfig();
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress(formatSentinelUrls(atlasConfig.getStringArray(ATLAS_REDIS_URL))[0])
+                .setUsername(atlasConfig.getString(ATLAS_REDIS_USERNAME))
+                .setPassword(atlasConfig.getString(ATLAS_REDIS_PASSWORD));
+        return config;
+    }
+
+    Config getProdConfig() throws AtlasException {
+        initAtlasConfig();
+        Config config = new Config();
+        config.useSentinelServers()
+                .setReadMode(ReadMode.MASTER_SLAVE)
+                .setCheckSentinelsList(false)
+                .setMasterName(atlasConfig.getString(ATLAS_REDIS_MASTER_NAME))
+                .addSentinelAddress(formatSentinelUrls(atlasConfig.getStringArray(ATLAS_REDIS_SENTINEL_URLS)))
+                .setUsername(atlasConfig.getString(ATLAS_REDIS_USERNAME))
+                .setPassword(atlasConfig.getString(ATLAS_REDIS_PASSWORD));
+        return config;
+    }
+
+    private String[] formatSentinelUrls(String[] urls) throws IllegalArgumentException {
+        if (ArrayUtils.isEmpty(urls)) {
+            getLogger().error("Invalid redis cluster urls");
+            throw new IllegalArgumentException("Invalid redis cluster urls");
+        }
+        return Arrays.stream(urls).map(url -> {
+            if (url.startsWith(REDIS_URL_PREFIX)) {
+                return url;
+            }
+            return REDIS_URL_PREFIX + url;
+        }).toArray(String[]::new);
+    }
+
+}

--- a/common/src/main/java/org/apache/atlas/service/redis/AbstractRedisService.java
+++ b/common/src/main/java/org/apache/atlas/service/redis/AbstractRedisService.java
@@ -87,7 +87,7 @@ public abstract class AbstractRedisService implements RedisService {
         initAtlasConfig();
         Config config = new Config();
         config.useSingleServer()
-                .setAddress(formatSentinelUrls(atlasConfig.getStringArray(ATLAS_REDIS_URL))[0])
+                .setAddress(formatUrls(atlasConfig.getStringArray(ATLAS_REDIS_URL))[0])
                 .setUsername(atlasConfig.getString(ATLAS_REDIS_USERNAME))
                 .setPassword(atlasConfig.getString(ATLAS_REDIS_PASSWORD));
         return config;
@@ -100,13 +100,13 @@ public abstract class AbstractRedisService implements RedisService {
                 .setReadMode(ReadMode.MASTER_SLAVE)
                 .setCheckSentinelsList(false)
                 .setMasterName(atlasConfig.getString(ATLAS_REDIS_MASTER_NAME))
-                .addSentinelAddress(formatSentinelUrls(atlasConfig.getStringArray(ATLAS_REDIS_SENTINEL_URLS)))
+                .addSentinelAddress(formatUrls(atlasConfig.getStringArray(ATLAS_REDIS_SENTINEL_URLS)))
                 .setUsername(atlasConfig.getString(ATLAS_REDIS_USERNAME))
                 .setPassword(atlasConfig.getString(ATLAS_REDIS_PASSWORD));
         return config;
     }
 
-    private String[] formatSentinelUrls(String[] urls) throws IllegalArgumentException {
+    private String[] formatUrls(String[] urls) throws IllegalArgumentException {
         if (ArrayUtils.isEmpty(urls)) {
             getLogger().error("Invalid redis cluster urls");
             throw new IllegalArgumentException("Invalid redis cluster urls");

--- a/common/src/main/java/org/apache/atlas/service/redis/AbstractRedisService.java
+++ b/common/src/main/java/org/apache/atlas/service/redis/AbstractRedisService.java
@@ -9,6 +9,7 @@ import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
 import org.redisson.config.ReadMode;
 
+import javax.annotation.PreDestroy;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Arrays;
@@ -119,4 +120,8 @@ public abstract class AbstractRedisService implements RedisService {
         }).toArray(String[]::new);
     }
 
+    @PreDestroy
+    public void flushLocks(){
+        keyLockMap.keySet().stream().forEach(k->keyLockMap.get(k).unlock());
+    }
 }

--- a/common/src/main/java/org/apache/atlas/service/redis/NoRedisServiceImpl.java
+++ b/common/src/main/java/org/apache/atlas/service/redis/NoRedisServiceImpl.java
@@ -15,7 +15,7 @@ public class NoRedisServiceImpl extends AbstractRedisService {
 
     @PostConstruct
     public void init() {
-        LOG.info("Enabled local redis implementation.");
+        LOG.info("Enabled no redis implementation.");
     }
 
     @Override

--- a/common/src/main/java/org/apache/atlas/service/redis/NoRedisServiceImpl.java
+++ b/common/src/main/java/org/apache/atlas/service/redis/NoRedisServiceImpl.java
@@ -1,0 +1,37 @@
+package org.apache.atlas.service.redis;
+
+import org.apache.atlas.annotation.ConditionalOnAtlasProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+
+@Component
+@ConditionalOnAtlasProperty(property = "atlas.redis.service.impl", isDefault = true)
+public class NoRedisServiceImpl extends AbstractRedisService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NoRedisServiceImpl.class);
+
+    @PostConstruct
+    public void init() {
+        LOG.info("Enabled local redis implementation.");
+    }
+
+    @Override
+    public boolean acquireDistributedLock(String key) {
+        //do nothing
+        return true;
+    }
+
+    @Override
+    public void releaseDistributedLock(String key) {
+        //do nothing
+    }
+
+    @Override
+    public Logger getLogger() {
+        return LOG;
+    }
+
+}

--- a/common/src/main/java/org/apache/atlas/service/redis/RedisService.java
+++ b/common/src/main/java/org/apache/atlas/service/redis/RedisService.java
@@ -1,0 +1,13 @@
+package org.apache.atlas.service.redis;
+
+import org.slf4j.Logger;
+
+public interface RedisService {
+
+  boolean acquireDistributedLock(String key) throws Exception;
+
+  void releaseDistributedLock(String key);
+
+  Logger getLogger();
+
+}

--- a/common/src/main/java/org/apache/atlas/service/redis/RedisServiceImpl.java
+++ b/common/src/main/java/org/apache/atlas/service/redis/RedisServiceImpl.java
@@ -1,0 +1,29 @@
+package org.apache.atlas.service.redis;
+
+import org.apache.atlas.AtlasException;
+import org.apache.atlas.annotation.ConditionalOnAtlasProperty;
+import org.redisson.Redisson;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+
+@Component
+@ConditionalOnAtlasProperty(property = "atlas.redis.service.impl")
+public class RedisServiceImpl extends AbstractRedisService{
+
+    private static final Logger LOG = LoggerFactory.getLogger(RedisServiceImpl.class);
+
+    @PostConstruct
+    public void init() throws AtlasException {
+        redisClient = Redisson.create(getProdConfig());
+        LOG.info("Sentinel Redis Client created successfully.");
+    }
+
+    @Override
+    public Logger getLogger() {
+        return LOG;
+    }
+
+}

--- a/common/src/main/java/org/apache/atlas/service/redis/RedisServiceImpl.java
+++ b/common/src/main/java/org/apache/atlas/service/redis/RedisServiceImpl.java
@@ -18,7 +18,7 @@ public class RedisServiceImpl extends AbstractRedisService{
     @PostConstruct
     public void init() throws AtlasException {
         redisClient = Redisson.create(getProdConfig());
-        LOG.info("Sentinel Redis Client created successfully.");
+        LOG.info("Sentinel redis client created successfully.");
     }
 
     @Override

--- a/common/src/main/java/org/apache/atlas/service/redis/RedisServiceLocalImpl.java
+++ b/common/src/main/java/org/apache/atlas/service/redis/RedisServiceLocalImpl.java
@@ -1,0 +1,28 @@
+package org.apache.atlas.service.redis;
+
+import org.apache.atlas.AtlasException;
+import org.apache.atlas.annotation.ConditionalOnAtlasProperty;
+import org.redisson.Redisson;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+
+@Component
+@ConditionalOnAtlasProperty(property = "atlas.redis.service.impl")
+public class RedisServiceLocalImpl extends AbstractRedisService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RedisServiceLocalImpl.class);
+
+    @PostConstruct
+    public void init() throws AtlasException {
+        redisClient = Redisson.create(getLocalConfig());
+        LOG.info("Local Redis Client created successfully.");
+    }
+
+    @Override
+    public Logger getLogger() {
+        return LOG;
+    }
+}

--- a/common/src/main/java/org/apache/atlas/service/redis/RedisServiceLocalImpl.java
+++ b/common/src/main/java/org/apache/atlas/service/redis/RedisServiceLocalImpl.java
@@ -18,7 +18,7 @@ public class RedisServiceLocalImpl extends AbstractRedisService {
     @PostConstruct
     public void init() throws AtlasException {
         redisClient = Redisson.create(getLocalConfig());
-        LOG.info("Local Redis Client created successfully.");
+        LOG.info("Local redis client created successfully.");
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -773,7 +773,7 @@
         <tinkerpop.version>3.5.1</tinkerpop.version>
         <woodstox-core.version>5.0.3</woodstox-core.version>
         <zookeeper.version>3.4.6</zookeeper.version>
-        <redis.client.version>3.13.1</redis.client.version>
+        <redis.client.version>3.20.1</redis.client.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -773,6 +773,7 @@
         <tinkerpop.version>3.5.1</tinkerpop.version>
         <woodstox-core.version>5.0.3</woodstox-core.version>
         <zookeeper.version>3.4.6</zookeeper.version>
+        <redis.client.version>3.13.1</redis.client.version>
     </properties>
 
     <modules>

--- a/repository/src/main/java/org/apache/atlas/repository/graph/IndexRecoveryService.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/IndexRecoveryService.java
@@ -105,7 +105,6 @@ public class IndexRecoveryService implements Service, ActiveStateChangeHandler {
     public void stop() throws AtlasException {
         try {
             recoveryThread.shutdown();
-
             indexHealthMonitor.join();
         } catch (InterruptedException e) {
             LOG.error("indexHealthMonitor: Interrupted", e);
@@ -209,6 +208,7 @@ public class IndexRecoveryService implements Service, ActiveStateChangeHandler {
                 }
 
                 shouldRun.set(false);
+                this.redisService.releaseDistributedLock(ATLAS_INDEX_RECOVERY_LOCK);
             } finally {
                 LOG.info("Index Health Monitor: Shutdown: Done!");
             }

--- a/repository/src/main/java/org/apache/atlas/repository/graph/IndexRecoveryService.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/IndexRecoveryService.java
@@ -69,9 +69,7 @@ public class IndexRecoveryService implements Service, ActiveStateChangeHandler {
         long healthCheckFrequencyMillis  = config.getLong(SOLR_STATUS_CHECK_RETRY_INTERVAL, SOLR_STATUS_RETRY_DEFAULT_MS);
         this.recoveryInfoManagement      = new RecoveryInfoManagement(graph);
 
-        final String zkRoot = HAConfiguration.getZookeeperProperties(configuration).getZkRoot();
-        final boolean isActiveActiveHAEnabled = HAConfiguration.isActiveActiveHAEnabled(configuration);
-        this.recoveryThread = new RecoveryThread(recoveryInfoManagement, graph, recoveryStartTimeFromConfig, healthCheckFrequencyMillis, redisService, zkRoot, isActiveActiveHAEnabled);
+        this.recoveryThread = new RecoveryThread(recoveryInfoManagement, graph, recoveryStartTimeFromConfig, healthCheckFrequencyMillis, redisService);
         this.indexHealthMonitor = new Thread(recoveryThread, INDEX_HEALTH_MONITOR_THREAD_NAME);
     }
 
@@ -155,19 +153,15 @@ public class IndexRecoveryService implements Service, ActiveStateChangeHandler {
         private       long                   indexStatusCheckRetryMillis;
         private       Object                 txRecoveryObject;
         private final RedisService redisService;
-        private final String zkRoot;
-        private final boolean isActiveActiveHAEnabled;
 
         private final AtomicBoolean          shouldRun = new AtomicBoolean(false);
 
         private RecoveryThread(RecoveryInfoManagement recoveryInfoManagement, AtlasGraph graph, long startTimeFromConfig, long healthCheckFrequencyMillis,
-                               RedisService redisService, String zkRoot, boolean isActiveActiveHAEnabled) {
+                               RedisService redisService) {
             this.graph                       = graph;
             this.recoveryInfoManagement      = recoveryInfoManagement;
             this.indexStatusCheckRetryMillis = healthCheckFrequencyMillis;
             this.redisService = redisService;
-            this.zkRoot = zkRoot;
-            this.isActiveActiveHAEnabled = isActiveActiveHAEnabled;
 
             if (startTimeFromConfig > 0) {
                 this.recoveryInfoManagement.updateStartTime(startTimeFromConfig);

--- a/repository/src/main/java/org/apache/atlas/tasks/TaskQueueWatcher.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/TaskQueueWatcher.java
@@ -20,8 +20,8 @@ package org.apache.atlas.tasks;
 import org.apache.atlas.AtlasConfiguration;
 import org.apache.atlas.ICuratorFactory;
 import org.apache.atlas.model.tasks.AtlasTask;
+import org.apache.atlas.service.redis.RedisService;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.curator.framework.recipes.locks.InterProcessMutex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,21 +43,24 @@ public class TaskQueueWatcher implements Runnable {
     private final Map<String, TaskFactory> taskTypeFactoryMap;
     private final TaskManagement.Statistics statistics;
     private final ICuratorFactory curatorFactory;
+    private final RedisService redisService;
 
     private static long pollInterval = AtlasConfiguration.TASKS_REQUEUE_POLL_INTERVAL.getLong();
     private static final String TASK_LOCK = "/task-lock";
+    private static final String ATLAS_TASK_LOCK = "atlas:task:lock";
 
     private final AtomicBoolean shouldRun = new AtomicBoolean(false);
 
     public TaskQueueWatcher(ExecutorService executorService, TaskRegistry registry,
                             Map<String, TaskFactory> taskTypeFactoryMap, TaskManagement.Statistics statistics,
-                            ICuratorFactory curatorFactory, final String zkRoot, boolean isActiveActiveHAEnabled) {
+                            ICuratorFactory curatorFactory, RedisService redisService, final String zkRoot, boolean isActiveActiveHAEnabled) {
 
         this.registry = registry;
         this.executorService = executorService;
         this.taskTypeFactoryMap = taskTypeFactoryMap;
         this.statistics = statistics;
         this.curatorFactory = curatorFactory;
+        this.redisService = redisService;
         this.zkRoot = zkRoot;
         this.isActiveActiveHAEnabled = isActiveActiveHAEnabled;
     }
@@ -74,11 +77,11 @@ public class TaskQueueWatcher implements Runnable {
         if (LOG.isDebugEnabled()) {
             LOG.debug("TaskQueueWatcher: running {}:{}", Thread.currentThread().getName(), Thread.currentThread().getId());
         }
-        InterProcessMutex lock = null;
-
         while (shouldRun.get()) {
             try {
-                lock = acquireDistributedLock();
+                if(!redisService.acquireDistributedLock(ATLAS_TASK_LOCK)){
+                    return;
+                }
 
                 TasksFetcher fetcher = new TasksFetcher(registry);
 
@@ -93,30 +96,18 @@ public class TaskQueueWatcher implements Runnable {
                     waitForTasksToComplete(latch);
                 } else {
                     LOG.info("No tasks to queue, sleeping for {} ms", pollInterval);
-                    releaseLock(lock);
+                    redisService.releaseDistributedLock(ATLAS_TASK_LOCK);
                 }
                 Thread.sleep(pollInterval);
             } catch (InterruptedException interruptedException) {
                 LOG.error("TaskQueueWatcher: Interrupted: thread is terminated, new tasks will not be loaded into the queue until next restart");
                 break;
-            } catch (Exception e){
-                LOG.error("TaskQueueWatcher: Exception occurred " +e.getMessage(),e);
-            }
-            finally {
-                releaseLock(lock);
+            } catch (Exception e) {
+                LOG.error("TaskQueueWatcher: Exception occurred " + e.getMessage(), e);
+            } finally {
+                redisService.releaseDistributedLock(ATLAS_TASK_LOCK);
             }
         }
-    }
-
-    private InterProcessMutex acquireDistributedLock() throws Exception {
-        if (!isActiveActiveHAEnabled)
-            return null;
-
-        final InterProcessMutex lockForTask = curatorFactory.lockInstance(zkRoot, TASK_LOCK);
-        LOG.info("Attempting to acquire a lock on task");
-        lockForTask.acquire();
-        LOG.info("Acquired a lock on task");
-        return lockForTask;
     }
 
     private void waitForTasksToComplete(final CountDownLatch latch) throws InterruptedException {
@@ -127,20 +118,6 @@ public class TaskQueueWatcher implements Runnable {
         }
     }
 
-    private void releaseLock(InterProcessMutex lock) {
-        if (lock == null)
-            return;
-        try {
-            if (lock.isOwnedByCurrentThread()) {
-                LOG.info("About to release task lock");
-                lock.release();
-                LOG.info("successfully released task lock");
-            }
-        } catch (Exception e) {
-            LOG.error("Error while releasing a lock of Task " + e.getMessage(), e);
-            //Not throwing exception here as it will terminate continuous while-loop
-        }
-    }
     private void submitAll(List<AtlasTask> tasks, CountDownLatch latch) {
         if (CollectionUtils.isNotEmpty(tasks)) {
 

--- a/repository/src/test/java/org/apache/atlas/tasks/TaskExecutorTest.java
+++ b/repository/src/test/java/org/apache/atlas/tasks/TaskExecutorTest.java
@@ -54,7 +54,7 @@ public class TaskExecutorTest extends BaseTaskFixture {
         TaskManagement.createTaskTypeFactoryMap(new HashMap<>(), spyingFactory);
 
         TaskManagement.Statistics statistics = new TaskManagement.Statistics();
-        new TaskExecutor(taskRegistry, taskFactoryMap, statistics, null, defaultZkRoot, false);
+        new TaskExecutor(taskRegistry, taskFactoryMap, statistics, null, null, defaultZkRoot, false);
 
         Assert.assertEquals(statistics.getTotal(), 0);
     }
@@ -66,7 +66,7 @@ public class TaskExecutorTest extends BaseTaskFixture {
         TaskManagement.createTaskTypeFactoryMap(taskFactoryMap, spyingFactory);
 
         TaskManagement.Statistics statistics = new TaskManagement.Statistics();
-        TaskExecutor taskExecutor = new TaskExecutor(taskRegistry, taskFactoryMap, statistics, null,defaultZkRoot,false);
+        TaskExecutor taskExecutor = new TaskExecutor(taskRegistry, taskFactoryMap, statistics, null, null, defaultZkRoot,false);
 
         taskManagement.createTask(SPYING_TASK_ADD, "test", Collections.emptyMap(), "testId", "testGuid");
 
@@ -87,7 +87,7 @@ public class TaskExecutorTest extends BaseTaskFixture {
         TaskManagement.Statistics statistics = new TaskManagement.Statistics();
         graph.commit();
 
-        TaskExecutor taskExecutor = new TaskExecutor(taskRegistry, taskFactoryMap, statistics, null,defaultZkRoot,false);
+        TaskExecutor taskExecutor = new TaskExecutor(taskRegistry, taskFactoryMap, statistics, null, null, defaultZkRoot,false);
 
         Thread.sleep(pollingInterval + 5000);
         Assert.assertEquals(statistics.getTotal(), 2);

--- a/repository/src/test/java/org/apache/atlas/tasks/TaskManagementTest.java
+++ b/repository/src/test/java/org/apache/atlas/tasks/TaskManagementTest.java
@@ -26,7 +26,6 @@ import org.testng.Assert;
 import org.testng.annotations.Guice;
 import org.testng.annotations.Test;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -49,14 +48,14 @@ public class TaskManagementTest extends BaseTaskFixture {
 
     @Test
     public void factoryReturningNullIsHandled() throws AtlasException {
-        TaskManagement taskManagement = new TaskManagement(null, taskRegistry, new NullFactory(),null);
+        TaskManagement taskManagement = new TaskManagement(null, taskRegistry, new NullFactory(),null, null);
         taskManagement.start();
     }
 
     @Test
     public void taskSucceedsTaskVertexRemoved() throws AtlasException, InterruptedException, AtlasBaseException {
         SpyingFactory spyingFactory = new SpyingFactory();
-        TaskManagement taskManagement = new TaskManagement(null, taskRegistry, spyingFactory,null);
+        TaskManagement taskManagement = new TaskManagement(null, taskRegistry, spyingFactory,null, null);
         taskManagement.start();
 
         AtlasTask spyTask = createTask(taskManagement, SPYING_TASK_ADD);

--- a/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
@@ -37,6 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.servlet.http.HttpServletRequest;
@@ -613,5 +614,10 @@ public class TypesREST {
         }
 
         return ret;
+    }
+
+    @PreDestroy
+    public void cleanUp() {
+        this.redisService.releaseDistributedLock(ATLAS_TYPEDEF_LOCK);
     }
 }

--- a/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
@@ -21,7 +21,6 @@ import org.apache.atlas.AtlasErrorCode;
 import org.apache.atlas.RequestContext;
 import org.apache.atlas.annotation.Timed;
 import org.apache.atlas.exception.AtlasBaseException;
-import org.apache.atlas.ha.HAConfiguration;
 import org.apache.atlas.model.SearchFilter;
 import org.apache.atlas.model.typedef.*;
 import org.apache.atlas.repository.graph.TypeCacheRefresher;
@@ -66,14 +65,12 @@ public class TypesREST {
     private final AtlasTypeDefStore typeDefStore;
     private final RedisService redisService;
     private final TypeCacheRefresher typeCacheRefresher;
-    private final boolean isActiveActiveHAEnabled;
 
     @Inject
     public TypesREST(AtlasTypeDefStore typeDefStore, RedisService redisService, Configuration configuration, TypeCacheRefresher typeCacheRefresher) {
         this.typeDefStore = typeDefStore;
         this.redisService = redisService;
         this.typeCacheRefresher = typeCacheRefresher;
-        this.isActiveActiveHAEnabled = HAConfiguration.isActiveActiveHAEnabled(configuration);
     }
 
     /**
@@ -377,9 +374,6 @@ public class TypesREST {
     }
 
     private void attemptAcquiringLock() throws AtlasBaseException {
-        if (!isActiveActiveHAEnabled)
-            return;
-
         final String traceId = RequestContext.get().getTraceId();
         try {
             if (!redisService.acquireDistributedLock(ATLAS_TYPEDEF_LOCK)) {


### PR DESCRIPTION
## Change description
Deprecated zookeeper lock, and implemented redis distributed lock for 
- **Task Management**: In order to run background tasks for classification propagation, update meanings.
- **Create Typedef**: Inorder to isolate creation of typedefs through one instance only to avoid corruptions.
- **IndexRecoveryService**: Background tasks which dynamically recovers ES index in case of failures during certain period. The background thread checks for ES indexHealth, followed by recovering it in case of failures, through processing JG transaction logs.

NOTE: There will be another PR for removing zk dependency, this PR is only for distributed lock

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues
https://linear.app/atlanproduct/issue/PLT-314/deprecate-zookeeper-from-atlas
