### PR TITLE
feat: Search cancellation from Metastore with global context cache using Redis

### DIFF
--- a/common/src/main/java/org/apache/atlas/service/redis/AbstractRedisService.java
+++ b/common/src/main/java/org/apache/atlas/service/redis/AbstractRedisService.java
@@ -122,7 +122,7 @@ public abstract class AbstractRedisService implements RedisService {
         Config config = initAtlasConfig();
         config.useSentinelServers()
                 .setClientName(ATLAS_METASTORE_SERVICE)
-                .setReadMode(ReadMode.MASTER)
+                .setReadMode(ReadMode.MASTER_SLAVE)
                 .setCheckSentinelsList(false)
                 .setKeepAlive(true)
                 .setMasterConnectionMinimumIdleSize(10)

--- a/common/src/main/java/org/apache/atlas/service/redis/AbstractRedisService.java
+++ b/common/src/main/java/org/apache/atlas/service/redis/AbstractRedisService.java
@@ -71,6 +71,25 @@ public abstract class AbstractRedisService implements RedisService {
         }
     }
 
+    @Override
+    public String getValue(String key) {
+        // If value doesn't exist, return null else return the value
+        return (String) redisClient.getBucket(convertToNamespace(key)).get();
+    }
+
+    @Override
+    public String putValue(String key, String value) {
+        // Put the value in the redis cache with TTL
+        redisClient.getBucket(convertToNamespace(key)).set(value, 30, TimeUnit.SECONDS);
+        return value;
+    }
+
+    @Override
+    public void removeValue(String key)  {
+        // Remove the value from the redis cache
+        redisClient.getBucket(convertToNamespace(key)).delete();
+    }
+
     private String getHostAddress() throws UnknownHostException {
         return InetAddress.getLocalHost().getHostAddress();
     }
@@ -85,6 +104,11 @@ public abstract class AbstractRedisService implements RedisService {
         return redisConfig;
     }
 
