### PR TITLE
fix(master): Skip assigning duplicate terms to assets

### DIFF
--- a/repository/src/main/java/org/apache/atlas/glossary/GlossaryTermUtils.java
+++ b/repository/src/main/java/org/apache/atlas/glossary/GlossaryTermUtils.java
@@ -105,8 +105,8 @@ public class GlossaryTermUtils extends GlossaryUtils {
             if (CollectionUtils.isNotEmpty(assignedEntities) && assignedEntities.contains(objectId)) {
                 if (DEBUG_ENABLED) {
                     LOG.debug("Skipping already assigned entity {}", objectId);
-                    continue;
                 }
+                continue;
             }
 
             if (DEBUG_ENABLED) {


### PR DESCRIPTION
## Change description

Trying to assign the same term to an asset succeeds via the endpoint POST /v2/glossary/terms/{termGuid}/assignedEntities, leading to duplicate terms. The uniqueness check isn't enforced. This PR fixes that.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [PLT-305](https://atlanhq.atlassian.net/browse/PLT-305)

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable


[PLT-305]: https://atlanhq.atlassian.net/browse/PLT-305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