### PR TITLE
Update AtlasErrorCode to enable pinpoint asset publishing

### DIFF
--- a/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
@@ -270,7 +270,7 @@ public enum AtlasErrorCode {
     CINV_UNHEALTHY(500, "ATLAS-500-00-21", "Unable to process type-definition operations"),
     RUNTIME_EXCEPTION(500, "ATLAS-500-00-020", "Runtime exception {0}"),
     KEYCLOAK_INIT_FAILED(500, "ATLAS-500-00-022", "Failed to initialize keycloak client: {0}"),
-    BATCH_SIZE_TOO_LARGE(500, "ATLAS-500-00-023", "Batch size is too large, please use a smaller batch size"),
+    BATCH_SIZE_TOO_LARGE(406, "ATLAS-406-00-001", "Batch size is too large, please use a smaller batch size"),
 
 
     CLASSIFICATION_CURRENTLY_BEING_PROPAGATED(400, "ATLAS-400-00-105", "Classification {0} is currently being propagated."),


### PR DESCRIPTION
## Instead of making change in workflow failure handler logic we can update the error code to start PINPOINT failure handler

>  Instead of making change in workflow failure handler logic we can update the error code to start PINPOINT failure handler