### PR TITLE
fix: just tap the utm tags metrics coming from product for indexsearch metric

### DIFF
--- a/webapp/src/main/java/org/apache/atlas/web/rest/DiscoveryREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/DiscoveryREST.java
@@ -94,6 +94,7 @@ public class DiscoveryREST {
 
     private static final String INDEXSEARCH_TAG_NAME = "indexsearch";
     private static final Set<String> TRACKING_UTM_TAGS = new HashSet<>(Arrays.asList("ui_main_list", "ui_popup_searchbar"));
+    private static final String UTM_TAG_FROM_PRODUCT = "project_webapp";
 
     @Inject
     public DiscoveryREST(AtlasTypeRegistry typeRegistry, AtlasDiscoveryService discoveryService,
@@ -433,7 +434,7 @@ public class DiscoveryREST {
             }
             throw abe;
         } finally {
-            if(CollectionUtils.isNotEmpty(parameters.getUtmTags())) {
+            if(CollectionUtils.isNotEmpty(parameters.getUtmTags()) && parameters.getUtmTags().contains(UTM_TAG_FROM_PRODUCT)) {
                 AtlasPerfMetrics.Metric indexsearchMetric = new AtlasPerfMetrics.Metric(INDEXSEARCH_TAG_NAME);
                 indexsearchMetric.addTag("utmTag", "other");
                 for (String utmTag : parameters.getUtmTags()) {

--- a/webapp/src/main/java/org/apache/atlas/web/rest/DiscoveryREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/DiscoveryREST.java
@@ -434,14 +434,18 @@ public class DiscoveryREST {
             }
             throw abe;
         } finally {
-            if(CollectionUtils.isNotEmpty(parameters.getUtmTags()) && parameters.getUtmTags().contains(UTM_TAG_FROM_PRODUCT)) {
+            if(CollectionUtils.isNotEmpty(parameters.getUtmTags())) {
                 AtlasPerfMetrics.Metric indexsearchMetric = new AtlasPerfMetrics.Metric(INDEXSEARCH_TAG_NAME);
                 indexsearchMetric.addTag("utmTag", "other");
+                indexsearchMetric.addTag("source", "other");
                 for (String utmTag : parameters.getUtmTags()) {
                     if (TRACKING_UTM_TAGS.contains(utmTag)) {
                         indexsearchMetric.addTag("utmTag", utmTag);
                         break;
                     }
+                }
+                if (parameters.getUtmTags().contains(UTM_TAG_FROM_PRODUCT)) {
+                    indexsearchMetric.addTag("source", UTM_TAG_FROM_PRODUCT);
                 }
                 indexsearchMetric.addTag("name", INDEXSEARCH_TAG_NAME);
                 indexsearchMetric.setTotalTimeMSecs(System.currentTimeMillis() - startTime);


### PR DESCRIPTION
## Fix the indexsearch metric by only capturing the calls coming from product

> Previously we were pushing the all the indexsearch metrics contains utmTags, which means utmTags from SDK was also included, fixing that to include only the indexsearch calls coming from product

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
