### PR TITLE
Fix/lin 302 cyclic lineage

### DIFF
--- a/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
@@ -620,14 +620,14 @@ public class EntityLineageService implements AtlasLineageService {
         return hasRelationsLimitReached;
     }
 
-    private void setHasDownstream(AtlasLineageOnDemandContext atlasLineageOnDemandContext, AtlasVertex outVertex, LineageInfoOnDemand inLineageInfo) {
-        List<AtlasEdge> filteredEdges = getFilteredAtlasEdges(outVertex, PROCESS_INPUTS_EDGE, atlasLineageOnDemandContext);
+    private void setHasDownstream(AtlasLineageOnDemandContext atlasLineageOnDemandContext, AtlasVertex inVertex, LineageInfoOnDemand inLineageInfo) {
+        List<AtlasEdge> filteredEdges = getFilteredAtlasEdges(inVertex, PROCESS_INPUTS_EDGE, atlasLineageOnDemandContext);
         if (!filteredEdges.isEmpty())
             inLineageInfo.setHasDownstream(true);
     }
 
-    private void setHasUpstream(AtlasLineageOnDemandContext atlasLineageOnDemandContext, AtlasVertex inVertex, LineageInfoOnDemand outLineageInfo) {
-        List<AtlasEdge> filteredEdges = getFilteredAtlasEdges(inVertex, PROCESS_OUTPUTS_EDGE, atlasLineageOnDemandContext);
+    private void setHasUpstream(AtlasLineageOnDemandContext atlasLineageOnDemandContext, AtlasVertex outVertex, LineageInfoOnDemand outLineageInfo) {
+        List<AtlasEdge> filteredEdges = getFilteredAtlasEdges(outVertex, PROCESS_OUTPUTS_EDGE, atlasLineageOnDemandContext);
         if (!filteredEdges.isEmpty())
             outLineageInfo.setHasUpstream(true);
     }

--- a/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
@@ -608,7 +608,7 @@ public class EntityLineageService implements AtlasLineageService {
             if (isInput && ! isOutVertexVisited)
                 setHasUpstream(atlasLineageOnDemandContext, outVertex, outLineageInfo);
             else if (! isInput && ! isInVertexVisited)
-                setHasDownstream(atlasLineageOnDemandContext, outVertex, inLineageInfo);
+                setHasDownstream(atlasLineageOnDemandContext, inVertex, inLineageInfo);
         }
 
         if (!hasRelationsLimitReached) {

--- a/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
@@ -56,7 +56,6 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;

--- a/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
@@ -633,7 +633,6 @@ public class EntityLineageService implements AtlasLineageService {
             outLineageInfo.setHasUpstream(true);
     }
 
-    @NotNull
     private List<AtlasEdge> getFilteredAtlasEdges(AtlasVertex outVertex, String processEdgeLabel, AtlasLineageOnDemandContext atlasLineageOnDemandContext) {
         List<AtlasEdge> filteredEdges = new ArrayList<>();
         Iterable<AtlasEdge> edges = outVertex.getEdges(IN, processEdgeLabel);


### PR DESCRIPTION
## Fix: Included relationship traversal filters to horizontal pagination in lineage graph API
Applied edge filters (sent in request) to calculate the hasUpstream/hasDownstream in relationsOnDemand key of the lineage graph API response.
Fix for [https://atlanhq.atlassian.net/browse/LIN-302](url)