### PR TITLE
Add Github Workflow Repository Dispatcher for atlan repo

### DIFF
--- a/.github/workflows/chart-release-dispatcher.yaml
+++ b/.github/workflows/chart-release-dispatcher.yaml
@@ -1,0 +1,40 @@
+# Name of the Workflow
+name: Charts Values Seed Trigger Dispatcher
+on:
+  workflow_run:
+    workflows:
+      - "Java CI with Maven"
+    branches:
+      - main
+      - beta
+      - staging
+    types:
+      - completed
+
+jobs:
+  charts-release-dispatcher:
+    name: Dispatch
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repo: ['atlanhq/atlan']
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      # extract branch name
+      - name: Get branch name
+        id: extract_branch
+        run: |
+          echo "branch=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_OUTPUT
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.my_pat }}
+          repository: ${{ matrix.repo }}
+          event-type: dispatch_chart_release_workflow
+          client-payload: |-
+            {
+              "repo": {
+                "name": "${{ github.repository }}",
+                "branch": "${{ steps.extract_branch.outputs.branch }}"
+              }
+            }

--- a/.github/workflows/chart-release-dispatcher.yaml
+++ b/.github/workflows/chart-release-dispatcher.yaml
@@ -5,7 +5,6 @@ on:
     workflows:
       - "Java CI with Maven"
     branches:
-      - main
       - beta
       - staging
     types:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -117,27 +117,3 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2.1.33
         with:
           sarif_file: 'trivy-image-results.sarif'
-
-      - name: Check out into atlan repo
-        uses: actions/checkout@v2
-        with:
-          ref: main
-          repository: atlanhq/atlan
-          token: ${{ secrets.my_pat }}
-
-      - name: Add Changelog
-        run: |
-          mkdir -p gitlog
-          echo "- ${{ github.event.head_commit.message }}">>gitlog/${{ github.event.repository.name }}.txt
-          chmod +x ./scripts/create_changelog.sh
-          ./scripts/create_changelog.sh
-
-      - name: Commit changes
-        uses: EndBug/add-and-commit@v7
-        with:
-          branch: main
-          author_name: atlan-ci
-          author_email: it@atlan.com
-          message: '${{ github.event.repository.name }}'
-          default_author: user_info
-          push: origin main

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,7 +25,6 @@ on:
       - beta
       - development
       - master
-      - staging
       - lineageondemand
 
 jobs:
@@ -78,7 +77,7 @@ jobs:
         shell: bash
 
       - name: Get version tag
-        run: echo "##[set-output name=version;]$(echo `git ls-remote https://${{ secrets.my_pat }}@github.com/atlanhq/${REPOSITORY_NAME}.git refs/heads/${{ steps.get_branch.outputs.branch }} | awk '{ print $1}' | cut -c1-7`)abcd"
+        run: echo "##[set-output name=version;]$(echo `git ls-remote https://${{ secrets.my_pat }}@github.com/atlanhq/${REPOSITORY_NAME}.git ${{ steps.get_branch.outputs.branch }} | awk '{ print $1}' | cut -c1-7`)abcd"
         id: get_version
 
       - name: Set up Buildx 
@@ -105,6 +104,7 @@ jobs:
           tags: |
             ghcr.io/atlanhq/${{ github.event.repository.name }}-${{ steps.get_branch.outputs.branch }}:latest
             ghcr.io/atlanhq/${{ github.event.repository.name }}-${{ steps.get_branch.outputs.branch }}:${{ steps.get_version.outputs.version }}
+
       - name: Scan Image
         uses: aquasecurity/trivy-action@master
         with:
@@ -121,7 +121,7 @@ jobs:
       - name: Check out into atlan repo
         uses: actions/checkout@v2
         with:
-          ref: ${{ steps.get_branch.outputs.branch }}
+          ref: main
           repository: atlanhq/atlan
           token: ${{ secrets.my_pat }}
 
@@ -131,12 +131,13 @@ jobs:
           echo "- ${{ github.event.head_commit.message }}">>gitlog/${{ github.event.repository.name }}.txt
           chmod +x ./scripts/create_changelog.sh
           ./scripts/create_changelog.sh
+
       - name: Commit changes
         uses: EndBug/add-and-commit@v7
         with:
-          branch: ${{ steps.get_branch.outputs.branch }}
+          branch: main
           author_name: atlan-ci
           author_email: it@atlan.com
           message: '${{ github.event.repository.name }}'
           default_author: user_info
-          push: origin ${{ steps.get_branch.outputs.branch }}
+          push: origin main

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,6 +25,7 @@ on:
       - beta
       - development
       - master
+      - staging
       - lineageondemand
 
 jobs:
@@ -77,7 +78,7 @@ jobs:
         shell: bash
 
       - name: Get version tag
-        run: echo "##[set-output name=version;]$(echo `git ls-remote https://${{ secrets.my_pat }}@github.com/atlanhq/${REPOSITORY_NAME}.git ${{ steps.get_branch.outputs.branch }} | awk '{ print $1}' | cut -c1-7`)abcd"
+        run: echo "##[set-output name=version;]$(echo `git ls-remote https://${{ secrets.my_pat }}@github.com/atlanhq/${REPOSITORY_NAME}.git refs/heads/${{ steps.get_branch.outputs.branch }} | awk '{ print $1}' | cut -c1-7`)abcd"
         id: get_version
 
       - name: Set up Buildx 
@@ -104,7 +105,6 @@ jobs:
           tags: |
             ghcr.io/atlanhq/${{ github.event.repository.name }}-${{ steps.get_branch.outputs.branch }}:latest
             ghcr.io/atlanhq/${{ github.event.repository.name }}-${{ steps.get_branch.outputs.branch }}:${{ steps.get_version.outputs.version }}
-
       - name: Scan Image
         uses: aquasecurity/trivy-action@master
         with:
@@ -117,3 +117,26 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2.1.33
         with:
           sarif_file: 'trivy-image-results.sarif'
+
+      - name: Check out into atlan repo
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ steps.get_branch.outputs.branch }}
+          repository: atlanhq/atlan
+          token: ${{ secrets.my_pat }}
+
+      - name: Add Changelog
+        run: |
+          mkdir -p gitlog
+          echo "- ${{ github.event.head_commit.message }}">>gitlog/${{ github.event.repository.name }}.txt
+          chmod +x ./scripts/create_changelog.sh
+          ./scripts/create_changelog.sh
+      - name: Commit changes
+        uses: EndBug/add-and-commit@v7
+        with:
+          branch: ${{ steps.get_branch.outputs.branch }}
+          author_name: atlan-ci
+          author_email: it@atlan.com
+          message: '${{ github.event.repository.name }}'
+          default_author: user_info
+          push: origin ${{ steps.get_branch.outputs.branch }}


### PR DESCRIPTION
## Change description

Currently, the chart release GitHub action on Atlan repository is triggered by committing to a gitlog file from the service repositories. To enhance the workflow and streamline the release process, we are planning to decommission this approach and introduce a new method.

A new approach where the chart release GitHub action on the Atlan repository is triggered directly from the service repositories whenever a push occurs to branches such as main, master, alpha, beta, development, etc.

[Release Plan](https://www.notion.so/atlanhq/Release-Plan-Streamlining-Chart-Release-Workflow-59f688c267db49d390b61698efa974bd)

## Type of change
- [x] New feature (adds functionality)

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
