### PR TITLE
Update Classification add/delete behaviour

### DIFF
--- a/intg/src/main/java/org/apache/atlas/model/audit/EntityAuditEventV2.java
+++ b/intg/src/main/java/org/apache/atlas/model/audit/EntityAuditEventV2.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.apache.atlas.model.Clearable;
-import org.apache.atlas.model.instance.AtlasClassification;
 import org.apache.atlas.model.instance.AtlasEntity;
 import org.apache.atlas.model.instance.AtlasEntityHeader;
 import org.apache.atlas.type.AtlasType;
@@ -134,7 +133,10 @@ public class EntityAuditEventV2 implements Serializable, Clearable {
     private AtlasEntity         entity;
     private EntityAuditType     type;
     private Map<String, Object> detail;
-    private List<AtlasClassification> classificationDetails;
+    private List<Map<String,Object>> classificationDetails;
+
+    @JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)
+    private String classificationDetail;
     private AtlasEntityHeader   entityDetail;
     private Map<String, String> headers;
 
@@ -292,12 +294,13 @@ public class EntityAuditEventV2 implements Serializable, Clearable {
                Objects.equals(created, that.created) &&
                Objects.equals(typeName, that.typeName) &&
                Objects.equals(entityQualifiedName, that.entityQualifiedName) &&
-               Objects.equals(headers, that.headers);
+               Objects.equals(headers, that.headers)&&
+               Objects.equals(classificationDetails, that.classificationDetails);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(entityId, timestamp, user, action, details, eventKey, entity, type, detail, created, entityQualifiedName, typeName, headers);
+        return Objects.hash(entityId, timestamp, user, action, details, eventKey, entity, type, detail, created, entityQualifiedName, typeName, headers, classificationDetails);
     }
 
     @Override
