### PR TITLE
Add online keycloak introspection for requests

### DIFF
--- a/client-keycloak/src/main/java/org/apache/atlas/keycloak/client/AtlasKeycloakClient.java
+++ b/client-keycloak/src/main/java/org/apache/atlas/keycloak/client/AtlasKeycloakClient.java
@@ -9,6 +9,7 @@ import org.apache.commons.lang.StringUtils;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
 import org.keycloak.representations.idm.*;
+import org.keycloak.representations.oidc.TokenMetadataRepresentation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -172,6 +173,10 @@ public final class AtlasKeycloakClient {
 
     public List<EventRepresentation> getEvents(List<String> type, String client, String user, String dateFrom, String dateTo, String ipAddress, Integer first, Integer max) throws AtlasBaseException {
         return KEYCLOAK.getEvents(type, client, user, dateFrom, dateTo, ipAddress, first, max).body();
+    }
+
+    public TokenMetadataRepresentation introspectToken(String token) throws AtlasBaseException {
+        return KEYCLOAK.introspectToken(token).body();
     }
 
     public static AtlasKeycloakClient getKeycloakClient() throws AtlasBaseException {

--- a/client-keycloak/src/main/java/org/apache/atlas/keycloak/client/KeycloakRestClient.java
+++ b/client-keycloak/src/main/java/org/apache/atlas/keycloak/client/KeycloakRestClient.java
@@ -1,8 +1,11 @@
 package org.apache.atlas.keycloak.client;
 
+import okhttp3.FormBody;
+import okhttp3.RequestBody;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.keycloak.client.config.KeycloakConfig;
 import org.keycloak.representations.idm.*;
+import org.keycloak.representations.oidc.TokenMetadataRepresentation;
 import retrofit2.Response;
 
 import java.util.List;
@@ -13,6 +16,9 @@ import java.util.Set;
  */
 public final class KeycloakRestClient extends AbstractKeycloakClient {
 
+    private static final String TOKEN = "token";
+    private static final String CLIENT_ID = "client_id";
+    private static final String CLIENT_SECRET = "client_secret";
     public KeycloakRestClient(final KeycloakConfig keycloakConfig) {
         super(keycloakConfig);
     }
@@ -120,5 +126,17 @@ public final class KeycloakRestClient extends AbstractKeycloakClient {
     public Response<List<EventRepresentation>> getEvents(List<String> type, String client, String user, String dateFrom,
                                                          String dateTo, String ipAddress, Integer first, Integer max) throws AtlasBaseException {
         return processResponse(this.retrofit.getEvents(this.keycloakConfig.getRealmId(), type, client, user, dateFrom, dateTo, ipAddress, first, max));
+    }
+
+    public Response<TokenMetadataRepresentation> introspectToken(String token) throws AtlasBaseException {
+        return processResponse(this.retrofit.introspectToken(this.keycloakConfig.getRealmId(), getIntrospectTokenRequest(token)));
+    }
+
+    private RequestBody getIntrospectTokenRequest(String token) {
+        return new FormBody.Builder()
+                .addEncoded(TOKEN, token)
+                .addEncoded(CLIENT_ID, this.keycloakConfig.getClientId())
+                .addEncoded(CLIENT_SECRET, this.keycloakConfig.getClientSecret())
+                .build();
     }
 }

--- a/client-keycloak/src/main/java/org/apache/atlas/keycloak/client/RetrofitKeycloakClient.java
+++ b/client-keycloak/src/main/java/org/apache/atlas/keycloak/client/RetrofitKeycloakClient.java
@@ -3,6 +3,7 @@ package org.apache.atlas.keycloak.client;
 import okhttp3.RequestBody;
 import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.idm.*;
+import org.keycloak.representations.oidc.TokenMetadataRepresentation;
 import retrofit2.Call;
 import retrofit2.http.*;
 
@@ -141,5 +142,9 @@ public interface RetrofitKeycloakClient {
     @Headers({"Accept: application/json", "Content-Type: application/x-www-form-urlencoded", "Cache-Control: no-store", "Cache-Control: no-cache"})
     @POST("realms/{realmId}/protocol/openid-connect/token")
     Call<AccessTokenResponse> grantToken(@Path("realmId") String realmId, @Body RequestBody request);
+
+    @Headers({"Accept: application/json", "Content-Type: application/x-www-form-urlencoded", "Cache-Control: no-store", "Cache-Control: no-cache"})
+    @POST("realms/{realmId}/protocol/openid-connect/token/introspect")
+    Call<TokenMetadataRepresentation> introspectToken(@Path("realmId") String realmId, @Body RequestBody request);
 
 }

--- a/webapp/src/main/java/org/apache/atlas/web/security/AtlasAuthenticationProvider.java
+++ b/webapp/src/main/java/org/apache/atlas/web/security/AtlasAuthenticationProvider.java
@@ -130,6 +130,8 @@ public class AtlasAuthenticationProvider extends AtlasAbstractAuthenticationProv
             } else if (keycloakAuthenticationEnabled) {
                 try {
                     authentication = atlasKeycloakAuthenticationProvider.authenticate(authentication);
+                } catch (KeycloakAuthenticationException ex) {
+                    throw new AtlasAuthenticationException("Authentication failed.");
                 } catch (Exception ex) {
                     LOG.error("Error while Keycloak authentication", ex);
                 }

--- a/webapp/src/main/java/org/apache/atlas/web/security/AtlasKeycloakAuthenticationProvider.java
+++ b/webapp/src/main/java/org/apache/atlas/web/security/AtlasKeycloakAuthenticationProvider.java
@@ -17,11 +17,15 @@
 package org.apache.atlas.web.security;
 
 import io.micrometer.core.instrument.Counter;
+import org.apache.atlas.keycloak.client.AtlasKeycloakClient;
 import org.apache.atlas.service.metrics.MetricUtils;
 import org.apache.atlas.ApplicationProperties;
 import org.apache.commons.configuration.Configuration;
 import org.keycloak.adapters.springsecurity.authentication.KeycloakAuthenticationProvider;
 import org.keycloak.adapters.springsecurity.token.KeycloakAuthenticationToken;
+import org.keycloak.representations.oidc.TokenMetadataRepresentation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -30,18 +34,25 @@ import org.springframework.stereotype.Component;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 @Component
 public class AtlasKeycloakAuthenticationProvider extends AtlasAbstractAuthenticationProvider {
   private final boolean groupsFromUGI;
   private final String groupsClaim;
+  private final boolean isTokenIntrospectionEnabled;
 
   private final KeycloakAuthenticationProvider keycloakAuthenticationProvider;
+  private final AtlasKeycloakClient atlasKeycloakClient;
+  private static final Logger LOG = LoggerFactory.getLogger(AtlasKeycloakAuthenticationProvider.class);
 
   public AtlasKeycloakAuthenticationProvider() throws Exception {
     this.keycloakAuthenticationProvider = new KeycloakAuthenticationProvider();
+    this.atlasKeycloakClient = AtlasKeycloakClient.getKeycloakClient();
 
     Configuration configuration = ApplicationProperties.get();
+
+    this.isTokenIntrospectionEnabled = configuration.getBoolean("atlas.canary.keycloak.token-introspection", false);
     this.groupsFromUGI = configuration.getBoolean("atlas.authentication.method.keycloak.ugi-groups", true);
     this.groupsClaim = configuration.getString("atlas.authentication.method.keycloak.groups_claim");
   }
@@ -68,9 +79,27 @@ public class AtlasKeycloakAuthenticationProvider extends AtlasAbstractAuthentica
       }
     }
 
-    if(authentication.getName().startsWith("service-account-apikey")) {
+    if (authentication.getName().startsWith("service-account-apikey")) {
       // Increment the counter when the authentication is for a service account.
       Counter.builder("service_account_apikey_request_counter").register(MetricUtils.getMeterRegistry()).increment();
+
+      // Validate the token online with keycloak server if token introspection is enabled
+      LOG.info("isTokenIntrospectionEnabled: {}", isTokenIntrospectionEnabled);
+      if (isTokenIntrospectionEnabled) {
+        LOG.info("Validating request for clientId: {}", authentication.getName().substring("service-account-".length()));
+        try {
+          KeycloakAuthenticationToken keycloakToken = (KeycloakAuthenticationToken) authentication;
+          String bearerToken = keycloakToken.getAccount().getKeycloakSecurityContext().getTokenString();
+          TokenMetadataRepresentation introspectToken = atlasKeycloakClient.introspectToken(bearerToken);
+          if (Objects.nonNull(introspectToken) && introspectToken.isActive()) {
+            authentication.setAuthenticated(true);
+          } else {
+            handleInvalidApiKey(authentication);
+          }
+        } catch (Exception e) {
+          throw new KeycloakAuthenticationException("Keycloak Authentication failed", e.getCause());
+        }
+      }
     }
 
     return authentication;
@@ -79,5 +108,11 @@ public class AtlasKeycloakAuthenticationProvider extends AtlasAbstractAuthentica
   @Override
   public boolean supports(Class<?> aClass) {
     return keycloakAuthenticationProvider.supports(aClass);
+  }
+
+  private void handleInvalidApiKey(Authentication authentication) {
+    authentication.setAuthenticated(false);
+    LOG.error("Invalid clientId: {}", authentication.getName().substring("service-account-".length()));
+    throw new KeycloakAuthenticationException("Invalid ClientId");
   }
 }

--- a/webapp/src/main/java/org/apache/atlas/web/security/KeycloakAuthenticationException.java
+++ b/webapp/src/main/java/org/apache/atlas/web/security/KeycloakAuthenticationException.java
@@ -1,0 +1,13 @@
+package org.apache.atlas.web.security;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class KeycloakAuthenticationException extends AuthenticationException {
+    public KeycloakAuthenticationException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+
+    public KeycloakAuthenticationException(String msg) {
+        super(msg);
+    }
+}


### PR DESCRIPTION
## Description
Add keycloak online validation for requests coming from `service-account-apikey`, to unauthorize tokens from invalid /revoked clients.
Add a feature flag `keycloak.token-introspection` to enable the above validation. 


## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Ticket
[Link](https://atlanhq.atlassian.net/browse/PLT-245?atlOrigin=eyJpIjoiMTE0NGViN2E2YWQ0NDRmNDljM2RjM2ViNDg4NDU1YjkiLCJwIjoiaiJ9)


## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
