### PR TITLE
Adding highlight support in the search

### DIFF
--- a/graphdb/api/src/main/java/org/apache/atlas/repository/graphdb/AtlasIndexQuery.java
+++ b/graphdb/api/src/main/java/org/apache/atlas/repository/graphdb/AtlasIndexQuery.java
@@ -23,6 +23,7 @@ import org.apache.atlas.model.discovery.SearchParams;
 import org.apache.tinkerpop.gremlin.process.traversal.Order;
 
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -100,6 +101,8 @@ public interface AtlasIndexQuery<V, E> {
         Set<String> getCollapseKeys();
 
         DirectIndexQueryResult<V, E> getCollapseVertices(String key);
+
+        Map<String, List<String>> getHighLights();
 
     }
 

--- a/graphdb/api/src/main/java/org/apache/atlas/repository/graphdb/DirectIndexQueryResult.java
+++ b/graphdb/api/src/main/java/org/apache/atlas/repository/graphdb/DirectIndexQueryResult.java
@@ -8,8 +8,6 @@ import java.util.Map;
 public class DirectIndexQueryResult<V, E> {
     private Iterator<AtlasIndexQuery.Result<V, E>> iterator;
     private Map<String, Aggregation> aggregationMap;
-
-    private Map<String, Object> highlightMap;
     private Integer approximateCount;
 
     public Iterator<AtlasIndexQuery.Result<V, E>> getIterator() {
@@ -36,11 +34,4 @@ public class DirectIndexQueryResult<V, E> {
         this.approximateCount = approximateCount;
     }
 
-    public Map<String, Object> getHighlightMap() {
-        return highlightMap;
-    }
-
-    public void setHighlightMap(Map<String, Object> highlightMap) {
-        this.highlightMap = highlightMap;
-    }
 }

--- a/graphdb/api/src/main/java/org/apache/atlas/repository/graphdb/DirectIndexQueryResult.java
+++ b/graphdb/api/src/main/java/org/apache/atlas/repository/graphdb/DirectIndexQueryResult.java
@@ -8,6 +8,8 @@ import java.util.Map;
 public class DirectIndexQueryResult<V, E> {
     private Iterator<AtlasIndexQuery.Result<V, E>> iterator;
     private Map<String, Aggregation> aggregationMap;
+
+    private Map<String, Object> highlightMap;
     private Integer approximateCount;
 
     public Iterator<AtlasIndexQuery.Result<V, E>> getIterator() {
@@ -32,5 +34,13 @@ public class DirectIndexQueryResult<V, E> {
 
     public void setApproximateCount(Integer approximateCount) {
         this.approximateCount = approximateCount;
+    }
+
+    public Map<String, Object> getHighlightMap() {
+        return highlightMap;
+    }
+
+    public void setHighlightMap(Map<String, Object> highlightMap) {
+        this.highlightMap = highlightMap;
     }
 }

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchQuery.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchQuery.java
@@ -280,6 +280,11 @@ public class AtlasElasticsearchQuery implements AtlasIndexQuery<AtlasJanusVertex
         public DirectIndexQueryResult<AtlasJanusVertex, AtlasJanusEdge> getCollapseVertices(String key) {
             return null;
         }
+
+        @Override
+        public Map<String, List<String>> getHighLights() {
+            return null;
+        }
     }
 
 
@@ -335,6 +340,11 @@ public class AtlasElasticsearchQuery implements AtlasIndexQuery<AtlasJanusVertex
                 return -1;
             }
             return Double.parseDouble(String.valueOf(hit.get("_score")));
+        }
+
+        @Override
+        public Map<String, List<String>> getHighLights() {
+            return (Map<String, List<String>>) this.hit.get("highlight");
         }
     }
 }

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchQuery.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchQuery.java
@@ -283,7 +283,7 @@ public class AtlasElasticsearchQuery implements AtlasIndexQuery<AtlasJanusVertex
 
         @Override
         public Map<String, List<String>> getHighLights() {
-            return null;
+            return new HashMap<>();
         }
     }
 
@@ -348,7 +348,7 @@ public class AtlasElasticsearchQuery implements AtlasIndexQuery<AtlasJanusVertex
             if(Objects.isNull(highlight)) {
                 return (Map<String, List<String>>) highlight;
             }
