### PR TITLE
CLD-5728: Removed unwanted netty deps

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -138,6 +138,12 @@
             <groupId>org.redisson</groupId>
             <artifactId>redisson</artifactId>
             <version>${redis.client.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
## Change description
netty 4.1.9 has new methods, which has missing implementations, and at runtime this was causing issues in azure 'hclpartner` tenant.

Verified changes in azbeta, staging and hclpartner by deploying custom image.

Deployed custom image with these changes, and everything works fine
<img width="300" alt="Screenshot 2023-09-20 at 11 08 40 PM" src="https://github.com/atlanhq/atlas-metastore/assets/119731738/717b134c-5f63-4b42-85f8-537c2dd212dc">

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
