### PR TITLE
Validate token for service account with prefix of 'service-account-apikey'

### DIFF
--- a/webapp/src/main/java/org/apache/atlas/web/security/AtlasAuthenticationProvider.java
+++ b/webapp/src/main/java/org/apache/atlas/web/security/AtlasAuthenticationProvider.java
@@ -132,6 +132,8 @@ public class AtlasAuthenticationProvider extends AtlasAbstractAuthenticationProv
                 try {
                     authentication = atlasKeycloakAuthenticationProvider.authenticate(authentication);
                 } catch (KeycloakAuthenticationException ex) {
+                    // this exception signals that the authentication process for Keycloak has failed
+                    // possibly due to token introspection issues or an inactive client.
                     throw new AtlasAuthenticationException("Authentication failed.");
                 } catch (Exception ex) {
                     LOG.error("Error while Keycloak authentication", ex);

--- a/webapp/src/main/java/org/apache/atlas/web/security/AtlasKeycloakAuthenticationProvider.java
+++ b/webapp/src/main/java/org/apache/atlas/web/security/AtlasKeycloakAuthenticationProvider.java
@@ -75,7 +75,7 @@ public class AtlasKeycloakAuthenticationProvider extends AtlasAbstractAuthentica
         authentication = new KeycloakAuthenticationToken(token.getAccount(), token.isInteractive(), grantedAuthorities);
       }
     }
-    if(authentication.getName().startsWith("service-account")) {
+    if(authentication.getName().startsWith("service-account-apikey")) {
       LOG.info("Validating request for clientId: {}", authentication.getName().substring("service-account-".length()));
       try{
         KeycloakAuthenticationToken keycloakToken = (KeycloakAuthenticationToken)authentication;


### PR DESCRIPTION
Introspect the JWT token online with keycloak server, when the username present in the token starts with prefix `service-account-apikey`. It represents that the token was created from heracles. 