### PR TITLE
Restrict moving a term with multiple categories

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/glossary/TermPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/glossary/TermPreProcessor.java
@@ -45,6 +45,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 import static org.apache.atlas.repository.Constants.*;
 import static org.apache.atlas.repository.graph.GraphHelper.getActiveParentVertices;
@@ -129,6 +130,8 @@ public class TermPreProcessor extends AbstractGlossaryPreProcessor {
             //Auth check
             isAuthorized(currentGlossaryHeader, anchor);
 
+            ensureOnlyOneCategoryIsAssociated(entity);
+
             String updatedTermQualifiedName = moveTermToAnotherGlossary(entity, vertex, currentGlossaryQualifiedName, newGlossaryQualifiedName, termQualifiedName);
 
             if (checkEntityTermAssociation(termQualifiedName)) {
@@ -157,6 +160,19 @@ public class TermPreProcessor extends AbstractGlossaryPreProcessor {
         }
 
         RequestContext.get().endMetricRecord(metricRecorder);
+    }
+
+    private static void ensureOnlyOneCategoryIsAssociated(AtlasEntity entity) throws AtlasBaseException {
+        if(entity.hasRelationshipAttribute(ATTR_CATEGORIES) && Objects.nonNull(entity.getRelationshipAttribute(ATTR_CATEGORIES))) {
+            List<AtlasObjectId> categories = (List<AtlasObjectId>) entity.getRelationshipAttribute(ATTR_CATEGORIES);
+
+            if(categories.size() > 1) {
+                throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST, "Cannot move term with multiple " +
+                        "categories associated to another glossary");
+            }
+
+        }
+
     }
 
     private void validateCategory(AtlasEntity entity) throws AtlasBaseException {


### PR DESCRIPTION
[Ticket Link](https://atlanhq.atlassian.net/browse/PLT-463?atlOrigin=eyJpIjoiYjAzODcyODg1NjJmNGIzMzlhZmM1MTQzODFjMTUxMjAiLCJwIjoiaiJ9)

Why?
1. Atlas Metastore allows categories to be linked with terms and also treat categories and term as a parent-child relationship due to which there are multiple issues that came up recently( linked in ticket ). 

How?
We are restricting moving the terms or categories with terms consisting of multiple categories inter/intra glossary. 