### PR TITLE
DG-1370 Write Mesh parent attributes in server

### DIFF
--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -133,6 +133,11 @@ public final class Constants {
     public static final String GLOSSARY_TERMS_EDGE_LABEL           = "r:AtlasGlossaryTermAnchor";
     public static final String GLOSSARY_CATEGORY_EDGE_LABEL        = "r:AtlasGlossaryCategoryAnchor";
 
+    /**
+     * MESH property keys.
+     */
+    public static final String DATA_DOMAIN_ENTITY_TYPE     = "DataDomain";
+    public static final String DATA_PRODUCT_ENTITY_TYPE    = "DataProduct";
 
     /**
      * SQL property keys.

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -59,6 +59,8 @@ import org.apache.atlas.repository.store.graph.v1.RestoreHandlerV1;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.AuthPolicyPreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.ConnectionPreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.contract.ContractPreProcessor;
+import org.apache.atlas.repository.store.graph.v2.preprocessor.datamesh.DataProductPreProcessor;
+import org.apache.atlas.repository.store.graph.v2.preprocessor.datamesh.DomainPreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.resource.LinkPreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.accesscontrol.PersonaPreProcessor;
@@ -1839,6 +1841,14 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
 
             case CONTRACT_ENTITY_TYPE:
                 preProcessor = new ContractPreProcessor(graph, typeRegistry, entityRetriever, storeDifferentialAudits, discovery);
+                break;
+
+            case DATA_DOMAIN_ENTITY_TYPE:
+                preProcessor = new DomainPreProcessor(typeRegistry, graph);
+                break;
+
+            case DATA_PRODUCT_ENTITY_TYPE:
+                preProcessor = new DataProductPreProcessor(typeRegistry, graph);
                 break;
         }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -1844,11 +1844,11 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
                 break;
 
             case DATA_DOMAIN_ENTITY_TYPE:
-                preProcessor = new DomainPreProcessor(typeRegistry, graph);
+                preProcessor = new DomainPreProcessor(graph, typeRegistry, entityRetriever);
                 break;
 
             case DATA_PRODUCT_ENTITY_TYPE:
-                preProcessor = new DataProductPreProcessor(typeRegistry, graph);
+                preProcessor = new DataProductPreProcessor(graph, typeRegistry, entityRetriever);
                 break;
         }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/PreProcessorUtils.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/PreProcessorUtils.java
@@ -15,6 +15,8 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Map;
+
 import static org.apache.atlas.repository.Constants.QUERY_COLLECTION_ENTITY_TYPE;
 import static org.apache.atlas.repository.Constants.QUALIFIED_NAME;
 import static org.apache.atlas.repository.Constants.ENTITY_TYPE_PROPERTY_KEY;
@@ -114,5 +116,19 @@ public class PreProcessorUtils {
         entity.setAttribute(COLLECTION_QUALIFIED_NAME, newCollectionQualifiedName);
 
         return newCollectionQualifiedName;
+    }
+
+    public static AtlasObjectId getAtlasObjectIdFromMapObject(Object obj) {
+        Map<String, Object> parentDomainMap = (Map<String, Object>) obj;
+        AtlasObjectId objectId = new AtlasObjectId();
+
+        objectId.setTypeName((String) parentDomainMap.get("typeName"));
+        if (parentDomainMap.containsKey("guid")) {
+            objectId.setGuid((String) parentDomainMap.get("guid"));
+        } else {
+            objectId.setUniqueAttributes((Map<String, Object>) parentDomainMap.get("uniqueAttributes"));
+        }
+
+        return objectId;
     }
 }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/PreProcessorUtils.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/PreProcessorUtils.java
@@ -32,6 +32,15 @@ public class PreProcessorUtils {
     public static final String GLOSSARY_TERM_REL_TYPE = "AtlasGlossaryTermAnchor";
     public static final String GLOSSARY_CATEGORY_REL_TYPE = "AtlasGlossaryCategoryAnchor";
 
+    //DataMesh models constants
+    public static final String PARENT_DOMAIN_QN = "parentDomainQualifiedName";
+    public static final String SUPER_DOMAIN_QN = "superDomainQualifiedName";
+    public static final String MIGRATION_CUSTOM_ATTRIBUTE = "isQualifiedNameMigrated";
+    public static final String DOMAIN_DOMAIN_PARENT_REL_TYPE = "parentDomain";
+    public static final String PRODUCT_DOMAIN_REL_TYPE = "dataDomain";
+
+
+
     //Query models constants
     public static final String PREFIX_QUERY_QN   = "default/collection/";
     public static final String COLLECTION_QUALIFIED_NAME = "collectionQualifiedName";

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
@@ -1,0 +1,84 @@
+package org.apache.atlas.repository.store.graph.v2.preprocessor.datamesh;
+
+import org.apache.atlas.AtlasErrorCode;
+import org.apache.atlas.RequestContext;
+import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.model.instance.*;
+import org.apache.atlas.repository.graphdb.AtlasGraph;
+import org.apache.atlas.repository.graphdb.AtlasVertex;
+import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
+import org.apache.atlas.repository.store.graph.v2.EntityMutationContext;
+import org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessor;
+import org.apache.atlas.type.AtlasTypeRegistry;
+import org.apache.atlas.utils.AtlasPerfMetrics;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+import static org.apache.atlas.repository.Constants.*;
+import static org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessorUtils.*;
+import static org.apache.atlas.repository.util.AtlasEntityUtils.mapOf;
+
+public class DataProductPreProcessor implements PreProcessor {
+    private static final Logger LOG = LoggerFactory.getLogger(DataProductPreProcessor.class);
+
+    private EntityGraphRetriever retriever = null;
+
+    public DataProductPreProcessor(AtlasTypeRegistry typeRegistry, AtlasGraph graph) {
+        this.retriever = new EntityGraphRetriever(graph, typeRegistry, true);
+    }
+
+    @Override
+    public void processAttributes(AtlasStruct entityStruct, EntityMutationContext context,
+                                  EntityMutations.EntityOperation operation) throws AtlasBaseException {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("DataProductPreProcessor.processAttributes: pre processing {}, {}",
+                    entityStruct.getAttribute(QUALIFIED_NAME), operation);
+        }
+
+        AtlasEntity entity = (AtlasEntity) entityStruct;
+
+        switch (operation) {
+            case CREATE:
+                processCreateProduct(entity);
+                break;
+            case UPDATE:
+                processUpdateProduct(entity);
+                break;
+        }
+    }
+
+    private void processCreateProduct(AtlasEntity entity) throws AtlasBaseException {
+        AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("processCreateProduct");
+        AtlasObjectId parentDomainObject = (AtlasObjectId) entity.getRelationshipAttribute(DOMAIN_DOMAIN_PARENT_REL_TYPE);
+
+        if (parentDomainObject == null) {
+            entity.removeAttribute(PARENT_DOMAIN_QN);
+            entity.removeAttribute(SUPER_DOMAIN_QN);
+        } else {
+            AtlasVertex parentDomain = retriever.getEntityVertex(parentDomainObject);
+            String parentDomainQualifiedName = parentDomain.getProperty(QUALIFIED_NAME, String.class);
+
+            entity.setAttribute(PARENT_DOMAIN_QN, parentDomainQualifiedName);
+
+            String[] splitted = parentDomainQualifiedName.split("/");
+            String superDomainQualifiedName = String.format("%s/%s/%s", splitted[0], splitted[1], splitted[2]);
+            entity.setAttribute(SUPER_DOMAIN_QN, superDomainQualifiedName);
+        }
+
+        RequestContext.get().endMetricRecord(metricRecorder);
+    }
+
+    private void processUpdateProduct(AtlasEntity entity) throws AtlasBaseException {
+        AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("processUpdateProduct");
+
+        //never update these attributes with API request
+        entity.removeAttribute(PARENT_DOMAIN_QN);
+        entity.removeAttribute(SUPER_DOMAIN_QN);
+
+        RequestContext.get().endMetricRecord(metricRecorder);
+    }
+}

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
@@ -15,6 +15,8 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Map;
+
 import static org.apache.atlas.repository.Constants.*;
 import static org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessorUtils.*;
 
@@ -108,11 +110,18 @@ public class DataProductPreProcessor implements PreProcessor {
     private AtlasEntityHeader getNewParentDomain(AtlasEntity entity, EntityMutationContext context) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("ProductPreProcessor.getNewParentDomain");
 
-        AtlasObjectId objectId = (AtlasObjectId) entity.getRelationshipAttribute(PRODUCT_DOMAIN_REL_TYPE);
-
         try {
-            if (objectId == null) {
+            Object parentDomainObject = entity.getRelationshipAttribute(PRODUCT_DOMAIN_REL_TYPE);
+            if (parentDomainObject == null) {
                 return null;
+            }
+
+            AtlasObjectId objectId;
+
+            if (parentDomainObject instanceof Map) {
+                objectId = getAtlasObjectIdFromMapObject(parentDomainObject);
+            } else {
+                objectId = (AtlasObjectId) parentDomainObject;
             }
 
             if (StringUtils.isNotEmpty(objectId.getGuid())) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DomainPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DomainPreProcessor.java
@@ -21,7 +21,9 @@ package org.apache.atlas.repository.store.graph.v2.preprocessor.datamesh;
 import org.apache.atlas.RequestContext;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.instance.AtlasEntity;
+import org.apache.atlas.model.instance.AtlasEntityHeader;
 import org.apache.atlas.model.instance.AtlasObjectId;
+import org.apache.atlas.model.instance.AtlasRelatedObjectId;
 import org.apache.atlas.model.instance.AtlasStruct;
 import org.apache.atlas.model.instance.EntityMutations;
 import org.apache.atlas.repository.graphdb.AtlasGraph;
@@ -31,6 +33,8 @@ import org.apache.atlas.repository.store.graph.v2.EntityMutationContext;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessor;
 import org.apache.atlas.type.AtlasTypeRegistry;
 import org.apache.atlas.utils.AtlasPerfMetrics;
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,10 +43,12 @@ import static org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcess
 
 public class DomainPreProcessor implements PreProcessor {
     private static final Logger LOG = LoggerFactory.getLogger(DomainPreProcessor.class);
-    private EntityGraphRetriever retriever = null;
+    private EntityGraphRetriever entityRetriever = null;
+    private EntityGraphRetriever retrieverNoRelation = null;
 
-    public DomainPreProcessor(AtlasTypeRegistry typeRegistry, AtlasGraph graph) {
-        this.retriever = new EntityGraphRetriever(graph, typeRegistry, true);
+    public DomainPreProcessor(AtlasGraph graph, AtlasTypeRegistry typeRegistry, EntityGraphRetriever entityRetriever) {
+        this.entityRetriever = entityRetriever;
+        this.retrieverNoRelation = new EntityGraphRetriever(graph, typeRegistry, true);
     }
 
     @Override
@@ -55,13 +61,14 @@ public class DomainPreProcessor implements PreProcessor {
         }
 
         AtlasEntity entity = (AtlasEntity) entityStruct;
+        AtlasVertex vertex = context.getVertex(entity.getGuid());
 
         switch (operation) {
             case CREATE:
                 processCreateDomain(entity);
                 break;
             case UPDATE:
-                processUpdateDomain(entity);
+                processUpdateDomain(entity, vertex, context);
                 break;
         }
     }
@@ -74,7 +81,7 @@ public class DomainPreProcessor implements PreProcessor {
             entity.removeAttribute(PARENT_DOMAIN_QN);
             entity.removeAttribute(SUPER_DOMAIN_QN);
         } else {
-            AtlasVertex parentDomain = retriever.getEntityVertex(parentDomainObject);
+            AtlasVertex parentDomain = retrieverNoRelation.getEntityVertex(parentDomainObject);
             String parentDomainQualifiedName = parentDomain.getProperty(QUALIFIED_NAME, String.class);
 
             entity.setAttribute(PARENT_DOMAIN_QN, parentDomainQualifiedName);
@@ -87,16 +94,68 @@ public class DomainPreProcessor implements PreProcessor {
         RequestContext.get().endMetricRecord(metricRecorder);
     }
 
-    private void processUpdateDomain(AtlasEntity entity) throws AtlasBaseException {
+    private void processUpdateDomain(AtlasEntity entity, AtlasVertex vertex, EntityMutationContext context) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("processUpdateDomain");
 
-        //never update these attributes with API request
-        entity.removeAttribute(PARENT_DOMAIN_QN);
-        entity.removeAttribute(SUPER_DOMAIN_QN);
-        if (entity.getRelationshipAttributes() != null) {
-            entity.getRelationshipAttributes().remove(DOMAIN_DOMAIN_PARENT_REL_TYPE);
+        AtlasEntity storedDomain = entityRetriever.toAtlasEntity(vertex);
+        AtlasObjectId currentParent = (AtlasObjectId) storedDomain.getRelationshipAttribute(DOMAIN_DOMAIN_PARENT_REL_TYPE);
+
+        AtlasEntityHeader newParent = getNewParentDomain(entity, context);
+
+        if (currentParent == null && newParent != null) {
+            // attaching parent for the first time, set attributes as well
+
+            String parentDomainQualifiedName = (String) newParent.getAttribute(QUALIFIED_NAME);
+            entity.setAttribute(PARENT_DOMAIN_QN, parentDomainQualifiedName);
+
+            String superDomainQualifiedName = (String) newParent.getAttribute(SUPER_DOMAIN_QN);
+            if (StringUtils.isEmpty(superDomainQualifiedName)) {
+                String[] splitted = parentDomainQualifiedName.split("/");
+                superDomainQualifiedName = String.format("%s/%s/%s", splitted[0], splitted[1], splitted[2]);
+            }
+
+            entity.setAttribute(SUPER_DOMAIN_QN, superDomainQualifiedName);
+
+        } else {
+            //never update these attributes with API request
+            entity.removeAttribute(PARENT_DOMAIN_QN);
+            entity.removeAttribute(SUPER_DOMAIN_QN);
+            if (entity.getRelationshipAttributes() != null) {
+                entity.getRelationshipAttributes().remove(DOMAIN_DOMAIN_PARENT_REL_TYPE);
+            }
         }
 
         RequestContext.get().endMetricRecord(metricRecorder);
+    }
+
+    private AtlasEntityHeader getNewParentDomain(AtlasEntity entity, EntityMutationContext context) throws AtlasBaseException {
+    AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("DomainPreProcessor.getNewParentDomain");
+
+        AtlasObjectId objectId = (AtlasObjectId) entity.getRelationshipAttribute(DOMAIN_DOMAIN_PARENT_REL_TYPE);
+
+        try {
+            if (objectId == null) {
+                return null;
+            }
+
+            if (StringUtils.isNotEmpty(objectId.getGuid())) {
+                AtlasVertex vertex = context.getVertex(objectId.getGuid());
+
+                if (vertex == null) {
+                    return retrieverNoRelation.toAtlasEntityHeader(objectId.getGuid());
+                } else {
+                    return retrieverNoRelation.toAtlasEntityHeader(vertex);
+                }
+
+            } else if (MapUtils.isNotEmpty(objectId.getUniqueAttributes()) &&
+                    StringUtils.isNotEmpty((String) objectId.getUniqueAttributes().get(QUALIFIED_NAME))) {
+                return new AtlasEntityHeader(objectId.getTypeName(), objectId.getUniqueAttributes());
+
+            }
+        } finally {
+            RequestContext.get().endMetricRecord(metricRecorder);
+        }
+
+        return null;
     }
 }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DomainPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DomainPreProcessor.java
@@ -38,6 +38,8 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Map;
+
 import static org.apache.atlas.repository.Constants.*;
 import static org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessorUtils.*;
 
@@ -130,12 +132,18 @@ public class DomainPreProcessor implements PreProcessor {
 
     private AtlasEntityHeader getNewParentDomain(AtlasEntity entity, EntityMutationContext context) throws AtlasBaseException {
     AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("DomainPreProcessor.getNewParentDomain");
-
-        AtlasObjectId objectId = (AtlasObjectId) entity.getRelationshipAttribute(DOMAIN_DOMAIN_PARENT_REL_TYPE);
-
         try {
-            if (objectId == null) {
+            Object parentDomainObject = entity.getRelationshipAttribute(DOMAIN_DOMAIN_PARENT_REL_TYPE);
+            if (parentDomainObject == null) {
                 return null;
+            }
+
+            AtlasObjectId objectId;
+
+            if (parentDomainObject instanceof Map) {
+                objectId = getAtlasObjectIdFromMapObject(parentDomainObject);
+            } else {
+                objectId = (AtlasObjectId) parentDomainObject;
             }
 
             if (StringUtils.isNotEmpty(objectId.getGuid())) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DomainPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DomainPreProcessor.java
@@ -1,0 +1,108 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas.repository.store.graph.v2.preprocessor.datamesh;
+
+
+import org.apache.atlas.AtlasErrorCode;
+import org.apache.atlas.AtlasException;
+import org.apache.atlas.RequestContext;
+import org.apache.atlas.discovery.EntityDiscoveryService;
+import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.model.instance.AtlasEntity;
+import org.apache.atlas.model.instance.AtlasEntityHeader;
+import org.apache.atlas.model.instance.AtlasObjectId;
+import org.apache.atlas.model.instance.AtlasStruct;
+import org.apache.atlas.model.instance.EntityMutations;
+import org.apache.atlas.repository.graphdb.AtlasGraph;
+import org.apache.atlas.repository.graphdb.AtlasVertex;
+import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
+import org.apache.atlas.repository.store.graph.v2.EntityMutationContext;
+import org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessor;
+import org.apache.atlas.type.AtlasTypeRegistry;
+import org.apache.atlas.utils.AtlasPerfMetrics;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+import static org.apache.atlas.repository.Constants.*;
+import static org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessorUtils.*;
+import static org.apache.atlas.repository.util.AtlasEntityUtils.mapOf;
+
+public class DomainPreProcessor implements PreProcessor {
+    private static final Logger LOG = LoggerFactory.getLogger(DomainPreProcessor.class);
+    private EntityGraphRetriever retriever = null;
+
+    public DomainPreProcessor(AtlasTypeRegistry typeRegistry, AtlasGraph graph) {
+        this.retriever = new EntityGraphRetriever(graph, typeRegistry, true);
+    }
+
+    @Override
+    public void processAttributes(AtlasStruct entityStruct, EntityMutationContext context,
+                                  EntityMutations.EntityOperation operation) throws AtlasBaseException {
+        //Handle name & qualifiedName
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("DomainPreProcessor.processAttributes: pre processing {}, {}",
+                    entityStruct.getAttribute(QUALIFIED_NAME), operation);
+        }
+
+        AtlasEntity entity = (AtlasEntity) entityStruct;
+
+        switch (operation) {
+            case CREATE:
+                processCreateDomain(entity);
+                break;
+            case UPDATE:
+                processUpdateDomain(entity);
+                break;
+        }
+    }
+
+    private void processCreateDomain(AtlasEntity entity) throws AtlasBaseException {
+        AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("processCreateDomain");
+        AtlasObjectId parentDomainObject = (AtlasObjectId) entity.getRelationshipAttribute(PRODUCT_DOMAIN_REL_TYPE);
+
+        if (parentDomainObject == null) {
+            entity.removeAttribute(PARENT_DOMAIN_QN);
+            entity.removeAttribute(SUPER_DOMAIN_QN);
+        } else {
+            AtlasVertex parentDomain = retriever.getEntityVertex(parentDomainObject);
+            String parentDomainQualifiedName = parentDomain.getProperty(QUALIFIED_NAME, String.class);
+
+            entity.setAttribute(PARENT_DOMAIN_QN, parentDomainQualifiedName);
+
+            String[] splitted = parentDomainQualifiedName.split("/");
+            String superDomainQualifiedName = String.format("%s/%s/%s", splitted[0], splitted[1], splitted[2]);
+            entity.setAttribute(SUPER_DOMAIN_QN, superDomainQualifiedName);
+        }
+
+        RequestContext.get().endMetricRecord(metricRecorder);
+    }
+
+    private void processUpdateDomain(AtlasEntity entity) throws AtlasBaseException {
+        AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("processUpdateDomain");
+
+        //never update these attributes with API request
+        entity.removeAttribute(PARENT_DOMAIN_QN);
+        entity.removeAttribute(SUPER_DOMAIN_QN);
+
+        RequestContext.get().endMetricRecord(metricRecorder);
+    }
+}


### PR DESCRIPTION
## Change description
We have the following de-normalized for mesh assets:

parentDomainQualifiedName → stores qualifiedName of the immediate parent domain

superDomainQualifiedName → stores qualifiedName of the root domain


These attributes are managed by client, this can lead to inconsistencies like we saw for [JPMC](https://atlanhq.atlassian.net/browse/DG-1338).

Writing these values from BE itself will help us avoid inconsistencies between actual relationships & these de-normalized attributes.


## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
