### PR TITLE
PLT-1071 :- Repair Index endpoints

### DIFF
--- a/addons/policies/bootstrap_admin_policies.json
+++ b/addons/policies/bootstrap_admin_policies.json
@@ -1,0 +1,29 @@
+{
+  "entities": [
+    {
+      "typeName": "AuthPolicy",
+      "attributes": {
+        "name": "RUN_REPAIR_INDEX",
+        "qualifiedName": "RUN_REPAIR_INDEX",
+        "policyCategory": "bootstrap",
+        "policySubCategory": "default",
+        "policyServiceName": "atlas",
+        "policyType": "allow",
+        "policyPriority": 1,
+        "policyUsers": [
+          "service-account-atlan-argo",
+          "service-account-atlan-backend"
+        ],
+        "policyGroups": [],
+        "policyRoles": [],
+        "policyResourceCategory": "ADMIN",
+        "policyResources": [
+          "atlas-service:*"
+        ],
+        "policyActions": [
+          "admin-repair-index"
+        ]
+      }
+    }
+  ]
+}

--- a/addons/policies/bootstrap_entity_policies.json
+++ b/addons/policies/bootstrap_entity_policies.json
@@ -2860,31 +2860,6 @@
                     "entity-update"
                 ]
             }
-        },
-        {
-            "typeName": "AuthPolicy",
-            "attributes": {
-                "name": "RUN_REPAIR_INDEX",
-                "qualifiedName": "RUN_REPAIR_INDEX",
-                "policyCategory": "bootstrap",
-                "policySubCategory": "default",
-                "policyServiceName": "atlas",
-                "policyType": "allow",
-                "policyPriority": 1,
-                "policyUsers": [
-                    "service-account-atlan-argo",
-                    "service-account-atlan-backend"
-                ],
-                "policyGroups": [],
-                "policyRoles": [],
-                "policyResourceCategory": "ADMIN",
-                "policyResources": [
-                    "atlas-service:*"
-                ],
-                "policyActions": [
-                    "admin-repair-index"
-                ]
-            }
         }
     ]
 }

--- a/addons/policies/bootstrap_entity_policies.json
+++ b/addons/policies/bootstrap_entity_policies.json
@@ -2860,6 +2860,31 @@
                     "entity-update"
                 ]
             }
+        },
+        {
+            "typeName": "AuthPolicy",
+            "attributes": {
+                "name": "RUN_REPAIR_INDEX",
+                "qualifiedName": "RUN_REPAIR_INDEX",
+                "policyCategory": "bootstrap",
+                "policySubCategory": "default",
+                "policyServiceName": "atlas",
+                "policyType": "allow",
+                "policyPriority": 1,
+                "policyUsers": [
+                    "service-account-atlan-argo",
+                    "service-account-atlan-backend"
+                ],
+                "policyGroups": [],
+                "policyRoles": [],
+                "policyResourceCategory": "ADMIN",
+                "policyResources": [
+                    "atlas-service:*"
+                ],
+                "policyActions": [
+                    "admin-repair-index"
+                ]
+            }
         }
     ]
 }

--- a/auth-agents-common/src/main/resources/service-defs/atlas-servicedef-atlas.json
+++ b/auth-agents-common/src/main/resources/service-defs/atlas-servicedef-atlas.json
@@ -115,7 +115,7 @@
 			},
 			"label": "Atlas Service",
 			"description": "Atlas Service",
-			"accessTypeRestrictions": ["admin-import", "admin-export", "admin-purge", "admin-audits", "admin-entity-audits"]
+			"accessTypeRestrictions": ["admin-import", "admin-export", "admin-purge", "admin-audits", "admin-entity-audits", "admin-repair-index"]
 		},
 		{
 			"itemId": 7,
@@ -440,7 +440,13 @@
 			"itemId": 22,
 			"name": "admin-entity-audits",
 			"label": "Admin Entity Audits"
+		},
+		{
+			"itemId": 23,
+			"name": "admin-repair-index",
+			"label": "Admin Repair Index"
 		}
