### PR TITLE
[staging] feat: add update tag permission with add and remove

### DIFF
--- a/addons/static/templates/policy_cache_transformer_persona.json
+++ b/addons/static/templates/policy_cache_transformer_persona.json
@@ -97,7 +97,10 @@
         "entity-classification:*",
         "classification:*"
       ],
-      "actions": ["entity-add-classification"]
+      "actions": [
+        "entity-add-classification",
+        "entity-update-classification"
+      ]
     }
   ],
   "persona-entity-update-classification": [
@@ -125,7 +128,10 @@
         "entity-classification:*",
         "classification:*"
       ],
-      "actions": ["entity-remove-classification"]
+      "actions": [
+        "entity-remove-classification",
+        "entity-update-classification"
+      ]
     }
   ],
   "persona-add-terms": [
@@ -306,7 +312,10 @@
         "entity-classification:*",
         "classification:*"
       ],
-      "actions": ["entity-add-classification"]
+      "actions": [
+        "entity-add-classification",
+        "entity-update-classification"
+      ]
     }
   ],
   "persona-glossary-update-classifications": [
@@ -336,7 +345,10 @@
         "entity-classification:*",
         "classification:*"
       ],
-      "actions": ["entity-remove-classification"]
+      "actions": [
+        "entity-remove-classification",
+        "entity-update-classification"
+      ]
     }
   ],
   "select": [


### PR DESCRIPTION
### feat: add update tag permission with add and remove

>Right now if the user has given tag delete/add permission they don't generally have permission to update the tag right now and need to change the behavior. This is causing 10% WF failure in whole Atlan