### PR TITLE
Add parallelisation for classification level method to optimise scrubSearch

### DIFF
--- a/auth-plugin-atlas/src/main/java/org/apache/atlas/authorization/atlas/authorizer/RangerAtlasAuthorizerUtil.java
+++ b/auth-plugin-atlas/src/main/java/org/apache/atlas/authorization/atlas/authorizer/RangerAtlasAuthorizerUtil.java
@@ -43,6 +43,8 @@ import static org.apache.atlas.services.atlas.RangerServiceAtlas.RESOURCE_ENTITY
 
 public class RangerAtlasAuthorizerUtil {
 
+    public static Integer NUM_THREADS = 5;
+
     static void toRangerRequest(AtlasEntityAccessRequest request, RangerAccessRequestImpl rangerRequest, RangerAccessResourceImpl rangerResource){
 
         final String                   action         = request.getAction() != null ? request.getAction().getType() : null;


### PR DESCRIPTION
## Description
- For some queries scrubSearchResults takes a long time (> 3s). This is due to access for each classification inside an entity being checked for a user. 
- Though most of the entities consist of fewer classifications. The latency increases for those with more classifications. 

## Changes
- Initialise Ranger Request and Resource for each classification. 
- Add a thread pool with 5 threads to check access for classifications in parallel. 
- Minor Refactoring.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
