### PR TITLE
[Staging] Fetch the user group mapping for service users

### DIFF
--- a/auth-agents-common/src/main/java/org/apache/atlas/plugin/util/KeycloakUserStore.java
+++ b/auth-agents-common/src/main/java/org/apache/atlas/plugin/util/KeycloakUserStore.java
@@ -251,9 +251,13 @@ public class KeycloakUserStore {
 
         List<UserRepresentation> kUsers = KeycloakClient.getKeycloakClient().getAllUsers();
         LOG.info("Found {} keycloak users", kUsers.size());
+        List<UserRepresentation> serviceUsersList = KeycloakClient.getKeycloakClient().getServiceUsers();
+        LOG.info("Found {} service users", serviceUsersList.size());
+        List<UserRepresentation> allUsersList = new ArrayList<>(kUsers);
+        allUsersList.addAll(serviceUsersList);
 
         List<Callable<Object>> callables = new ArrayList<>();
-        kUsers.forEach(x -> callables.add(new UserGroupsFetcher(x, userGroupMapping)));
+        allUsersList.forEach(x -> callables.add(new UserGroupsFetcher(x, userGroupMapping)));
 
         submitCallablesAndWaitToFinish("UserGroupsFetcher", callables);
 

--- a/client-keycloak/src/main/java/org/apache/atlas/keycloak/client/KeycloakClient.java
+++ b/client-keycloak/src/main/java/org/apache/atlas/keycloak/client/KeycloakClient.java
@@ -28,6 +28,7 @@ import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.KeycloakBuilder;
 import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.GroupRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
@@ -210,5 +211,19 @@ public final class KeycloakClient {
         } while (found && ret.size() % size == 0);
 
         return ret;
+    }
+
+    public List <UserRepresentation> getServiceUsers() {
+        List<UserRepresentation> serviceUsers = new ArrayList<>();
+
+        List<ClientRepresentation> clients =  getRealm().clients().findAll();
+        for (ClientRepresentation client : clients) {
+            if (client.isServiceAccountsEnabled()) {
+                String username = "service-account-" + client.getClientId();
+                UserRepresentation user = getRealm().users().search(username).get(0);
+                serviceUsers.add(user);
+            }
+        }   
+        return serviceUsers;
     }
 }


### PR DESCRIPTION
##Fetch the user group mapping for service users

> As we were not fetching the service users group mapping, if somehow apikeys were associated via personas they were unable to provide permission based on those personas. Added feature which will now store the service users and group mapping and this will solve the issue we were facing.