### PR TITLE
GOV-1311: Update removepropagationOnEntityDelete default as true and remove propagation if updated after archiving asset

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -103,7 +103,7 @@ public final class GraphHelper {
 
     private int     maxRetries = 3;
     private long    retrySleepTimeMillis = 1000;
-    private boolean removePropagations = false;
+    private boolean removePropagations = true;
 
     public GraphHelper(AtlasGraph graph) {
         this.graph = graph;

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -110,7 +110,7 @@ public final class GraphHelper {
         try {
             maxRetries           = ApplicationProperties.get().getInt(RETRY_COUNT, 3);
             retrySleepTimeMillis = ApplicationProperties.get().getLong(RETRY_DELAY, 1000);
-            removePropagations   = ApplicationProperties.get().getBoolean(DEFAULT_REMOVE_PROPAGATIONS_ON_ENTITY_DELETE, false);
+            removePropagations   = ApplicationProperties.get().getBoolean(DEFAULT_REMOVE_PROPAGATIONS_ON_ENTITY_DELETE, true);
         } catch (AtlasException e) {
             LOG.error("Could not load configuration. Setting to default value for " + RETRY_COUNT, e);
         }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -1292,17 +1292,10 @@ public abstract class DeleteHandlerV1 {
             }
         }
     }
-
-
-    public void createAndQueueTask(String taskType, AtlasVertex entityVertex, String classificationVertexId, String relationshipGuid, Boolean currentRestrictPropagationThroughLineage) throws AtlasBaseException {
-        if (!CLASSIFICATION_PROPAGATION_DELETE.equals(taskType) && skipClassificationTaskCreation(classificationVertexId)) {
-            LOG.info("Task is already scheduled for classification id {}, no need to schedule task for vertex {}", classificationVertexId, entityVertex.getIdForDisplay());
-            return;
-        }
-
+    public void createAndQueueTaskWithoutCheck(String taskType, AtlasVertex entityVertex, String classificationVertexId, String relationshipGuid) throws AtlasBaseException {
         String              currentUser = RequestContext.getCurrentUser();
         String              entityGuid  = GraphHelper.getGuid(entityVertex);
-        Map<String, Object> taskParams  = ClassificationTask.toParameters(entityGuid, classificationVertexId, relationshipGuid, currentRestrictPropagationThroughLineage);
+        Map<String, Object> taskParams  = ClassificationTask.toParameters(entityGuid, classificationVertexId, relationshipGuid);
         AtlasTask           task        = taskManagement.createTask(taskType, currentUser, taskParams, classificationVertexId, entityGuid);
 
         AtlasGraphUtilsV2.addEncodedProperty(entityVertex, PENDING_TASKS_PROPERTY_KEY, task.getGuid());
@@ -1316,9 +1309,13 @@ public abstract class DeleteHandlerV1 {
             return;
         }
 
+        createAndQueueTaskWithoutCheck(taskType, entityVertex, classificationVertexId, relationshipGuid);
+    }
+
+    public void createAndQueueTaskWithoutCheck(String taskType, AtlasVertex entityVertex, String classificationVertexId, String relationshipGuid, Boolean currentRestrictPropagationThroughLineage) throws AtlasBaseException {
         String              currentUser = RequestContext.getCurrentUser();
         String              entityGuid  = GraphHelper.getGuid(entityVertex);
-        Map<String, Object> taskParams  = ClassificationTask.toParameters(entityGuid, classificationVertexId, relationshipGuid);
+        Map<String, Object> taskParams  = ClassificationTask.toParameters(entityGuid, classificationVertexId, relationshipGuid, currentRestrictPropagationThroughLineage);
         AtlasTask           task        = taskManagement.createTask(taskType, currentUser, taskParams, classificationVertexId, entityGuid);
 
         AtlasGraphUtilsV2.addEncodedProperty(entityVertex, PENDING_TASKS_PROPERTY_KEY, task.getGuid());

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -3186,7 +3186,7 @@ public class EntityGraphMapper {
                 isClassificationUpdated = true;
 
                 boolean isEntityDeleted = DELETED.toString().equals(entityVertex.getProperty(STATE_PROPERTY_KEY, String.class));
-                if (isEntityDeleted && !updatedRemovePropagations) {
+                if (isEntityDeleted && updatedRemovePropagations) {
                     removePropagation = true;
                 }
             }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -3185,12 +3185,17 @@ public class EntityGraphMapper {
                 AtlasGraphUtilsV2.setEncodedProperty(classificationVertex, CLASSIFICATION_VERTEX_REMOVE_PROPAGATIONS_KEY, updatedRemovePropagations);
 
                 // If value set true from false and source entity is deleted, remove propagated classification from propagated entities
-                if (updatedRemovePropagations && !currentRemovePropagations) {
-                    boolean isEntityDeleted = entityVertex.getProperty(STATE_PROPERTY_KEY, String.class).equals(DELETED.toString());
-                    if(isEntityDeleted && taskManagement != null && DEFERRED_ACTION_ENABLED) {
-                        createAndQueueTask(CLASSIFICATION_PROPAGATION_DELETE, entityVertex, classificationVertex.getIdForDisplay());
-                    }
+                boolean isEntityDeleted = entityVertex.getProperty(STATE_PROPERTY_KEY, String.class).equals(DELETED.toString());
+                boolean isUpdatedRemovePropagationsDifferentFromCurrent = updatedRemovePropagations != currentRemovePropagations;
+
+                if (isEntityDeleted && taskManagement != null && DEFERRED_ACTION_ENABLED && isUpdatedRemovePropagationsDifferentFromCurrent) {
+                    createAndQueueTask(
+                            updatedRemovePropagations ? CLASSIFICATION_PROPAGATION_DELETE : CLASSIFICATION_PROPAGATION_ADD,
+                            entityVertex,
+                            classificationVertex.getIdForDisplay()
+                    );
                 }
+
 
                 isClassificationUpdated = true;
             }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -3229,10 +3229,10 @@ public class EntityGraphMapper {
             Boolean updatedRestrictPropagationThroughLineage = classification.getRestrictPropagationThroughLineage();
 
             if (taskManagement != null && DEFERRED_ACTION_ENABLED) {
-                String propagationType = updatedTagPropagation ? CLASSIFICATION_PROPAGATION_ADD : CLASSIFICATION_PROPAGATION_DELETE;
-
-                createAndQueueTask(propagationType, entityVertex, classificationVertex.getIdForDisplay(), currentRestrictPropagationThroughLineage);
-
+                String propagationType = updatedTagPropagation && !currentTagPropagation ? CLASSIFICATION_PROPAGATION_ADD : CLASSIFICATION_PROPAGATION_DELETE;
+                if (currentTagPropagation != updatedTagPropagation) {
+                    createAndQueueTask(propagationType, entityVertex, classificationVertex.getIdForDisplay(), currentRestrictPropagationThroughLineage);
+                }
                 updatedTagPropagation = null;
             }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -3229,13 +3229,12 @@ public class EntityGraphMapper {
             Boolean updatedRestrictPropagationThroughLineage = classification.getRestrictPropagationThroughLineage();
 
             if (taskManagement != null && DEFERRED_ACTION_ENABLED) {
-                String propagationType = updatedTagPropagation && !currentTagPropagation ? CLASSIFICATION_PROPAGATION_ADD : CLASSIFICATION_PROPAGATION_DELETE;
-                if (currentTagPropagation != updatedTagPropagation) {
+                String propagationType = updatedTagPropagation ? CLASSIFICATION_PROPAGATION_ADD : CLASSIFICATION_PROPAGATION_DELETE;
+                if (!Objects.equals(currentTagPropagation, updatedTagPropagation) || !Objects.equals(currentRestrictPropagationThroughLineage, updatedRestrictPropagationThroughLineage)) {
                     createAndQueueTask(propagationType, entityVertex, classificationVertex.getIdForDisplay(), currentRestrictPropagationThroughLineage);
                 }
                 updatedTagPropagation = null;
             }
-
 
             // compute propagatedEntityVertices once and use it for subsequent iterations and notifications
             if (updatedTagPropagation != null && (currentTagPropagation != updatedTagPropagation || currentRestrictPropagationThroughLineage != updatedRestrictPropagationThroughLineage)) {
@@ -3979,11 +3978,11 @@ public class EntityGraphMapper {
 
     private void createAndQueueTask(String taskType, AtlasVertex entityVertex, String classificationVertexId, Boolean currentPropagateThroughLineage) throws AtlasBaseException{
 
-        deleteDelegate.getHandler().createAndQueueTask(taskType, entityVertex, classificationVertexId, null, currentPropagateThroughLineage);
+        deleteDelegate.getHandler().createAndQueueTaskWithoutCheck(taskType, entityVertex, classificationVertexId, null, currentPropagateThroughLineage);
     }
 
     private void createAndQueueTask(String taskType, AtlasVertex entityVertex, String classificationVertexId) throws AtlasBaseException {
-        deleteDelegate.getHandler().createAndQueueTask(taskType, entityVertex, classificationVertexId, null);
+        deleteDelegate.getHandler().createAndQueueTaskWithoutCheck(taskType, entityVertex, classificationVertexId, null);
     }
 
     public void removePendingTaskFromEntity(String entityGuid, String taskGuid) throws EntityNotFoundException {


### PR DESCRIPTION
We set multiple configurations during tag attachment, such as whether we want to propagate or not. Among them, there is one configuration named removepropagationOnEntityDelete. How this works is that if we delete the source entity and this is set to false, it will not remove any propagation, and vice versa. By default, in most places in the UI and playbook, we set it as true, but the default value from the Metastore is still false. This means if you don’t send anything, it defaults to false.
Now, some customers have this property set as false, so the deletion of the source didn’t remove the propagations, and they can’t remove it as it is not discoverable via playbook filters and UI.
We discussed this and concluded that we need to set this as true by default, as it is causing confusion from the customer’s side. We also found another important issue: if we update this value to true from false and the entity is already archived, then it should remove the propagation afterward, which it is not currently doing. We have to add this enhancement.
So, from the Metastore, we have to do two things:

Set the default value of the property removepropagationOnEntityDelete as true.

Delete all the propagation if removepropagationOnEntityDelete is set to true while updating tags, and the asset is already archived.