### PR TITLE
PLT-1879: enable method level metrics in metastore to show in prometheus

### DIFF
--- a/common/src/main/java/org/apache/atlas/service/metrics/MetricsRegistryServiceImpl.java
+++ b/common/src/main/java/org/apache/atlas/service/metrics/MetricsRegistryServiceImpl.java
@@ -1,10 +1,8 @@
 package org.apache.atlas.service.metrics;
 
-import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tags;
-import io.micrometer.core.instrument.binder.BaseUnits;
-import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import io.micrometer.core.instrument.Timer;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import org.apache.atlas.ApplicationProperties;
 import org.apache.atlas.AtlasException;
@@ -16,7 +14,10 @@ import org.springframework.stereotype.Component;
 import javax.inject.Inject;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static org.apache.atlas.service.metrics.MetricUtils.getMeterRegistry;
 
@@ -31,18 +32,12 @@ public class MetricsRegistryServiceImpl implements MetricsRegistry {
     private static final double[] PERCENTILES = {0.99};
     private static final int SEC_MILLIS_SCALE = 1;
     private static final String METHOD_LEVEL_METRICS_ENABLE = "atlas.metrics.method_level.enable";
-
-    private final DistributionStatisticConfig distributionStatisticConfig;
+    private static final String ATLAS_METRICS_METHOD_PATTERNS = "atlas.metrics.method_patterns";
+    private final List<String> filteredMethods;
 
     @Inject
-    public MetricsRegistryServiceImpl() {
-        this.distributionStatisticConfig =  DistributionStatisticConfig.builder().percentilePrecision(2)
-                                            .percentiles(PERCENTILES)
-                                            .bufferLength(3)
-                                            .percentilesHistogram(false)
-                                            .minimumExpectedValue(1.0)
-                                            .maximumExpectedValue(Double.MAX_VALUE)
-                                            .expiry(Duration.ofMinutes(2)).build();
+    public MetricsRegistryServiceImpl() throws AtlasException {
+        this.filteredMethods = Arrays.stream(ApplicationProperties.get().getStringArray(ATLAS_METRICS_METHOD_PATTERNS)).collect(Collectors.toList());
     }
 
     @Override
@@ -55,12 +50,11 @@ public class MetricsRegistryServiceImpl implements MetricsRegistry {
             LOG.error("Failed to read {} property from atlas config", METHOD_LEVEL_METRICS_ENABLE, e);
             return;
         }
-        for (String name : metrics.getMetricsNames()) {
+
+        for (String name : this.filteredMethods) {
             AtlasPerfMetrics.Metric metric = metrics.getMetric(name);
-            getMeterRegistry().newDistributionSummary(new Meter.Id(METHOD_DIST_SUMMARY,
-                                    Tags.of(NAME, metric.getName()), BaseUnits.MILLISECONDS, METHOD_DIST_SUMMARY,
-                                    Meter.Type.TIMER), distributionStatisticConfig, SEC_MILLIS_SCALE)
-                    .record(metric.getTotalTimeMSecs());
+            Timer.builder(METHOD_DIST_SUMMARY).tags(Tags.of(NAME, metric.getName())).publishPercentiles(PERCENTILES)
+                    .register(getMeterRegistry()).record(metric.getTotalTimeMSecs(), TimeUnit.MILLISECONDS);
         }
     }
 
@@ -72,7 +66,7 @@ public class MetricsRegistryServiceImpl implements MetricsRegistry {
                 writer.flush();
             } catch (IOException e) {
                 LOG.warn("Failed to write metrics while scraping", e);
-            }finally {
+            } finally {
                 writer.close();
             }
         });

--- a/repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java
@@ -53,6 +53,7 @@ import org.apache.atlas.util.AtlasGremlinQueryProvider;
 import org.apache.atlas.util.AtlasGremlinQueryProvider.AtlasGremlinQuery;
 import org.apache.atlas.util.SearchPredicateUtil;
 import org.apache.atlas.util.SearchTracker;
+import org.apache.atlas.utils.AtlasPerfMetrics;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.Predicate;
 import org.apache.commons.collections4.IteratorUtils;
@@ -933,7 +934,9 @@ public class EntityDiscoveryService implements AtlasDiscoveryService {
     }
 
     private void scrubSearchResults(AtlasSearchResult result, boolean suppressLogs) throws AtlasBaseException {
+        AtlasPerfMetrics.MetricRecorder scrubSearchResultsMetrics = RequestContext.get().startMetricRecord("scrubSearchResults");
         AtlasAuthorizationUtils.scrubSearchResults(new AtlasSearchResultScrubRequest(typeRegistry, result), suppressLogs);
+        RequestContext.get().endMetricRecord(scrubSearchResultsMetrics);
     }
 
     private Set<String> getAggregationFields() {
@@ -993,9 +996,9 @@ public class EntityDiscoveryService implements AtlasDiscoveryService {
             String indexName = getIndexName(params);
 
             indexQuery = graph.elasticsearchQuery(indexName);
-
+            AtlasPerfMetrics.MetricRecorder elasticSearchQueryMetric = RequestContext.get().startMetricRecord("elasticSearchQuery");
             DirectIndexQueryResult indexQueryResult = indexQuery.vertices(searchParams);
-
+            RequestContext.get().endMetricRecord(elasticSearchQueryMetric);
             prepareSearchResult(ret, indexQueryResult, resultAttributes, true);
 
             ret.setAggregations(indexQueryResult.getAggregationMap());


### PR DESCRIPTION
## Change description
enable method level metrics in metastore to show in prometheus

Sample Metrics:
```
# HELP method_dist_summary_seconds_max  
# TYPE method_dist_summary_seconds_max gauge
method_dist_summary_seconds_max{integration="local",name="scrubSearchResults",service="atlas-metastore",} 0.003
method_dist_summary_seconds_max{integration="local",name="elasticSearchQuery",service="atlas-metastore",} 0.158
# HELP method_dist_summary_seconds  
# TYPE method_dist_summary_seconds summary
method_dist_summary_seconds{integration="local",name="scrubSearchResults",service="atlas-metastore",quantile="0.99",} 0.002883584
method_dist_summary_seconds_count{integration="local",name="scrubSearchResults",service="atlas-metastore",} 1.0
method_dist_summary_seconds_sum{integration="local",name="scrubSearchResults",service="atlas-metastore",} 0.003
method_dist_summary_seconds{integration="local",name="elasticSearchQuery",service="atlas-metastore",quantile="0.99",} 0.150994944
method_dist_summary_seconds_count{integration="local",name="elasticSearchQuery",service="atlas-metastore",} 1.0
method_dist_summary_seconds_sum{integration="local",name="elasticSearchQuery",service="atlas-metastore",} 0.158
```
## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
