### PR TITLE
Gov-967: Move terms/categories across anchor

### DIFF
--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -198,6 +198,7 @@ public final class Constants {
 
     public static final String NAME                                    = "name";
     public static final String QUALIFIED_NAME                          = "qualifiedName";
+    public static final String PARENT_CATEGORY                          = "parentCategory";
     public static final String TYPE_NAME_PROPERTY_KEY                  = INTERNAL_PROPERTY_KEY_PREFIX + "typeName";
     public static final String INDEX_SEARCH_MAX_RESULT_SET_SIZE        = "atlas.graph.index.search.max-result-set-size";
     public static final String INDEX_SEARCH_TYPES_MAX_QUERY_STR_LENGTH = "atlas.graph.index.search.types.max-query-str-length";

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -355,7 +355,7 @@ public abstract class DeleteHandlerV1 {
         }
 
         boolean isInternalType = isInternalType(entityVertex);
-        boolean forceDelete    = (typeCategory == STRUCT || typeCategory == CLASSIFICATION) && (forceDeleteStructTrait || isInternalType);
+        boolean forceDelete    = (typeCategory == STRUCT || typeCategory == CLASSIFICATION || edge.getLabel().equals(GLOSSARY_TERMS_EDGE_LABEL) || edge.getLabel().equals(GLOSSARY_CATEGORY_EDGE_LABEL) || edge.getLabel().equals(CATEGORY_TERMS_EDGE_LABEL) || edge.getLabel().equals(CATEGORY_PARENT_EDGE_LABEL)) && (forceDeleteStructTrait || isInternalType);
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("isInternal = {}, forceDelete = {}", isInternalType, forceDelete);
@@ -380,7 +380,7 @@ public abstract class DeleteHandlerV1 {
 
             // for relationship edges, inverse vertex's relationship attribute doesn't need to be updated.
             // only delete the reference relationship edge
-            if (GraphHelper.isRelationshipEdge(edge)) {
+            if (GraphHelper.isRelationshipEdge(edge) && !edge.getLabel().equals(GLOSSARY_TERMS_EDGE_LABEL) && !edge.getLabel().equals(GLOSSARY_CATEGORY_EDGE_LABEL) && edge.getLabel().equals(CATEGORY_TERMS_EDGE_LABEL) && edge.getLabel().equals(CATEGORY_PARENT_EDGE_LABEL)) {
                 deleteEdge(edge, isInternalType);
                 AtlasVertex referencedVertex = entityRetriever.getReferencedEntityVertex(edge, relationshipDirection, entityVertex);
 
@@ -398,7 +398,11 @@ public abstract class DeleteHandlerV1 {
                 //legacy case - not a relationship edge
                 //If deleting just the edge, reverse attribute should be updated for any references
                 //For example, for the department type system, if the person's manager edge is deleted, subordinates of manager should be updated
-                deleteEdge(edge, true, isInternalType);
+                if (edge.getLabel().equals(GLOSSARY_TERMS_EDGE_LABEL) || edge.getLabel().equals(GLOSSARY_CATEGORY_EDGE_LABEL) || edge.getLabel().equals(CATEGORY_TERMS_EDGE_LABEL) || edge.getLabel().equals(CATEGORY_PARENT_EDGE_LABEL)) {
+                    deleteEdge(edge, true, forceDelete);
+                } else {
+                    deleteEdge(edge, true, isInternalType);
+                }
             }
         }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasGraphUtilsV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasGraphUtilsV2.java
@@ -50,19 +50,7 @@ import org.slf4j.LoggerFactory;
 import java.text.SimpleDateFormat;
 import java.util.*;
 
-import static org.apache.atlas.repository.Constants.ATLAS_GLOSSARY_ENTITY_TYPE;
-import static org.apache.atlas.repository.Constants.CLASSIFICATION_NAMES_KEY;
-import static org.apache.atlas.repository.Constants.ENTITY_TYPE_PROPERTY_KEY;
-import static org.apache.atlas.repository.Constants.GLOSSARY_TERMS_EDGE_LABEL;
-import static org.apache.atlas.repository.Constants.INDEX_SEARCH_VERTEX_PREFIX_DEFAULT;
-import static org.apache.atlas.repository.Constants.INDEX_SEARCH_VERTEX_PREFIX_PROPERTY;
-import static org.apache.atlas.repository.Constants.NAME;
-import static org.apache.atlas.repository.Constants.PROPAGATED_CLASSIFICATION_NAMES_KEY;
-import static org.apache.atlas.repository.Constants.QUALIFIED_NAME;
-import static org.apache.atlas.repository.Constants.STATE_PROPERTY_KEY;
-import static org.apache.atlas.repository.Constants.SUPER_TYPES_PROPERTY_KEY;
-import static org.apache.atlas.repository.Constants.TYPENAME_PROPERTY_KEY;
-import static org.apache.atlas.repository.Constants.TYPE_NAME_PROPERTY_KEY;
+import static org.apache.atlas.repository.Constants.*;
 import static org.apache.atlas.repository.graph.AtlasGraphProvider.getGraphInstance;
 import static org.apache.atlas.repository.graphdb.AtlasGraphQuery.SortOrder.ASC;
 import static org.apache.atlas.repository.graphdb.AtlasGraphQuery.SortOrder.DESC;
@@ -632,6 +620,28 @@ public class AtlasGraphUtilsV2 {
 
         RequestContext.get().endMetricRecord(metric);
         return false;
+    }
+
+    public static boolean termExists1(String name) {
+        MetricRecorder  metric = RequestContext.get().startMetricRecord("AtlasGraphUtilsV2.termExists");
+        boolean ret = false;
+        AtlasGraphQuery query = getGraphInstance().query()
+                .has(ENTITY_TYPE_PROPERTY_KEY, ATLAS_GLOSSARY_TERM_ENTITY_TYPE);
+
+        Iterator<AtlasVertex> result = query.vertices().iterator();
+
+        while (result.hasNext()) {
+            AtlasVertex glossaryTermVertex = result.next();
+            if (getState(glossaryTermVertex) == Status.ACTIVE) {
+                String existingGlossaryTermName = glossaryTermVertex.getProperty(NAME, String.class);
+                if (name.equals(existingGlossaryTermName)) {
+                    ret = true;
+                }
+            }
+        }
+
+        RequestContext.get().endMetricRecord(metric);
+        return ret;
     }
 
     public static AtlasVertex findByTypeAndPropertyName(AtlasGraph graph, String typeName, Map<String, Object> attributeValues) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -565,7 +565,7 @@ public class EntityGraphMapper {
                 break;
 
             case ATLAS_GLOSSARY_CATEGORY_ENTITY_TYPE:
-                preProcessor = new CategoryPreProcessor(typeRegistry, entityRetriever);
+                preProcessor = new CategoryPreProcessor(typeRegistry, entityRetriever, graphHelper, deleteDelegate, graph, relationshipStore);
                 break;
 
             case QUERY_ENTITY_TYPE:

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/PreProcessorUtils.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/PreProcessorUtils.java
@@ -15,9 +15,7 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.atlas.repository.Constants.QUERY_COLLECTION_ENTITY_TYPE;
-import static org.apache.atlas.repository.Constants.QUALIFIED_NAME;
-import static org.apache.atlas.repository.Constants.ENTITY_TYPE_PROPERTY_KEY;
+import static org.apache.atlas.repository.Constants.*;
 
 public class PreProcessorUtils {
     private static final Logger LOG = LoggerFactory.getLogger(PreProcessorUtils.class);
@@ -103,5 +101,37 @@ public class PreProcessorUtils {
         entity.setAttribute(COLLECTION_QUALIFIED_NAME, newCollectionQualifiedName);
 
         return newCollectionQualifiedName;
+    }
+
+    public static String updateTermResourceAttributes(AtlasTypeRegistry typeRegistry, EntityGraphRetriever entityRetriever,
+                                                       AtlasEntity entity, AtlasVertex vertex, EntityMutationContext context) throws AtlasBaseException {
+        AtlasEntityType entityType      = typeRegistry.getEntityTypeByName(entity.getTypeName());
+        AtlasObjectId newParentObjectId = (AtlasObjectId) entity.getRelationshipAttribute(ANCHOR);
+        String relationshipType         = AtlasEntityUtil.getRelationshipType(newParentObjectId);
+        AtlasStructType.AtlasAttribute parentAttribute  = entityType.getRelationshipAttribute(ANCHOR, relationshipType);
+        AtlasObjectId currentParentObjectId = (AtlasObjectId) entityRetriever.getEntityAttribute(vertex, parentAttribute);
+        //Qualified name of the category/term will not be updated if anchor is not changed
+        String qualifiedName      = vertex.getProperty(QUALIFIED_NAME, String.class);
+        entity.setAttribute(QUALIFIED_NAME, qualifiedName);
+
+        if (parentAttribute.getAttributeType().areEqualValues(currentParentObjectId, newParentObjectId, context.getGuidAssignments())) {
+            return null;
+        }
+
+        AtlasVertex currentParentVertex         = entityRetriever.getEntityVertex(currentParentObjectId);
+        AtlasVertex newParentVertex             = entityRetriever.getEntityVertex(newParentObjectId);
+
+        if (currentParentVertex == null || newParentVertex == null) {
+            LOG.error("Current or New parent vertex is null");
+            throw new AtlasBaseException("Current or New parent vertex is null");
+        }
+
+        String newAnchorQualifiedName = newParentVertex.getProperty(QUALIFIED_NAME, String.class);
+        String currentAnchorQualifiedName = currentParentVertex.getProperty(QUALIFIED_NAME, String.class);
+        if(newAnchorQualifiedName.equals(currentAnchorQualifiedName))
+            return null;
+        String termNewQualifiedName = qualifiedName.replaceAll(currentAnchorQualifiedName, newAnchorQualifiedName);
+        entity.setAttribute(QUALIFIED_NAME, termNewQualifiedName);
+        return newAnchorQualifiedName;
     }
 }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/glossary/CategoryPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/glossary/CategoryPreProcessor.java
@@ -24,17 +24,18 @@ import org.apache.atlas.authorize.AtlasAuthorizationUtils;
 import org.apache.atlas.authorize.AtlasEntityAccessRequest;
 import org.apache.atlas.authorize.AtlasPrivilege;
 import org.apache.atlas.exception.AtlasBaseException;
-import org.apache.atlas.model.instance.AtlasEntity;
-import org.apache.atlas.model.instance.AtlasEntityHeader;
-import org.apache.atlas.model.instance.AtlasObjectId;
-import org.apache.atlas.model.instance.AtlasRelatedObjectId;
-import org.apache.atlas.model.instance.AtlasStruct;
-import org.apache.atlas.model.instance.EntityMutations;
+import org.apache.atlas.model.instance.*;
+import org.apache.atlas.repository.graph.GraphHelper;
+import org.apache.atlas.repository.graphdb.AtlasEdge;
+import org.apache.atlas.repository.graphdb.AtlasEdgeDirection;
+import org.apache.atlas.repository.graphdb.AtlasGraph;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
-import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
-import org.apache.atlas.repository.store.graph.v2.EntityMutationContext;
+import org.apache.atlas.repository.store.graph.AtlasRelationshipStore;
+import org.apache.atlas.repository.store.graph.v1.DeleteHandlerDelegate;
+import org.apache.atlas.repository.store.graph.v2.*;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessor;
-import org.apache.atlas.type.AtlasTypeRegistry;
+import org.apache.atlas.type.*;
+import org.apache.atlas.utils.AtlasEntityUtil;
 import org.apache.atlas.utils.AtlasPerfMetrics;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
@@ -42,27 +43,36 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
-import static org.apache.atlas.repository.Constants.NAME;
-import static org.apache.atlas.repository.Constants.QUALIFIED_NAME;
+import static org.apache.atlas.model.instance.AtlasRelatedObjectId.KEY_RELATIONSHIP_ATTRIBUTES;
+import static org.apache.atlas.model.instance.EntityMutations.EntityOperation.UPDATE;
+import static org.apache.atlas.repository.Constants.*;
+import static org.apache.atlas.repository.Constants.ACTIVE_STATE_VALUE;
 import static org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessorUtils.*;
+import static org.apache.atlas.type.AtlasStructType.AtlasAttribute.AtlasRelationshipEdgeDirection.IN;
 
 public class CategoryPreProcessor implements PreProcessor {
     private static final Logger LOG = LoggerFactory.getLogger(CategoryPreProcessor.class);
 
     private final AtlasTypeRegistry typeRegistry;
     private final EntityGraphRetriever entityRetriever;
+    private final GraphHelper graphHelper;
+    private final DeleteHandlerDelegate deleteDelegate;
+    private final AtlasGraph graph;
+    private final AtlasRelationshipStore relationshipStore;
 
     private AtlasEntityHeader anchor;
     private AtlasEntityHeader parentCategory;
 
-    public CategoryPreProcessor(AtlasTypeRegistry typeRegistry, EntityGraphRetriever entityRetriever) {
+    public CategoryPreProcessor(AtlasTypeRegistry typeRegistry, EntityGraphRetriever entityRetriever, GraphHelper graphHelper, DeleteHandlerDelegate deleteDelegate, AtlasGraph graph, AtlasRelationshipStore relationshipStore) {
         this.entityRetriever = entityRetriever;
         this.typeRegistry = typeRegistry;
+        this.graphHelper = graphHelper;
+        this.deleteDelegate = deleteDelegate;
+        this.graph = graph;
+        this.relationshipStore = relationshipStore;
     }
 
     @Override
@@ -84,7 +94,7 @@ public class CategoryPreProcessor implements PreProcessor {
                 processCreateCategory(entity, vertex);
                 break;
             case UPDATE:
-                processUpdateCategory(entity, vertex);
+                processUpdateCategory(entity, vertex, context);
                 break;
         }
     }
@@ -115,10 +125,248 @@ public class CategoryPreProcessor implements PreProcessor {
         RequestContext.get().endMetricRecord(metricRecorder);
     }
 
-    private void processUpdateCategory(AtlasEntity entity, AtlasVertex vertex) throws AtlasBaseException {
+    private void processUpdate(AtlasEntity entity, AtlasVertex vertex, EntityMutationContext context) throws AtlasBaseException {
+
+        AtlasEntityType entityType      = typeRegistry.getEntityTypeByName(entity.getTypeName());
+        AtlasObjectId newParentObjectId = (AtlasObjectId) entity.getRelationshipAttribute(ANCHOR);
+        String relationshipType         = AtlasEntityUtil.getRelationshipType(newParentObjectId);
+        AtlasStructType.AtlasAttribute parentAttribute  = entityType.getRelationshipAttribute(ANCHOR, relationshipType);
+        AtlasObjectId currentParentObjectId = (AtlasObjectId) entityRetriever.getEntityAttribute(vertex, parentAttribute);
+        AtlasVertex currentParentVertex         = entityRetriever.getEntityVertex(currentParentObjectId);
+        String currentAnchorQualifiedName = currentParentVertex.getProperty(QUALIFIED_NAME, String.class);
+        //Qualified name of the category/term will not be updated if anchor is not changed
+        String qualifiedName      = vertex.getProperty(QUALIFIED_NAME, String.class);
+        entity.setAttribute(QUALIFIED_NAME, qualifiedName);
+        String newAnchorQualifiedName = updateTermResourceAttributes(typeRegistry, entityRetriever, entity, vertex, context);
+
+        if(StringUtils.isNotEmpty(newAnchorQualifiedName) && !currentAnchorQualifiedName.equals(newAnchorQualifiedName)) {
+            processParentAnchorUpdation(entity, vertex, currentAnchorQualifiedName, newAnchorQualifiedName);
+            LOG.debug("Moved folder {} from collection {} to collection {}", entity.getAttribute(QUALIFIED_NAME), currentAnchorQualifiedName, newAnchorQualifiedName);
+        }
+
+    }
+
+
+    private void processParentAnchorUpdation(AtlasEntity entity, AtlasVertex categoryVertex, String currentAnchorQualifiedName, String newAnchorQualifiedName) throws AtlasBaseException {
+        AtlasPerfMetrics.MetricRecorder categroyProcessMetric = RequestContext.get().startMetricRecord("processParentAnchorUpdation");
+
+        String categoryQualifiedName        = categoryVertex.getProperty(QUALIFIED_NAME, String.class);
+        String updatedCategoryQualifiedName = categoryQualifiedName.replaceAll(currentAnchorQualifiedName, newAnchorQualifiedName);
+
+        /**
+         * 1. Move all the terms to new anchor first
+         * 2. Move all the child categories to new anchor
+         * 3. Update the qualified name of current category
+         * 4. Recursively find the child categories and move child terms to new glossary
+         */
+        moveTermsToDifferentAnchor(entity, categoryVertex, currentAnchorQualifiedName, newAnchorQualifiedName, updatedCategoryQualifiedName);
+
+        Iterator<AtlasVertex> childrenCategories = getActiveChildren(categoryVertex, CATEGORY_PARENT_EDGE_LABEL);
+
+        while (childrenCategories.hasNext()) {
+            AtlasVertex nestedCategoryVertex = childrenCategories.next();
+
+            AtlasEntity categoryEntity = entityRetriever.toAtlasEntity(categoryVertex);
+            AtlasObjectId parentCategory = (AtlasObjectId) categoryEntity.getRelationshipAttribute(PARENT_CATEGORY);
+            if(parentCategory != null && parentCategory.getGuid().equals(nestedCategoryVertex.getProperty(GUID_PROPERTY_KEY, String.class))){
+                return;
+            }
+
+            if (nestedCategoryVertex != null){// && (parentCategory != null && parentCategory.getGuid().equals(nestedCategroyVertex.getProperty(GUID_PROPERTY_KEY, String.class)))) {
+                updateChildAttributesOnUpdatingAnchor(entity, nestedCategoryVertex, currentAnchorQualifiedName, newAnchorQualifiedName, updatedCategoryQualifiedName);
+                /**
+                 * Recursively find the child folders and move child queries to new collection
+                 * folder1 -> folder2 -> query1
+                 * When we will move folder1 to new collection, recursively it will find folder2
+                 * Then it will move all the children of folder2 also to new collection
+                 */
+                processParentAnchorUpdation(entity, nestedCategoryVertex, currentAnchorQualifiedName, newAnchorQualifiedName);
+
+                LOG.info("Moved nested folder into new collection {}", newAnchorQualifiedName);
+            }
+        }
+
+        LOG.info("Moved current folder with qualified name {} into new collection {}", categoryQualifiedName, newAnchorQualifiedName);
+
+        RequestContext.get().endMetricRecord(categroyProcessMetric);
+    }
+
+    private void moveTermsToDifferentAnchor(AtlasEntity entity, AtlasVertex categoryVertex, String currentAnchorQualifiedName,
+                                                  String newAnchorQualifiedName, String categoryQualifiedName) throws AtlasBaseException {
+
+        AtlasPerfMetrics.MetricRecorder termProcessMetric = RequestContext.get().startMetricRecord("moveTermsToDifferentCollection");
+        Iterator<AtlasVertex> childrenTermsIterator = getActiveChildren(categoryVertex, CATEGORY_TERMS_EDGE_LABEL);
+
+        //Update all the children terms attribute
+        while (childrenTermsIterator.hasNext()) {
+            AtlasVertex termVertex = childrenTermsIterator.next();
+            if(termVertex != null) {
+                updateChildAttributesOnUpdatingAnchor(entity, termVertex, currentAnchorQualifiedName,
+                        newAnchorQualifiedName, categoryQualifiedName);
+            }
+        }
+
+        RequestContext.get().endMetricRecord(termProcessMetric);
+    }
+
+    private static Map<String, Object> getRelationshipAttributes(Object val) throws AtlasBaseException {
+        if (val instanceof AtlasRelatedObjectId) {
+            AtlasStruct relationshipStruct = ((AtlasRelatedObjectId) val).getRelationshipAttributes();
+
+            return (relationshipStruct != null) ? relationshipStruct.getAttributes() : null;
+        } else if (val instanceof Map) {
+            Object relationshipStruct = ((Map) val).get(KEY_RELATIONSHIP_ATTRIBUTES);
+
+            if (relationshipStruct instanceof Map) {
+                return AtlasTypeUtil.toStructAttributes(((Map) relationshipStruct));
+            }
+        }
+
+        return null;
+    }
+
+    private static String getRelationshipGuid(Object val) throws AtlasBaseException {
+        if (val instanceof AtlasRelatedObjectId) {
+            return ((AtlasRelatedObjectId) val).getRelationshipGuid();
+        } else if (val instanceof Map) {
+            Object relationshipGuidVal = ((Map) val).get(AtlasRelatedObjectId.KEY_RELATIONSHIP_GUID);
+
+            return relationshipGuidVal != null ? relationshipGuidVal.toString() : null;
+        }
+
+        return null;
+    }
+
+    private void updateChildAttributesOnUpdatingAnchor(AtlasEntity entity, AtlasVertex childVertex,  String currentAnchorQualifiedName, String newAnchorQualifiedName,
+                                                           String categoryQualifiedName) throws AtlasBaseException {
+        AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("updateChildAttributesOnUpdatingAnchor");
+        Map<String, Object> updatedAttributes = new HashMap<>();
+        String qualifiedName            =   childVertex.getProperty(QUALIFIED_NAME, String.class);
+        String updatedQualifiedName     =   qualifiedName.replaceAll(currentAnchorQualifiedName, newAnchorQualifiedName);
+        String typeName = childVertex.getProperty(TYPE_NAME_PROPERTY_KEY,String.class);
+        AtlasEntityType entityType = typeRegistry.getEntityTypeByName(typeName);
+        for(String attrName : entityType.getRelationshipAttributes().keySet()) {
+            Object attrValue = entity.getRelationshipAttribute(attrName);
+            String relationType = "";
+            if (attrValue != null) relationType = AtlasEntityUtil.getRelationshipType(attrValue);
+
+            if (attrName.equals("anchor") && typeName.equals("AtlasGlossaryTerm"))
+                relationType = GLOSSARY_TERMS_EDGE_LABEL;
+            else if (attrName.equals("anchor")) relationType = GLOSSARY_CATEGORY_EDGE_LABEL;
+
+            if (StringUtils.isNotEmpty(relationType)) {
+                AtlasStructType.AtlasAttribute attribute = entityType.getRelationshipAttribute(attrName, relationType);
+                AttributeMutationContext ctx = new AttributeMutationContext(UPDATE, childVertex, attribute, attrValue);
+                AtlasStructType.AtlasAttribute.AtlasRelationshipEdgeDirection edgeDirection = ctx.getAttribute().getRelationshipEdgeDirection();
+                String edgeLabel = ctx.getAttribute().getRelationshipEdgeLabel();
+
+                // if relationshipDefs doesn't exist, use legacy way of finding edge label.
+                if (org.apache.commons.lang3.StringUtils.isEmpty(edgeLabel)) {
+                    edgeLabel = AtlasGraphUtilsV2.getEdgeLabel(ctx.getVertexProperty());
+                }
+
+                String relationshipGuid = getRelationshipGuid(ctx.getValue());
+                AtlasEdge currentEdge;
+
+                // if relationshipGuid is assigned in AtlasRelatedObjectId use it to fetch existing AtlasEdge
+                if (org.apache.commons.lang3.StringUtils.isNotEmpty(relationshipGuid) && !RequestContext.get().isImportInProgress()) {
+                    currentEdge = graphHelper.getEdgeForGUID(relationshipGuid);
+                } else {
+                    currentEdge = graphHelper.getEdgeForLabel(ctx.getReferringVertex(), edgeLabel, edgeDirection);
+                }
+
+                deleteDelegate.getHandler().deleteEdgeReference(currentEdge, ctx.getAttrType().getTypeCategory(), false, true, ctx.getReferringVertex());
+
+                AtlasObjectId anchor = (AtlasObjectId) entity.getRelationshipAttribute("anchor");
+                AtlasVertex entityVertex = AtlasGraphUtilsV2.findByGuid(this.graph, anchor.getGuid());
+
+                String relationshipName = attribute.getRelationshipName();
+                AtlasVertex toVertex;
+                AtlasVertex fromVertex;
+                if (attribute.getRelationshipEdgeDirection() == IN) {
+                    fromVertex = entityVertex;
+                    toVertex = childVertex;
+
+                } else {
+                    fromVertex = childVertex;
+                    toVertex = entityVertex;
+                }
+                Map<String, Object> relationshipAttributes = getRelationshipAttributes(ctx.getValue());
+
+                AtlasEdge newEdge = relationshipStore.getOrCreate(fromVertex, toVertex, new AtlasRelationship(relationshipName, relationshipAttributes));
+                if (RequestContext.get().isImportInProgress()) {
+                    String relationshipGuid1 = getRelationshipGuid(ctx.getValue());
+
+                    if (!org.apache.commons.lang3.StringUtils.isEmpty(relationshipGuid1)) {
+                        AtlasGraphUtilsV2.setEncodedProperty(newEdge, RELATIONSHIP_GUID_PROPERTY_KEY, relationshipGuid1);
+                    }
+                }
+
+            }
+        }
+
+        if (!qualifiedName.equals(updatedQualifiedName)) {
+            AtlasGraphUtilsV2.setEncodedProperty(childVertex, QUALIFIED_NAME, updatedQualifiedName);
+            updatedAttributes.put(QUALIFIED_NAME, updatedQualifiedName);
+        }
+
+        recordUpdatedChildEntities(childVertex, updatedAttributes);
+
+        RequestContext.get().endMetricRecord(metricRecorder);
+    }
+
+    private void recordUpdatedChildEntities(AtlasVertex entityVertex, Map<String, Object> updatedAttributes) {
+        RequestContext requestContext = RequestContext.get();
+        AtlasPerfMetrics.MetricRecorder metricRecorder = requestContext.startMetricRecord("recordUpdatedChildEntities");
+        AtlasEntity entity = new AtlasEntity();
+        entity = entityRetriever.mapSystemAttributes(entityVertex, entity);
+        entity.setAttributes(updatedAttributes);
+        requestContext.cacheDifferentialEntity(new AtlasEntity(entity));
+
+        AtlasEntityType entityType = typeRegistry.getEntityTypeByName(entity.getTypeName());
+
+        //Add the min info attributes to entity header to be sent as part of notification
+        if(entityType != null) {
+            AtlasEntity finalEntity = entity;
+            entityType.getMinInfoAttributes().values().stream().filter(attribute -> !updatedAttributes.containsKey(attribute.getName())).forEach(attribute -> {
+                Object attrValue = null;
+                try {
+                    attrValue = entityRetriever.getVertexAttribute(entityVertex, attribute);
+                } catch (AtlasBaseException e) {
+                    LOG.error("Error while getting vertex attribute", e);
+                }
+                if(attrValue != null) {
+                    finalEntity.setAttribute(attribute.getName(), attrValue);
+                }
+            });
+            requestContext.recordEntityUpdate(new AtlasEntityHeader(finalEntity));
+        }
+
+        requestContext.endMetricRecord(metricRecorder);
+    }
+
+    private Iterator<AtlasVertex> getActiveChildren(AtlasVertex childVertex, String childrenEdgeLabel) throws AtlasBaseException {
+        AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("getActiveChildren");
+        try {
+            return childVertex.query()
+                    .direction(AtlasEdgeDirection.BOTH)
+                    .label(childrenEdgeLabel)
+                    .has(STATE_PROPERTY_KEY, ACTIVE_STATE_VALUE)
+                    .vertices()
+                    .iterator();
+        } catch (Exception e) {
+            LOG.error("Error while getting active children of category", e);
+            throw new AtlasBaseException(AtlasErrorCode.INTERNAL_ERROR, e);
+        }
+        finally {
+            RequestContext.get().endMetricRecord(metricRecorder);
+        }
+
+    }
+
+    private void processUpdateCategory(AtlasEntity entity, AtlasVertex vertex, EntityMutationContext context) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("processUpdateCategory");
         String catName = (String) entity.getAttribute(NAME);
-        String vertexQnName = vertex.getProperty(QUALIFIED_NAME, String.class);
 
         if (StringUtils.isEmpty(catName) || isNameInvalid(catName)) {
             throw new AtlasBaseException(AtlasErrorCode.INVALID_DISPLAY_NAME);
@@ -127,7 +375,10 @@ public class CategoryPreProcessor implements PreProcessor {
         AtlasEntity storeObject = entityRetriever.toAtlasEntity(vertex);
         AtlasRelatedObjectId existingAnchor = (AtlasRelatedObjectId) storeObject.getRelationshipAttribute(ANCHOR);
         if (existingAnchor != null && !existingAnchor.getGuid().equals(anchor.getGuid())){
-            throw new AtlasBaseException(AtlasErrorCode.ACHOR_UPDATION_NOT_SUPPORTED);
+            processUpdate(entity, vertex, context);
+        } else{
+            String vertexQnName = vertex.getProperty(QUALIFIED_NAME, String.class);
+            entity.setAttribute(QUALIFIED_NAME, vertexQnName);
         }
 
         if (parentCategory != null) {
@@ -140,8 +391,6 @@ public class CategoryPreProcessor implements PreProcessor {
         }
 
         validateChildren(entity, storeObject);
-
-        entity.setAttribute(QUALIFIED_NAME, vertexQnName);
         RequestContext.get().endMetricRecord(metricRecorder);
     }
 


### PR DESCRIPTION
Moving terms/categories across anchors.

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