-            return null;
+            return new HashMap<>();
         }
     }
 }

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchQuery.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchQuery.java
@@ -344,7 +344,11 @@ public class AtlasElasticsearchQuery implements AtlasIndexQuery<AtlasJanusVertex
 
         @Override
         public Map<String, List<String>> getHighLights() {
-            return (Map<String, List<String>>) this.hit.get("highlight");
+            Object highlight = this.hit.get("highlight");
+            if(Objects.isNull(highlight)) {
+                return (Map<String, List<String>>) highlight;
+            }
+            return null;
         }
     }
 }

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusIndexQuery.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusIndexQuery.java
@@ -151,7 +151,7 @@ public class AtlasJanusIndexQuery implements AtlasIndexQuery<AtlasJanusVertex, A
 
         @Override
         public Map<String, List<String>> getHighLights() {
-            return null;
+            return new HashMap<>();
         }
     }
 }

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusIndexQuery.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusIndexQuery.java
@@ -17,9 +17,7 @@
  */
 package org.apache.atlas.repository.graphdb.janus;
 
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import com.google.common.base.Preconditions;
 import org.apache.atlas.exception.AtlasBaseException;
@@ -148,6 +146,11 @@ public class AtlasJanusIndexQuery implements AtlasIndexQuery<AtlasJanusVertex, A
 
         @Override
         public DirectIndexQueryResult<AtlasJanusVertex, AtlasJanusEdge> getCollapseVertices(String key) {
+            return null;
+        }
+
+        @Override
+        public Map<String, List<String>> getHighLights() {
             return null;
         }
     }

