### PR TITLE
[Master] Increase janusgraph_vertex_index ES field limit to 2000

### DIFF
--- a/addons/elasticsearch/es-settings.json
+++ b/addons/elasticsearch/es-settings.json
@@ -1,7 +1,7 @@
 {
   "mapping" : {
     "total_fields" : {
-      "limit" : "1500"
+      "limit" : "2000"
     },
     "nested_objects" : {
       "limit" : "100000"


### PR DESCRIPTION
## Increase janusgraph_vertex_index ES field limit to 2000

> Update es-settings.json to update field limit to 2000