### PR TITLE
Add online validation for keycloak apikeys

### DIFF
--- a/client-keycloak/src/main/java/org/apache/atlas/keycloak/client/AtlasKeycloakClient.java
+++ b/client-keycloak/src/main/java/org/apache/atlas/keycloak/client/AtlasKeycloakClient.java
@@ -9,6 +9,7 @@ import org.apache.commons.lang.StringUtils;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
 import org.keycloak.representations.idm.*;
+import org.keycloak.representations.oidc.TokenMetadataRepresentation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -172,6 +173,10 @@ public final class AtlasKeycloakClient {
 
     public List<EventRepresentation> getEvents(List<String> type, String client, String user, String dateFrom, String dateTo, String ipAddress, Integer first, Integer max) throws AtlasBaseException {
         return KEYCLOAK.getEvents(type, client, user, dateFrom, dateTo, ipAddress, first, max).body();
+    }
+
+    public TokenMetadataRepresentation introspectToken(String token) throws AtlasBaseException {
+        return KEYCLOAK.introspectToken(token).body();
     }
 
     public static AtlasKeycloakClient getKeycloakClient() throws AtlasBaseException {

--- a/client-keycloak/src/main/java/org/apache/atlas/keycloak/client/KeycloakRestClient.java
+++ b/client-keycloak/src/main/java/org/apache/atlas/keycloak/client/KeycloakRestClient.java
@@ -1,9 +1,12 @@
 package org.apache.atlas.keycloak.client;
 
+import okhttp3.FormBody;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.keycloak.client.config.KeycloakConfig;
 import org.keycloak.representations.idm.*;
+import org.keycloak.representations.oidc.TokenMetadataRepresentation;
 import retrofit2.Response;
+import okhttp3.RequestBody;
 
 import java.util.List;
 import java.util.Set;
@@ -12,6 +15,10 @@ import java.util.Set;
  * Keycloak Rest client wrapper used in atlas metastore
  */
 public final class KeycloakRestClient extends AbstractKeycloakClient {
+
+    private static final String TOKEN = "token";
+    private static final String CLIENT_ID = "client_id";
+    private static final String CLIENT_SECRET = "client_secret";
 
     public KeycloakRestClient(final KeycloakConfig keycloakConfig) {
         super(keycloakConfig);
@@ -120,5 +127,17 @@ public final class KeycloakRestClient extends AbstractKeycloakClient {
     public Response<List<EventRepresentation>> getEvents(List<String> type, String client, String user, String dateFrom,
                                                          String dateTo, String ipAddress, Integer first, Integer max) throws AtlasBaseException {
         return processResponse(this.retrofit.getEvents(this.keycloakConfig.getRealmId(), type, client, user, dateFrom, dateTo, ipAddress, first, max));
+    }
+
+    public Response<TokenMetadataRepresentation> introspectToken(String token) throws AtlasBaseException {
+        return processResponse(this.retrofit.introspectToken(this.keycloakConfig.getRealmId(), getIntrospectTokenRequest(token)));
+    }
+
+    private RequestBody getIntrospectTokenRequest(String token) {
+        return new FormBody.Builder()
+                .addEncoded(TOKEN, token)
+                .addEncoded(CLIENT_ID, this.keycloakConfig.getClientId())
+                .addEncoded(CLIENT_SECRET, this.keycloakConfig.getClientSecret())
+                .build();
     }
 }

--- a/client-keycloak/src/main/java/org/apache/atlas/keycloak/client/RetrofitKeycloakClient.java
+++ b/client-keycloak/src/main/java/org/apache/atlas/keycloak/client/RetrofitKeycloakClient.java
@@ -3,6 +3,7 @@ package org.apache.atlas.keycloak.client;
 import okhttp3.RequestBody;
 import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.idm.*;
+import org.keycloak.representations.oidc.TokenMetadataRepresentation;
 import retrofit2.Call;
 import retrofit2.http.*;
 
@@ -141,5 +142,11 @@ public interface RetrofitKeycloakClient {
     @Headers({"Accept: application/json", "Content-Type: application/x-www-form-urlencoded", "Cache-Control: no-store", "Cache-Control: no-cache"})
     @POST("realms/{realmId}/protocol/openid-connect/token")
     Call<AccessTokenResponse> grantToken(@Path("realmId") String realmId, @Body RequestBody request);
+
+
+    @Headers({"Accept: application/json", "Content-Type: application/x-www-form-urlencoded", "Cache-Control: no-store", "Cache-Control: no-cache"})
+    @POST("realms/{realmId}/protocol/openid-connect/token/introspect")
+    Call<TokenMetadataRepresentation> introspectToken(@Path("realmId") String realmId, @Body RequestBody request);
+
 
 }

--- a/webapp/src/main/java/org/apache/atlas/web/security/AtlasAuthenticationProvider.java
+++ b/webapp/src/main/java/org/apache/atlas/web/security/AtlasAuthenticationProvider.java
@@ -132,6 +132,8 @@ public class AtlasAuthenticationProvider extends AtlasAbstractAuthenticationProv
                 try {
                     authentication = atlasKeycloakAuthenticationProvider.authenticate(authentication);
                 } catch (KeycloakAuthenticationException ex) {
+                    // this exception signals that the authentication process for Keycloak has failed
+                    // possibly due to token introspection issues or an inactive client.
                     throw new AtlasAuthenticationException("Authentication failed.");
                 } catch (Exception ex) {
                     LOG.error("Error while Keycloak authentication", ex);

--- a/webapp/src/main/java/org/apache/atlas/web/security/AtlasAuthenticationProvider.java
+++ b/webapp/src/main/java/org/apache/atlas/web/security/AtlasAuthenticationProvider.java
@@ -19,6 +19,7 @@ package org.apache.atlas.web.security;
 
 import org.apache.atlas.ApplicationProperties;
 import org.apache.commons.configuration.Configuration;
+import org.keycloak.adapters.springsecurity.token.KeycloakAuthenticationToken;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Scope;
@@ -130,6 +131,8 @@ public class AtlasAuthenticationProvider extends AtlasAbstractAuthenticationProv
             } else if (keycloakAuthenticationEnabled) {
                 try {
                     authentication = atlasKeycloakAuthenticationProvider.authenticate(authentication);
+                } catch (KeycloakAuthenticationException ex) {
+                    throw new AtlasAuthenticationException("Authentication failed.");
                 } catch (Exception ex) {
                     LOG.error("Error while Keycloak authentication", ex);
                 }

--- a/webapp/src/main/java/org/apache/atlas/web/security/AtlasKeycloakAuthenticationProvider.java
+++ b/webapp/src/main/java/org/apache/atlas/web/security/AtlasKeycloakAuthenticationProvider.java
@@ -17,9 +17,13 @@
 package org.apache.atlas.web.security;
 
 import org.apache.atlas.ApplicationProperties;
+import org.apache.atlas.keycloak.client.AtlasKeycloakClient;
 import org.apache.commons.configuration.Configuration;
 import org.keycloak.adapters.springsecurity.authentication.KeycloakAuthenticationProvider;
 import org.keycloak.adapters.springsecurity.token.KeycloakAuthenticationToken;
+import org.keycloak.representations.oidc.TokenMetadataRepresentation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -28,6 +32,7 @@ import org.springframework.stereotype.Component;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 @Component
 public class AtlasKeycloakAuthenticationProvider extends AtlasAbstractAuthenticationProvider {
@@ -36,8 +41,13 @@ public class AtlasKeycloakAuthenticationProvider extends AtlasAbstractAuthentica
 
   private final KeycloakAuthenticationProvider keycloakAuthenticationProvider;
 
+  private final AtlasKeycloakClient atlasKeycloakClient;
+
+  private static final Logger LOG = LoggerFactory.getLogger(AtlasKeycloakAuthenticationProvider.class);
+
   public AtlasKeycloakAuthenticationProvider() throws Exception {
     this.keycloakAuthenticationProvider = new KeycloakAuthenticationProvider();
+    this.atlasKeycloakClient = AtlasKeycloakClient.getKeycloakClient();
 
     Configuration configuration = ApplicationProperties.get();
     this.groupsFromUGI = configuration.getBoolean("atlas.authentication.method.keycloak.ugi-groups", true);
@@ -65,8 +75,29 @@ public class AtlasKeycloakAuthenticationProvider extends AtlasAbstractAuthentica
         authentication = new KeycloakAuthenticationToken(token.getAccount(), token.isInteractive(), grantedAuthorities);
       }
     }
+    if(authentication.getName().startsWith("service-account-apikey")) {
+      LOG.info("Validating request for clientId: {}", authentication.getName().substring("service-account-".length()));
+      try{
+        KeycloakAuthenticationToken keycloakToken = (KeycloakAuthenticationToken)authentication;
+        String bearerToken = keycloakToken.getAccount().getKeycloakSecurityContext().getTokenString();
+        TokenMetadataRepresentation introspectToken = atlasKeycloakClient.introspectToken(bearerToken);
+        if(Objects.nonNull(introspectToken) && introspectToken.isActive()) {
+          authentication.setAuthenticated(true);
+        } else {
+          handleInvalidApiKey(authentication);
+        }
+      } catch (Exception e) {
+        throw new KeycloakAuthenticationException("Keycloak Authentication failed", e.getCause());
+      }
+    }
 
     return authentication;
+  }
+
+  private void handleInvalidApiKey(Authentication authentication) {
+    authentication.setAuthenticated(false);
+    LOG.error("Invalid clientId: {}", authentication.getName().substring("service-account-".length()));
+    throw new KeycloakAuthenticationException("Invalid ClientId");
   }
 
   @Override

--- a/webapp/src/main/java/org/apache/atlas/web/security/KeycloakAuthenticationException.java
+++ b/webapp/src/main/java/org/apache/atlas/web/security/KeycloakAuthenticationException.java
@@ -1,0 +1,12 @@
+package org.apache.atlas.web.security;
+
+import org.springframework.security.core.AuthenticationException;
+public class KeycloakAuthenticationException extends AuthenticationException {
+    public KeycloakAuthenticationException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+
+    public KeycloakAuthenticationException(String msg) {
+        super(msg);
+    }
+}


### PR DESCRIPTION
[Ticket Link](https://atlanhq.atlassian.net/browse/PLT-245?atlOrigin=eyJpIjoiMDZkMTM4MTA2MWVmNDY2NmI3NDY4YjUyMTNhMDBkY2EiLCJwIjoiaiJ9)

Add a validation in AtlasKeycloakAuthenticationProvider for every request from a service account to introspect if the API Key is still active in Keycloak.