### PR TITLE
PLT-290: Added “uri” projection as part of method level metrics

### DIFF
--- a/common/src/main/java/org/apache/atlas/service/metrics/MetricUtils.java
+++ b/common/src/main/java/org/apache/atlas/service/metrics/MetricUtils.java
@@ -6,6 +6,7 @@ import io.micrometer.core.instrument.Timer;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import org.apache.atlas.ApplicationProperties;
+import org.apache.atlas.AtlasException;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,18 +37,15 @@ public class MetricUtils {
     private static final PrometheusMeterRegistry METER_REGISTRY;
 
     static {
-        METER_REGISTRY = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
-        METER_REGISTRY.config().withHighCardinalityTagsDetector().commonTags(SERVICE, ATLAS_METASTORE, INTEGRATION, LOCAL);
-        Metrics.globalRegistry.add(METER_REGISTRY);
-    }
-
-    public MetricUtils() {
         try {
             METRIC_URI_PATTERNS_MAP = Arrays.stream(ApplicationProperties.get().getStringArray(ATLAS_METRICS_URI_PATTERNS))
                     .distinct().collect(Collectors.toMap(uri->uri, uri->uri.replaceAll(REGEX_URI_PLACEHOLDER, "*")));
         } catch (Exception e) {
             LOG.error("Failed to load 'atlas.metrics.uri_patterns from properties");
         }
+        METER_REGISTRY = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        METER_REGISTRY.config().withHighCardinalityTagsDetector().commonTags(SERVICE, ATLAS_METASTORE, INTEGRATION, LOCAL);
+        Metrics.globalRegistry.add(METER_REGISTRY);
     }
 
     public Timer.Sample start(String uri) {
@@ -78,7 +76,7 @@ public class MetricUtils {
                 URI, matchCanonicalPattern(uri).get());
     }
 
-    private Optional<String> matchCanonicalPattern(String uri) {
+    public static Optional<String> matchCanonicalPattern(String uri) {
         if (Objects.isNull(uri) || uri.isEmpty()) {
             return Optional.empty();
         }

--- a/common/src/main/java/org/apache/atlas/service/metrics/MetricsRegistry.java
+++ b/common/src/main/java/org/apache/atlas/service/metrics/MetricsRegistry.java
@@ -7,7 +7,7 @@ import java.io.PrintWriter;
 
 public interface MetricsRegistry {
 
-    void collect(String requestId, AtlasPerfMetrics metrics);
+    void collect(String requestId, String requestUri, AtlasPerfMetrics metrics);
 
     void scrape(PrintWriter writer) throws IOException;
 

--- a/common/src/main/java/org/apache/atlas/service/metrics/MetricsRegistryServiceImpl.java
+++ b/common/src/main/java/org/apache/atlas/service/metrics/MetricsRegistryServiceImpl.java
@@ -28,6 +28,7 @@ public class MetricsRegistryServiceImpl implements MetricsRegistry {
     private static final Logger LOG = LoggerFactory.getLogger(MetricsRegistryServiceImpl.class);
 
     private static final String NAME = "name";
+    private static final String URI = "uri";
     private static final String METHOD_DIST_SUMMARY = "method_dist_summary";
     private static final double[] PERCENTILES = {0.99};
     private static final String METHOD_LEVEL_METRICS_ENABLE = "atlas.metrics.method_level.enable";
@@ -40,7 +41,7 @@ public class MetricsRegistryServiceImpl implements MetricsRegistry {
     }
 
     @Override
-    public void collect(String requestId, AtlasPerfMetrics metrics) {
+    public void collect(String requestId, String requestUri, AtlasPerfMetrics metrics) {
         try {
             if (!ApplicationProperties.get().getBoolean(METHOD_LEVEL_METRICS_ENABLE, false)) {
                 return;
@@ -49,7 +50,7 @@ public class MetricsRegistryServiceImpl implements MetricsRegistry {
             for (String name : this.filteredMethods) {
                 if(metrics.hasMetric(name)) {
                     AtlasPerfMetrics.Metric metric = metrics.getMetric(name);
-                    Timer.builder(METHOD_DIST_SUMMARY).tags(Tags.of(NAME, metric.getName())).publishPercentiles(PERCENTILES)
+                    Timer.builder(METHOD_DIST_SUMMARY).tags(Tags.of(NAME, metric.getName(), URI, requestUri)).publishPercentiles(PERCENTILES)
                             .register(getMeterRegistry()).record(metric.getTotalTimeMSecs(), TimeUnit.MILLISECONDS);
                 }
             }

--- a/server-api/src/main/java/org/apache/atlas/RequestContext.java
+++ b/server-api/src/main/java/org/apache/atlas/RequestContext.java
@@ -95,7 +95,7 @@ public class RequestContext {
     private MetricsRegistry metricsRegistry;
     private boolean skipAuthorizationCheck = false;
     private Set<String> deletedEdgesIdsForResetHasLineage = new HashSet<>(0);
-
+    private String requestUri;
 
     private RequestContext() {
     }
@@ -159,7 +159,7 @@ public class RequestContext {
         if (metrics != null && !metrics.isEmpty()) {
             METRICS.debug(metrics.toString());
             if (Objects.nonNull(this.metricsRegistry)){
-                this.metricsRegistry.collect(traceId, metrics);
+                this.metricsRegistry.collect(traceId, this.requestUri, metrics);
             }
             metrics.clear();
         }
@@ -640,6 +640,14 @@ public class RequestContext {
 
     public void setMetricRegistry(MetricsRegistry metricsRegistry) {
         this.metricsRegistry = metricsRegistry;
+    }
+
+    public void setUri(String uri) {
+        this.requestUri = uri;
+    }
+
+    public String getRequestUri() {
+        return this.requestUri;
     }
 
     public class EntityGuidPair {

--- a/webapp/src/main/java/org/apache/atlas/web/filters/AuditFilter.java
+++ b/webapp/src/main/java/org/apache/atlas/web/filters/AuditFilter.java
@@ -20,6 +20,7 @@ package org.apache.atlas.web.filters;
 
 import org.apache.atlas.*;
 import org.apache.atlas.authorize.AtlasAuthorizationUtils;
+import org.apache.atlas.service.metrics.MetricUtils;
 import org.apache.atlas.service.metrics.MetricsRegistry;
 import org.apache.atlas.util.AtlasRepositoryConfiguration;
 import org.apache.atlas.web.util.DateTimeHelper;
@@ -95,6 +96,7 @@ public class AuditFilter implements Filter {
 
             RequestContext.clear();
             RequestContext requestContext = RequestContext.get();
+            requestContext.setUri(MetricUtils.matchCanonicalPattern(httpRequest.getRequestURI()).orElse(EMPTY));
             requestContext.setTraceId(internalRequestId);
             requestContext.setUser(user, userGroups);
             requestContext.setClientIPAddress(AtlasAuthorizationUtils.getRequestIpAddress(httpRequest));


### PR DESCRIPTION
## Change description
Added “uri” as one of the projections for metastore observability metrics, which are published at method level

```
method_dist_summary_seconds_count{integration="local",name="elasticSearchQuery",service="atlas-metastore",uri="/api/(meta|atlas/v2)/search/indexsearch",} 1.0
method_dist_summary_seconds_sum{integration="local",name="elasticSearchQuery",service="atlas-metastore",uri="/api/(meta|atlas/v2)/search/indexsearch",} 0.528
```

In beta COPS
<img width="1033" alt="Screenshot 2023-10-27 at 5 00 08 PM" src="https://github.com/atlanhq/atlas-metastore/assets/119731738/04432fd5-9741-4103-b3d8-ce3f82b7f394">


## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
