### PR TITLE
fix: skip BFS iteration if vertex contains null guid

### DIFF
--- a/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
@@ -494,12 +494,16 @@ public class EntityLineageService implements AtlasLineageService {
             else
                 neighbourVertex = currentEdge.getInVertex();
 
+            String vertexGuid = getGuid(neighbourVertex);
+            if (StringUtils.isEmpty(vertexGuid))
+                continue;
+
             if (!lineageListContext.evaluateTraversalFilter(neighbourVertex))
                 continue;
 
-            if (!skippedVertices.contains(getGuid(neighbourVertex)) && !visitedVertices.contains(getGuid(neighbourVertex))) {
-                visitedVertices.add(getGuid(neighbourVertex));
-                traversalQueue.add(getGuid(neighbourVertex));
+            if (!skippedVertices.contains(vertexGuid) && !visitedVertices.contains(vertexGuid)) {
+                visitedVertices.add(vertexGuid);
+                traversalQueue.add(vertexGuid);
                 addEntitiesToCache(neighbourVertex);
             }
         }

--- a/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
@@ -495,10 +495,7 @@ public class EntityLineageService implements AtlasLineageService {
                 neighbourVertex = currentEdge.getInVertex();
 
             String vertexGuid = getGuid(neighbourVertex);
-            if (StringUtils.isEmpty(vertexGuid))
-                continue;
-
-            if (!lineageListContext.evaluateTraversalFilter(neighbourVertex))
+            if (StringUtils.isEmpty(vertexGuid) || !lineageListContext.evaluateTraversalFilter(neighbourVertex))
                 continue;
 
             if (!skippedVertices.contains(vertexGuid) && !visitedVertices.contains(vertexGuid)) {


### PR DESCRIPTION
## Change description
Skip vertex addition to queue if the vertex has guid attribute as null.

Jira: [https://atlanhq.atlassian.net/browse/PES-129](url)