--- a/intg/src/main/java/org/apache/atlas/model/discovery/AtlasSearchResult.java
+++ b/intg/src/main/java/org/apache/atlas/model/discovery/AtlasSearchResult.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import org.apache.atlas.model.instance.AtlasEntityHeader;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -57,6 +58,10 @@ public class AtlasSearchResult implements Serializable {
     private String                         nextMarker;
     private Map<String, Object>            aggregations;
     private Map<String,Double>             searchScore;
+
+    private Map<String, SearchMetadata>   searchMetadata;
+
+
 
     public AtlasSearchResult() {}
 
@@ -150,6 +155,19 @@ public class AtlasSearchResult implements Serializable {
     public String getNextMarker() { return nextMarker; }
 
     public void setNextMarker(String nextMarker) { this.nextMarker = nextMarker; }
+
+    public Map<String, SearchMetadata> getSearchMetadata() {
+        return searchMetadata;
+    }
+
+    public void addHighlights(String guid, Map<String, List<String>> highlights) {
+        if(MapUtils.isEmpty(this.searchMetadata)) {
+            this.searchMetadata = new HashMap<>();
+        }
+        SearchMetadata v = this.searchMetadata.getOrDefault(guid, new SearchMetadata());
+        v.addHighlights(highlights);
+        this.searchMetadata.put(guid, v);
+    }
 
     @Override
     public int hashCode() { return Objects.hash(queryType, searchParameters, queryText, type, classification, entities, attributes, fullTextResult, referredEntities, nextMarker); }

--- a/intg/src/main/java/org/apache/atlas/model/discovery/AtlasSearchResult.java
+++ b/intg/src/main/java/org/apache/atlas/model/discovery/AtlasSearchResult.java
@@ -59,7 +59,7 @@ public class AtlasSearchResult implements Serializable {
     private Map<String, Object>            aggregations;
     private Map<String,Double>             searchScore;
 
-    private Map<String, SearchMetadata>   searchMetadata;
+    private Map<String, ElasticsearchMetadata>   searchMetadata;
 
 
 
@@ -156,7 +156,7 @@ public class AtlasSearchResult implements Serializable {
 
     public void setNextMarker(String nextMarker) { this.nextMarker = nextMarker; }
 
-    public Map<String, SearchMetadata> getSearchMetadata() {
+    public Map<String, ElasticsearchMetadata> getSearchMetadata() {
         return searchMetadata;
     }
 
@@ -164,7 +164,7 @@ public class AtlasSearchResult implements Serializable {
         if(MapUtils.isEmpty(this.searchMetadata)) {
             this.searchMetadata = new HashMap<>();
         }
-        SearchMetadata v = this.searchMetadata.getOrDefault(guid, new SearchMetadata());
+        ElasticsearchMetadata v = this.searchMetadata.getOrDefault(guid, new ElasticsearchMetadata());
         v.addHighlights(highlights);
         this.searchMetadata.put(guid, v);
     }

--- a/intg/src/main/java/org/apache/atlas/model/discovery/ElasticsearchMetadata.java
+++ b/intg/src/main/java/org/apache/atlas/model/discovery/ElasticsearchMetadata.java
@@ -6,7 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class SearchMetadata {
+public class ElasticsearchMetadata {
 
     private Map<String, List<String>> highlights;
 

--- a/intg/src/main/java/org/apache/atlas/model/discovery/ElasticsearchMetadata.java
+++ b/intg/src/main/java/org/apache/atlas/model/discovery/ElasticsearchMetadata.java
@@ -14,10 +14,6 @@ public class ElasticsearchMetadata {
         return highlights;
     }
 
-    public void setHighlights(Map<String, List<String>> highlights) {
-        this.highlights = highlights;
-    }
-
     public void addHighlights(Map<String, List<String>> highlights) {
         if(MapUtils.isNotEmpty(highlights)) {
             if (MapUtils.isEmpty(this.highlights)) {

--- a/intg/src/main/java/org/apache/atlas/model/discovery/SearchMetadata.java
+++ b/intg/src/main/java/org/apache/atlas/model/discovery/SearchMetadata.java
@@ -1,0 +1,37 @@
+package org.apache.atlas.model.discovery;
+
+import org.apache.commons.collections.MapUtils;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SearchMetadata {
+
+    private Map<String, List<String>> highlights;
+
+    public Map<String, List<String>> getHighlights() {
+        return highlights;
+    }
+
+    public void setHighlights(Map<String, List<String>> highlights) {
+        this.highlights = highlights;
+    }
+
+    public void addHighlights(Map<String, List<String>> highlights) {
+        if(MapUtils.isNotEmpty(highlights)) {
+            if (MapUtils.isEmpty(this.highlights)) {
+                this.highlights = new HashMap<>();
+            }
+            this.highlights.putAll(highlights);
+        }
+    }
+
+
+    @Override
+    public String toString() {
+        return "SearchMetadata{" +
+                "highlights=" + highlights +
+                '}';
+    }
+}

--- a/intg/src/main/java/org/apache/atlas/model/discovery/SearchParams.java
+++ b/intg/src/main/java/org/apache/atlas/model/discovery/SearchParams.java
@@ -20,6 +20,7 @@ public class SearchParams {
     boolean excludeClassifications;
 
     RequestMetadata requestMetadata = new RequestMetadata();
+    boolean showHighlights;
 
     public String getQuery() {
         return getQuery();
@@ -117,6 +118,10 @@ public class SearchParams {
         return this.requestMetadata.getSearchInput();
     }
 
+    public boolean isShowHighlights() {
+        return showHighlights;
+    }
+
     static class RequestMetadata {
         private String searchInput;
         private Set<String> utmTags;
@@ -146,4 +151,6 @@ public class SearchParams {
             this.saveSearchLog = saveSearchLog;
         }
     }
+
+
 }

--- a/repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java
@@ -1093,6 +1093,10 @@ public class EntityDiscoveryService implements AtlasDiscoveryService {
                     }
                 }
 
+                if (searchParams.isShowHighlights()) {
+                    ret.addHighlights(header.getGuid(), result.getHighLights());
+                }
+
                 ret.addEntity(header);
             }
         } catch (Exception e) {


### PR DESCRIPTION
[Highlight](https://www.elastic.co/guide/en/elasticsearch/reference/current/highlighting.html) support is added 

 Changes in request 

1. `highlight` needs to be added as the top-level attribute in the DSL
```
 "highlight": {
            "fields": {
                "name": {},
                "displayName": {},
                "description": {},
                "userDescription": {},
                "__meaningsText": {},
                "__meaningNames.text": {}
            }
        }
```
2. `showHighlights`  needs to be set to true if it is required in response
 Changes in Response 

A new object in response will come when `showHighlights` is set to true (default is false)
```
 "searchMetadata": {
        "810b0998-27c0-4feb-9606-b2863c4a2651": {
            "highlights": {
                "name": [
                    "<em>arpit</em>_6"
                ],
                "description": [
                    "<em>arpit</em>_6"
                ],
                "userDescription": [
                    "<em>arpit</em>_6"
                ],
                "displayName": [
                    "<em>arpit</em>_6"
                ]
            }
        },
        "3632ebdd-e7cd-4aca-bca9-0ee91c6445db": {
            "highlights": {
                "name": [
                    "<em>arpit</em>_5"
                ],
                "description": [
                    "<em>arpit</em>_5"
                ],
                "userDescription": [
                    "<em>arpit</em>_5"
                ],
                "displayName": [
                    "<em>arpit</em>_5"
                ]
            }
        }
```


- [x] tested on local 