+
 	],
 	"configs": [
 		{

--- a/authorization/src/main/java/org/apache/atlas/authorize/AtlasPrivilege.java
+++ b/authorization/src/main/java/org/apache/atlas/authorize/AtlasPrivilege.java
@@ -48,7 +48,8 @@ public enum AtlasPrivilege {
 
      ADMIN_AUDITS("admin-audits"),
 
-     ADMIN_ENTITY_AUDITS("admin-entity-audits");
+     ADMIN_ENTITY_AUDITS("admin-entity-audits"),
+     ADMIN_REPAIR_INDEX("admin-repair-index");
 
      private final String type;
 

--- a/tools/atlas-index-repair/src/main/java/org/apache/atlas/tools/RepairIndex.java
+++ b/tools/atlas-index-repair/src/main/java/org/apache/atlas/tools/RepairIndex.java
@@ -266,12 +266,11 @@ public class RepairIndex {
         IndexSerializer indexSerializer = janusGraph.getIndexSerializer();
 
         for (String indexName : getIndexes()) {
-            displayCrlf("Restoring: " + indexName);
+            LOG.info("Restoring: " + indexName);
             long startTime = System.currentTimeMillis();
             reindexVertex(indexName, indexSerializer, referencedGUIDs);
 
-            display(": Time taken: " + (System.currentTimeMillis() - startTime) + " ms");
-            displayCrlf(": Done!");
+            LOG.info(": Time taken: " + (System.currentTimeMillis() - startTime) + " ms");
         }
     }
 
@@ -281,12 +280,12 @@ public class RepairIndex {
         IndexSerializer indexSerializer = janusGraph.getIndexSerializer();
 
         for (String indexName : getIndexes()) {
-//            displayCrlf("Restoring: " + indexName);
+            LOG.info("Restoring: " + indexName);
             long startTime = System.currentTimeMillis();
             reindexVertex(indexName, indexSerializer, guids);
 
-//            display(": Time taken: " + (System.currentTimeMillis() - startTime) + " ms");
-//            displayCrlf(": Done!");
+            LOG.info(": Time taken: " + (System.currentTimeMillis() - startTime) + " ms");
+            LOG.info(": Done!");
         }
     }
 }

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -577,6 +577,13 @@
             <artifactId>jackson-core</artifactId>
             <version>${jackson.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.atlas</groupId>
+            <artifactId>atlas-index-repair-tool</artifactId>
+            <version>3.0.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
@@ -1805,6 +1805,8 @@ public class EntityREST {
     public void repairEntityIndex(@PathParam("guid") String guid) throws AtlasBaseException {
         Servlets.validateQueryParamLength("guid", guid);
 
+        AtlasAuthorizationUtils.verifyAccess(new AtlasAdminAccessRequest(AtlasPrivilege.ADMIN_REPAIR_INDEX), "Admin Repair Index");
+
         AtlasPerfTracer perf = null;
 
         try {
@@ -1838,6 +1840,8 @@ public class EntityREST {
             if (AtlasPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
                 perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "EntityREST.repairAllEntitiesIndex");
             }
+
+            AtlasAuthorizationUtils.verifyAccess(new AtlasAdminAccessRequest(AtlasPrivilege.ADMIN_REPAIR_INDEX), "Admin Repair Index");
 
             RepairIndex repairIndex = new RepairIndex();
             repairIndex.setupGraph();

--- a/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
@@ -1821,7 +1821,7 @@ public class EntityREST {
 
            repairIndex.restoreSelective(guid, referredEntities);
         } catch (Exception e) {
-            System.out.println(e);
+            LOG.error("Exception while repairEntityIndex ", e);
             throw new AtlasBaseException(e);
         } finally {
             AtlasPerfTracer.log(perf);
@@ -1883,7 +1883,7 @@ public class EntityREST {
             LOG.info("Repaired index for entities for typeName " + typename + " in " + (System.currentTimeMillis() - startTime) + " ms");
 
         } catch (Exception e) {
-            System.out.println(e);
+            LOG.error("Exception while repairIndexByTypeName ", e);
             throw new AtlasBaseException(e);
         } finally {
             AtlasPerfTracer.log(perf);


### PR DESCRIPTION
## Change description
Ported repair index endpoint from 1.0

Repair with typeName
`/api/meta/entity/repairindex/View?limit=1000&offset=21000&batchSize=100&delay=2
`
Selective guid
`/api/meta/entity/guid/90a5230d-8d2a-412b-930c-1741b73c4a3d/repairindex`



## Testing
Tested endpoint on pes.atlan.dev instance for around 21000 asset of type view.
Takes around 1min for 1000 assets

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
