### PR TITLE
fix: Add error code for unknown errors so we could run pinpoint on them

### DIFF
--- a/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
@@ -240,6 +240,8 @@ public enum AtlasErrorCode {
     CATEGORY_PARENT_FROM_OTHER_GLOSSARY(409, "ATLAS-400-00-0015", "Parent category from another Anchor(glossary) not supported"),
     CLASSIFICATION_TYPE_HAS_REFERENCES(409, "ATLAS-400-00-0016", "Given classification {0} [{1}] has references"),
     // All internal errors go here
+    UNKNOWN_SERVER_ERROR(500, "ATLAS-500-00-000", "Unknown server error detected {0}"),
+
     INTERNAL_ERROR(500, "ATLAS-500-00-001", "Internal server error {0}"),
     INDEX_CREATION_FAILED(500, "ATLAS-500-00-002", "Index creation failed for {0}"),
     INDEX_ROLLBACK_FAILED(500, "ATLAS-500-00-003", "Index rollback failed for {0}"),
@@ -271,6 +273,7 @@ public enum AtlasErrorCode {
     CINV_UNHEALTHY(500, "ATLAS-500-00-21", "Unable to process type-definition operations"),
     RUNTIME_EXCEPTION(500, "ATLAS-500-00-020", "Runtime exception {0}"),
     KEYCLOAK_INIT_FAILED(500, "ATLAS-500-00-022", "Failed to initialize keycloak client: {0}"),
+
     BATCH_SIZE_TOO_LARGE(406, "ATLAS-406-00-001", "Batch size is too large, please use a smaller batch size"),
 
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/SoftDeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/SoftDeleteHandlerV1.java
@@ -18,7 +18,6 @@
 
 package org.apache.atlas.repository.store.graph.v1;
 
-import org.apache.atlas.AtlasErrorCode;
 import org.apache.atlas.RequestContext;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.instance.AtlasEntity.Status;
@@ -99,7 +98,7 @@ public class SoftDeleteHandlerV1 extends DeleteHandlerV1 {
                 AtlasRelationshipStoreV2.recordRelationshipMutation(AtlasRelationshipStoreV2.RelationshipMutation.RELATIONSHIP_SOFT_DELETE, edge, entityRetriever);
         } catch (Exception e) {
             LOG.error("Error while deleting edge {}", GraphHelper.string(edge), e);
-            throw new AtlasBaseException(AtlasErrorCode.UNKNOWN_SERVER_ERROR, e, "Error while deleting edge " + GraphHelper.string(edge));
+            throw new AtlasBaseException(e);
         }
     }
 }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/SoftDeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/SoftDeleteHandlerV1.java
@@ -18,6 +18,7 @@
 
 package org.apache.atlas.repository.store.graph.v1;
 
+import org.apache.atlas.AtlasErrorCode;
 import org.apache.atlas.RequestContext;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.instance.AtlasEntity.Status;
