### PR TITLE
PLT-1765: update thread logic to continue with wait time and loop

### DIFF
--- a/common/src/main/java/org/apache/atlas/AtlasConstants.java
+++ b/common/src/main/java/org/apache/atlas/AtlasConstants.java
@@ -39,5 +39,5 @@ public final class AtlasConstants {
     public static final String DEFAULT_ATLAS_REST_ADDRESS    = "http://localhost:21000";
     public static final String DEFAULT_TYPE_VERSION          = "1.0";
     public static final int    ATLAS_SHUTDOWN_HOOK_PRIORITY  = 30;
-    public static final int TASK_WAIT_TIME_MS = 100_000;
+    public static final int TASK_WAIT_TIME_MS = 200_000;
 }

--- a/common/src/main/java/org/apache/atlas/AtlasConstants.java
+++ b/common/src/main/java/org/apache/atlas/AtlasConstants.java
@@ -38,5 +38,5 @@ public final class AtlasConstants {
     public static final String DEFAULT_ATLAS_REST_ADDRESS    = "http://localhost:21000";
     public static final String DEFAULT_TYPE_VERSION          = "1.0";
     public static final int    ATLAS_SHUTDOWN_HOOK_PRIORITY  = 30;
-    public static final int TASK_WAIT_TIME_MS = 200_000;
+    public static final int TASK_WAIT_TIME_MS = 180_000;
 }

--- a/common/src/main/java/org/apache/atlas/AtlasConstants.java
+++ b/common/src/main/java/org/apache/atlas/AtlasConstants.java
@@ -22,6 +22,7 @@ package org.apache.atlas;
  * Constants used in Atlas configuration.
  */
 public final class AtlasConstants {
+
     private AtlasConstants() {
     }
 
@@ -38,4 +39,5 @@ public final class AtlasConstants {
     public static final String DEFAULT_ATLAS_REST_ADDRESS    = "http://localhost:21000";
     public static final String DEFAULT_TYPE_VERSION          = "1.0";
     public static final int    ATLAS_SHUTDOWN_HOOK_PRIORITY  = 30;
+    public static final int TASK_WAIT_TIME_MS = 100_000;
 }

--- a/common/src/main/java/org/apache/atlas/AtlasConstants.java
+++ b/common/src/main/java/org/apache/atlas/AtlasConstants.java
@@ -22,7 +22,6 @@ package org.apache.atlas;
  * Constants used in Atlas configuration.
  */
 public final class AtlasConstants {
-
     private AtlasConstants() {
     }
 

--- a/repository/src/main/java/org/apache/atlas/repository/graph/IndexRecoveryService.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/IndexRecoveryService.java
@@ -19,6 +19,7 @@ package org.apache.atlas.repository.graph;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.atlas.ApplicationProperties;
+import org.apache.atlas.AtlasConstants;
 import org.apache.atlas.AtlasException;
 import org.apache.atlas.ha.HAConfiguration;
 import org.apache.atlas.listener.ActiveStateChangeHandler;
@@ -176,7 +177,8 @@ public class IndexRecoveryService implements Service, ActiveStateChangeHandler {
                 if (shouldRun.get()) {
                     try {
                         if(!redisService.acquireDistributedLock(ATLAS_INDEX_RECOVERY_LOCK)){
-                            return;
+                            Thread.sleep(AtlasConstants.TASK_WAIT_TIME_MS);
+                            continue;
                         }
                         boolean indexHealthy = isIndexHealthy();
 

--- a/repository/src/main/java/org/apache/atlas/tasks/TaskQueueWatcher.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/TaskQueueWatcher.java
@@ -18,6 +18,7 @@
 package org.apache.atlas.tasks;
 
 import org.apache.atlas.AtlasConfiguration;
+import org.apache.atlas.AtlasConstants;
 import org.apache.atlas.ICuratorFactory;
 import org.apache.atlas.model.tasks.AtlasTask;
 import org.apache.atlas.service.redis.RedisService;
@@ -83,7 +84,8 @@ public class TaskQueueWatcher implements Runnable {
         while (shouldRun.get()) {
             try {
                 if (!redisService.acquireDistributedLock(ATLAS_TASK_LOCK)) {
-                    return;
+                    Thread.sleep(AtlasConstants.TASK_WAIT_TIME_MS);
+                    continue;
                 }
 
                 TasksFetcher fetcher = new TasksFetcher(registry);


### PR DESCRIPTION
## Change description
Increase wait time for thread to 2min, in case lock isnt acquired. And continue the thread instead of exit when lock isnt acquired.

Verified in beta, lock is getting acquired alternatively by both the pods.

<img width="300" alt="Screenshot 2023-08-16 at 11 15 27 PM" src="https://github.com/atlanhq/atlas-metastore/assets/119731738/1e0fa8ac-ca1e-4a32-b249-98e9257bee4e">
<img width="300" alt="Screenshot 2023-08-16 at 11 15 36 PM" src="https://github.com/atlanhq/atlas-metastore/assets/119731738/337eaf85-c244-4fc9-8609-704339ef3aea">


> Description here

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