@@ -317,6 +320,7 @@ public class EntityAuditEventV2 implements Serializable, Clearable {
         sb.append(", detail=").append(detail);
         sb.append(", created=").append(created);
         sb.append(", headers=").append(headers);
+        sb.append(", classificationDetails").append(classificationDetails);
         sb.append('}');
 
         return sb.toString();
@@ -348,6 +352,7 @@ public class EntityAuditEventV2 implements Serializable, Clearable {
         detail = null;
         created = 0L;
         headers = null;
+        classificationDetails = null;
     }
 
     private String getJsonPartFromDetails() {
@@ -418,11 +423,19 @@ public class EntityAuditEventV2 implements Serializable, Clearable {
         events.sort(sortOrderDesc ? comparator.reversed() : comparator);
     }
 
-    public List<AtlasClassification> getClassificationDetails() {
+    public List<Map<String, Object>> getClassificationDetails() {
         return classificationDetails;
     }
 
-    public void setClassificationDetails(List<AtlasClassification> classificationDetails) {
+    public void setClassificationDetails(List<Map<String,Object>> classificationDetails) {
         this.classificationDetails = classificationDetails;
+    }
+
+    public String getClassificationDetail() {
+        return classificationDetail;
+    }
+
+    public void setClassificationDetail(String classificationDetail) {
+        this.classificationDetail = classificationDetail;
     }
 }

--- a/intg/src/main/java/org/apache/atlas/model/audit/EntityAuditEventV2.java
+++ b/intg/src/main/java/org/apache/atlas/model/audit/EntityAuditEventV2.java
@@ -133,6 +133,7 @@ public class EntityAuditEventV2 implements Serializable, Clearable {
     private AtlasEntity         entity;
     private EntityAuditType     type;
     private Map<String, Object> detail;
+    private List<Map<String, Object>> classificationDetails;
     private AtlasEntityHeader   entityDetail;
     private Map<String, String> headers;
 
@@ -414,5 +415,13 @@ public class EntityAuditEventV2 implements Serializable, Clearable {
         }
 
         events.sort(sortOrderDesc ? comparator.reversed() : comparator);
+    }
+
+    public List<Map<String, Object>> getClassificationDetails() {
+        return classificationDetails;
+    }
+
+    public void setClassificationDetails(List<Map<String, Object>> classificationDetails) {
+        this.classificationDetails = classificationDetails;
     }
 }

--- a/intg/src/main/java/org/apache/atlas/model/audit/EntityAuditEventV2.java
+++ b/intg/src/main/java/org/apache/atlas/model/audit/EntityAuditEventV2.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.apache.atlas.model.Clearable;
+import org.apache.atlas.model.instance.AtlasClassification;
 import org.apache.atlas.model.instance.AtlasEntity;
 import org.apache.atlas.model.instance.AtlasEntityHeader;
 import org.apache.atlas.type.AtlasType;
@@ -133,7 +134,7 @@ public class EntityAuditEventV2 implements Serializable, Clearable {
     private AtlasEntity         entity;
     private EntityAuditType     type;
     private Map<String, Object> detail;
-    private List<Map<String, Object>> classificationDetails;
+    private List<AtlasClassification> classificationDetails;
     private AtlasEntityHeader   entityDetail;
     private Map<String, String> headers;
 
@@ -417,11 +418,11 @@ public class EntityAuditEventV2 implements Serializable, Clearable {
         events.sort(sortOrderDesc ? comparator.reversed() : comparator);
     }
 
-    public List<Map<String, Object>> getClassificationDetails() {
+    public List<AtlasClassification> getClassificationDetails() {
         return classificationDetails;
     }
 
-    public void setClassificationDetails(List<Map<String, Object>> classificationDetails) {
+    public void setClassificationDetails(List<AtlasClassification> classificationDetails) {
         this.classificationDetails = classificationDetails;
     }
 }

--- a/intg/src/main/java/org/apache/atlas/type/AtlasTypeRegistry.java
+++ b/intg/src/main/java/org/apache/atlas/type/AtlasTypeRegistry.java
@@ -85,6 +85,10 @@ public class AtlasTypeRegistry {
             LOG.debug("==> AtlasTypeRegistry.getType({})", typeName);
         }
 
+        if (typeName == null) {
+            return null;
+        }
+
         AtlasType ret = registryData.allTypes.getTypeByName(typeName);
 
         if (ret == null) {

--- a/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
@@ -29,6 +29,7 @@ import org.apache.atlas.annotation.ConditionalOnAtlasProperty;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.audit.EntityAuditEventV2;
 import org.apache.atlas.model.audit.EntityAuditSearchResult;
+import org.apache.atlas.model.instance.AtlasClassification;
 import org.apache.atlas.type.AtlasType;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.configuration.Configuration;
@@ -229,7 +230,7 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
             event.setAction(EntityAuditEventV2.EntityAuditActionV2.fromString((String) source.get(ACTION)));
             event.setDetail((Map<String, Object>) source.get(DETAIL));
             if(source.get(CLASSIFICATION_DETAILS) instanceof java.util.ArrayList){
-                event.setClassificationDetails((List<Map<String, Object>>) source.get(CLASSIFICATION_DETAILS));
+                event.setClassificationDetails((List<AtlasClassification>) source.get(CLASSIFICATION_DETAILS));
             }
             event.setUser((String) source.get(USER));
             event.setCreated((long) source.get(CREATED));

--- a/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
@@ -84,6 +84,7 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
     private static final String USER = "user";
     private static final String DETAIL = "detail";
     private static final String ENTITY = "entity";
+    private static final String CLASSIFICATION_DETAILS = "classification_details";
     private static final String bulkMetadata = String.format("{ \"index\" : { \"_index\" : \"%s\" } }%n", INDEX_NAME);
 
     /*
@@ -227,6 +228,9 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
             event.setEntityId(entityGuid);
             event.setAction(EntityAuditEventV2.EntityAuditActionV2.fromString((String) source.get(ACTION)));
             event.setDetail((Map<String, Object>) source.get(DETAIL));
+            if(source.get(CLASSIFICATION_DETAILS) instanceof java.util.ArrayList){
+                event.setClassificationDetails((List<Map<String, Object>>) source.get(CLASSIFICATION_DETAILS));
+            }
             event.setUser((String) source.get(USER));
             event.setCreated((long) source.get(CREATED));
             if (source.get(TIMESTAMP) != null) {

--- a/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
@@ -85,7 +85,7 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
     private static final String USER = "user";
     private static final String DETAIL = "detail";
     private static final String ENTITY = "entity";
-    private static final String CLASSIFICATION_DETAILS = "classification_details";
+    private static final String CLASSIFICATION_DETAIL= "classificationDetail";
     private static final String bulkMetadata = String.format("{ \"index\" : { \"_index\" : \"%s\" } }%n", INDEX_NAME);
 
     /*
@@ -136,7 +136,8 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
                             event.getEntityQualifiedName(),
                             event.getEntity().getTypeName(),
                             created,
-                            "" + event.getEntity().getUpdateTime().getTime());
+                            "" + event.getEntity().getUpdateTime().getTime(),
+                            event.getClassificationDetail());
 
                     bulkRequestBody.append(bulkMetadata);
                     bulkRequestBody.append(bulkItem);
@@ -176,7 +177,7 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
         StringBuilder template = new StringBuilder();
 
         template.append("'{'\"entityId\":\"{0}\",\"action\":\"{1}\",\"detail\":{2},\"user\":\"{3}\", \"eventKey\":\"{4}\", " +
-                        "\"entityQualifiedName\": {5}, \"typeName\": \"{6}\",\"created\":{7}, \"timestamp\":{8}");
+                        "\"entityQualifiedName\": {5}, \"typeName\": \"{6}\",\"created\":{7}, \"timestamp\":{8}, \"classificationDetail\":{9}");
 
         if (MapUtils.isNotEmpty(requestContextHeaders)) {
             template.append(",")
@@ -228,9 +229,13 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
             EntityAuditEventV2 event = new EntityAuditEventV2();
             event.setEntityId(entityGuid);
             event.setAction(EntityAuditEventV2.EntityAuditActionV2.fromString((String) source.get(ACTION)));
-            event.setDetail((Map<String, Object>) source.get(DETAIL));
-            if(source.get(CLASSIFICATION_DETAILS) instanceof java.util.ArrayList){
-                event.setClassificationDetails((List<AtlasClassification>) source.get(CLASSIFICATION_DETAILS));
+            if (source.get(DETAIL) != null) {
+                if (source.get(DETAIL) instanceof Map) {
+                    event.setDetail((Map<String, Object>) source.get(DETAIL));
+                }
+            }
+            if (source.get(CLASSIFICATION_DETAIL) instanceof List) {
+                event.setClassificationDetails((List<Map<String, Object>>) source.get(CLASSIFICATION_DETAIL));
             }
             event.setUser((String) source.get(USER));
             event.setCreated((long) source.get(CREATED));

--- a/repository/src/main/java/org/apache/atlas/repository/audit/EntityAuditListenerV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/EntityAuditListenerV2.java
@@ -204,17 +204,10 @@ public class EntityAuditListenerV2 implements EntityChangeListenerV2 {
             MetricRecorder metric = RequestContext.get().startMetricRecord("entityAudit");
 
             FixedBufferList<EntityAuditEventV2> classificationsAdded = getAuditEventsList();
-            for (AtlasClassification classification : classifications) {
-                if (entity.getGuid().equals(classification.getEntityGuid())) {
-                    createEvent(classificationsAdded.next(), entity, CLASSIFICATION_ADD, "Added classification: " + AtlasType.toJson(classification));
-                } else {
-                    createEvent(classificationsAdded.next(), entity, PROPAGATED_CLASSIFICATION_ADD, "Added propagated classification: " + AtlasType.toJson(classification));
-                }
-            }
-
-            for (EntityAuditRepository auditRepository: auditRepositories) {
-                auditRepository.putEventsV2(classificationsAdded.toList());
-            }
+            Map<AtlasEntity, List<AtlasClassification>> entityClassifications = new HashMap<>();
+            Map<AtlasEntity, List<AtlasClassification>> propagatedClassifications = new HashMap<>();
+            getClassificationsFromEntity(classifications, entity, entityClassifications, propagatedClassifications);
+            emitAddClassificationEvent(classificationsAdded, entityClassifications, propagatedClassifications);
 
             RequestContext.get().endMetricRecord(metric);
         }
@@ -225,20 +218,10 @@ public class EntityAuditListenerV2 implements EntityChangeListenerV2 {
         if (CollectionUtils.isNotEmpty(classifications)) {
             MetricRecorder metric = RequestContext.get().startMetricRecord("entityAudit");
             FixedBufferList<EntityAuditEventV2> events = getAuditEventsList();
-
-            for (AtlasClassification classification : classifications) {
-                for (AtlasEntity entity : entities) {
-                    if (entity.getGuid().equals(classification.getEntityGuid())) {
-                        createEvent(events.next(), entity, CLASSIFICATION_ADD, "Added classification: " + AtlasType.toJson(classification));
-                    } else {
-                        createEvent(events.next(), entity, PROPAGATED_CLASSIFICATION_ADD, "Added propagated classification: " + AtlasType.toJson(classification));
-                    }
-                }
-            }
-
-            for (EntityAuditRepository auditRepository: auditRepositories) {
-                auditRepository.putEventsV2(events.toList());
-            }
+            Map<AtlasEntity, List<AtlasClassification>> entityClassifications = new HashMap<>();
+            Map<AtlasEntity, List<AtlasClassification>> propagatedClassifications = new HashMap<>();
+            getClassificationsFromEntities(classifications, entities,entityClassifications, propagatedClassifications );
+            emitAddClassificationEvent(events, entityClassifications, propagatedClassifications);
 
             RequestContext.get().endMetricRecord(metric);
         }
@@ -251,22 +234,51 @@ public class EntityAuditListenerV2 implements EntityChangeListenerV2 {
 
             FixedBufferList<EntityAuditEventV2> events = getAuditEventsList();
             String guid = entity.getGuid();
+            Map<AtlasEntity, List<AtlasClassification>> entityClassifications = new HashMap<>();
+            Map<AtlasEntity, List<AtlasClassification>> propagatedClassifications = new HashMap<>();
+            getClassificationsFromEntity(classifications, entity, entityClassifications, propagatedClassifications);
 
-            for (AtlasClassification classification : classifications) {
-                if (guid.equals(classification.getEntityGuid())) {
-                    createEvent(events.next(), entity, CLASSIFICATION_UPDATE, "Updated classification: " + AtlasType.toJson(classification));
-                } else {
+            List<AtlasClassification> addedClassification = new ArrayList<>(0);
+            List<AtlasClassification> deletedClassification = new ArrayList<>(0);
+            List<AtlasClassification> updatedClassification = new ArrayList<>(0);
+
+            if (CollectionUtils.isNotEmpty(propagatedClassifications.get(entity))) {
+                propagatedClassifications.get(entity).forEach(classification -> {
                     if (isPropagatedClassificationAdded(guid, classification)) {
-                        createEvent(events.next(), entity, PROPAGATED_CLASSIFICATION_ADD, "Added propagated classification: " + AtlasType.toJson(classification));
+                        addedClassification.add(classification);
                     } else if (isPropagatedClassificationDeleted(guid, classification)) {
-                        createEvent(events.next(), entity, PROPAGATED_CLASSIFICATION_DELETE, "Deleted propagated classification: " + getDeleteClassificationString(classification.getTypeName()));
+                        deletedClassification.add(new AtlasClassification(classification.getTypeName()));
                     } else {
-                        createEvent(events.next(), entity, PROPAGATED_CLASSIFICATION_UPDATE, "Updated propagated classification: " + AtlasType.toJson(classification));
+                        updatedClassification.add(classification);
                     }
-                }
+                });
             }
 
-            for (EntityAuditRepository auditRepository: auditRepositories) {
+            if (CollectionUtils.isNotEmpty(addedClassification)) {
+                EntityAuditEventV2 auditEvent = events.next();
+                auditEvent.setClassificationDetails(addedClassification);
+                createEvent(auditEvent, entity, PROPAGATED_CLASSIFICATION_ADD, "Added propagated classifications: " + AtlasType.toJson(new AtlasClassification()));
+            }
+
+            if (CollectionUtils.isNotEmpty(deletedClassification)) {
+                EntityAuditEventV2 auditEvent = events.next();
+                auditEvent.setClassificationDetails(deletedClassification);
+                createEvent(auditEvent, entity, PROPAGATED_CLASSIFICATION_DELETE, "Deleted propagated classifications: " + AtlasType.toJson(new AtlasClassification()));
+            }
+
+            if (CollectionUtils.isNotEmpty(updatedClassification)) {
+                EntityAuditEventV2 auditEvent = events.next();
+                auditEvent.setClassificationDetails(updatedClassification);
+                createEvent(auditEvent, entity, PROPAGATED_CLASSIFICATION_UPDATE, "Updated propagated classifications: " + AtlasType.toJson(new AtlasClassification()));
+            }
+
+            if (entityClassifications.get(entity) != null) {
+                EntityAuditEventV2 auditEvent = events.next();
+                auditEvent.setClassificationDetails(entityClassifications.get(entity));
+                createEvent(auditEvent, entity, CLASSIFICATION_UPDATE, "Updated classifications: " + AtlasType.toJson(new AtlasClassification()));
+            }
+
+            for (EntityAuditRepository auditRepository : auditRepositories) {
                 auditRepository.putEventsV2(events.toList());
             }
 
@@ -288,18 +300,10 @@ public class EntityAuditListenerV2 implements EntityChangeListenerV2 {
             MetricRecorder metric = RequestContext.get().startMetricRecord("onClassificationsDeleted");
 
             FixedBufferList<EntityAuditEventV2> events = getAuditEventsList();
-
-            for (AtlasClassification classification : classifications) {
-                if (StringUtils.equals(entity.getGuid(), classification.getEntityGuid())) {
-                    createEvent(events.next(), entity, CLASSIFICATION_DELETE, "Deleted classification: " + getDeleteClassificationString(classification.getTypeName()));
-                } else {
-                    createEvent(events.next(), entity, PROPAGATED_CLASSIFICATION_DELETE, "Deleted propagated classification: " + getDeleteClassificationString(classification.getTypeName()));
-                }
-            }
-
-            for (EntityAuditRepository auditRepository: auditRepositories) {
-                auditRepository.putEventsV2(events.toList());
-            }
+            Map<AtlasEntity, List<AtlasClassification>> entityClassifications = new HashMap<>();
+            Map<AtlasEntity, List<AtlasClassification>> propagatedClassifications = new HashMap<>();
+            getClassificationTextFromEntity(classifications, entity, entityClassifications, propagatedClassifications);
+            emitDeleteClassificationEvent(events, entityClassifications, propagatedClassifications);
 
             RequestContext.get().endMetricRecord(metric);
         }
@@ -310,20 +314,10 @@ public class EntityAuditListenerV2 implements EntityChangeListenerV2 {
         if (CollectionUtils.isNotEmpty(classifications) && CollectionUtils.isNotEmpty(entities)) {
             MetricRecorder metric = RequestContext.get().startMetricRecord("onClassificationsDeleted");
             FixedBufferList<EntityAuditEventV2> events = getAuditEventsList();
-
-            for (AtlasClassification classification : classifications) {
-                for (AtlasEntity entity : entities) {
-                    if (StringUtils.equals(entity.getGuid(), classification.getEntityGuid())) {
-                        createEvent(events.next(), entity, CLASSIFICATION_DELETE, "Deleted classification: " + getDeleteClassificationString(classification.getTypeName()));
-                    } else {
-                        createEvent(events.next(), entity, PROPAGATED_CLASSIFICATION_DELETE, "Deleted propagated classification: " + getDeleteClassificationString(classification.getTypeName()));
-                    }
-                }
-            }
-
-            for (EntityAuditRepository auditRepository: auditRepositories) {
-                auditRepository.putEventsV2(events.toList());
-            }
+            Map<AtlasEntity, List<AtlasClassification>> entityClassifications = new HashMap<>();
+            Map<AtlasEntity, List<AtlasClassification>> propagatedClassifications = new HashMap<>();
+            getClassificationsTextFromEntities(classifications, entities, entityClassifications, propagatedClassifications);
+            emitDeleteClassificationEvent(events, entityClassifications, propagatedClassifications);
 
             RequestContext.get().endMetricRecord(metric);
         }
@@ -762,22 +756,22 @@ public class EntityAuditListenerV2 implements EntityChangeListenerV2 {
                 ret = "Purged: ";
                 break;
             case CLASSIFICATION_ADD:
-                ret = "Added classification: ";
+                ret = "Added classifications: ";
                 break;
             case CLASSIFICATION_DELETE:
-                ret = "Deleted classification: ";
+                ret = "Deleted classifications: ";
                 break;
             case CLASSIFICATION_UPDATE:
-                ret = "Updated classification: ";
+                ret = "Updated classifications: ";
                 break;
             case PROPAGATED_CLASSIFICATION_ADD:
-                ret = "Added propagated classification: ";
+                ret = "Added propagated classifications: ";
                 break;
             case PROPAGATED_CLASSIFICATION_DELETE:
-                ret = "Deleted propagated classification: ";
+                ret = "Deleted propagated classifications: ";
                 break;
             case PROPAGATED_CLASSIFICATION_UPDATE:
-                ret = "Updated propagated classification: ";
+                ret = "Updated propagated classifications: ";
                 break;
             case ENTITY_IMPORT_CREATE:
                 ret = "Created by import: ";
@@ -812,5 +806,89 @@ public class EntityAuditListenerV2 implements EntityChangeListenerV2 {
         ret.reset();
         return ret;
 
+    }
+    private Map<String, Object> getDeleteClassificationMap(String typeName) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("typeName", typeName);
+        return map;
+    }
+    private void getClassificationsFromEntity(List<AtlasClassification> classifications, AtlasEntity entity, Map<AtlasEntity, List<AtlasClassification>> entityClassifications, Map<AtlasEntity, List<AtlasClassification>> propagatedClassifications) {
+        if (entityClassifications == null) {
+            entityClassifications = new HashMap<>();
+        }
+        if (propagatedClassifications == null) {
+            propagatedClassifications = new HashMap<>();
+        }
+
+        for (AtlasClassification classification : classifications) {
+            if (entity.getGuid().equals(classification.getEntityGuid())) {
+                entityClassifications.computeIfAbsent(entity, key -> new ArrayList<>()).add(classification);
+            } else {
+                propagatedClassifications.computeIfAbsent(entity, key -> new ArrayList<>()).add(classification);
+            }
+        }
+    }
+
+    private void getClassificationsFromEntities(List<AtlasClassification> classifications, List<AtlasEntity> entities, Map<AtlasEntity, List<AtlasClassification>> entityClassifications, Map<AtlasEntity, List<AtlasClassification>> propagatedClassifications) {
+        for (AtlasEntity entity : entities) {
+            getClassificationsFromEntity(classifications, entity, entityClassifications, propagatedClassifications);
+        }
+    }
+
+    private void emitAddClassificationEvent(FixedBufferList<EntityAuditEventV2> events, Map<AtlasEntity, List<AtlasClassification>> entityClassifications, Map<AtlasEntity, List<AtlasClassification>> propagatedClassifications) throws AtlasBaseException {
+        entityClassifications.forEach((entity, eClassifications) -> {
+            EntityAuditEventV2 auditEvent = events.next();
+            auditEvent.setClassificationDetails(eClassifications);
+            createEvent(auditEvent, entity, CLASSIFICATION_ADD, "Added classifications: " + AtlasType.toJson(new AtlasClassification()));
+        });
+
+        propagatedClassifications.forEach((entity, pClassifications) -> {
+            EntityAuditEventV2 auditEvent = events.next();
+            auditEvent.setClassificationDetails(pClassifications);
+            createEvent(auditEvent, entity, PROPAGATED_CLASSIFICATION_ADD, "Added propagated classifications: " + AtlasType.toJson(new AtlasClassification()));
+        });
+        for (EntityAuditRepository auditRepository : auditRepositories) {
+            auditRepository.putEventsV2(events.toList());
+        }
+    }
+    private void getClassificationTextFromEntity(List<AtlasClassification> classifications, AtlasEntity entity, Map<AtlasEntity, List<AtlasClassification>> entityClassifications, Map<AtlasEntity, List<AtlasClassification>> propagatedClassifications) {
+        if (entityClassifications == null) {
+            entityClassifications = new HashMap<>();
+        }
+        if (propagatedClassifications == null) {
+            propagatedClassifications = new HashMap<>();
+        }
+
+        for (AtlasClassification classification : classifications) {
+            if (entity.getGuid().equals(classification.getEntityGuid())) {
+                entityClassifications.computeIfAbsent(entity, key -> new ArrayList<>()).add(new AtlasClassification(classification.getTypeName()));
+            } else {
+                propagatedClassifications.computeIfAbsent(entity, key -> new ArrayList<>()).add(new AtlasClassification(classification.getTypeName()));
+            }
+        }
+    }
+
+    private void getClassificationsTextFromEntities(List<AtlasClassification> classifications, List<AtlasEntity> entities, Map<AtlasEntity, List<AtlasClassification>> entityClassifications, Map<AtlasEntity, List<AtlasClassification>> propagatedClassifications) {
+        for (AtlasEntity entity : entities) {
+            getClassificationTextFromEntity(classifications, entity, entityClassifications, propagatedClassifications);
+        }
+    }
+
+    private void emitDeleteClassificationEvent(FixedBufferList<EntityAuditEventV2> events, Map<AtlasEntity, List<AtlasClassification>> entityClassifications, Map<AtlasEntity, List<AtlasClassification>> propagatedClassifications) throws AtlasBaseException {
+        entityClassifications.forEach((entity, eClassifications) -> {
+            EntityAuditEventV2 auditEvent = events.next();
+            auditEvent.setClassificationDetails(eClassifications);
+            createEvent(events.next(), entity, CLASSIFICATION_DELETE, "Deleted classifications: " + AtlasType.toJson(new ArrayList<>()));
+        });
+
+        propagatedClassifications.forEach((entity, pClassifications) -> {
+            EntityAuditEventV2 auditEvent = events.next();
+            auditEvent.setClassificationDetails(pClassifications);
+            createEvent(events.next(), entity, PROPAGATED_CLASSIFICATION_DELETE, "Deleted propagated classifications: " + AtlasType.toJson(new ArrayList<>()));
+        });
+
+        for (EntityAuditRepository auditRepository : auditRepositories) {
+            auditRepository.putEventsV2(events.toList());
+        }
     }
 }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasEntityStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasEntityStore.java
@@ -295,6 +295,8 @@ public interface AtlasEntityStore {
 
     void deleteClassification(String guid, String classificationName, String associatedEntityGuid) throws AtlasBaseException;
 
+    void deleteClassifications(String guid, List<AtlasClassification> classificationName) throws AtlasBaseException;
+    public void deleteClassifications(final String guid, final List<AtlasClassification> classifications, final String associatedEntityGuid) throws AtlasBaseException;
     List<AtlasClassification> getClassifications(String guid) throws AtlasBaseException;
 
     AtlasClassification getClassification(String guid, String classificationName) throws AtlasBaseException;

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -2649,6 +2649,41 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
         }
 
     }
+    @Override
+    @GraphTransaction
+    public void deleteClassifications(final String guid, final List<AtlasClassification> classifications) throws AtlasBaseException {
+        deleteClassifications(guid, classifications, null);
+    }
+
+    @Override
+    @GraphTransaction
+    public void deleteClassifications(final String guid, final List<AtlasClassification> classifications, final String associatedEntityGuid) throws AtlasBaseException {
+        if (StringUtils.isEmpty(guid)) {
+            throw new AtlasBaseException(AtlasErrorCode.INVALID_PARAMETERS, "Guid(s) not specified");
+        }
+        if (CollectionUtils.isEmpty(classifications)) {
+            throw new AtlasBaseException(AtlasErrorCode.INVALID_PARAMETERS, "classifications not specified");
+        }
+
+        GraphTransactionInterceptor.lockObjectAndReleasePostCommit(guid);
+
+        AtlasEntityHeader entityHeader = entityRetriever.toAtlasEntityHeaderWithClassifications(guid);
+
+        // verify authorization only for removal of directly associated classification and not propagated one.
+        for (AtlasClassification classification : classifications) {
+            if (StringUtils.isEmpty(associatedEntityGuid) || guid.equals(associatedEntityGuid)) {
+                AtlasAuthorizationUtils.verifyAccess(new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_REMOVE_CLASSIFICATION,
+                                entityHeader, new AtlasClassification(classification.getTypeName())),
+                        "remove classification: guid=", guid, ", classification=", classification.getDisplayName());
+            }
+
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Deleting classification={} from entity={}", classification.getDisplayName(), guid);
+            }
+        }
+        entityGraphMapper.deleteClassifications(guid, classifications, associatedEntityGuid);
+    }
 }
+
 
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/ClassificationAssociator.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/ClassificationAssociator.java
@@ -193,43 +193,20 @@ public class ClassificationAssociator {
 
             AtlasPerfMetrics.MetricRecorder recorder = RequestContext.get().startMetricRecord("commitChanges.notify");
             Map<AtlasClassification, Collection<Object>> deleted = RequestContext.get().getDeletedClassificationAndVertices();
-            Set<AtlasVertex> allVertices = new HashSet<>();
-
             if (MapUtils.isNotEmpty(deleted)) {
-                for (AtlasClassification deletedClassification: deleted.keySet()) {
-                    Collection<Object> vertices =  deleted.get(deletedClassification);
-                    List<AtlasEntity> propagatedEntities = new ArrayList<>();
-
-                    for (Object obj: vertices) {
-                        AtlasVertex vertex = (AtlasVertex) obj;
-                        AtlasEntity entity = instanceConverter.getAndCacheEntity(GraphHelper.getGuid(vertex), IGNORE_REL);
-
-                        allVertices.add(vertex);
-                        propagatedEntities.add(entity);
-                    }
-
-                    entityChangeNotifier.onClassificationsDeletedFromEntities(propagatedEntities, Collections.singletonList(deletedClassification));
+                Map<AtlasEntity, List<AtlasClassification>> entityClassification = getEntityClassificationsMapping(deleted);
+                for (Map.Entry<AtlasEntity, List<AtlasClassification>> atlasEntityListEntry : entityClassification.entrySet()) {
+                    entityChangeNotifier.onClassificationDeletedFromEntity(atlasEntityListEntry.getKey(), atlasEntityListEntry.getValue());
                 }
             }
 
             Map<AtlasClassification, Collection<Object>> added = RequestContext.get().getAddedClassificationAndVertices();
             if (MapUtils.isNotEmpty(added)) {
-                for (AtlasClassification addedClassification: added.keySet()) {
-                    Collection<Object> vertices =  added.get(addedClassification);
-                    List<AtlasEntity> propagatedEntities = new ArrayList<>();
-
-                    for (Object obj: vertices) {
-                        AtlasVertex vertex = (AtlasVertex) obj;
-                        AtlasEntity entity = instanceConverter.getAndCacheEntity(GraphHelper.getGuid(vertex), IGNORE_REL);
-
-                        allVertices.add(vertex);
-                        propagatedEntities.add(entity);
-                    }
-
-                    entityChangeNotifier.onClassificationsAddedToEntities(propagatedEntities, Collections.singletonList(addedClassification), false);
+                Map<AtlasEntity, List<AtlasClassification>> entityClassification = getEntityClassificationsMapping(added);
+                for (Map.Entry<AtlasEntity, List<AtlasClassification>> atlasEntityListEntry : entityClassification.entrySet()) {
+                    entityChangeNotifier.onClassificationAddedToEntity(atlasEntityListEntry.getKey(), atlasEntityListEntry.getValue());
                 }
             }
-            entityGraphMapper.updateClassificationText(null, allVertices);
             transactionInterceptHelper.intercept();
 
             RequestContext.get().endMetricRecord(recorder);
@@ -310,14 +287,12 @@ public class ClassificationAssociator {
             if (CollectionUtils.isEmpty(list)) {
                 return;
             }
-
-            for (AtlasClassification c : list) {
-                try {
-                    entitiesStore.deleteClassification(entityGuid, c.getTypeName());
-                } catch (AtlasBaseException e) {
-                    LOG.error("Failed to remove classification association between {}, entity with guid {}", c.getTypeName(), c.getEntityGuid());
-                    throw e;
-                }
+            String classificationNames = getClassificationNames(list);
+            try {
+                entitiesStore.deleteClassifications(entityGuid, list);
+            } catch (AtlasBaseException e) {
+                LOG.error("Failed to remove classification association between {}, entity with guid {}", classificationNames, entityGuid);
+                throw e;
             }
         }
 
@@ -382,6 +357,20 @@ public class ClassificationAssociator {
 
         private String getJsonArray(StringBuilder actionSummary) {
             return "[" + StringUtils.removeEnd(actionSummary.toString(), ",") + "]";
+        }
+
+        private Map<AtlasEntity, List<AtlasClassification>> getEntityClassificationsMapping(Map<AtlasClassification, Collection<Object>> classificationVertices) throws AtlasBaseException {
+            Map<AtlasEntity, List<AtlasClassification>> entityClassifications = new HashMap<>();
+            Set<AtlasVertex> vertices = new HashSet<>();
+            for (AtlasClassification classification : classificationVertices.keySet()) {
+                for (Object obj : classificationVertices.get(classification)) {
+                    AtlasVertex vertex = (AtlasVertex) obj;
+                    vertices.add(vertex);
+                }
+                List<AtlasEntity> propagatedEntities = entityGraphMapper.updateClassificationText(null, vertices);
+                propagatedEntities.forEach(entity -> entityClassifications.computeIfAbsent(entity, key -> new ArrayList<>()).add(classification));
+            }
+            return entityClassifications;
         }
     }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -2764,16 +2764,21 @@ public class EntityGraphMapper {
                 notificationVertices.addAll(entitiesToPropagateTo);
             }
 
-
-            for (AtlasClassification classification : addedClassifications.keySet()) {
-                Set<AtlasVertex>  vertices           = addedClassifications.get(classification);
-
-                if (RequestContext.get().isDelayTagNotifications()) {
+            if (RequestContext.get().isDelayTagNotifications()) {
+                for (AtlasClassification classification : addedClassifications.keySet()) {
+                    Set<AtlasVertex> vertices = addedClassifications.get(classification);
                     RequestContext.get().addAddedClassificationAndVertices(classification, new ArrayList<>(vertices));
-                } else {
+                }
+            } else {
+                Map<AtlasEntity, List<AtlasClassification>> entityClassification = new HashMap<>();
+                for (AtlasClassification classification : addedClassifications.keySet()) {
+                    Set<AtlasVertex> vertices = addedClassifications.get(classification);
                     List<AtlasEntity> propagatedEntities = updateClassificationText(classification, vertices);
+                    propagatedEntities.forEach(entity -> entityClassification.computeIfAbsent(entity, key -> new ArrayList<>()).add(classification));
+                }
 
-                    entityChangeNotifier.onClassificationsAddedToEntities(propagatedEntities, Collections.singletonList(classification), false);
+                for (Map.Entry<AtlasEntity, List<AtlasClassification>> atlasEntityListEntry : entityClassification.entrySet()) {
+                    entityChangeNotifier.onClassificationAddedToEntity(atlasEntityListEntry.getKey(), atlasEntityListEntry.getValue());
                 }
             }
 
@@ -3025,13 +3030,17 @@ public class EntityGraphMapper {
 
         updateModificationMetadata(entityVertex);
 
+        Map<AtlasEntity, List<AtlasClassification>> entityClassification = new HashMap<>();
+
         if (RequestContext.get().isDelayTagNotifications()) {
             RequestContext.get().addDeletedClassificationAndVertices(classification, new ArrayList<>(entityVertices));
         } else if (CollectionUtils.isNotEmpty(entityVertices)) {
             List<AtlasEntity> propagatedEntities = updateClassificationText(classification, entityVertices);
-
+            propagatedEntities.forEach(entity -> entityClassification.computeIfAbsent(entity, key -> new ArrayList<>()).add(classification));
             //Sending audit request for all entities at once
-            entityChangeNotifier.onClassificationsDeletedFromEntities(propagatedEntities, Collections.singletonList(classification));
+            for (Map.Entry<AtlasEntity, List<AtlasClassification>> atlasEntityListEntry : entityClassification.entrySet()) {
+                entityChangeNotifier.onClassificationDeletedFromEntity(atlasEntityListEntry.getKey(), atlasEntityListEntry.getValue());
+            }
         }
         AtlasPerfTracer.log(perf);
     }
@@ -4062,6 +4071,181 @@ public class EntityGraphMapper {
             }
         }
         RequestContext.get().endMetricRecord(metricRecorder);
+    }
+
+    public void deleteClassifications(String entityGuid, List<AtlasClassification> classifications, String associatedEntityGuid) throws AtlasBaseException {
+        if (StringUtils.isEmpty(associatedEntityGuid) || associatedEntityGuid.equals(entityGuid)) {
+            deleteClassifications(entityGuid, classifications);
+        } else {
+            for (AtlasClassification classification : classifications) {
+                deletePropagatedClassifications(entityGuid, classification.getTypeName(), associatedEntityGuid);
+            }
+        }
+    }
+
+    private void deletePropagatedClassifications(String entityGuid, String classificationName, String associatedEntityGuid) throws AtlasBaseException {
+        if (StringUtils.isEmpty(classificationName)) {
+            throw new AtlasBaseException(AtlasErrorCode.INVALID_CLASSIFICATION_PARAMS, "delete", entityGuid);
+        }
+
+        AtlasVertex entityVertex = AtlasGraphUtilsV2.findByGuid(this.graph, entityGuid);
+
+        if (entityVertex == null) {
+            throw new AtlasBaseException(AtlasErrorCode.INSTANCE_GUID_NOT_FOUND, entityGuid);
+        }
+
+        deleteDelegate.getHandler().deletePropagatedClassification(entityVertex, classificationName, associatedEntityGuid);
+    }
+
+    public void deleteClassifications(String entityGuid, List<AtlasClassification> classifications) throws AtlasBaseException {
+        if (CollectionUtils.isEmpty(classifications)) {
+            return;
+        }
+
+        AtlasPerfTracer perf = null;
+
+        if (AtlasPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
+            perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "EntityGraphMapper.deleteClassification");
+        }
+        Map<AtlasClassification, HashSet<AtlasVertex>> deletedClassifications = new HashMap<>();
+
+        for (AtlasClassification classificationn : classifications) {
+
+            if (StringUtils.isEmpty(classificationn.getTypeName())) {
+                throw new AtlasBaseException(AtlasErrorCode.INVALID_CLASSIFICATION_PARAMS, "delete", entityGuid);
+            }
+
+            AtlasVertex entityVertex = AtlasGraphUtilsV2.findByGuid(this.graph, entityGuid);
+
+            if (entityVertex == null) {
+                throw new AtlasBaseException(AtlasErrorCode.INSTANCE_GUID_NOT_FOUND, entityGuid);
+            }
+
+            List<String> traitNames = getTraitNames(entityVertex);
+
+            if (CollectionUtils.isEmpty(traitNames)) {
+                throw new AtlasBaseException(AtlasErrorCode.NO_CLASSIFICATIONS_FOUND_FOR_ENTITY, entityGuid);
+            }
+
+            String classificationName = classificationn.getTypeName();
+            validateClassificationExists(traitNames, classificationName);
+
+            AtlasVertex classificationVertex = getClassificationVertex(entityVertex, classificationName);
+
+            // Get in progress task to see if there already is a propagation for this particular vertex
+            List<AtlasTask> inProgressTasks = taskManagement.getInProgressTasks();
+            for (AtlasTask task : inProgressTasks) {
+                if (isTaskMatchingWithVertexIdAndEntityGuid(task, classificationVertex.getIdForDisplay(), entityGuid)) {
+                    throw new AtlasBaseException(AtlasErrorCode.CLASSIFICATION_CURRENTLY_BEING_PROPAGATED, classificationName);
+                }
+            }
+
+            AtlasClassification classification = entityRetriever.toAtlasClassification(classificationVertex);
+
+            if (classification == null) {
+                throw new AtlasBaseException(AtlasErrorCode.CLASSIFICATION_NOT_FOUND, classificationName);
+            }
+
+            // remove classification from propagated entities if propagation is turned on
+            final List<AtlasVertex> entityVertices;
+
+            if (isPropagationEnabled(classificationVertex)) {
+                if (taskManagement != null && DEFERRED_ACTION_ENABLED) {
+                    boolean propagateDelete = true;
+                    String classificationVertexId = classificationVertex.getIdForDisplay();
+
+                    List<String> entityTaskGuids = (List<String>) entityVertex.getPropertyValues(PENDING_TASKS_PROPERTY_KEY, String.class);
+
+                    if (CollectionUtils.isNotEmpty(entityTaskGuids)) {
+                        List<AtlasTask> entityPendingTasks = taskManagement.getByGuidsES(entityTaskGuids);
+
+                        boolean pendingTaskExists = entityPendingTasks.stream()
+                                .anyMatch(x -> isTaskMatchingWithVertexIdAndEntityGuid(x, classificationVertexId, entityGuid));
+
+                        if (pendingTaskExists) {
+                            List<AtlasTask> entityClassificationPendingTasks = entityPendingTasks.stream()
+                                    .filter(t -> t.getParameters().containsKey("entityGuid")
+                                            && t.getParameters().containsKey("classificationVertexId"))
+                                    .filter(t -> t.getParameters().get("entityGuid").equals(entityGuid)
+                                            && t.getParameters().get("classificationVertexId").equals(classificationVertexId)
+                                            && t.getType().equals(CLASSIFICATION_PROPAGATION_ADD))
+                                    .collect(Collectors.toList());
+                            for (AtlasTask entityClassificationPendingTask : entityClassificationPendingTasks) {
+                                String taskGuid = entityClassificationPendingTask.getGuid();
+                                taskManagement.deleteByGuid(taskGuid, TaskManagement.DeleteType.SOFT);
+                                AtlasGraphUtilsV2.deleteProperty(entityVertex, PENDING_TASKS_PROPERTY_KEY, taskGuid);
+//                            propagateDelete = false;  TODO: Uncomment when all unnecessary ADD tasks are resolved
+                            }
+                        }
+                    }
+
+                    if (propagateDelete) {
+                        createAndQueueTask(CLASSIFICATION_PROPAGATION_DELETE, entityVertex, classificationVertex.getIdForDisplay());
+                    }
+
+                    entityVertices = new ArrayList<>();
+                } else {
+                    entityVertices = deleteDelegate.getHandler().removeTagPropagation(classificationVertex);
+
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Number of propagations to delete -> {}", entityVertices.size());
+                    }
+                }
+            } else {
+                entityVertices = new ArrayList<>();
+            }
+
+            // add associated entity to entityVertices list
+            if (!entityVertices.contains(entityVertex)) {
+                entityVertices.add(entityVertex);
+            }
+
+            // remove classifications from associated entity
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Removing classification: [{}] from: [{}][{}] with edge label: [{}]", classificationName,
+                        getTypeName(entityVertex), entityGuid, CLASSIFICATION_LABEL);
+            }
+
+            AtlasEdge edge = getClassificationEdge(entityVertex, classificationVertex);
+
+            deleteDelegate.getHandler().deleteEdgeReference(edge, CLASSIFICATION, false, true, entityVertex);
+
+            traitNames.remove(classificationName);
+
+            // update 'TRAIT_NAMES_PROPERTY_KEY' property
+            entityVertex.removePropertyValue(TRAIT_NAMES_PROPERTY_KEY, classificationName);
+
+            // update 'CLASSIFICATION_NAMES_KEY' property
+            entityVertex.removeProperty(CLASSIFICATION_NAMES_KEY);
+
+            entityVertex.setProperty(CLASSIFICATION_NAMES_KEY, getClassificationNamesString(traitNames));
+
+            updateModificationMetadata(entityVertex);
+
+            if (deletedClassifications.get(classification) == null) {
+                deletedClassifications.put(classification, new HashSet<>());
+            }
+            //Add current Vertex to be notified
+            deletedClassifications.get(classification).add(entityVertex);
+        }
+
+        Map<AtlasEntity, List<AtlasClassification>> entityClassification = new HashMap<>();
+
+        for (AtlasClassification classification : deletedClassifications.keySet()) {
+            Set<AtlasVertex> vertices = deletedClassifications.get(classification);
+            if (CollectionUtils.isNotEmpty(vertices)) {
+                List<AtlasEntity> propagatedEntities = updateClassificationText(classification, vertices);
+                propagatedEntities.forEach(entity -> entityClassification.computeIfAbsent(entity, key -> new ArrayList<>()).add(classification));
+            }
+        }
+
+        //Sending audit request for all entities at once
+        for (Map.Entry<AtlasEntity, List<AtlasClassification>> atlasEntityListEntry : entityClassification.entrySet()) {
+            entityChangeNotifier.onClassificationDeletedFromEntity(atlasEntityListEntry.getKey(), atlasEntityListEntry.getValue());
+        }
+
+        AtlasPerfTracer.log(perf);
+
     }
 
 }


### PR DESCRIPTION
## Change description

### JIRA :

 https://atlanhq.atlassian.net/browse/PLT-367


### **Current behaviour :**

Example :

If 3 tags are added to single entity

there use to be **three** `CLASSIFICATION_ADDED` events for that entity

If 3 tags are added to two entities

there use to be **six** `CLASSIFICATION_ADDED` events (3 events per entity)

### Desired **Behaviour:**

Example :

If 3 tags are added to single entity

there will be **one** `CLASSIFICATION_ADDED`event for that entity

If 3 tags are added to two entities

there will be **two** `CLASSIFICATION_ADDED`event (1 event per entity)

### Area of Impact :

1. Audit events
2. Kafka events
3. **AuditSearch API (consumed across multiple teams)**

### Proposed changes to embed desired behaviour :

-  **`Classification_added`** 
    
    **Current behaviour** 
    i. We have `detail` object that contains tag information.
    
      **Proposed behaviour** 
    
    1. Representing Future classification_added event
        i. `detail` object will be empty.
       ii.  add key `classificationsDetails` object to show current tags
              removed from entity.
    
    2.  Representing Past data classification_added event
          i. `detail` object contains tag information.
         ii. `classificationsDetails` object will be empty
    
- **`Classification_deleted`** event
    
    **Current behaviour :**       
     i. We have `detail` object that contains tag `typeName` only.
    
     **Proposed behaviour** 
    
    1. Representing Future classification_deleted event
        i. `detail` object will be empty.
       ii. add key `classificationsDetails` object to show current tags
              removed from entity.
    2.  Representing Past data classification_added event
        i. `detail` object contains tag information.
       ii. `classificationsDetails` object will be empty.

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
