### PR TITLE
Update Classification add/delete behaviour 

### DIFF
--- a/intg/src/main/java/org/apache/atlas/model/audit/EntityAuditEventV2.java
+++ b/intg/src/main/java/org/apache/atlas/model/audit/EntityAuditEventV2.java
@@ -136,6 +136,9 @@ public class EntityAuditEventV2 implements Serializable, Clearable {
 
     private AtlasEntityHeader   entityDetail;
     private Map<String, String> headers;
+    private List<Map<String,Object>> classificationDetails;
+    @JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)
+    private String classificationDetail;
 
     public EntityAuditEventV2() { }
 
@@ -291,12 +294,13 @@ public class EntityAuditEventV2 implements Serializable, Clearable {
                Objects.equals(created, that.created) &&
                Objects.equals(typeName, that.typeName) &&
                Objects.equals(entityQualifiedName, that.entityQualifiedName) &&
-               Objects.equals(headers, that.headers);
+                Objects.equals(headers, that.headers) &&
+                Objects.equals(classificationDetails, that.classificationDetails);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(entityId, timestamp, user, action, details, eventKey, entity, type, detail, created, entityQualifiedName, typeName, headers);
+        return Objects.hash(entityId, timestamp, user, action, details, eventKey, entity, type, detail, created, entityQualifiedName, typeName, headers, classificationDetails);
     }
 
     @Override
@@ -316,6 +320,7 @@ public class EntityAuditEventV2 implements Serializable, Clearable {
         sb.append(", detail=").append(detail);
         sb.append(", created=").append(created);
         sb.append(", headers=").append(headers);
+        sb.append(", classificationDetails").append(classificationDetails);
         sb.append('}');
 
         return sb.toString();
@@ -347,6 +352,7 @@ public class EntityAuditEventV2 implements Serializable, Clearable {
         detail = null;
         created = 0L;
         headers = null;
+        classificationDetails = null;
     }
 
     private String getJsonPartFromDetails() {
@@ -415,5 +421,21 @@ public class EntityAuditEventV2 implements Serializable, Clearable {
         }
 
         events.sort(sortOrderDesc ? comparator.reversed() : comparator);
+    }
+
+    public List<Map<String, Object>> getClassificationDetails() {
+        return classificationDetails;
+    }
+
+    public void setClassificationDetails(List<Map<String, Object>> classificationDetails) {
+        this.classificationDetails = classificationDetails;
+    }
+
+    public String getClassificationDetail() {
+        return classificationDetail;
+    }
+
+    public void setClassificationDetail(String classificationDetail) {
+        this.classificationDetail = classificationDetail;
     }
 }

--- a/intg/src/main/java/org/apache/atlas/type/AtlasTypeRegistry.java
+++ b/intg/src/main/java/org/apache/atlas/type/AtlasTypeRegistry.java
@@ -85,6 +85,10 @@ public class AtlasTypeRegistry {
             LOG.debug("==> AtlasTypeRegistry.getType({})", typeName);
         }
 
