### PR TITLE
Add Github Workflow Repository Dispatcher for atlan repo

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -117,26 +117,3 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2.1.33
         with:
           sarif_file: 'trivy-image-results.sarif'
-
-      - name: Check out into atlan repo
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ steps.get_branch.outputs.branch }}
-          repository: atlanhq/atlan
-          token: ${{ secrets.my_pat }}
-
-      - name: Add Changelog
-        run: |
-          mkdir -p gitlog
-          echo "- ${{ github.event.head_commit.message }}">>gitlog/${{ github.event.repository.name }}.txt
-          chmod +x ./scripts/create_changelog.sh
-          ./scripts/create_changelog.sh
-      - name: Commit changes
-        uses: EndBug/add-and-commit@v7
-        with:
-          branch: ${{ steps.get_branch.outputs.branch }}
-          author_name: atlan-ci
-          author_email: it@atlan.com
-          message: '${{ github.event.repository.name }}'
-          default_author: user_info
-          push: origin ${{ steps.get_branch.outputs.branch }}


### PR DESCRIPTION
## Change description

Currently, the chart release GitHub action on Atlan repository is triggered by committing to a gitlog file from the service repositories. To enhance the workflow and streamline the release process, we are planning to decommission this approach and introduce a new method.

A new approach where the chart release GitHub action on the Atlan repository is triggered directly from the service repositories whenever a push occurs to branches such as main, master, alpha, beta, development, etc.

[Release Plan](https://www.notion.so/atlanhq/Release-Plan-Streamlining-Chart-Release-Workflow-59f688c267db49d390b61698efa974bd)

## Type of change
- [x] New feature (adds functionality)

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
