### PR TITLE
PLT-1257 - Delete connection roles only in case of hard delete

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/patches/AtlasPatchManager.java
+++ b/repository/src/main/java/org/apache/atlas/repository/patches/AtlasPatchManager.java
@@ -93,7 +93,7 @@ public class AtlasPatchManager {
         handlers.add(new FreeTextRequestHandlerPatch(context));
         handlers.add(new SuggestionsRequestHandlerPatch(context));
         handlers.add(new IndexConsistencyPatch(context));
-//        handlers.add(new ReIndexPatch(context));
+        handlers.add(new ReIndexPatch(context));
         handlers.add(new ProcessNamePatch(context));
         handlers.add(new UpdateCompositeIndexStatusPatch(context));
 

--- a/repository/src/main/java/org/apache/atlas/repository/patches/AtlasPatchManager.java
+++ b/repository/src/main/java/org/apache/atlas/repository/patches/AtlasPatchManager.java
@@ -93,7 +93,7 @@ public class AtlasPatchManager {
         handlers.add(new FreeTextRequestHandlerPatch(context));
         handlers.add(new SuggestionsRequestHandlerPatch(context));
         handlers.add(new IndexConsistencyPatch(context));
-        handlers.add(new ReIndexPatch(context));
+//        handlers.add(new ReIndexPatch(context));
         handlers.add(new ProcessNamePatch(context));
         handlers.add(new UpdateCompositeIndexStatusPatch(context));
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -1727,7 +1727,7 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
                 break;
 
             case CONNECTION_ENTITY_TYPE:
-                preProcessor = new ConnectionPreProcessor(graph, discovery, entityRetriever, featureFlagStore, this);
+                preProcessor = new ConnectionPreProcessor(graph, discovery, entityRetriever, featureFlagStore, deleteDelegate, this);
                 break;
         }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/ConnectionPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/ConnectionPreProcessor.java
@@ -221,7 +221,7 @@ public class ConnectionPreProcessor implements PreProcessor {
     public void processDelete(AtlasVertex vertex) throws AtlasBaseException {
         checkAccessControlFeatureStatus(featureFlagStore);
         // Process Delete connection role and policies in case of hard delete or purge
-        if (isDeleteTypeSoft()) {
+        if (!isDeleteTypePurgeOrHard()) {
             LOG.info("Skipping processDelete for connection as delete type is {}", RequestContext.get().getDeleteType());
             return;
         }
@@ -239,9 +239,9 @@ public class ConnectionPreProcessor implements PreProcessor {
         }
     }
 
-    private boolean isDeleteTypeSoft() {
+    private boolean isDeleteTypePurgeOrHard() {
         DeleteType deleteType = RequestContext.get().getDeleteType();
-        return deleteType == DeleteType.DEFAULT || deleteType == DeleteType.SOFT;
+        return deleteType == DeleteType.PURGE || deleteType == DeleteType.HARD;
     }
 
     private List<AtlasEntityHeader> getConnectionPolicies(String guid, String roleName) throws AtlasBaseException {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/ConnectionPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/ConnectionPreProcessor.java
@@ -221,7 +221,7 @@ public class ConnectionPreProcessor implements PreProcessor {
     public void processDelete(AtlasVertex vertex) throws AtlasBaseException {
         checkAccessControlFeatureStatus(featureFlagStore);
         // Process Delete connection role and policies in case of hard delete or purge
-        if (!isDeleteTypePurgeOrHard()) {
+        if (isDeleteTypeSoft()) {
             LOG.info("Skipping processDelete for connection as delete type is {}", RequestContext.get().getDeleteType());
             return;
         }
@@ -239,9 +239,9 @@ public class ConnectionPreProcessor implements PreProcessor {
         }
     }
 
-    private boolean isDeleteTypePurgeOrHard() {
+    private boolean isDeleteTypeSoft() {
         DeleteType deleteType = RequestContext.get().getDeleteType();
-        return deleteType == DeleteType.PURGE || deleteType == DeleteType.HARD;
+        return deleteType == DeleteType.DEFAULT || deleteType == DeleteType.SOFT;
     }
 
     private List<AtlasEntityHeader> getConnectionPolicies(String guid, String roleName) throws AtlasBaseException {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/ConnectionPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/ConnectionPreProcessor.java
@@ -226,25 +226,23 @@ public class ConnectionPreProcessor implements PreProcessor {
             AtlasEntity connection = entityWithExtInfo.getEntity();
             String roleName = String.format(CONN_NAME_PATTERN, connection.getGuid());
 
-            if (!AtlasEntity.Status.ACTIVE.equals(connection.getStatus())) {
-                throw new AtlasBaseException("Connection is already deleted/purged");
-            }
-
             //delete connection policies
             List<AtlasEntityHeader> policies = getConnectionPolicies(connection.getGuid(), roleName);
             entityStore.deleteByIds(policies.stream().map(x -> x.getGuid()).collect(Collectors.toList()));
 
-            // Delete connection role
+            // Delete connection role in case of hard delete or purge
             if (isDeleteTypePurgeOrHard()) {
                 keycloakStore.removeRoleByName(roleName);
             }
 
         }
     }
+
     private boolean isDeleteTypePurgeOrHard() {
         DeleteType deleteType = RequestContext.get().getDeleteType();
         return deleteType == DeleteType.PURGE || deleteType == DeleteType.HARD;
     }
+
     private List<AtlasEntityHeader> getConnectionPolicies(String guid, String roleName) throws AtlasBaseException {
         List<AtlasEntityHeader> ret = new ArrayList<>();
         
@@ -253,9 +251,6 @@ public class ConnectionPreProcessor implements PreProcessor {
 
         List mustClauseList = new ArrayList();
         mustClauseList.add(mapOf("term", mapOf("__typeName.keyword", POLICY_ENTITY_TYPE)));
-        mustClauseList.add(mapOf("term", mapOf("__state", "ACTIVE")));
-
-
         mustClauseList.add(mapOf("wildcard", mapOf(QUALIFIED_NAME, guid + "/*")));
         mustClauseList.add(mapOf("term", mapOf("policyRoles", roleName)));
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/ConnectionPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/ConnectionPreProcessor.java
@@ -17,6 +17,7 @@
  */
 package org.apache.atlas.repository.store.graph.v2.preprocessor;
 
+import org.apache.atlas.DeleteType;
 import org.apache.atlas.RequestContext;
 import org.apache.atlas.discovery.EntityDiscoveryService;
 import org.apache.atlas.exception.AtlasBaseException;
@@ -231,6 +232,13 @@ public class ConnectionPreProcessor implements PreProcessor {
             AtlasEntity.AtlasEntityWithExtInfo entityWithExtInfo = entityRetriever.toAtlasEntityWithExtInfo(vertex);
             AtlasEntity connection = entityWithExtInfo.getEntity();
             String roleName = String.format(CONN_NAME_PATTERN, connection.getGuid());
+
+            boolean connectionIsDeleted = AtlasEntity.Status.DELETED.equals(connection.getStatus());
+
+            if (connectionIsDeleted && DeleteType.HARD.equals(RequestContext.get().getDeleteType())) {
+                LOG.warn("Connection {} is SOFT DELETED! Can't HARD DELETE connection role and policies", connection.getAttribute(QUALIFIED_NAME));
+                return;
+            }
 
             //delete connection policies
             List<AtlasEntityHeader> policies = getConnectionPolicies(connection.getGuid(), roleName);


### PR DESCRIPTION
## Delete connection roles only in case of hard delete

*Summary*

Now if we just soft delete the connection associated roles get deleted, two problems occurs here

No user has access to that connection

And It gives NPE in case any service user tries to delete the connection

So all the suers get locked, ideally we shouldn't delete the role in case of soft delete as archived assets also needs Access control.

## Type of change
- [x] Bug fix (fixes an issue)