+        if (typeName == null) {
+            return null;
+        }
+
         AtlasType ret = registryData.allTypes.getTypeByName(typeName);
 
         if (ret == null) {

--- a/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
@@ -84,6 +84,7 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
     private static final String USER = "user";
     private static final String DETAIL = "detail";
     private static final String ENTITY = "entity";
+    private static final String CLASSIFICATION_DETAIL= "classificationDetail";
     private static final String bulkMetadata = String.format("{ \"index\" : { \"_index\" : \"%s\" } }%n", INDEX_NAME);
 
     /*
@@ -134,7 +135,8 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
                             event.getEntityQualifiedName(),
                             event.getEntity().getTypeName(),
                             created,
-                            "" + event.getEntity().getUpdateTime().getTime());
+                            "" + event.getEntity().getUpdateTime().getTime(),
+                            event.getClassificationDetail());
 
                     bulkRequestBody.append(bulkMetadata);
                     bulkRequestBody.append(bulkItem);
@@ -174,7 +176,7 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
         StringBuilder template = new StringBuilder();
 
         template.append("'{'\"entityId\":\"{0}\",\"action\":\"{1}\",\"detail\":{2},\"user\":\"{3}\", \"eventKey\":\"{4}\", " +
-                        "\"entityQualifiedName\": {5}, \"typeName\": \"{6}\",\"created\":{7}, \"timestamp\":{8}");
+                        "\"entityQualifiedName\": {5}, \"typeName\": \"{6}\",\"created\":{7}, \"timestamp\":{8}, \"classificationDetail\":{9}");
 
         if (MapUtils.isNotEmpty(requestContextHeaders)) {
             template.append(",")
@@ -226,7 +228,14 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
             EntityAuditEventV2 event = new EntityAuditEventV2();
             event.setEntityId(entityGuid);
             event.setAction(EntityAuditEventV2.EntityAuditActionV2.fromString((String) source.get(ACTION)));
-            event.setDetail((Map<String, Object>) source.get(DETAIL));
+            if (source.get(DETAIL) != null) {
+                if (source.get(DETAIL) instanceof Map) {
+                    event.setDetail((Map<String, Object>) source.get(DETAIL));
+                }
+            }
+            if (source.get(CLASSIFICATION_DETAIL) instanceof List) {
+                event.setClassificationDetails((List<Map<String, Object>>) source.get(CLASSIFICATION_DETAIL));
+            }
             event.setUser((String) source.get(USER));
             event.setCreated((long) source.get(CREATED));
             if (source.get(TIMESTAMP) != null) {

--- a/repository/src/main/java/org/apache/atlas/repository/audit/EntityAuditListenerV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/EntityAuditListenerV2.java
@@ -204,17 +204,11 @@ public class EntityAuditListenerV2 implements EntityChangeListenerV2 {
             MetricRecorder metric = RequestContext.get().startMetricRecord("entityAudit");
 
             FixedBufferList<EntityAuditEventV2> classificationsAdded = getAuditEventsList();
-            for (AtlasClassification classification : classifications) {
-                if (entity.getGuid().equals(classification.getEntityGuid())) {
-                    createEvent(classificationsAdded.next(), entity, CLASSIFICATION_ADD, "Added classification: " + AtlasType.toJson(classification));
-                } else {
-                    createEvent(classificationsAdded.next(), entity, PROPAGATED_CLASSIFICATION_ADD, "Added propagated classification: " + AtlasType.toJson(classification));
-                }
-            }
+            Map<AtlasEntity, List<AtlasClassification>> entityClassifications = new HashMap<>();
+            Map<AtlasEntity, List<AtlasClassification>> propagatedClassifications = new HashMap<>();
+            getClassificationsFromEntity(classifications, entity, entityClassifications, propagatedClassifications);
+            emitAddClassificationEvent(classificationsAdded, entityClassifications, propagatedClassifications);
 
-            for (EntityAuditRepository auditRepository: auditRepositories) {
-                auditRepository.putEventsV2(classificationsAdded.toList());
-            }
             RequestContext.get().endMetricRecord(metric);
         }
     }
@@ -227,20 +221,10 @@ public class EntityAuditListenerV2 implements EntityChangeListenerV2 {
         if (CollectionUtils.isNotEmpty(classifications)) {
             MetricRecorder metric = RequestContext.get().startMetricRecord("entityAudit");
             FixedBufferList<EntityAuditEventV2> events = getAuditEventsList();
-            for (AtlasClassification classification : classifications) {
-                for (AtlasEntity entity : entities) {
-                    if (entity.getGuid().equals(classification.getEntityGuid())) {
-                        createEvent(events.next(), entity, CLASSIFICATION_ADD, "Added classification: " + AtlasType.toJson(classification));
-                    } else {
-                        createEvent(events.next(), entity, PROPAGATED_CLASSIFICATION_ADD, "Added propagated classification: " + AtlasType.toJson(classification));
-                    }
-                }
-            }
-
-            for (EntityAuditRepository auditRepository: auditRepositories) {
-                auditRepository.putEventsV2(events.toList());
-            }
-
+            Map<AtlasEntity, List<AtlasClassification>> entityClassifications = new HashMap<>();
+            Map<AtlasEntity, List<AtlasClassification>> propagatedClassifications = new HashMap<>();
+            getClassificationsFromEntities(classifications, entities,entityClassifications, propagatedClassifications );
+            emitAddClassificationEvent(events, entityClassifications, propagatedClassifications);
 
             RequestContext.get().endMetricRecord(metric);
         }
@@ -253,21 +237,51 @@ public class EntityAuditListenerV2 implements EntityChangeListenerV2 {
 
             FixedBufferList<EntityAuditEventV2> events = getAuditEventsList();
             String guid = entity.getGuid();
-            for (AtlasClassification classification : classifications) {
-                if (guid.equals(classification.getEntityGuid())) {
-                    createEvent(events.next(), entity, CLASSIFICATION_UPDATE, "Updated classification: " + AtlasType.toJson(classification));
-                } else {
+            Map<AtlasEntity, List<AtlasClassification>> entityClassifications = new HashMap<>();
+            Map<AtlasEntity, List<AtlasClassification>> propagatedClassifications = new HashMap<>();
+            getClassificationsFromEntity(classifications, entity, entityClassifications, propagatedClassifications);
+
+            List<AtlasClassification> addedClassification = new ArrayList<>(0);
+            List<AtlasClassification> deletedClassification = new ArrayList<>(0);
+            List<AtlasClassification> updatedClassification = new ArrayList<>(0);
+
+            if (CollectionUtils.isNotEmpty(propagatedClassifications.get(entity))) {
+                propagatedClassifications.get(entity).forEach(classification -> {
                     if (isPropagatedClassificationAdded(guid, classification)) {
-                        createEvent(events.next(), entity, PROPAGATED_CLASSIFICATION_ADD, "Added propagated classification: " + AtlasType.toJson(classification));
+                        addedClassification.add(classification);
                     } else if (isPropagatedClassificationDeleted(guid, classification)) {
-                        createEvent(events.next(), entity, PROPAGATED_CLASSIFICATION_DELETE, "Deleted propagated classification: " + getDeleteClassificationString(classification.getTypeName()));
+                        deletedClassification.add(new AtlasClassification(classification.getTypeName()));
                     } else {
-                        createEvent(events.next(), entity, PROPAGATED_CLASSIFICATION_UPDATE, "Updated propagated classification: " + AtlasType.toJson(classification));
+                        updatedClassification.add(classification);
                     }
-                }
+                });
             }
 
-            for (EntityAuditRepository auditRepository: auditRepositories) {
+            if (CollectionUtils.isNotEmpty(addedClassification)) {
+                EntityAuditEventV2 auditEvent = events.next();
+                auditEvent.setClassificationDetail(AtlasJson.toV1Json(addedClassification));
+                createEvent(auditEvent, entity, PROPAGATED_CLASSIFICATION_ADD, "Added propagated classifications: " + AtlasType.toJson(new AtlasClassification()));
+            }
+
+            if (CollectionUtils.isNotEmpty(deletedClassification)) {
+                EntityAuditEventV2 auditEvent = events.next();
+                auditEvent.setClassificationDetail(AtlasJson.toV1Json(deletedClassification));
+                createEvent(auditEvent, entity, PROPAGATED_CLASSIFICATION_DELETE, "Deleted propagated classifications: " + AtlasType.toJson(new AtlasClassification()));
+            }
+
+            if (CollectionUtils.isNotEmpty(updatedClassification)) {
+                EntityAuditEventV2 auditEvent = events.next();
+                auditEvent.setClassificationDetail(AtlasJson.toV1Json(updatedClassification));
+                createEvent(auditEvent, entity, PROPAGATED_CLASSIFICATION_UPDATE, "Updated propagated classifications: " + AtlasType.toJson(new AtlasClassification()));
+            }
+
+            if (entityClassifications.get(entity) != null) {
+                EntityAuditEventV2 auditEvent = events.next();
+                auditEvent.setClassificationDetail(AtlasJson.toV1Json(entityClassifications.get(entity)));
+                createEvent(auditEvent, entity, CLASSIFICATION_UPDATE, "Updated classifications: " + AtlasType.toJson(new AtlasClassification()));
+            }
+
+            for (EntityAuditRepository auditRepository : auditRepositories) {
                 auditRepository.putEventsV2(events.toList());
             }
 
@@ -301,18 +315,10 @@ public class EntityAuditListenerV2 implements EntityChangeListenerV2 {
             MetricRecorder metric = RequestContext.get().startMetricRecord("onClassificationsDeleted");
 
             FixedBufferList<EntityAuditEventV2> events = getAuditEventsList();
-
-            for (AtlasClassification classification : classifications) {
-                if (StringUtils.equals(entity.getGuid(), classification.getEntityGuid())) {
-                    createEvent(events.next(), entity, CLASSIFICATION_DELETE, "Deleted classification: " + getDeleteClassificationString(classification.getTypeName()));
-                } else {
-                    createEvent(events.next(), entity, PROPAGATED_CLASSIFICATION_DELETE, "Deleted propagated classification: " + getDeleteClassificationString(classification.getTypeName()));
-                }
-            }
-
-            for (EntityAuditRepository auditRepository: auditRepositories) {
-                auditRepository.putEventsV2(events.toList());
-            }
+            Map<AtlasEntity, List<Map<String,Object>>> entityClassifications = new HashMap<>();
+            Map<AtlasEntity, List<Map<String,Object>>> propagatedClassifications = new HashMap<>();
+            getClassificationTextFromEntity(classifications, entity, entityClassifications, propagatedClassifications);
+            emitDeleteClassificationEvent(events, entityClassifications, propagatedClassifications);
 
             RequestContext.get().endMetricRecord(metric);
         }
@@ -324,20 +330,10 @@ public class EntityAuditListenerV2 implements EntityChangeListenerV2 {
         if (CollectionUtils.isNotEmpty(classifications) && CollectionUtils.isNotEmpty(entities)) {
             MetricRecorder metric = RequestContext.get().startMetricRecord("onClassificationsDeleted");
             FixedBufferList<EntityAuditEventV2> events = getAuditEventsList();
-
-            for (AtlasClassification classification : classifications) {
-                for (AtlasEntity entity : entities) {
-                    if (StringUtils.equals(entity.getGuid(), classification.getEntityGuid())) {
-                        createEvent(events.next(), entity, CLASSIFICATION_DELETE, "Deleted classification: " + getDeleteClassificationString(classification.getTypeName()));
-                    } else {
-                        createEvent(events.next(), entity, PROPAGATED_CLASSIFICATION_DELETE, "Deleted propagated classification: " + getDeleteClassificationString(classification.getTypeName()));
-                    }
-                }
-            }
-
-            for (EntityAuditRepository auditRepository : auditRepositories) {
-                auditRepository.putEventsV2(events.toList());
-            }
+            Map<AtlasEntity, List<Map<String,Object>>> entityClassifications = new HashMap<>();
+            Map<AtlasEntity, List<Map<String,Object>>> propagatedClassifications = new HashMap<>();
+            getClassificationsTextFromEntities(classifications, entities, entityClassifications, propagatedClassifications);
+            emitDeleteClassificationEvent(events, entityClassifications, propagatedClassifications);
 
             RequestContext.get().endMetricRecord(metric);
         }
@@ -776,22 +772,22 @@ public class EntityAuditListenerV2 implements EntityChangeListenerV2 {
                 ret = "Purged: ";
                 break;
             case CLASSIFICATION_ADD:
-                ret = "Added classification: ";
+                ret = "Added classifications: ";
                 break;
             case CLASSIFICATION_DELETE:
-                ret = "Deleted classification: ";
+                ret = "Deleted classifications: ";
                 break;
             case CLASSIFICATION_UPDATE:
-                ret = "Updated classification: ";
+                ret = "Updated classifications: ";
                 break;
             case PROPAGATED_CLASSIFICATION_ADD:
-                ret = "Added propagated classification: ";
+                ret = "Added propagated classifications: ";
                 break;
             case PROPAGATED_CLASSIFICATION_DELETE:
-                ret = "Deleted propagated classification: ";
+                ret = "Deleted propagated classifications: ";
                 break;
             case PROPAGATED_CLASSIFICATION_UPDATE:
-                ret = "Updated propagated classification: ";
+                ret = "Updated propagated classifications: ";
                 break;
             case ENTITY_IMPORT_CREATE:
                 ret = "Created by import: ";
@@ -843,18 +839,24 @@ public class EntityAuditListenerV2 implements EntityChangeListenerV2 {
             }
         }
     }
+
     private void getClassificationsFromEntities(List<AtlasClassification> classifications, List<AtlasEntity> entities, Map<AtlasEntity, List<AtlasClassification>> entityClassifications, Map<AtlasEntity, List<AtlasClassification>> propagatedClassifications) {
-        for (AtlasEntity entity : entities){
+        for (AtlasEntity entity : entities) {
             getClassificationsFromEntity(classifications, entity, entityClassifications, propagatedClassifications);
         }
     }
+
     private void emitAddClassificationEvent(FixedBufferList<EntityAuditEventV2> events, Map<AtlasEntity, List<AtlasClassification>> entityClassifications, Map<AtlasEntity, List<AtlasClassification>> propagatedClassifications) throws AtlasBaseException {
         entityClassifications.forEach((entity, eClassifications) -> {
-            createEvent(events.next(), entity, CLASSIFICATION_ADD, "Added classifications: " + AtlasType.toJson(eClassifications));
+            EntityAuditEventV2 auditEvent = events.next();
+            auditEvent.setClassificationDetail(AtlasJson.toV1Json(eClassifications));
+            createEvent(auditEvent, entity, CLASSIFICATION_ADD, "Added classifications: " + null);
         });
 
         propagatedClassifications.forEach((entity, pClassifications) -> {
-            createEvent(events.next(), entity, PROPAGATED_CLASSIFICATION_ADD, "Added propagated classifications: " + AtlasType.toJson(pClassifications));
+            EntityAuditEventV2 auditEvent = events.next();
+            auditEvent.setClassificationDetail(AtlasJson.toV1Json(pClassifications));
+            createEvent(auditEvent, entity, PROPAGATED_CLASSIFICATION_ADD, "Added propagated classifications: " + null);
         });
         for (EntityAuditRepository auditRepository : auditRepositories) {
             auditRepository.putEventsV2(events.toList());
@@ -876,14 +878,23 @@ public class EntityAuditListenerV2 implements EntityChangeListenerV2 {
             }
         }
     }
+
     private void getClassificationsTextFromEntities(List<AtlasClassification> classifications, List<AtlasEntity> entities, Map<AtlasEntity, List<Map<String, Object>>> entityClassifications, Map<AtlasEntity, List<Map<String, Object>>> propagatedClassifications) {
         for (AtlasEntity entity : entities) {
             getClassificationTextFromEntity(classifications, entity, entityClassifications, propagatedClassifications);
         }
     }
     private void emitDeleteClassificationEvent(FixedBufferList<EntityAuditEventV2> events, Map<AtlasEntity, List<Map<String, Object>>> entityClassifications, Map<AtlasEntity, List<Map<String, Object>>> propagatedClassifications) throws AtlasBaseException {
-        entityClassifications.forEach((entity, eClassifications) -> createEvent(events.next(), entity, CLASSIFICATION_DELETE, "Deleted classifications: " + AtlasType.toJson(eClassifications)));
-        propagatedClassifications.forEach((entity, pClassifications) -> createEvent(events.next(), entity, PROPAGATED_CLASSIFICATION_DELETE, "Deleted propagated classifications: " + AtlasType.toJson(pClassifications)));
+        entityClassifications.forEach((entity, eClassifications) -> {
+            EntityAuditEventV2 auditEvent = events.next();
+            auditEvent.setClassificationDetail(AtlasJson.toV1Json(eClassifications));
+            createEvent(auditEvent, entity, CLASSIFICATION_DELETE, "Deleted classifications: " + null);
+        });
+        propagatedClassifications.forEach((entity, pClassifications) -> {
+            EntityAuditEventV2 auditEvent = events.next();
+            auditEvent.setClassificationDetail(AtlasJson.toV1Json(pClassifications));
+            createEvent(auditEvent, entity, PROPAGATED_CLASSIFICATION_DELETE, "Deleted propagated classifications: " + null);
+        });
 
         for (EntityAuditRepository auditRepository : auditRepositories) {
             auditRepository.putEventsV2(events.toList());


### PR DESCRIPTION
## Change description

### JIRA :

 https://atlanhq.atlassian.net/browse/PLT-367

### **Current behaviour :**

Example :

If 3 tags are added to single entity

there use to be **three** `CLASSIFICATION_ADDED` events for that entity

If 3 tags are added to two entities

there use to be **six** `CLASSIFICATION_ADDED` events (3 events per entity)

### Desired **Behaviour:**

Example :

If 3 tags are added to single entity

there will be **one** `CLASSIFICATION_ADDED`event for that entity

If 3 tags are added to two entities

there will be **two** `CLASSIFICATION_ADDED`event (1 event per entity)

### Area of Impact :

1. Audit events
2. Kafka events
3. **AuditSearch API (consumed across multiple teams)**

### Proposed changes to embed desired behaviour :

-  **`Classification_added`** 
    
    **Current behaviour** 
    i. We have `detail` object that contains tag information.
    
      **Proposed behaviour** 
    
    1. Representing Future classification_added event
        i. `detail` object will be empty.
       ii.  add key `classificationsDetails` object to show current tags
              removed from entity.
    
    2.  Representing Past data classification_added event
          i. `detail` object contains tag information.
         ii. `classificationsDetails` object will be empty
    
- **`Classification_deleted`** event
    
    **Current behaviour :**       
     i. We have `detail` object that contains tag `typeName` only.
    
     **Proposed behaviour** 
    
    1. Representing Future classification_deleted event
        i. `detail` object will be empty.
       ii. add key `classificationsDetails` object to show current tags
              removed from entity.
    2.  Representing Past data classification_added event
        i. `detail` object contains tag information.
       ii. `classificationsDetails` object will be empty.

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
