### PR TITLE
PES-179 - Endpoint to repair meanings for asset with terms

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasEntityStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasEntityStore.java
@@ -358,4 +358,7 @@ public interface AtlasEntityStore {
     void repairIndex() throws AtlasBaseException;
 
     void repairHasLineage(AtlasHasLineageRequests requests) throws AtlasBaseException;
+
+    void repairMeaningAttributeForTerms(List<String> termGuids) throws AtlasBaseException;
+
 }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -40,6 +40,7 @@ import org.apache.atlas.model.instance.AtlasEntity.AtlasEntityWithExtInfo;
 import org.apache.atlas.model.instance.AtlasEntity.Status;
 import org.apache.atlas.model.tasks.AtlasTask;
 import org.apache.atlas.model.typedef.AtlasBaseTypeDef;
+import org.apache.atlas.repository.Constants;
 import org.apache.atlas.repository.RepositoryException;
 import org.apache.atlas.repository.graph.GraphHelper;
 import org.apache.atlas.repository.graphdb.AtlasEdge;
@@ -2402,6 +2403,77 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
             if (isRelationshipEdge(edge))
                 AtlasRelationshipStoreV2.recordRelationshipMutation(AtlasRelationshipStoreV2.RelationshipMutation.RELATIONSHIP_HARD_DELETE, edge, entityRetriever);
         }
+    }
+
+    @Override
+    @GraphTransaction
+    public void repairMeaningAttributeForTerms(List<String> termGuid) {
+
+        for (String guid : termGuid) {
+            LOG.info(" term guid " + guid);
+
+            AtlasVertex termVertex = AtlasGraphUtilsV2.findByGuid(this.graph, guid);
+
+            if(termVertex!= null && ATLAS_GLOSSARY_TERM_ENTITY_TYPE.equals(getTypeName(termVertex)) &&
+                    GraphHelper.getStatus(termVertex) == AtlasEntity.Status.ACTIVE) {
+                Iterable<AtlasEdge> edges = termVertex.getEdges(AtlasEdgeDirection.OUT, Constants.TERM_ASSIGNMENT_LABEL);
+                // Get entity to tagged with term.
+                if (edges != null) {
+                    for (Iterator<AtlasEdge> iter = edges.iterator(); iter.hasNext(); ) {
+                        AtlasEdge edge = iter.next();
+                        if (GraphHelper.getStatus(edge) == AtlasEntity.Status.ACTIVE) {
+                            AtlasVertex entityVertex = edge.getInVertex();
+                            if (entityVertex != null & getStatus(entityVertex) == AtlasEntity.Status.ACTIVE) {
+                                repairMeanings(entityVertex);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private void repairMeanings(AtlasVertex assetVertex) {
+
+        Iterable<AtlasEdge> edges = assetVertex.getEdges(AtlasEdgeDirection.IN, Constants.TERM_ASSIGNMENT_LABEL);
+        List<String> termQNList = new ArrayList<>();
+        List<String> termNameList = new ArrayList<>();
+        if (edges != null) {
+            for (Iterator<AtlasEdge> iter = edges.iterator(); iter.hasNext(); ) {
+                AtlasEdge edge = iter.next();
+                if (GraphHelper.getStatus(edge) == AtlasEntity.Status.ACTIVE) {
+                    AtlasVertex termVertex = edge.getOutVertex();
+                    if (termVertex != null & getStatus(termVertex) == AtlasEntity.Status.ACTIVE) {
+                        String termQN = termVertex.getProperty(QUALIFIED_NAME, String.class);
+                        String termName = termVertex.getProperty(NAME, String.class);
+                        termQNList.add(termQN);
+                        termNameList.add(termName);
+                    }
+                }
+            }
+        }
+
+        if (termQNList.size() > 0) {
+
+            assetVertex.removeProperty(MEANINGS_PROPERTY_KEY);
+            assetVertex.removeProperty(MEANINGS_TEXT_PROPERTY_KEY);
+            assetVertex.removeProperty(MEANING_NAMES_PROPERTY_KEY);
+
+            if (CollectionUtils.isNotEmpty(termQNList)) {
+                termQNList.forEach(q -> AtlasGraphUtilsV2.addEncodedProperty(assetVertex, MEANINGS_PROPERTY_KEY, q));
+            }
+
+            if (CollectionUtils.isNotEmpty(termNameList)) {
+                AtlasGraphUtilsV2.setEncodedProperty(assetVertex, MEANINGS_TEXT_PROPERTY_KEY, StringUtils.join(termNameList, ","));
+            }
+
+            if (CollectionUtils.isNotEmpty(termNameList)) {
+                termNameList.forEach(q -> AtlasGraphUtilsV2.addListProperty(assetVertex, MEANING_NAMES_PROPERTY_KEY, q, true));
+            }
+
+            LOG.info("Updated asset {}  with term {} ",  getGuid(assetVertex) ,  StringUtils.join(termNameList, ","));
+        }
+
     }
 }
 

--- a/webapp/src/main/java/org/apache/atlas/web/resources/AdminResource.java
+++ b/webapp/src/main/java/org/apache/atlas/web/resources/AdminResource.java
@@ -829,6 +829,25 @@ public class AdminResource {
         }
     }
 
+    @POST
+    @Path("repairmeanings")
+    @Produces(Servlets.JSON_MEDIA_TYPE)
+    @Consumes(Servlets.JSON_MEDIA_TYPE)
+    public void repairmeanings(List<String> termGuid) throws AtlasBaseException {
+        AtlasPerfTracer perf = null;
+
+        try {
+            if (AtlasPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
+                perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "repairmeanings(" + termGuid + ")");
+            }
+
+            entityStore.repairMeaningAttributeForTerms(termGuid);
+
+        } finally {
+            AtlasPerfTracer.log(perf);
+        }
+    }
+
     @GET
     @Path("patches")
     @Produces(Servlets.JSON_MEDIA_TYPE)


### PR DESCRIPTION
## Change description
Added a new API Endpoint to repair meanings attribute for asset with their terms.

http://localhost:22000/api/atlas/admin/repairmeanings
```
[
    "a7ff66c6-8cf5-498d-8528-4b15f50975fd", [term's guid]
    "49442aa1-6cc6-4686-8406-b53ba05224b1",
    "dc3ef062-3596-4249-b5cd-36d8873c80a8"
]
```

> Description here

Here the endpoint implementation will fetch all entities of a each term with `r:AtlasGlossarySemanticAssignment` label.
And for each entity it will fetch all terms with  `r:AtlasGlossarySemanticAssignment` label and update attribute in meanings, meaningsText and meaningNames attribute on vertex with termQN's and termNames respectively.

Testing done:-
Deleted glossary where its terms were linked to assets. After glossary delete and restore, the linked assets were not discovered. After running the endpoint repairmeanings with list of term guid, the the linked assets were discovered for the term.


## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
