### PR TITLE
fix: reinitialize in case forbidden error

### DIFF
--- a/auth-agents-common/src/main/java/org/apache/atlas/plugin/util/KeycloakUserStore.java
+++ b/auth-agents-common/src/main/java/org/apache/atlas/plugin/util/KeycloakUserStore.java
@@ -38,6 +38,7 @@ import org.keycloak.representations.idm.UserRepresentation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.ws.rs.ForbiddenException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -149,7 +150,11 @@ public class KeycloakUserStore {
                 return true;
             }
 
-        } catch (Exception e) {
+        } catch (ForbiddenException fbde) {
+            LOG.error("ForbiddenException while fetching latest event time, Reinitializing Keycloak Client to refresh", fbde);
+            keycloakClient.reInit();
+        }
+        catch (Exception e) {
             LOG.error("Error while fetching latest event time", e);
         } finally {
             RequestContext.get().endMetricRecord(metricRecorder);

--- a/client-keycloak/src/main/java/org/apache/atlas/keycloak/client/KeycloakClient.java
+++ b/client-keycloak/src/main/java/org/apache/atlas/keycloak/client/KeycloakClient.java
@@ -148,6 +148,21 @@ public final class KeycloakClient {
         return KEYCLOAK.realm(REALM_ID);
     }
 
+    // Reinitialize Keycloak client
+    public void reInit() {
+        KEYCLOAK.close();
+        synchronized (KeycloakClient.class) {
+            KEYCLOAK = KeycloakBuilder.builder()
+                    .serverUrl(AUTH_SERVER_URL)
+                    .realm(REALM_ID)
+                    .clientId(CLIENT_ID)
+                    .clientSecret(CLIENT_SECRET)
+                    .grantType(GRANT_TYPE)
+                    .resteasyClient(new ResteasyClientBuilder().build())
+                    .build();
+        }
+    }
+
     public List<UserRepresentation> getAllUsers() {
         int start = 0;
         int size = 500;


### PR DESCRIPTION
## Reinitialize keycloak client if we are getting forbidden error

> When Atlas is starting up, client in keycloak, atlan-backend doesn’t have access to View events, Now we are initializing the keycloak client from Atlas to fetch events before it gets permission from the keycloak bootstrap step while onboarding the tenant, now this old initialized client is forbidden to have access to read admin events.
