### PR TITLE
Typo Fix in the key restrictPropagationThroughHierarchy

### DIFF
--- a/intg/src/main/java/org/apache/atlas/model/instance/AtlasClassification.java
+++ b/intg/src/main/java/org/apache/atlas/model/instance/AtlasClassification.java
@@ -95,15 +95,15 @@ public class AtlasClassification extends AtlasStruct implements Serializable {
             setDisplayName(other.getDisplayName());
             setRemovePropagationsOnEntityDelete(other.getRemovePropagationsOnEntityDelete());
             setRestrictPropagationThroughLineage(other.getRestrictPropagationThroughLineage());
-            setRestrictPropagationThroughHierarchy(other.getRestrictPropagationThroughHierachy());
+            setRestrictPropagationThroughHierarchy(other.getRestrictPropagationThroughHierarchy());
         }
     }
 
-    public void setRestrictPropagationThroughHierarchy(Boolean restrictPropagationThroughHierachy) {
-        this.restrictPropagationThroughHierarchy = restrictPropagationThroughHierachy;
+    public void setRestrictPropagationThroughHierarchy(Boolean restrictPropagationThroughHierarchy) {
+        this.restrictPropagationThroughHierarchy = restrictPropagationThroughHierarchy;
     }
 
-    public Boolean getRestrictPropagationThroughHierachy() {
+    public Boolean getRestrictPropagationThroughHierarchy() {
         return this.restrictPropagationThroughHierarchy;
     }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -2997,7 +2997,7 @@ public class EntityGraphMapper {
                 Boolean             propagateTags       = classification.isPropagate();
                 Boolean             removePropagations  = classification.getRemovePropagationsOnEntityDelete();
                 Boolean restrictPropagationThroughLineage = classification.getRestrictPropagationThroughLineage();
-                Boolean restrictPropagationThroughHierarchy = classification.getRestrictPropagationThroughHierachy();
+                Boolean restrictPropagationThroughHierarchy = classification.getRestrictPropagationThroughHierarchy();
 
                 if (propagateTags != null && propagateTags &&
                         classification.getEntityGuid() != null &&
@@ -3075,7 +3075,7 @@ public class EntityGraphMapper {
                     // compute propagatedEntityVertices only once
                     if (entitiesToPropagateTo == null) {
                         String propagationMode;
-                        propagationMode = entityRetriever.determinePropagationMode(classification.getRestrictPropagationThroughLineage(),classification.getRestrictPropagationThroughHierachy());
+                        propagationMode = entityRetriever.determinePropagationMode(classification.getRestrictPropagationThroughLineage(),classification.getRestrictPropagationThroughHierarchy());
                         Boolean toExclude = propagationMode == CLASSIFICATION_PROPAGATION_MODE_RESTRICT_LINEAGE ? true : false;
                         entitiesToPropagateTo = entityRetriever.getImpactedVerticesV2(entityVertex, CLASSIFICATION_PROPAGATION_MODE_LABELS_MAP.get(propagationMode),toExclude);
                     }
@@ -3578,8 +3578,8 @@ public class EntityGraphMapper {
             Boolean updatedTagPropagation = classification.isPropagate();
             Boolean currentRestrictPropagationThroughLineage = currentClassification.getRestrictPropagationThroughLineage();
             Boolean updatedRestrictPropagationThroughLineage = classification.getRestrictPropagationThroughLineage();
-            Boolean currentRestrictPropagationThroughHierarchy = currentClassification.getRestrictPropagationThroughHierachy();
-            Boolean updatedRestrictPropagationThroughHierarchy = classification.getRestrictPropagationThroughHierachy();
+            Boolean currentRestrictPropagationThroughHierarchy = currentClassification.getRestrictPropagationThroughHierarchy();
+            Boolean updatedRestrictPropagationThroughHierarchy = classification.getRestrictPropagationThroughHierarchy();
 
             if ((!Objects.equals(updatedRemovePropagations, currentRemovePropagations) ||
                     !Objects.equals(currentTagPropagation, updatedTagPropagation) ||
@@ -3705,8 +3705,8 @@ public class EntityGraphMapper {
             AtlasGraphUtilsV2.setEncodedProperty(traitInstanceVertex, CLASSIFICATION_VERTEX_RESTRICT_PROPAGATE_THROUGH_LINEAGE, classification.getRestrictPropagationThroughLineage());
         }
 
-        if(classification.getRestrictPropagationThroughHierachy() != null){
-            AtlasGraphUtilsV2.setEncodedProperty(traitInstanceVertex, CLASSIFICATION_VERTEX_RESTRICT_PROPAGATE_THROUGH_HIERARCHY, classification.getRestrictPropagationThroughHierachy());
+        if(classification.getRestrictPropagationThroughHierarchy() != null){
+            AtlasGraphUtilsV2.setEncodedProperty(traitInstanceVertex, CLASSIFICATION_VERTEX_RESTRICT_PROPAGATE_THROUGH_HIERARCHY, classification.getRestrictPropagationThroughHierarchy());
         }
 
         // map all the attributes to this newly created AtlasVertex

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -553,7 +553,7 @@ public class EntityGraphRetriever {
     public void verifyClassificationsPropagationMode(List<AtlasClassification> incomingClassifications) throws AtlasBaseException {
         for(AtlasClassification incomingClassification : incomingClassifications){
             if(Boolean.TRUE.equals(incomingClassification.isPropagate()))
-                determinePropagationMode(incomingClassification.getRestrictPropagationThroughLineage(),incomingClassification.getRestrictPropagationThroughHierachy());
+                determinePropagationMode(incomingClassification.getRestrictPropagationThroughLineage(),incomingClassification.getRestrictPropagationThroughHierarchy());
         }
     }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -561,7 +561,7 @@ public class EntityGraphRetriever {
         String propagationMode;
 
         if (Boolean.TRUE.equals(currentRestrictPropagationThroughLineage) && Boolean.TRUE.equals(currentRestrictPropagationThroughHierarchy)) {
-            throw new AtlasBaseException("Both currentRestrictPropagationThroughLineage and currentRestrictPropagationThroughHierarchy cannot be true simultaneously.");
+            throw new AtlasBaseException("Both restrictPropagationThroughLineage and restrictPropagationThroughHierarchy cannot be true simultaneously.");
         } else if (Boolean.TRUE.equals(currentRestrictPropagationThroughLineage)) {
             propagationMode = CLASSIFICATION_PROPAGATION_MODE_RESTRICT_LINEAGE;
         } else if (Boolean.TRUE.equals(currentRestrictPropagationThroughHierarchy)) {


### PR DESCRIPTION
## Change description

> Typo found in the response of AtlasClassification key restrictPropagationThroughHierarchy with a missing 'r'.
## Screenshot
![image](https://github.com/atlanhq/atlas-metastore/assets/162408549/8bf092f9-25c7-44f9-9f9c-6b11dbc5cca5)

## Type of change
- [ ] Bug fix (fixes an issue)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
