### PR TITLE
DQ-161: Fix IndexOutOfBoundsException when removing updated or created entities from context

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -1538,8 +1538,7 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
         PreProcessor preProcessor;
 
         List<AtlasEntity> copyOfCreated = new ArrayList<>(context.getCreatedEntities());
-        for (int i = 0; i < copyOfCreated.size() ; i++) {
-            AtlasEntity entity = ((List<AtlasEntity>) context.getCreatedEntities()).get(i);
+        for (AtlasEntity entity : copyOfCreated) {
             entityType = context.getType(entity.getGuid());
             preProcessor = getPreProcessor(entityType.getTypeName());
 
@@ -1549,8 +1548,7 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
         }
 
         List<AtlasEntity> copyOfUpdated = new ArrayList<>(context.getUpdatedEntities());
-        for (int i = 0; i < copyOfUpdated.size() ; i++) {
-            AtlasEntity entity = ((List<AtlasEntity>) context.getUpdatedEntities()).get(i);
+        for (AtlasEntity entity: copyOfUpdated) {
             entityType = context.getType(entity.getGuid());
             preProcessor = getPreProcessor(entityType.getTypeName());
 


### PR DESCRIPTION

## Change description

> Removing entities from `getCreatedEntities` or `getUpdatedEntities` in PreProcessor throwing IndexOutOfBoundsException error. Fixing the loop with the copy array instead of the original array which is getting updated. Also, tested the changes in the **[datamesh.atlan.com](https://datamesh.atlan.com)** tenant.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1](https://atlanhq.atlassian.net/browse/DQ-161) 

## Checklists

### Development

- [ ] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
