### PR TITLE
PLT-191 [Stage]: IndexSearch latency improvements

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -51,6 +51,16 @@ jobs:
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: get_branch
 
+      - name: Create Maven Settings
+        uses: s4u/maven-settings-action@v2.8.0
+        with:
+          servers: |
+            [{
+                "id": "github",
+                "username": "atlan-ci",
+                "password": "${{ secrets.my_pat }}"
+            }]
+
       - name: Build with Maven
         run: |
           branch_name=${{ steps.get_branch.outputs.branch }} 

--- a/build.sh
+++ b/build.sh
@@ -24,9 +24,9 @@ unzip -o keycloak-15.0.2.1.zip -d ~/.m2/repository/org
 echo "Maven Building"
 
 if [ "$1" == "build_without_dashboard" ]; then
-  mvn  -pl '!addons/hdfs-model,!addons/hive-bridge,!addons/hive-bridge-shim,!addons/falcon-bridge-shim,!addons/falcon-bridge,!addons/sqoop-bridge,!addons/sqoop-bridge-shim,!addons/hbase-bridge,!addons/hbase-bridge-shim,!addons/hbase-testing-util,!addons/kafka-bridge,!addons/impala-hook-api,!addons/impala-bridge-shim,!addons/impala-bridge,!dashboardv2,!dashboardv3' -Dmaven.test.skip -DskipTests -Drat.skip=true -DskipOverlay -DskipEnunciate=true package -Pdist
+  mvn  -pl '!test-tools,!addons/hdfs-model,!addons/hive-bridge,!addons/hive-bridge-shim,!addons/falcon-bridge-shim,!addons/falcon-bridge,!addons/sqoop-bridge,!addons/sqoop-bridge-shim,!addons/hbase-bridge,!addons/hbase-bridge-shim,!addons/hbase-testing-util,!addons/kafka-bridge,!addons/impala-hook-api,!addons/impala-bridge-shim,!addons/impala-bridge,!dashboardv2,!dashboardv3' -Dmaven.test.skip -DskipTests -Drat.skip=true -DskipOverlay -DskipEnunciate=true package -Pdist
 else
