### PR TITLE
Beta - Add a new multi-field mapping for __classificationText attribute

### DIFF
--- a/addons/elasticsearch/es-mappings.json
+++ b/addons/elasticsearch/es-mappings.json
@@ -49,18 +49,6 @@
           "type": "long"
         }
       }
-    },
-    "__classificationsText": {
-      "type": "text",
-      "fields": {
-        "text": {
-          "type": "text",
-          "analyzer": "atlan_space_analyzer"
-        }
-      },
-      "copy_to" : [
-        "all"
-      ]
     }
   }
 }

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphBackedSearchIndexer.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphBackedSearchIndexer.java
@@ -338,6 +338,12 @@ public class GraphBackedSearchIndexer implements SearchIndexer, ActiveStateChang
             HashMap<String, HashMap<String, Object>> ES_GLOSSARY_ANALYZER_MULTIFIELD = new HashMap<>();
             ES_GLOSSARY_ANALYZER_MULTIFIELD.put("text", ES_GLOSSARY_ANALYZER_TEXT_FIELD);
 
+            HashMap<String, Object> ES_SPACE_ANALYZER_TEXT_FIELD = new HashMap<>();
+            ES_SPACE_ANALYZER_TEXT_FIELD.put("type", "text");
+            ES_SPACE_ANALYZER_TEXT_FIELD.put("analyzer", "atlan_space_analyzer");
+            HashMap<String, HashMap<String, Object>> ES_SPACE_ANALYZER_MULTIFIELD = new HashMap<>();
+            ES_SPACE_ANALYZER_MULTIFIELD.put("text", ES_SPACE_ANALYZER_TEXT_FIELD);
+
             HashMap<String, Object> ES_ATLAN_TEXT_ANALYZER_CONFIG = new HashMap<>();
             ES_ATLAN_TEXT_ANALYZER_CONFIG.put("analyzer", "atlan_text_analyzer");
 
@@ -359,7 +365,7 @@ public class GraphBackedSearchIndexer implements SearchIndexer, ActiveStateChang
             createCommonVertexIndex(management, MODIFICATION_TIMESTAMP_PROPERTY_KEY, UniqueKind.NONE, Long.class, SINGLE, false, false, false, new HashMap<>(), TIMESTAMP_MULTIFIELDS);
             createCommonVertexIndex(management, STATE_PROPERTY_KEY, UniqueKind.NONE, String.class, SINGLE, false, false, true);
             createCommonVertexIndex(management, CREATED_BY_KEY, UniqueKind.NONE, String.class, SINGLE, false, false, true);
-            createCommonVertexIndex(management, CLASSIFICATION_TEXT_KEY, UniqueKind.NONE, String.class, SINGLE, false, false);
+            createCommonVertexIndex(management, CLASSIFICATION_TEXT_KEY, UniqueKind.NONE, String.class, SINGLE, false, false, false, new HashMap<>(), ES_SPACE_ANALYZER_MULTIFIELD);
             createCommonVertexIndex(management, MODIFIED_BY_KEY, UniqueKind.NONE, String.class, SINGLE, false, false, true);
             createCommonVertexIndex(management, CLASSIFICATION_NAMES_KEY, UniqueKind.NONE, String.class, SINGLE, true, false);
             createCommonVertexIndex(management, PROPAGATED_CLASSIFICATION_NAMES_KEY, UniqueKind.NONE, String.class, SINGLE, true, false);


### PR DESCRIPTION
Since, Source tag attachment metadata are saved in classification attributes that are not indexed in ES.
We use __classificationText which contents entire classification as string.

`__classificationsText": "Sog1oWyAxs21iGWFL0h3l0 SHO7M5ZTA3BBOnGFrOwGDN tagSyncTimestamp Thu Jan 01 00:00:00 GMT 1970 tagSyncError null tagQualifiedName default/snowflake/1679648643/ANALYTICS/WIDE_WORLD_IMPORTERS/CONFIDENTIAL tagGuid a32fefea-1947-4849-84e1-2437115eb0b5 tagValue tagAttachmentValue Highly Restricted tagAttachmentKey null isTagSynced false tagName CONFIDENTIAL tagSource snowflake`

__classificationText has a standard analyzer, we will also need a space based analyzer because this may cause false hits while search by GUID.