### PR TITLE
Fix for refresh propagation propagating tag to source vertex

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -3523,7 +3523,7 @@ public class EntityGraphMapper {
         LOG.info("{} entity vertices have classification with id {} attached", propagatedVerticesIds.size(), classificationId);
 
         List<String> verticesIdsToAddClassification =  new ArrayList<>();
-        List<String> propagatedVerticesIdWithoutEdge = entityRetriever.getImpactedVerticesIds(sourceEntityVertex , classificationId,
+        List<String> propagatedVerticesIdWithoutEdge = entityRetriever.getImpactedVerticesIdsClassificationAttached(sourceEntityVertex , classificationId,
                 CLASSIFICATION_PROPAGATION_EXCLUSION_MAP.get(propagationMode), verticesIdsToAddClassification);
 
         LOG.info("To add classification with id {} to {} vertices", classificationId, verticesIdsToAddClassification.size());

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -616,10 +616,15 @@ public class EntityGraphRetriever {
         return ret;
     }
 
-    public List<String> getImpactedVerticesIds(AtlasVertex entityVertex, String classificationId, List<String> edgeLabelsToExclude, List<String> verticesWithoutClassification) {
+    public List<String> getImpactedVerticesIdsClassificationAttached(AtlasVertex entityVertex, String classificationId, List<String> edgeLabelsToExclude, List<String> verticesWithoutClassification) {
         List<String> ret = new ArrayList<>();
 
-        traverseImpactedVerticesByLevel(entityVertex, null, classificationId, ret, edgeLabelsToExclude, verticesWithoutClassification);
+        GraphHelper.getAllClassificationEdges(entityVertex).forEach(classificationEdge -> {
+            AtlasVertex classificationVertex = classificationEdge.getInVertex();
+            if (classificationVertex != null && classificationId.equals(classificationVertex.getIdForDisplay())) {
+                traverseImpactedVerticesByLevel(entityVertex, null, classificationId, ret, edgeLabelsToExclude, verticesWithoutClassification);
+            }
+        });
 
         return ret;
     }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -619,7 +619,7 @@ public class EntityGraphRetriever {
     public List<String> getImpactedVerticesIdsClassificationAttached(AtlasVertex entityVertex, String classificationId, List<String> edgeLabelsToExclude, List<String> verticesWithoutClassification) {
         List<String> ret = new ArrayList<>();
 
-        GraphHelper.getAllClassificationEdges(entityVertex).forEach(classificationEdge -> {
+        GraphHelper.getClassificationEdges(entityVertex).forEach(classificationEdge -> {
             AtlasVertex classificationVertex = classificationEdge.getInVertex();
             if (classificationVertex != null && classificationId.equals(classificationVertex.getIdForDisplay())) {
                 traverseImpactedVerticesByLevel(entityVertex, null, classificationId, ret, edgeLabelsToExclude, verticesWithoutClassification);

--- a/repository/src/main/java/org/apache/atlas/tasks/AtlasTaskService.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/AtlasTaskService.java
@@ -151,7 +151,7 @@ public class AtlasTaskService implements TaskService {
                 if (isClassificationTaskType(taskType)) {
                     String classificationName = task.getClassificationName();
                     String entityGuid = task.getEntityGuid();
-                    String classificationId = resolveAndReturnClassificationId(classificationName, entityGuid);
+                    String classificationId = StringUtils.isEmpty(task.getClassificationId()) ? resolveAndReturnClassificationId(classificationName, entityGuid) : task.getClassificationId();
                     if (StringUtils.isEmpty(classificationId)) {
                         throw new AtlasBaseException(AtlasErrorCode.TASK_INVALID_PARAMETERS, task.toString());
                     }


### PR DESCRIPTION
## Fix for refresh propagation propagating tag to source vertex

> In a few customer instances found out source vertex has a tag attached which is propagated to itself. It is happening due to one issue in the refresh propagation task.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)