+    private String convertToNamespace(String key){
+        // Append key with namespace :atlas
+        return "atlas:"+key;
+    }
+
     Config getLocalConfig() throws AtlasException {
         Config config = initAtlasConfig();
         config.useSingleServer()
@@ -94,11 +118,11 @@ public abstract class AbstractRedisService implements RedisService {
         return config;
     }
 
-    Config getProdConfig() throws AtlasException {
+    protected Config getProdConfig() throws AtlasException {
         Config config = initAtlasConfig();
         config.useSentinelServers()
                 .setClientName(ATLAS_METASTORE_SERVICE)
-                .setReadMode(ReadMode.MASTER_SLAVE)
+                .setReadMode(ReadMode.MASTER)
                 .setCheckSentinelsList(false)
                 .setKeepAlive(true)
                 .setMasterConnectionMinimumIdleSize(10)

--- a/common/src/main/java/org/apache/atlas/service/redis/NoRedisServiceImpl.java
+++ b/common/src/main/java/org/apache/atlas/service/redis/NoRedisServiceImpl.java
@@ -30,6 +30,21 @@ public class NoRedisServiceImpl extends AbstractRedisService {
     }
 
     @Override
+    public String getValue(String key) {
+        return null;
+    }
+
+    @Override
+    public String putValue(String key, String value) {
+        return null;
+    }
+
+    @Override
+    public void removeValue(String key) {
+
+    }
+
+    @Override
     public Logger getLogger() {
         return LOG;
     }

--- a/common/src/main/java/org/apache/atlas/service/redis/RedisService.java
+++ b/common/src/main/java/org/apache/atlas/service/redis/RedisService.java
@@ -8,6 +8,12 @@ public interface RedisService {
 
   void releaseDistributedLock(String key);
 
+  String getValue(String key);
+
+  String putValue(String key, String value);
+
+  void removeValue(String key);
+
   Logger getLogger();
 
 }

--- a/common/src/main/java/org/apache/atlas/service/redis/RedisServiceLocalImpl.java
+++ b/common/src/main/java/org/apache/atlas/service/redis/RedisServiceLocalImpl.java
@@ -22,6 +22,21 @@ public class RedisServiceLocalImpl extends AbstractRedisService {
     }
 
     @Override
+    public String getValue(String key) {
+        return null;
+    }
+
+    @Override
+    public String putValue(String key, String value) {
+        return null;
+    }
+
+    @Override
+    public void removeValue(String key) {
+
+    }
+
+    @Override
     public Logger getLogger() {
         return LOG;
     }

--- a/graphdb/janus/pom.xml
+++ b/graphdb/janus/pom.xml
@@ -282,6 +282,10 @@
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.atlas</groupId>
+            <artifactId>atlas-server-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchQuery.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchQuery.java
@@ -240,16 +240,21 @@ public class AtlasElasticsearchQuery implements AtlasIndexQuery<AtlasJanusVertex
         * We also need to check if the search ID exists and delete if necessary
      */
     private void processRequestWithSameSearchContextId(SearchParams searchParams) {
-        // Extract search context ID and sequence number
-        String currentSearchContextId = searchParams.getSearchContextId();
-        Integer currentSequenceNumber = searchParams.getSearchContextSequenceNo();
-        // Get the search ID from the cache if sequence number is greater than the current sequence number
-        String previousESSearchId = SearchContextCache.getESAsyncSearchIdFromContextCache(currentSearchContextId, currentSequenceNumber);
+        AtlasPerfMetrics.MetricRecorder metric = RequestContext.get().startMetricRecord("processRequestWithSameSearchContextId");
+        try {
+            // Extract search context ID and sequence number
+            String currentSearchContextId = searchParams.getSearchContextId();
+            Integer currentSequenceNumber = searchParams.getSearchContextSequenceNo();
+            // Get the search ID from the cache if sequence number is greater than the current sequence number
+            String previousESSearchId = SearchContextCache.getESAsyncSearchIdFromContextCache(currentSearchContextId, currentSequenceNumber);
 
-        if (StringUtils.isNotEmpty(previousESSearchId)) {
-            LOG.debug("Deleting the previous async search response with ID {}", previousESSearchId);
-            // If the search ID exists, then we need to delete the search context
-            deleteAsyncSearchResponse(previousESSearchId);
+            if (StringUtils.isNotEmpty(previousESSearchId)) {
+                LOG.debug("Deleting the previous async search response with ID {}", previousESSearchId);
+                // If the search ID exists, then we need to delete the search context
+                deleteAsyncSearchResponse(previousESSearchId);
+            }
+        } finally {
+            RequestContext.get().endMetricRecord(metric);
         }
     }
 

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchQuery.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchQuery.java
@@ -19,12 +19,14 @@ package org.apache.atlas.repository.graphdb.janus;
 
 import org.apache.atlas.AtlasConfiguration;
 import org.apache.atlas.AtlasErrorCode;
+import org.apache.atlas.RequestContext;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.discovery.SearchParams;
 import org.apache.atlas.repository.graphdb.AtlasIndexQuery;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
 import org.apache.atlas.repository.graphdb.DirectIndexQueryResult;
 import org.apache.atlas.type.AtlasType;
+import org.apache.atlas.utils.AtlasPerfMetrics;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.commons.lang.StringUtils;
@@ -171,6 +173,7 @@ public class AtlasElasticsearchQuery implements AtlasIndexQuery<AtlasJanusVertex
     }
 
     private DirectIndexQueryResult performAsyncDirectIndexQuery(SearchParams searchParams) throws AtlasBaseException, IOException {
+        AtlasPerfMetrics.MetricRecorder metric = RequestContext.get().startMetricRecord("performAsyncDirectIndexQuery");
         DirectIndexQueryResult result = null;
         boolean contextIdExists = StringUtils.isNotEmpty(searchParams.getSearchContextId()) && searchParams.getSearchContextSequenceNo() != null;
         try {
@@ -222,6 +225,7 @@ public class AtlasElasticsearchQuery implements AtlasIndexQuery<AtlasJanusVertex
                     LOG.error("Failed to remove the search context from the cache {}", e.getMessage());
                 }
             }
+            RequestContext.get().endMetricRecord(metric);
         }
         return result;
     }

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/SearchContextCache.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/SearchContextCache.java
@@ -2,48 +2,59 @@ package org.apache.atlas.repository.graphdb.janus;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import org.apache.atlas.service.redis.AbstractRedisService;
+import org.apache.atlas.service.redis.RedisService;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+@Component
 public class SearchContextCache {
-    private static final Cache<String, HashMap<Integer, String>> searchContextCache = CacheBuilder.newBuilder()
-            .maximumSize(200)
-            .expireAfterWrite(30, TimeUnit.SECONDS)
-            .build();
+    private static RedisService redisService = null;
+
+    public static final String INVALID_SEQUENCE = "invalid_sequence";
+
+
+    public SearchContextCache(@Qualifier("redisServiceImpl") RedisService redisService) {
+        SearchContextCache.redisService = redisService;
+    }
+
 
     public static void put(String key, Integer sequence, String esAsyncId) {
-        HashMap<Integer, String> entry = new HashMap<>();
-        entry.put(sequence, esAsyncId);
-        searchContextCache.put(key, entry);
+        // Build the string in format `sequence/esAsyncId` and store it in redis
+        String val = sequence + "/" + esAsyncId;
+        redisService.putValue(key, val);
     }
-    public static HashMap<Integer, String> get(String key){
-        return searchContextCache.getIfPresent(key);
+    public static String get(String key){
+        return redisService.getValue(key);
     }
 
     public static String getESAsyncSearchIdFromContextCache(String key, Integer sequence){
         //Get the context cache for the given key
-        HashMap<Integer, String> contextCache = get(key);
+        String contextCache = get(key);
         if(contextCache == null || sequence == null){
             return null;
         }
-        //Find the highest sequence number
-        int maxStoredSequence = 0;
-        for (Integer seq : contextCache.keySet()) {
-            if (seq > maxStoredSequence) {
-                maxStoredSequence = seq;
-            }
+        // Split the context cache to get the sequence and ESAsyncId
+        String[] contextCacheSplit = contextCache.split("/");
+        if(contextCacheSplit.length != 2){
+            return null;
         }
-        //If the given sequence is greater than the max stored sequence, return the ESAsyncId else return null
-        return sequence > maxStoredSequence ? contextCache.getOrDefault(maxStoredSequence, null) : null;
+        int seq = Integer.parseInt(contextCacheSplit[0]);
+        if(sequence > seq){
+            return contextCacheSplit[1];
+        } else if (sequence < seq) {
+            return INVALID_SEQUENCE;
+        }
+        return null;
     }
 
     public static void remove(String key) {
-        searchContextCache.invalidate(key);
-    }
-
-    public static void clear() {
-        searchContextCache.cleanUp();
+        redisService.removeValue(key);
     }
 }
+

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/SearchContextCache.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/SearchContextCache.java
@@ -2,8 +2,10 @@ package org.apache.atlas.repository.graphdb.janus;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import org.apache.atlas.RequestContext;
 import org.apache.atlas.service.redis.AbstractRedisService;
 import org.apache.atlas.service.redis.RedisService;
+import org.apache.atlas.utils.AtlasPerfMetrics;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
@@ -25,36 +27,52 @@ public class SearchContextCache {
 
 
     public static void put(String key, Integer sequence, String esAsyncId) {
-        // Build the string in format `sequence/esAsyncId` and store it in redis
-        String val = sequence + "/" + esAsyncId;
-        redisService.putValue(key, val);
+        AtlasPerfMetrics.MetricRecorder metric = RequestContext.get().startMetricRecord("putInCache");
+       try {
+           // Build the string in format `sequence/esAsyncId` and store it in redis
+           String val = sequence + "/" + esAsyncId;
+           redisService.putValue(key, val);
+       } finally {
+           RequestContext.get().endMetricRecord(metric);
+       }
     }
     public static String get(String key){
         return redisService.getValue(key);
     }
 
     public static String getESAsyncSearchIdFromContextCache(String key, Integer sequence){
-        //Get the context cache for the given key
-        String contextCache = get(key);
-        if(contextCache == null || sequence == null){
+        AtlasPerfMetrics.MetricRecorder metric = RequestContext.get().startMetricRecord("getESAsyncSearchIdFromContextCache");
+        try {
+            //Get the context cache for the given key
+            String contextCache = get(key);
+            if(contextCache == null || sequence == null){
+                return null;
+            }
+            // Split the context cache to get the sequence and ESAsyncId
+            String[] contextCacheSplit = contextCache.split("/");
+            if(contextCacheSplit.length != 2){
+                return null;
+            }
+            int seq = Integer.parseInt(contextCacheSplit[0]);
+            if(sequence > seq){
+                return contextCacheSplit[1];
+            } else if (sequence < seq) {
+                return INVALID_SEQUENCE;
+            }
             return null;
+        } finally {
+            RequestContext.get().endMetricRecord(metric);
         }
-        // Split the context cache to get the sequence and ESAsyncId
-        String[] contextCacheSplit = contextCache.split("/");
-        if(contextCacheSplit.length != 2){
-            return null;
-        }
-        int seq = Integer.parseInt(contextCacheSplit[0]);
-        if(sequence > seq){
-            return contextCacheSplit[1];
-        } else if (sequence < seq) {
-            return INVALID_SEQUENCE;
-        }
-        return null;
-    }
 
+    }
     public static void remove(String key) {
-        redisService.removeValue(key);
+        AtlasPerfMetrics.MetricRecorder metric = RequestContext.get().startMetricRecord("removeFromCache");
+        try {
+            redisService.removeValue(key);
+        } finally {
+            RequestContext.get().endMetricRecord(metric);
+        }
+
     }
 }
 


### PR DESCRIPTION
## Search cancellation from Metastore with global context cache using Redis

  > https://www.notion.so/atlanhq/Indexsearch-request-cancellation-from-the-server-25bffe2dad10407397b6c04768296b15?pvs=4

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
