### PR TITLE
Fix updatedBy field in event stream

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -1917,7 +1917,6 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
                 }
                 entity.setDeleteHandler(handler);
                 entity.setStatus(Status.DELETED);
-                // PLT-373 : set current user name
                 entity.setUpdatedBy(RequestContext.get().getUser());
                 response.addEntity(DELETE, entity);
             }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -585,7 +585,6 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
             AtlasAuthorizationUtils.verifyDeleteEntityAccess(typeRegistry, entityHeader, "delete entity: guid=" + guid);
 
             deletionCandidates.add(vertex);
-
         } else {
             if (LOG.isDebugEnabled()) {
                 // Entity does not exist - treat as non-error, since the caller

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -585,6 +585,7 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
             AtlasAuthorizationUtils.verifyDeleteEntityAccess(typeRegistry, entityHeader, "delete entity: guid=" + guid);
 
             deletionCandidates.add(vertex);
+
         } else {
             if (LOG.isDebugEnabled()) {
                 // Entity does not exist - treat as non-error, since the caller
@@ -1917,6 +1918,8 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
                 }
                 entity.setDeleteHandler(handler);
                 entity.setStatus(Status.DELETED);
+                // PLT-373 : set current user name
+                entity.setUpdatedBy(RequestContext.get().getUser());
                 response.addEntity(DELETE, entity);
             }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -990,7 +990,7 @@ public class EntityGraphRetriever {
         ret.setLabels(getLabels(entityVertex));
 
         ret.setCreatedBy(GraphHelper.getCreatedByAsString(entityVertex));
-        ret.setUpdatedBy(GraphHelper.getModifiedByAsString(entityVertex));
+        ret.setUpdatedBy(RequestContext.get().getUser());
         ret.setCreateTime(new Date(GraphHelper.getCreatedTime(entityVertex)));
         ret.setUpdateTime(new Date(GraphHelper.getModifiedTime(entityVertex)));
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -990,7 +990,7 @@ public class EntityGraphRetriever {
         ret.setLabels(getLabels(entityVertex));
 
         ret.setCreatedBy(GraphHelper.getCreatedByAsString(entityVertex));
-        ret.setUpdatedBy(RequestContext.get().getUser());
+        ret.setUpdatedBy(GraphHelper.getModifiedByAsString(entityVertex));
         ret.setCreateTime(new Date(GraphHelper.getCreatedTime(entityVertex)));
         ret.setUpdateTime(new Date(GraphHelper.getModifiedTime(entityVertex)));
 


### PR DESCRIPTION
## Change description

> UpdatedBy field is the delete event is not correct
JIRA : https://atlanhq.atlassian.net/browse/PLT-373

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable

### Developer Testing Notes:
1. Create Glossary on Beta [with other user profile]
2. Delete Glossary with other user profile
3. Validate Events [updatedBy field should contain userId of step2]
4.  validate auditSearch API

a**. Beta testing**
```
curl --location 'https://beta.atlan.dev/api/meta/entity/auditSearch' \
--header 'authorization: Bearer  your token' \
--header 'content-type: application/json' \
--data '{
    "dsl": {
        "from": 0,
        "size": 10,
        "sort": [
            {
                "created": {
                    "order": "desc"
                }
            }
        ],
        "query": {
            "bool": {
                "filter": {
                    "bool": {
                        "should": [
                        
                            {
                                "term": {
                                    "entityId": "10f0cc44-45c5-449b-bc0e-0b3358989d07"
                                }
                            }
                        ]
                    }
                }
            }
        }
    }
}'
```
```
{
   "entityAudits":[
      {
         "entityQualifiedName":"Wojd826Y8Iw2iz98XdMuM",
         "typeName":"AtlasGlossary",
         "entityId":"10f0cc44-45c5-449b-bc0e-0b3358989d07",
         "timestamp":1701679563047,
         "created":1701692514253,
         "user":"aarshi.arora",
         "action":"ENTITY_DELETE",
         "details":null,
         "eventKey":"10f0cc44-45c5-449b-bc0e-0b3358989d07:1701679563047",
         "entity":null,
         "type":null,
         "detail":{
            "typeName":"AtlasGlossary",
            "attributes":{
               "qualifiedName":"Wojd826Y8Iw2iz98XdMuM"
            },
            "guid":"10f0cc44-45c5-449b-bc0e-0b3358989d07",
            "isIncomplete":false,
            "provenanceType":0,
            "status":"DELETED",
            "createdBy":"ekta.varma",
            "updatedBy":"aarshi.arora",
            "createTime":1701678803307,
            "updateTime":1701679563047,
            "version":0,
            "meanings":[
               
            ],
            "deleteHandler":"DEFAULT",
            "proxy":false
         },
         "entityDetail":{
            "typeName":"AtlasGlossary",
            "attributes":{
               
            },
            "guid":"10f0cc44-45c5-449b-bc0e-0b3358989d07",
            "status":"DELETED",
            "isIncomplete":false,
            "createdBy":"ekta.varma",
            "updatedBy":"aarshi.arora",
            "createTime":1701678803307,
            "updateTime":1701692513730
         },
         "headers":{
            "x-atlan-request-id":"18214413-5553-4c51-3d30-5349daac5bd0",
            "x-atlan-via-ui":"true"
         }
      },
      {
         "entityQualifiedName":"Wojd826Y8Iw2iz98XdMuM",
         "typeName":"AtlasGlossary",
         "entityId":"10f0cc44-45c5-449b-bc0e-0b3358989d07",
         "timestamp":1701678803307,
         "created":1701678803823,
         "user":"ekta.varma",
         "action":"ENTITY_CREATE",
         "details":null,
         "eventKey":"10f0cc44-45c5-449b-bc0e-0b3358989d07:1701678803307",
         "entity":null,
         "type":null,
         "detail":{
            "typeName":"AtlasGlossary",
            "attributes":{
               "popularityScore":1.17549435E-38,
               "assetMcMonitorNames":[
                  
               ],
               "lastSyncRunAt":0,
               "__hasLineage":false,
               "sourceQueryComputeCostRecordList":[
                  
               ],
               "assetSodaLastSyncRunAt":0,
               "starredCount":0,
               "adminUsers":[
                  
               ],
               "lastRowChangedAt":0,
               "sourceReadRecentUserList":[
                  
               ],
               "assetMcIncidentQualifiedNames":[
                  
               ],
               "assetMcIncidentTypes":[
                  
               ],
               "assetSodaLastScanAt":0,
               "sourceUpdatedAt":0,
               "assetDbtJobLastRunArtifactsSaved":false,
               "starredDetailsList":[
                  
               ],
               "isEditable":true,
               "sourceReadCount":0,
               "announcementUpdatedAt":0,
               "sourceCreatedAt":0,
               "assetDbtJobLastRunDequedAt":0,
               "assetDbtTags":[
                  
               ],
               "sourceReadSlowQueryRecordList":[
                  
               ],
               "qualifiedName":"Wojd826Y8Iw2iz98XdMuM",
               "sourceQueryComputeCostList":[
                  
               ],
               "assetDbtJobLastRunNotificationsSent":false,
               "assetMcMonitorTypes":[
                  
               ],
               "assetSodaCheckCount":0,
               "assetMcMonitorStatuses":[
                  
               ],
               "starredBy":[
                  
               ],
               "sourceLastReadAt":0,
               "name":"test",
               "certificateUpdatedAt":1701678803307,
               "assetMcIncidentSeverities":[
                  
               ],
               "sourceReadQueryCost":0.0,
               "ownerUsers":[
                  "ekta.varma"
               ],
               "certificateStatus":"DRAFT",
               "assetDbtJobLastRunHasSourcesGenerated":false,
               "assetMcIncidentSubTypes":[
                  
               ],
               "isAIGenerated":false,
               "assetDbtJobLastRunHasDocsGenerated":false,
               "assetTags":[
                  
               ],
               "assetMcIncidentStates":[
                  
               ],
               "assetDbtJobLastRunUpdatedAt":0,
               "ownerGroups":[
                  
               ],
               "certificateUpdatedBy":"ekta.varma",
               "assetMcMonitorQualifiedNames":[
                  
               ],
               "sourceReadExpensiveQueryRecordList":[
                  
               ],
               "assetDbtJobLastRunStartedAt":0,
               "isDiscoverable":true,
               "isPartial":false,
               "sourceReadTopUserRecordList":[
                  
               ],
               "assetMcMonitorScheduleTypes":[
                  
               ],
               "viewerUsers":[
                  
               ],
               "viewScore":1.17549435E-38,
               "sourceReadTopUserList":[
                  
               ],
               "assetMcIncidentNames":[
                  
               ],
               "userDescription":"",
               "adminRoles":[
                  
               ],
               "adminGroups":[
                  
               ],
               "assetDbtJobLastRunCreatedAt":0,
               "assetDbtJobNextRun":0,
               "sourceReadRecentUserRecordList":[
                  
               ],
               "assetIcon":"atlanGlossary",
               "sourceReadPopularQueryRecordList":[
                  
               ],
               "sourceTotalCost":0.0,
               "assetMcLastSyncRunAt":0,
               "sourceReadUserCount":0,
               "viewerGroups":[
                  
               ],
               "assetDbtJobLastRun":0
            },
            "guid":"10f0cc44-45c5-449b-bc0e-0b3358989d07",
            "isIncomplete":false,
            "provenanceType":0,
            "createdBy":"ekta.varma",
            "updatedBy":"ekta.varma",
            "createTime":1701678803307,
            "updateTime":1701678803307,
            "version":0,
            "classifications":[
               
            ],
            "proxy":false
         },
         "entityDetail":{
            "typeName":"AtlasGlossary",
            "attributes":{
               
            },
            "guid":"10f0cc44-45c5-449b-bc0e-0b3358989d07",
            "status":"DELETED",
            "isIncomplete":false,
            "createdBy":"ekta.varma",
            "updatedBy":"aarshi.arora",
            "createTime":1701678803307,
            "updateTime":1701692513730
         },
         "headers":{
            "x-atlan-request-id":"c4977a17-2d96-4264-38ff-4c6509b299f6",
            "x-atlan-via-ui":"true"
         }
      }
   ],
   "aggregations":null,
   "count":2,
   "totalCount":2
}
```

b. **staging testing** :
```
curl --location 'https://staging-governance.atlan.dev/api/meta/entity/auditSearch' \
--header 'content-type: application/json' \
--header 'x-atlan-request-id: bdd9c786-7861-4672-b4fd-6b7779dfc7bd' \
--header 'Authorization: Bearer your auth token' \
--data '{
    "dsl": {
        "from": 0,
        "size": 10,
        "sort": [
            {
                "created": {
                    "order": "desc"
                }
            }
        ],
        "query": {
            "bool": {
                "filter": {
                    "bool": {
                        "should": [
                        
                            {
                                "term": {
                                    "entityId": "03e5f988-fd06-489f-9e14-63a1af8b51f6"
                                }
                            }
                        ]
                    }
                }
            }
        }
    }
}'
```