### PR TITLE
Add metric counter when authenticating a request from a service-account

### DIFF
--- a/webapp/src/main/java/org/apache/atlas/web/security/AtlasKeycloakAuthenticationProvider.java
+++ b/webapp/src/main/java/org/apache/atlas/web/security/AtlasKeycloakAuthenticationProvider.java
@@ -16,6 +16,8 @@
  */
 package org.apache.atlas.web.security;
 
+import io.micrometer.core.instrument.Counter;
+import org.apache.atlas.service.metrics.MetricUtils;
 import org.apache.atlas.ApplicationProperties;
 import org.apache.commons.configuration.Configuration;
 import org.keycloak.adapters.springsecurity.authentication.KeycloakAuthenticationProvider;
@@ -64,6 +66,11 @@ public class AtlasKeycloakAuthenticationProvider extends AtlasAbstractAuthentica
         }
         authentication = new KeycloakAuthenticationToken(token.getAccount(), token.isInteractive(), grantedAuthorities);
       }
+    }
+
+    if(authentication.getName().startsWith("service-account-apikey")) {
+      // Increment the counter when the authentication is for a service account.
+      Counter.builder("service_account_apikey_request_counter").register(MetricUtils.getMeterRegistry()).increment();
     }
 
     return authentication;


### PR DESCRIPTION
## What
We're fixing a security issue where deleted API tokens are still able to access Atlas API. This PR adds a counter for evaluate request count when username in bearer token starts with service-account-apikey.

## Why
We're fixing the issue by adding online validation of api key via KeyCloak. This would increase requests to KeyCloak from Atlas.

We currently don't have data around the number of requests from service accounts going to KeyCloak from metastore. This is needed so that we can take a call on whether this increase in requests would lead to any performance issues on KeyCloak.