### PR TITLE
fix: Remove changelog push to atlan repo

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -92,25 +92,3 @@ jobs:
           tags: |
             ghcr.io/atlanhq/${{ github.event.repository.name }}-${{ steps.get_branch.outputs.branch }}:latest
             ghcr.io/atlanhq/${{ github.event.repository.name }}-${{ steps.get_branch.outputs.branch }}:${{ steps.get_version.outputs.version }}
-      - name: Check out into atlan repo
-        uses: actions/checkout@v2
-        with:
-          ref: lineageOnDemand
-          repository: atlanhq/atlan
-          token: ${{ secrets.my_pat }}
-
-      - name: Add Changelog
-        run: |
-          mkdir -p gitlog
-          echo "- ${{ github.event.head_commit.message }}">>gitlog/${{ github.event.repository.name }}.txt
-          chmod +x ./scripts/create_changelog.sh
-          ./scripts/create_changelog.sh
-      - name: Commit changes
-        uses: EndBug/add-and-commit@v7
-        with:
-          branch: lineageOnDemand
-          author_name: atlan-ci
-          author_email: it@atlan.com
-          message: '${{ github.event.repository.name }}'
-          default_author: user_info
-          push: origin lineageOnDemand


### PR DESCRIPTION
## Change description

We are deprecating the gitlog directory on atlan repo.

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
