### PR TITLE
Update the policy cache in case of update in Accesscontrol entities

### DIFF
--- a/webapp/src/main/java/org/apache/atlas/web/rest/AuthREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/AuthREST.java
@@ -58,6 +58,9 @@ import java.util.Map;
 
 import static org.apache.atlas.policytransformer.CachePolicyTransformerImpl.ATTR_SERVICE_LAST_SYNC;
 import static org.apache.atlas.repository.Constants.POLICY_ENTITY_TYPE;
+import static org.apache.atlas.repository.Constants.PERSONA_ENTITY_TYPE;
+import static org.apache.atlas.repository.Constants.PURPOSE_ENTITY_TYPE;
+import static org.apache.atlas.repository.Constants.ACCESS_CONTROL_ENTITY_TYPE;
 
 /**
  * REST interface for CRUD operations on tasks
@@ -184,12 +187,17 @@ public class AuthREST {
 
     private boolean isPolicyUpdated(String serviceName, long lastUpdatedTime) {
         AtlasPerfMetrics.MetricRecorder recorder = RequestContext.get().startMetricRecord("AuthRest.isPolicyUpdated." + serviceName);
+        List<String> entityUpdateToWatch = new ArrayList<>();
+        entityUpdateToWatch.add(POLICY_ENTITY_TYPE);
+        entityUpdateToWatch.add(PERSONA_ENTITY_TYPE);
+        entityUpdateToWatch.add(PURPOSE_ENTITY_TYPE);
+        entityUpdateToWatch.add(ACCESS_CONTROL_ENTITY_TYPE);
 
         AuditSearchParams parameters = new AuditSearchParams();
         Map<String, Object> dsl = getMap("size", 1);
 
         List<Map<String, Object>> mustClauseList = new ArrayList<>();
-        mustClauseList.add(getMap("term", getMap("typeName", POLICY_ENTITY_TYPE)));
+        mustClauseList.add(getMap("terms", getMap("typeName", entityUpdateToWatch)));
 
         lastUpdatedTime = lastUpdatedTime == -1 ? 0 : lastUpdatedTime;
         mustClauseList.add(getMap("range", getMap("timestamp", getMap("gte", lastUpdatedTime))));


### PR DESCRIPTION
# Update the policy cache in case of update in Access control entities

Policy were not getting updated when we are updating persona/purpose entities, updated few cheks