### PR TITLE
Increase field limit to 5000 for vertex index

### DIFF
--- a/addons/elasticsearch/es-settings.json
+++ b/addons/elasticsearch/es-settings.json
@@ -1,7 +1,7 @@
 {
   "mapping" : {
     "total_fields" : {
-      "limit" : "2000"
+      "limit" : "5000"
     },
     "nested_objects" : {
       "limit" : "100000"


### PR DESCRIPTION
## Description

- Increase default field limit of janusgraph_vertex_index to 5000. 
- This is done keeping in mind the current number of tenants' field count approaching the previous limit of 2000. 
- For more details, please visit the ticket [Link](https://atlanhq.atlassian.net/browse/PLT-205)

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