-  mvn  -pl '!addons/hdfs-model,!addons/hive-bridge,!addons/hive-bridge-shim,!addons/falcon-bridge-shim,!addons/falcon-bridge,!addons/sqoop-bridge,!addons/sqoop-bridge-shim,!addons/hbase-bridge,!addons/hbase-bridge-shim,!addons/hbase-testing-util,!addons/kafka-bridge,!addons/impala-hook-api,!addons/impala-bridge-shim,!addons/impala-bridge' -Dmaven.test.skip -DskipTests -Drat.skip=true -DskipEnunciate=true package -Pdist
+  mvn  -pl '!test-tools,!addons/hdfs-model,!addons/hive-bridge,!addons/hive-bridge-shim,!addons/falcon-bridge-shim,!addons/falcon-bridge,!addons/sqoop-bridge,!addons/sqoop-bridge-shim,!addons/hbase-bridge,!addons/hbase-bridge-shim,!addons/hbase-testing-util,!addons/kafka-bridge,!addons/impala-hook-api,!addons/impala-bridge-shim,!addons/impala-bridge' -Dmaven.test.skip -DskipTests -Drat.skip=true -DskipEnunciate=true package -Pdist
 fi
 
 echo "[DEBUG listing distro/target"

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -145,7 +145,51 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+            <version>${netty4.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler</artifactId>
+            <version>${netty4.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-common</artifactId>
+            <version>${netty4.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver</artifactId>
+            <version>${netty4.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec</artifactId>
+            <version>${netty4.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport</artifactId>
+            <version>${netty4.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-buffer</artifactId>
+            <version>${netty4.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
+            <version>${netty4.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-unix-common</artifactId>
+            <version>${netty4.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/common/src/main/java/org/apache/atlas/service/redis/AbstractRedisService.java
+++ b/common/src/main/java/org/apache/atlas/service/redis/AbstractRedisService.java
@@ -29,6 +29,7 @@ public abstract class AbstractRedisService implements RedisService {
     private static final String ATLAS_REDIS_LOCK_WATCHDOG_TIMEOUT_MS = "atlas.redis.lock.watchdog_timeout.ms";
     private static final int DEFAULT_REDIS_WAIT_TIME_MS = 15_000;
     private static final int DEFAULT_REDIS_LOCK_WATCHDOG_TIMEOUT_MS = 600_000;
+    private static final String ATLAS_METASTORE_SERVICE = "atlas-metastore-service";
 
     RedissonClient redisClient;
     Map<String, RLock> keyLockMap;
@@ -99,6 +100,7 @@ public abstract class AbstractRedisService implements RedisService {
     Config getProdConfig() throws AtlasException {
         Config config = initAtlasConfig();
         config.useSentinelServers()
+                .setClientName(ATLAS_METASTORE_SERVICE)
                 .setReadMode(ReadMode.MASTER_SLAVE)
                 .setCheckSentinelsList(false)
                 .setMasterName(atlasConfig.getString(ATLAS_REDIS_MASTER_NAME))

--- a/graphdb/api/src/main/java/org/apache/atlas/repository/graphdb/AtlasGraph.java
+++ b/graphdb/api/src/main/java/org/apache/atlas/repository/graphdb/AtlasGraph.java
@@ -383,4 +383,9 @@ public interface AtlasGraph<V, E> {
      * @throws AtlasException when error encountered in creating the client.
      */
     AtlasGraphIndexClient getGraphIndexClient()throws AtlasException;
+
+
+    void setEnableCache(boolean enableCache);
+
+    Boolean isCacheEnabled();
 }

--- a/graphdb/janus/pom.xml
+++ b/graphdb/janus/pom.xml
@@ -209,6 +209,10 @@
                     <groupId>org.codehaus.woodstox</groupId>
                     <artifactId>woodstox-core-asl</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <!-- CVE Overrides for Lucene -->

--- a/graphdb/janus/pom.xml
+++ b/graphdb/janus/pom.xml
@@ -120,6 +120,10 @@
                       <artifactId>*</artifactId>
                   </exclusion>
                   <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                  <exclusion>
                       <groupId>com.codahale.metrics</groupId>
                       <artifactId>metrics-core</artifactId>
                   </exclusion>

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusGraph.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusGraph.java
@@ -126,7 +126,6 @@ public class AtlasJanusGraph implements AtlasGraph<AtlasJanusVertex, AtlasJanusE
         return new GremlinGroovyScriptEngine(builder.create());
     });
 
-
     public AtlasJanusGraph() {
         this(getGraphInstance(), getClient(), getLowLevelClient());
     }
@@ -679,5 +678,13 @@ public class AtlasJanusGraph implements AtlasGraph<AtlasJanusVertex, AtlasJanusE
         }
 
         return null;
+    }
+
+    public void setEnableCache(boolean enableCache) {
+        this.janusGraph.setEnableCache(enableCache);
+    }
+
+    public Boolean isCacheEnabled() {
+        return this.janusGraph.isCacheEnabled();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -717,7 +717,7 @@
         <httpcomponents-httpcore.version>4.4.13</httpcomponents-httpcore.version>
         <jackson.databind.version>2.11.3</jackson.databind.version>
         <jackson.version>2.11.3</jackson.version>
-        <janusgraph.version>0.6.01</janusgraph.version>
+        <janusgraph.version>0.6.02</janusgraph.version>
         <janusgraph.cassandra.version>0.5.3</janusgraph.cassandra.version>
         <javax-inject.version>1</javax-inject.version>
         <javax.servlet.version>3.1.0</javax.servlet.version>

--- a/pom.xml
+++ b/pom.xml
@@ -717,7 +717,7 @@
         <httpcomponents-httpcore.version>4.4.13</httpcomponents-httpcore.version>
         <jackson.databind.version>2.11.3</jackson.databind.version>
         <jackson.version>2.11.3</jackson.version>
-        <janusgraph.version>0.6.0</janusgraph.version>
+        <janusgraph.version>0.6.01</janusgraph.version>
         <janusgraph.cassandra.version>0.5.3</janusgraph.cassandra.version>
         <javax-inject.version>1</javax-inject.version>
         <javax.servlet.version>3.1.0</javax.servlet.version>
@@ -778,6 +778,7 @@
         <zookeeper.version>3.4.6</zookeeper.version>
         <redis.client.version>3.20.1</redis.client.version>
         <micrometer.version>1.11.1</micrometer.version>
+        <netty4.version>4.1.61.Final</netty4.version>
     </properties>
 
     <modules>
@@ -834,6 +835,16 @@
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
+        </repository>
+        <repository>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/atlanhq/atlan-janusgraph</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
         </repository>
         <repository>
             <id>hortonworks.repo</id>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -393,6 +393,7 @@
                     <groupId>org.apache.atlas</groupId>
                     <artifactId>atlas-testtools</artifactId>
                     <version>${project.version}</version>
+                    <scope>test</scope>
                     <exclusions>
                         <exclusion>
                             <groupId>com.fasterxml.jackson.core</groupId>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -111,7 +111,7 @@
                 </exclusion>
                 <exclusion>
                     <groupId>io.netty</groupId>
-                    <artifactId>netty-handler</artifactId>
+                    <artifactId>*</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/repository/src/main/java/org/apache/atlas/repository/graph/IndexRecoveryService.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/IndexRecoveryService.java
@@ -21,6 +21,7 @@ import com.google.common.annotations.VisibleForTesting;
 import org.apache.atlas.ApplicationProperties;
 import org.apache.atlas.AtlasConstants;
 import org.apache.atlas.AtlasException;
+import org.apache.atlas.RequestContext;
 import org.apache.atlas.ha.HAConfiguration;
 import org.apache.atlas.listener.ActiveStateChangeHandler;
 import org.apache.atlas.repository.graphdb.AtlasGraph;
@@ -181,7 +182,6 @@ public class IndexRecoveryService implements Service, ActiveStateChangeHandler {
                             continue;
                         }
                         boolean indexHealthy = isIndexHealthy();
-
                         if (this.txRecoveryObject == null && indexHealthy) {
                             startMonitoring();
                         }
@@ -228,6 +228,7 @@ public class IndexRecoveryService implements Service, ActiveStateChangeHandler {
             try {
                 startTime        = recoveryInfoManagement.getStartTime();
                 Instant newStartTime = Instant.now();
+                this.graph.setEnableCache(false);
                 txRecoveryObject = this.graph.getManagementSystem().startIndexRecovery(startTime);
                 recoveryInfoManagement.updateStartTime(newStartTime.toEpochMilli());
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -1567,7 +1567,7 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
 
     private EntityMutationContext preCreateOrUpdate(EntityStream entityStream, EntityGraphMapper entityGraphMapper, boolean isPartialUpdate) throws AtlasBaseException {
         MetricRecorder metric = RequestContext.get().startMetricRecord("preCreateOrUpdate");
-
+        this.graph.setEnableCache(RequestContext.get().isCacheEnabled());
         EntityGraphDiscovery        graphDiscoverer  = new AtlasEntityGraphDiscoveryV2(graph, typeRegistry, entityStream, entityGraphMapper);
         EntityGraphDiscoveryContext discoveryContext = graphDiscoverer.discoverEntities();
         EntityMutationContext       context          = new EntityMutationContext(discoveryContext);

--- a/repository/src/main/java/org/apache/atlas/services/MetricsService.java
+++ b/repository/src/main/java/org/apache/atlas/services/MetricsService.java
@@ -98,7 +98,7 @@ public class MetricsService {
     @SuppressWarnings("unchecked")
     @GraphTransaction
     public AtlasMetrics getMetrics() {
-
+        this.atlasGraph.setEnableCache(false);
         final AtlasTypesDef typesDef = getTypesDef();
 
         Collection<AtlasEntityDef> entityDefs = typesDef.getEntityDefs();

--- a/repository/src/main/java/org/apache/atlas/util/AtlasMetricsUtil.java
+++ b/repository/src/main/java/org/apache/atlas/util/AtlasMetricsUtil.java
@@ -194,9 +194,11 @@ public class AtlasMetricsUtil {
 
     private boolean getBackendStoreStatus(){
         try {
+            boolean isCacheEnabled = this.graph.isCacheEnabled();
             runWithTimeout(new Runnable() {
                 @Override
                 public void run() {
+                    graph.setEnableCache(isCacheEnabled);
                     graph.query().has(TYPE_NAME_PROPERTY_KEY, TYPE_NAME_INTERNAL).vertices(1);
 
                     graphCommit();
@@ -217,9 +219,11 @@ public class AtlasMetricsUtil {
         final String query = AtlasGraphUtilsV2.getIndexSearchPrefix() + "\"" + Constants.TYPE_NAME_PROPERTY_KEY + "\":(" + TYPE_NAME_INTERNAL + ")";
 
         try {
+            boolean isCacheEnabled = this.graph.isCacheEnabled();
             runWithTimeout(new Runnable() {
                 @Override
                 public void run() {
+                    graph.setEnableCache(isCacheEnabled);
                     graph.indexQuery(Constants.VERTEX_INDEX, query).vertices(0, 1);
 
                     graphCommit();

--- a/server-api/src/main/java/org/apache/atlas/RequestContext.java
+++ b/server-api/src/main/java/org/apache/atlas/RequestContext.java
@@ -96,6 +96,7 @@ public class RequestContext {
     private boolean skipAuthorizationCheck = false;
     private Set<String> deletedEdgesIdsForResetHasLineage = new HashSet<>(0);
     private String requestUri;
+    private boolean cacheEnabled;
 
     private RequestContext() {
     }
@@ -648,6 +649,14 @@ public class RequestContext {
 
     public String getRequestUri() {
         return this.requestUri;
+    }
+
+    public void setEnableCache(boolean cacheEnabled) {
+        this.cacheEnabled = cacheEnabled;
+    }
+
+    public boolean isCacheEnabled() {
+        return this.cacheEnabled;
     }
 
     public class EntityGuidPair {

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -552,6 +552,7 @@
             <groupId>org.apache.atlas</groupId>
             <artifactId>atlas-testtools</artifactId>
             <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
@@ -883,7 +883,7 @@ public class EntityREST {
                                                  @QueryParam("replaceBusinessAttributes") @DefaultValue("false") boolean replaceBusinessAttributes,
                                                  @QueryParam("overwriteBusinessAttributes") @DefaultValue("false") boolean isOverwriteBusinessAttributes) throws AtlasBaseException {
         AtlasPerfTracer perf = null;
-
+        RequestContext.get().setEnableCache(false);
         try {
             if (AtlasPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
                 perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "EntityREST.createOrUpdate(entityCount=" +


### PR DESCRIPTION
## Change description
Support for caching through Janusgraph in metastore.

- We have forked the Janusgraph project and added support for Redis caching.
- While addition of Redis has impacted the write path which there by slowed down the  ingestion rate, hence  we have added support to make caching driven through request context. and removed the caching from write path ( entity bulk API) has kept the ingestion rate intact. 
- Caching strategy:
    -   TTL : 30mins
    -   Eviction Policy: LFU
    -   Type: Read Through Cache
    - Cache hit ratio is now ~98.3%, which is good, while doing the perf test.
- mapVertexToAtlasEntityHeader is ~600ms from 1.3s ==> 2x improvement
- getAdjacentEdgesByLabel is ~400ms from 1s ===> 2.5x improvement

**Performance numbers**
<img width="1419" alt="Screenshot 2023-12-12 at 11 02 19 AM" src="https://github.com/atlanhq/atlas-metastore/assets/119731738/89fdae01-3fde-4cc2-805e-72947fb2ceb6">
<img width="445" alt="Screenshot 2023-12-12 at 11 02 33 AM" src="https://github.com/atlanhq/atlas-metastore/assets/119731738/e014f719-5aa4-4798-a79c-3ee2bfc379c6">
## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
