### PR TITLE
Fix/gov 1259 - Add deny data access policy for all the guest

### DIFF
--- a/addons/policies/bootstrap_heka_policies.json
+++ b/addons/policies/bootstrap_heka_policies.json
@@ -1,0 +1,35 @@
+{
+  "entities":
+  [
+    {
+    "typeName": "AuthPolicy",
+    "attributes":
+    {
+      "name": "DENY_DATA_ACCESS_GUEST",
+      "qualifiedName": "DENY_DATA_ACCESS_GUEST",
+      "description": "deny data access for guest users",
+      "policyCategory": "bootstrap",
+      "policySubCategory": "data",
+      "policyServiceName": "heka",
+      "policyType": "deny",
+      "policyPriority": 0,
+      "policyUsers": [],
+      "policyGroups": [],
+      "policyRoles":
+      [
+        "$guest"
+      ],
+      "policyResourceCategory": "ENTITY",
+      "policyResources":
+      [
+        "entity:*",
+        "entity-type:*"
+      ],
+      "policyActions":
+      [
+        "select"
+      ]
+    }
+    }
+  ]
+}

--- a/addons/policies/bootstrap_heka_policies.json
+++ b/addons/policies/bootstrap_heka_policies.json
@@ -9,7 +9,7 @@
       "qualifiedName": "DENY_DATA_ACCESS_GUEST",
       "description": "deny data access for guest users",
       "policyCategory": "bootstrap",
-      "policySubCategory": "data",
+      "policySubCategory": "default",
       "policyServiceName": "heka",
       "policyType": "deny",
       "policyPriority": 1,

--- a/addons/policies/bootstrap_heka_policies.json
+++ b/addons/policies/bootstrap_heka_policies.json
@@ -12,7 +12,7 @@
       "policySubCategory": "data",
       "policyServiceName": "heka",
       "policyType": "deny",
-      "policyPriority": 0,
+      "policyPriority": 1,
       "policyUsers": [],
       "policyGroups": [],
       "policyRoles":


### PR DESCRIPTION
**Issue Summary:**
It was previously stated that Guest users shouldn’t be able to preview data, which is expected behavior. However, we’ve observed that Guest users can, in fact, preview the data.
**Root Cause:**
Guest users aren’t permitted to use the insights feature, and thus, by default, they should not have any data operations. In the Atlas Authorizer, there’s no specific deny policy for guests to block data access, whereas this policy exists in the Ranger Authorizer.
Guest users can access data if given permission through the persona or connection admin policy. Moreover, Guest users can also retrieve actual data via API. When I tested the query/stream API with a Guest user token, it successfully returned data. Although we’ve disabled insights from the UI, if they tap into the Heka API, they can access the data.
**Solution:**
We need to promptly set up a deny policy for Guest users to prevent data access. I will try to release this today itself.
Linear: https://linear.app/atlanproduct/issue/GOV-1259/guest-user-can-view-data