### PR TITLE
Add keycloak.token_introspection in Atlas Configuration

### DIFF
--- a/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
@@ -106,7 +106,9 @@ public enum AtlasConfiguration {
     ENABLE_SEARCH_LOGGER("atlas.enable.search.logger", true),
     SEARCH_LOGGER_MAX_THREADS("atlas.enable.search.logger.max.threads", 20),
 
-    PERSONA_POLICY_ASSET_MAX_LIMIT("atlas.persona.policy.asset.maxlimit", 1000);
+    PERSONA_POLICY_ASSET_MAX_LIMIT("atlas.persona.policy.asset.maxlimit", 1000),
+
+    ENABLE_KEYCLOAK_TOKEN_INTROSPECTION("atlas.canary.keycloak.token_introspection", false);
 
 
     private static final Configuration APPLICATION_PROPERTIES;

--- a/webapp/src/main/java/org/apache/atlas/web/security/AtlasKeycloakAuthenticationProvider.java
+++ b/webapp/src/main/java/org/apache/atlas/web/security/AtlasKeycloakAuthenticationProvider.java
@@ -17,6 +17,7 @@
 package org.apache.atlas.web.security;
 
 import io.micrometer.core.instrument.Counter;
+import org.apache.atlas.AtlasConfiguration;
 import org.apache.atlas.keycloak.client.AtlasKeycloakClient;
 import org.apache.atlas.service.metrics.MetricUtils;
 import org.apache.atlas.ApplicationProperties;
@@ -52,7 +53,7 @@ public class AtlasKeycloakAuthenticationProvider extends AtlasAbstractAuthentica
 
     Configuration configuration = ApplicationProperties.get();
 
-    this.isTokenIntrospectionEnabled = configuration.getBoolean("atlas.canary.keycloak.token-introspection", false);
+    this.isTokenIntrospectionEnabled = AtlasConfiguration.ENABLE_KEYCLOAK_TOKEN_INTROSPECTION.getBoolean();
     this.groupsFromUGI = configuration.getBoolean("atlas.authentication.method.keycloak.ugi-groups", true);
     this.groupsClaim = configuration.getString("atlas.authentication.method.keycloak.groups_claim");
   }


### PR DESCRIPTION
- Add `atlas.canary.keycloak.token_introspection` property in AtlasConfiguration.
- This property act as a feature flag for validating api-tokens from `service-account-apikey`.