### PR TITLE
Fix: A Member Role User Can Delete the Personas

### DIFF
--- a/addons/policies/bootstrap_entity_policies.json
+++ b/addons/policies/bootstrap_entity_policies.json
@@ -2522,7 +2522,6 @@
                 "policyRoles":
                 [
                     "$admin",
-                    "$member",
                     "$api-token-default-access"
                 ],
                 "policyResourceCategory": "ENTITY",


### PR DESCRIPTION
## Change description

> During the security assessment of the application, it has been observed that the server-side permission checks are not properly implemented on the DELETE /api/meta/entity/guid/{:guid} HTTP request. A low-privileged user with a member role can delete the personas, which is not allowed from the UI of the member user.  Privilege escalation occurs when a user gets access to more resources or functionality than they are normally allowed, and such elevation or changes should have been prevented by the application. This is usually caused by a flaw in the application. The result is that the application performs actions with more privileges than those intended by the developer or system administrator. Reference: https://cwe.mitre.org/data/definitions/284.html

*Linear* https://linear.app/atlanproduct/issue/PLT-1143/privilege-escalation-a-member-role-user-can-delete-the-personas