### PR TITLE
scrub search optimisation

### DIFF
--- a/auth-plugin-atlas/src/main/java/org/apache/atlas/authorization/atlas/authorizer/RangerAtlasAuthorizer.java
+++ b/auth-plugin-atlas/src/main/java/org/apache/atlas/authorization/atlas/authorizer/RangerAtlasAuthorizer.java
@@ -61,6 +61,14 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.Objects;
+import java.util.ArrayList;
+import java.util.Optional;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
 
 import static org.apache.atlas.authorization.atlas.authorizer.RangerAtlasAuthorizerUtil.*;
 import static org.apache.atlas.authorize.AtlasAuthorizationUtils.getCurrentUserGroups;
@@ -80,6 +88,8 @@ public class RangerAtlasAuthorizer implements AtlasAuthorizer {
         add(AtlasPrivilege.ENTITY_REMOVE_CLASSIFICATION);
         add(AtlasPrivilege.ENTITY_UPDATE_CLASSIFICATION);
     }};
+
+    static final ExecutorService entityAccessThreadpool = Executors.newFixedThreadPool(5);
 
     @Override
     public void init() {
@@ -589,22 +599,27 @@ public class RangerAtlasAuthorizer implements AtlasAuthorizer {
             if (RangerPerfTracer.isPerfTraceEnabled(PERF_LOG))
                 perf = RangerPerfTracer.getPerfTracer(PERF_LOG, "RangerAtlasAuthorizer.scrubSearchResults(" + request + ")");
             AtlasSearchResult result = request.getSearchResult();
+            List<AtlasEntityHeader> entitiesToCheck = new ArrayList<>();
+
             if (CollectionUtils.isNotEmpty(result.getEntities())) {
-                for (AtlasEntityHeader entity : result.getEntities()) {
-                    checkAccessAndScrub(entity, request, isScrubAuditEnabled);
-                }
+                entitiesToCheck.addAll(result.getEntities());
             }
+
             if (CollectionUtils.isNotEmpty(result.getFullTextResult())) {
-                for (AtlasSearchResult.AtlasFullTextResult fullTextResult : result.getFullTextResult()) {
-                    if (fullTextResult != null)
-                        checkAccessAndScrub(fullTextResult.getEntity(), request, isScrubAuditEnabled);
-                }
+                entitiesToCheck.addAll(
+                        result.getFullTextResult()
+                                .stream()
+                                .filter(Objects::nonNull)
+                                .map(res -> res.getEntity())
+                                .collect(Collectors.toList())
+                );
             }
+
             if (MapUtils.isNotEmpty(result.getReferredEntities())) {
-                for (AtlasEntityHeader entity : result.getReferredEntities().values()) {
-                    checkAccessAndScrub(entity, request, isScrubAuditEnabled);
-                }
+                entitiesToCheck.addAll(result.getReferredEntities().values());
             }
+
+            checkAccessAndScrubAsync(entitiesToCheck, request, isScrubAuditEnabled);
         } finally {
             RangerPerfTracer.log(perf);
         }
@@ -624,6 +639,36 @@ public class RangerAtlasAuthorizer implements AtlasAuthorizer {
         filterTypes(request, typesDef.getRelationshipDefs());
         filterTypes(request, typesDef.getBusinessMetadataDefs());
 
+    }
+
+    private void checkAccessAndScrubAsync(List<AtlasEntityHeader> entitiesToCheck, AtlasSearchResultScrubRequest request, boolean isScrubAuditEnabled) throws AtlasAuthorizationException {
+        LOG.info("Creating futures to check access and scrub " + entitiesToCheck.size() + " entities");
+        List<CompletableFuture<AtlasAuthorizationException>> completableFutures = entitiesToCheck
+                .stream()
+                .map(entity -> CompletableFuture.supplyAsync(() -> {
+                    try {
+                        checkAccessAndScrub(entity, request, isScrubAuditEnabled);
+                        return null;
+                    } catch (AtlasAuthorizationException e) {
+                        return e;
+                    }
+                }, entityAccessThreadpool))
+                .collect(Collectors.toList());
+
+        // wait for all threads to complete their execution
+        CompletableFuture.allOf(completableFutures.toArray(new CompletableFuture[0])).join();
+
+        // get the first exception from any checkAccessAndScrub calls
+        Optional<AtlasAuthorizationException> maybeAuthException = completableFutures
+                .stream()
+                .map(CompletableFuture::join)
+                .filter(Objects::nonNull)
+                .findFirst();
+
+        LOG.info("Async check access and scrub is complete");
+        if (maybeAuthException.isPresent()) {
+            throw maybeAuthException.get();
+        }
     }
 
     private void filterTypes(AtlasAccessRequest request, List<? extends AtlasBaseTypeDef> typeDefs)throws AtlasAuthorizationException {


### PR DESCRIPTION
## Description
- For some queries scrubSearchResults takes a long time (> 3s). This is due to access for each classification inside an entity being checked for a user. 
- Though most of the entities consist of fewer classifications. The latency increases for those with more classifications. 

## Changes
- Add a thread pool with 5 threads to check access for entities in parallel.
- Minor Refactoring.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