@@ -98,7 +99,7 @@ public class SoftDeleteHandlerV1 extends DeleteHandlerV1 {
                 AtlasRelationshipStoreV2.recordRelationshipMutation(AtlasRelationshipStoreV2.RelationshipMutation.RELATIONSHIP_SOFT_DELETE, edge, entityRetriever);
         } catch (Exception e) {
             LOG.error("Error while deleting edge {}", GraphHelper.string(edge), e);
-            throw new AtlasBaseException(e);
+            throw new AtlasBaseException(AtlasErrorCode.UNKNOWN_SERVER_ERROR, e, "Error while deleting edge " + GraphHelper.string(edge));
         }
     }
 }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -975,76 +975,83 @@ public class EntityGraphRetriever {
     private AtlasEntityHeader mapVertexToAtlasEntityHeader(AtlasVertex entityVertex, Set<String> attributes) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("mapVertexToAtlasEntityHeader");
         AtlasEntityHeader ret = new AtlasEntityHeader();
+        try {
+            String  typeName     = entityVertex.getProperty(Constants.TYPE_NAME_PROPERTY_KEY, String.class);
+            String  guid         = entityVertex.getProperty(Constants.GUID_PROPERTY_KEY, String.class);
+            Boolean isIncomplete = isEntityIncomplete(entityVertex);
 
-        String  typeName     = entityVertex.getProperty(Constants.TYPE_NAME_PROPERTY_KEY, String.class);
-        String  guid         = entityVertex.getProperty(Constants.GUID_PROPERTY_KEY, String.class);
-        Boolean isIncomplete = isEntityIncomplete(entityVertex);
-
-        ret.setTypeName(typeName);
-        ret.setGuid(guid);
-        ret.setStatus(GraphHelper.getStatus(entityVertex));
-        if(RequestContext.get().includeClassifications()){
-            ret.setClassificationNames(getAllTraitNames(entityVertex));
-        }
-        ret.setIsIncomplete(isIncomplete);
-        ret.setLabels(getLabels(entityVertex));
-
-        ret.setCreatedBy(GraphHelper.getCreatedByAsString(entityVertex));
-        ret.setUpdatedBy(GraphHelper.getModifiedByAsString(entityVertex));
-        ret.setCreateTime(new Date(GraphHelper.getCreatedTime(entityVertex)));
-        ret.setUpdateTime(new Date(GraphHelper.getModifiedTime(entityVertex)));
-
-        if(RequestContext.get().includeMeanings()) {
-            List<AtlasTermAssignmentHeader> termAssignmentHeaders = mapAssignedTerms(entityVertex);
-            ret.setMeanings(termAssignmentHeaders);
-            ret.setMeaningNames(
-                termAssignmentHeaders.stream().map(AtlasTermAssignmentHeader::getDisplayText)
-                    .collect(Collectors.toList()));
-        }
-        AtlasEntityType entityType = typeRegistry.getEntityTypeByName(typeName);
-
-        if (entityType != null) {
-            for (AtlasAttribute headerAttribute : entityType.getHeaderAttributes().values()) {
-                Object attrValue = getVertexAttribute(entityVertex, headerAttribute);
-
-                if (attrValue != null) {
-                    ret.setAttribute(headerAttribute.getName(), attrValue);
-                }
+            ret.setTypeName(typeName);
+            ret.setGuid(guid);
+            ret.setStatus(GraphHelper.getStatus(entityVertex));
+            if(RequestContext.get().includeClassifications()){
+                ret.setClassificationNames(getAllTraitNames(entityVertex));
             }
+            ret.setIsIncomplete(isIncomplete);
+            ret.setLabels(getLabels(entityVertex));
 
-            Object displayText = getDisplayText(entityVertex, entityType);
+            ret.setCreatedBy(GraphHelper.getCreatedByAsString(entityVertex));
+            ret.setUpdatedBy(GraphHelper.getModifiedByAsString(entityVertex));
+            ret.setCreateTime(new Date(GraphHelper.getCreatedTime(entityVertex)));
+            ret.setUpdateTime(new Date(GraphHelper.getModifiedTime(entityVertex)));
 
-            if (displayText != null) {
-                ret.setDisplayText(displayText.toString());
+            if(RequestContext.get().includeMeanings()) {
+                List<AtlasTermAssignmentHeader> termAssignmentHeaders = mapAssignedTerms(entityVertex);
+                ret.setMeanings(termAssignmentHeaders);
+                ret.setMeaningNames(
+                        termAssignmentHeaders.stream().map(AtlasTermAssignmentHeader::getDisplayText)
+                                .collect(Collectors.toList()));
             }
+            AtlasEntityType entityType = typeRegistry.getEntityTypeByName(typeName);
 
-            if (CollectionUtils.isNotEmpty(attributes)) {
-                for (String attrName : attributes) {
-                    AtlasAttribute attribute = entityType.getAttribute(attrName);
-
-                    if (attribute == null) {
-                        attrName = toNonQualifiedName(attrName);
-
-                        if (ret.hasAttribute(attrName)) {
-                            continue;
-                        }
-
-                        attribute = entityType.getAttribute(attrName);
-
-                        if (attribute == null) {
-                            attribute = entityType.getRelationshipAttribute(attrName, null);
-                        }
-                    }
-
-                    Object attrValue = getVertexAttribute(entityVertex, attribute);
+            if (entityType != null) {
+                for (AtlasAttribute headerAttribute : entityType.getHeaderAttributes().values()) {
+                    Object attrValue = getVertexAttribute(entityVertex, headerAttribute);
 
                     if (attrValue != null) {
-                        ret.setAttribute(attrName, attrValue);
+                        ret.setAttribute(headerAttribute.getName(), attrValue);
+                    }
+                }
+
+                Object displayText = getDisplayText(entityVertex, entityType);
+
+                if (displayText != null) {
+                    ret.setDisplayText(displayText.toString());
+                }
+
+                if (CollectionUtils.isNotEmpty(attributes)) {
+                    for (String attrName : attributes) {
+                        AtlasAttribute attribute = entityType.getAttribute(attrName);
+
+                        if (attribute == null) {
+                            attrName = toNonQualifiedName(attrName);
+
+                            if (ret.hasAttribute(attrName)) {
+                                continue;
+                            }
+
+                            attribute = entityType.getAttribute(attrName);
+
+                            if (attribute == null) {
+                                attribute = entityType.getRelationshipAttribute(attrName, null);
+                            }
+                        }
+
+                        Object attrValue = getVertexAttribute(entityVertex, attribute);
+
+                        if (attrValue != null) {
+                            ret.setAttribute(attrName, attrValue);
+                        }
                     }
                 }
             }
         }
-        RequestContext.get().endMetricRecord(metricRecorder);
+        catch (NullPointerException npe){
+            LOG.error("mapVertexToAtlasEntityHeader: failed for entityVertex {}", entityVertex, npe);
+            throw new AtlasBaseException(AtlasErrorCode.UNKNOWN_SERVER_ERROR, npe, "mapVertexToAtlasEntityHeader: failed for entityVertex " + entityVertex);
+        }
+        finally {
+            RequestContext.get().endMetricRecord(metricRecorder);
+        }
         return ret;
     }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -121,7 +121,6 @@ import static org.apache.atlas.repository.Constants.*;
 import static org.apache.atlas.repository.graph.GraphHelper.*;
 import static org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2.getIdFromVertex;
 import static org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2.isReference;
-import static org.apache.atlas.repository.store.graph.v2.tasks.ClassificationPropagateTaskFactory.CLASSIFICATION_ONLY_PROPAGATION_DELETE;
 import static org.apache.atlas.type.AtlasStructType.AtlasAttribute.AtlasRelationshipEdgeDirection;
 import static org.apache.atlas.type.AtlasStructType.AtlasAttribute.AtlasRelationshipEdgeDirection.BOTH;
 import static org.apache.atlas.type.AtlasStructType.AtlasAttribute.AtlasRelationshipEdgeDirection.IN;
@@ -1045,9 +1044,10 @@ public class EntityGraphRetriever {
                 }
             }
         }
-        catch (NullPointerException npe){
-            LOG.error("mapVertexToAtlasEntityHeader: failed for entityVertex {}", entityVertex, npe);
-            throw new AtlasBaseException(AtlasErrorCode.UNKNOWN_SERVER_ERROR, npe, "mapVertexToAtlasEntityHeader: failed for entityVertex " + entityVertex);
+        catch (NullPointerException npe) {
+            String id = entityVertex.getIdForDisplay()==null ? "null" :entityVertex.getIdForDisplay();
+            LOG.error("mapVertexToAtlasEntityHeader: failed for entityVertex with id {}", id, npe);
+            throw new AtlasBaseException(AtlasErrorCode.UNKNOWN_SERVER_ERROR, npe, "mapVertexToAtlasEntityHeader: failed for entityVertex with id" + id);
         }
         finally {
             RequestContext.get().endMetricRecord(metricRecorder);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -1047,7 +1047,7 @@ public class EntityGraphRetriever {
         catch (NullPointerException npe) {
             String id = entityVertex.getIdForDisplay()==null ? "null" :entityVertex.getIdForDisplay();
             LOG.error("mapVertexToAtlasEntityHeader: failed for entityVertex with id {}", id, npe);
-            throw new AtlasBaseException(AtlasErrorCode.UNKNOWN_SERVER_ERROR, npe, "mapVertexToAtlasEntityHeader: failed for entityVertex with id" + id);
+            throw new AtlasBaseException(AtlasErrorCode.UNKNOWN_SERVER_ERROR, npe, "mapVertexToAtlasEntityHeader: failed for entityVertex with id " + id);
         }
         finally {
             RequestContext.get().endMetricRecord(metricRecorder);


### PR DESCRIPTION
## Add special error code to select WF failure handler as PinPoint
> We retry some failures but do not run the pinpoint handler in cases of handled errors, or when the error code is greater than 500. Therefore, if an error is thrown intentionally, we will select the failure handler PINPOINT, which is `UNKNOWN_SERVER_ERROR`.
## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
