### PR TITLE
fix: LIN-824: lineage api node limit exceeds max allowed node

### DIFF
--- a/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
@@ -653,7 +653,7 @@ public class EntityLineageService implements AtlasLineageService {
     }
 
     private boolean isEntityTraversalLimitReached(AtomicInteger entitiesTraversed) {
-        return entitiesTraversed.get() == getLineageMaxNodeAllowedCount();
+        return entitiesTraversed.get() >= getLineageMaxNodeAllowedCount();
     }
 
     @Override


### PR DESCRIPTION
## Change description
* Fix the issue where the API node limit exceeds the max allowed node and returns more than 100 nodes.

> Description here

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
