### PR TITLE
feat: add optimization to fetch required details

### DIFF
--- a/auth-agents-common/src/main/java/org/apache/atlas/plugin/util/KeycloakUserStore.java
+++ b/auth-agents-common/src/main/java/org/apache/atlas/plugin/util/KeycloakUserStore.java
@@ -55,6 +55,14 @@ public class KeycloakUserStore {
     private static List<String> OPERATION_TYPES = Arrays.asList("CREATE", "UPDATE", "DELETE");
     private static List<String> RESOURCE_TYPES = Arrays.asList("USER", "GROUP", "REALM_ROLE", "CLIENT", "REALM_ROLE_MAPPING", "GROUP_MEMBERSHIP", "CLIENT_ROLE_MAPPING");
 
+    private enum KEYCLOAK_FIELDS {
+        ROLES,
+        COMPOSITE_ROLES,
+        GROUPS,
+        USERS,
+
+    }
+
     private final String serviceName;
 
     public KeycloakUserStore(String serviceName) {
@@ -155,7 +163,7 @@ public class KeycloakUserStore {
         List<UserRepresentation> userRetrievalResult;
 
         do {
-            userRetrievalResult = getHeraclesClient().getUsersMappings(userFrom, userSize, new String[]{"roles"});
+            userRetrievalResult = getHeraclesClient().getUsersMappings(userFrom, userSize, new String[]{KEYCLOAK_FIELDS.ROLES.name().toLowerCase()});
 
             if (!CollectionUtils.isEmpty(userRetrievalResult)) {
                 userRetrievalResult.forEach(user -> {
@@ -177,7 +185,8 @@ public class KeycloakUserStore {
         List<HeraclesRoleViewRepresentation> roleRetrievalResult;
 
         do {
-            roleRetrievalResult = getHeraclesClient().getRolesMappings(roleFrom, roleSize, new String[]{"composite_roles", "groups"});
+            roleRetrievalResult = getHeraclesClient().getRolesMappings(roleFrom, roleSize, new String[]{KEYCLOAK_FIELDS.COMPOSITE_ROLES.name().toLowerCase(),
+                    KEYCLOAK_FIELDS.GROUPS.name()});
 
             if (!CollectionUtils.isEmpty(roleRetrievalResult)) {
                 roleRetrievalResult.forEach(role -> {
@@ -317,7 +326,8 @@ public class KeycloakUserStore {
         List<UserRepresentation> ret = new ArrayList<>();
 
         do {
-            List<UserRepresentation> users = getHeraclesClient().getUsersMappings(userFrom, userSize, new String[]{"groups"});
+            List<UserRepresentation> users = getHeraclesClient().getUsersMappings(userFrom, userSize,
+                    new String[]{KEYCLOAK_FIELDS.GROUPS.name().toLowerCase()});
             if (CollectionUtils.isEmpty(users)) {
                 userFound = false;
             } else {

--- a/auth-agents-common/src/main/java/org/apache/atlas/plugin/util/KeycloakUserStore.java
+++ b/auth-agents-common/src/main/java/org/apache/atlas/plugin/util/KeycloakUserStore.java
@@ -155,7 +155,7 @@ public class KeycloakUserStore {
         List<UserRepresentation> userRetrievalResult;
 
         do {
-            userRetrievalResult = getHeraclesClient().getUsersMappings(userFrom, userSize, new String[]{"roles", "groups"});
+            userRetrievalResult = getHeraclesClient().getUsersMappings(userFrom, userSize, new String[]{"roles"});
 
             if (!CollectionUtils.isEmpty(userRetrievalResult)) {
                 userRetrievalResult.forEach(user -> {
@@ -177,7 +177,7 @@ public class KeycloakUserStore {
         List<HeraclesRoleViewRepresentation> roleRetrievalResult;
 
         do {
-            roleRetrievalResult = getHeraclesClient().getRolesMappings(roleFrom, roleSize, new String[]{"roles", "groups"});
+            roleRetrievalResult = getHeraclesClient().getRolesMappings(roleFrom, roleSize, new String[]{"composite_roles", "groups"});
 
             if (!CollectionUtils.isEmpty(roleRetrievalResult)) {
                 roleRetrievalResult.forEach(role -> {

--- a/auth-agents-common/src/main/java/org/apache/atlas/plugin/util/KeycloakUserStore.java
+++ b/auth-agents-common/src/main/java/org/apache/atlas/plugin/util/KeycloakUserStore.java
@@ -155,7 +155,7 @@ public class KeycloakUserStore {
         List<UserRepresentation> userRetrievalResult;
 
         do {
-            userRetrievalResult = getHeraclesClient().getUsersMappings(userFrom, userSize);
+            userRetrievalResult = getHeraclesClient().getUsersMappings(userFrom, userSize, new String[]{"roles", "groups"});
 
             if (!CollectionUtils.isEmpty(userRetrievalResult)) {
                 userRetrievalResult.forEach(user -> {
@@ -177,7 +177,7 @@ public class KeycloakUserStore {
         List<HeraclesRoleViewRepresentation> roleRetrievalResult;
 
         do {
-            roleRetrievalResult = getHeraclesClient().getRolesMappings(roleFrom, roleSize);
+            roleRetrievalResult = getHeraclesClient().getRolesMappings(roleFrom, roleSize, new String[]{"roles", "groups"});
 
             if (!CollectionUtils.isEmpty(roleRetrievalResult)) {
                 roleRetrievalResult.forEach(role -> {
@@ -317,7 +317,7 @@ public class KeycloakUserStore {
         List<UserRepresentation> ret = new ArrayList<>();
 
         do {
-            List<UserRepresentation> users = getHeraclesClient().getUsersMappings(userFrom, userSize);
+            List<UserRepresentation> users = getHeraclesClient().getUsersMappings(userFrom, userSize, new String[]{"groups"});
             if (CollectionUtils.isEmpty(users)) {
                 userFound = false;
             } else {

--- a/client-auth/src/main/java/org/apache/atlas/auth/client/heracles/AtlasHeraclesClient.java
+++ b/client-auth/src/main/java/org/apache/atlas/auth/client/heracles/AtlasHeraclesClient.java
@@ -41,8 +41,7 @@ public class AtlasHeraclesClient {
         }
     }
 
-    public List<UserRepresentation> getUsersMappings(int start, int size) throws AtlasBaseException {
-        String[] columns = {"roles", "groups"};
+    public List<UserRepresentation> getUsersMappings(int start, int size, String[] columns) throws AtlasBaseException {;
         List<HeraclesUserViewRepresentation> views =  HERACLES.getUsersMappings(start, size, HeraclesUserViewRepresentation.sortBy, columns).body();
         return views.stream().map(x -> {
             UserRepresentation userRepresentation = new UserRepresentation();
@@ -54,8 +53,7 @@ public class AtlasHeraclesClient {
         }).collect(Collectors.toList());
     }
 
-    public List<HeraclesRoleViewRepresentation> getRolesMappings(int start, int size) throws AtlasBaseException {
-        String[] columns = {"composite_roles","groups"};
+    public List<HeraclesRoleViewRepresentation> getRolesMappings(int start, int size,  String[] columns) throws AtlasBaseException {
         return   HERACLES.getRolesMappings(start, size, HeraclesRoleViewRepresentation.sortBy, columns).body();
     }
 }


### PR DESCRIPTION
### feat: add optimization to fetch required details

We merged and tested the changes required for policy cache building optimization. During this process, we realized we could further optimize the cache by simply fetching only essential information from the custom Herackes APIs.

Specifically, we identified the following areas for optimization:

**Role Cache:** When building the role cache, we no longer retrieve user-group information, as it's not required for this cache.
**User Group Cache**: Similarly, we don't fetch role information when building the user group cache.
Previously, we were fetching all details for each cache, even when those details weren't necessary. This optimization reduces the number of JOIN operations by 30%, leading to a noticeable decrease in Postgres CPU usage.

**Overall CPU Usage graph in Postgres Namespace**(Right side is after the optimization)

<img width="1041" alt="image" src="https://github.com/atlanhq/atlas-metastore/assets/59254445/241c8272-3790-4445-ab63-8a1e6ae6123e">



