### PR TITLE
DG-1235 Support Stakeholder for Domains

### DIFF
--- a/addons/models/0000-Area0/0010-base_model.json
+++ b/addons/models/0000-Area0/0010-base_model.json
@@ -1046,7 +1046,7 @@
       "name": "StakeholderTitle",
       "description": "Instance of a stakeholder title for Domains in Atlan",
       "superTypes": [
-        "Catalog"
+        "Asset"
       ],
       "serviceType": "atlan",
       "typeVersion": "1.0",

--- a/addons/models/0000-Area0/0010-base_model.json
+++ b/addons/models/0000-Area0/0010-base_model.json
@@ -984,7 +984,7 @@
       ],
       "description": "Atlan Type representing a Persona model",
       "serviceType": "atlan",
-      "typeVersion": "1.1",
+      "typeVersion": "1.2",
       "attributeDefs": [
         {
           "name": "personaGroups",
@@ -1019,7 +1019,7 @@
           "includeInNotification": false
         },
         {
-          "name": "domainGuid",
+          "name": "domainQualifiedName",
           "typeName": "string",
           "indexType": "STRING",
           "cardinality": "SINGLE",

--- a/addons/models/0000-Area0/0010-base_model.json
+++ b/addons/models/0000-Area0/0010-base_model.json
@@ -984,7 +984,7 @@
       ],
       "description": "Atlan Type representing a Persona model",
       "serviceType": "atlan",
-      "typeVersion": "1.2",
+      "typeVersion": "1.1",
       "attributeDefs": [
         {
           "name": "personaGroups",
@@ -1017,26 +1017,6 @@
           "isOptional": true,
           "isUnique": false,
           "includeInNotification": false
-        },
-        {
-          "name": "domainQualifiedName",
-          "typeName": "string",
-          "indexType": "STRING",
-          "cardinality": "SINGLE",
-          "isIndexable": false,
-          "isOptional": true,
-          "isUnique": false,
-          "includeInNotification": false
-        },
-        {
-          "name": "stakeholderTitleGuid",
-          "typeName": "string",
-          "indexType": "STRING",
-          "cardinality": "SINGLE",
-          "isIndexable": false,
-          "isOptional": true,
-          "isUnique": false,
-          "includeInNotification": false
         }
       ]
     },
@@ -1057,6 +1037,29 @@
           "isIndexable": false,
           "isOptional": true,
           "isUnique": false,
+          "skipScrubbing": true,
+          "includeInNotification": false
+        }
+      ]
+    },
+    {
+      "name": "StakeholderTitle",
+      "description": "Instance of a stakeholder title for Domains in Atlan",
+      "superTypes": [
+        "Catalog"
+      ],
+      "serviceType": "atlan",
+      "typeVersion": "1.0",
+      "attributeDefs": [
+        {
+          "name": "domainQualifiedNames",
+          "description": "qualified name array representing the Domains for which this StakeholderTitle is applicable",
+          "typeName": "array<string>",
+          "indexType": "STRING",
+          "isOptional": true,
+          "cardinality": "SET",
+          "isUnique": false,
+          "isIndexable": false,
           "skipScrubbing": true,
           "includeInNotification": false
         }

--- a/addons/models/0000-Area0/0010-base_model.json
+++ b/addons/models/0000-Area0/0010-base_model.json
@@ -1052,7 +1052,7 @@
       "typeVersion": "1.0",
       "attributeDefs": [
         {
-          "name": "domainQualifiedNames",
+          "name": "stakeholderTitleDomainQualifiedNames",
           "description": "qualified name array representing the Domains for which this StakeholderTitle is applicable",
           "typeName": "array<string>",
           "indexType": "STRING",

--- a/addons/models/0000-Area0/0010-base_model.json
+++ b/addons/models/0000-Area0/0010-base_model.json
@@ -1017,6 +1017,26 @@
           "isOptional": true,
           "isUnique": false,
           "includeInNotification": false
+        },
+        {
+          "name": "domainGuid",
+          "typeName": "string",
+          "indexType": "STRING",
+          "cardinality": "SINGLE",
+          "isIndexable": false,
+          "isOptional": true,
+          "isUnique": false,
+          "includeInNotification": false
+        },
+        {
+          "name": "stakeholderTitleGuid",
+          "typeName": "string",
+          "indexType": "STRING",
+          "cardinality": "SINGLE",
+          "isIndexable": false,
+          "isOptional": true,
+          "isUnique": false,
+          "includeInNotification": false
         }
       ]
     },

--- a/addons/policies/global_stakeholder-titles.json
+++ b/addons/policies/global_stakeholder-titles.json
@@ -6,7 +6,7 @@
       {
         "qualifiedName": "stakeholderTitle/default/DOMAIN_OWNER",
         "name": "Domain Owner",
-        "domainQualifiedNames": ["*"]
+        "stakeholderTitleDomainQualifiedNames": ["*"]
       }
     },
     {
@@ -15,7 +15,7 @@
       {
         "qualifiedName": "stakeholderTitle/default/DATA_PRODUCT_OWNER",
         "name": "Data Product Owner",
-        "domainQualifiedNames": ["*"]
+        "stakeholderTitleDomainQualifiedNames": ["*"]
       }
     },
     {
@@ -24,7 +24,7 @@
       {
         "qualifiedName": "stakeholderTitle/default/DATA_ENGINEER",
         "name": "Data Engineer",
-        "domainQualifiedNames": ["*"]
+        "stakeholderTitleDomainQualifiedNames": ["*"]
       }
     },
     {
@@ -33,7 +33,7 @@
       {
         "qualifiedName": "stakeholderTitle/default/ARCHITECT",
         "name": "Architect",
-        "domainQualifiedNames": ["*"]
+        "stakeholderTitleDomainQualifiedNames": ["*"]
       }
     }
   ]

--- a/addons/policies/global_stakeholder-titles.json
+++ b/addons/policies/global_stakeholder-titles.json
@@ -4,8 +4,8 @@
       "typeName": "StakeholderTitle",
       "attributes":
       {
-        "qualifiedName": "stakeholderTitle/default/DOMAIN_OWNERS",
-        "name": "Domain Owners",
+        "qualifiedName": "stakeholderTitle/default/DOMAIN_OWNER",
+        "name": "Domain Owner",
         "domainQualifiedNames": ["*"]
       }
     },
@@ -13,8 +13,26 @@
       "typeName": "StakeholderTitle",
       "attributes":
       {
-        "qualifiedName": "stakeholderTitle/default/DATA_STEWARDS",
-        "name": "Data Stewards",
+        "qualifiedName": "stakeholderTitle/default/DATA_PRODUCT_OWNER",
+        "name": "Data Product Owner",
+        "domainQualifiedNames": ["*"]
+      }
+    },
+    {
+      "typeName": "StakeholderTitle",
+      "attributes":
+      {
+        "qualifiedName": "stakeholderTitle/default/DATA_ENGINEER",
+        "name": "Data Engineer",
+        "domainQualifiedNames": ["*"]
+      }
+    },
+    {
+      "typeName": "StakeholderTitle",
+      "attributes":
+      {
+        "qualifiedName": "stakeholderTitle/default/ARCHITECT",
+        "name": "Architect",
         "domainQualifiedNames": ["*"]
       }
     }

--- a/addons/policies/global_stakeholder-titles.json
+++ b/addons/policies/global_stakeholder-titles.json
@@ -6,7 +6,7 @@
       {
         "qualifiedName": "stakeholderTitle/default/DOMAIN_OWNERS",
         "name": "Domain Owners",
-        "domainGuid": "*"
+        "domainQualifiedNames": ["*"]
       }
     },
     {
@@ -15,7 +15,7 @@
       {
         "qualifiedName": "stakeholderTitle/default/DATA_STEWARDS",
         "name": "Data Stewards",
-        "domainGuid": "*"
+        "domainQualifiedNames": ["*"]
       }
     }
   ]

--- a/addons/policies/global_stakeholder-titles.json
+++ b/addons/policies/global_stakeholder-titles.json
@@ -1,0 +1,23 @@
+{
+  "entities": [
+    {
+      "typeName": "StakeholderTitle",
+      "attributes":
+      {
+        "qualifiedName": "stakeholderTitle/default/DOMAIN_OWNERS",
+        "name": "Domain Owners",
+        "domainGuid": "*"
+      }
+    },
+    {
+      "typeName": "StakeholderTitle",
+      "attributes":
+      {
+        "qualifiedName": "stakeholderTitle/default/DATA_STEWARDS",
+        "name": "Data Stewards",
+        "domainGuid": "*"
+      }
+    }
+  ]
+}
+

--- a/addons/static/templates/policy_cache_transformer_persona.json
+++ b/addons/static/templates/policy_cache_transformer_persona.json
@@ -422,7 +422,7 @@
     {
       "policyResourceCategory": "RELATIONSHIP",
       "policyType": "ACCESS",
-      "description": "Link/unlink any Stakeholder to this Domain",
+      "description": "Link/unlink Stakeholder to this Domain",
 
       "resources": [
         "relationship-type:*",
@@ -454,22 +454,6 @@
         "end-two-entity:default/*/{entity}"
       ],
       "actions": ["add-relationship", "update-relationship", "remove-relationship"]
-    },
-    {
-      "policyResourceCategory": "ENTITY",
-      "policyType": "ACCESS",
-      "description": "Create Stakeholder Title for this Domain",
-
-      "resources": [
-        "entity:stakeholderTitle/domain/*/{entity}",
-        "entity-type:StakeholderTitle",
-        "entity-classification:*"
-      ],
-      "actions": [
-        "entity-create",
-        "entity-update",
-        "entity-delete"
-      ]
     },
     {
       "policyResourceCategory": "RELATIONSHIP",
@@ -660,22 +644,6 @@
         "end-two-entity:default/*/{entity}/*"
       ],
       "actions": ["add-relationship", "update-relationship", "remove-relationship"]
-    },
-    {
-      "policyResourceCategory": "ENTITY",
-      "policyType": "ACCESS",
-      "description": "Create Stakeholder Title for Sub Domains",
-
-      "resources": [
-        "entity:stakeholderTitle/domain/*/{entity}/*domain/*",
-        "entity-type:StakeholderTitle",
-        "entity-classification:*"
-      ],
-      "actions": [
-        "entity-create",
-        "entity-update",
-        "entity-delete"
-      ]
     },
     {
       "policyResourceCategory": "RELATIONSHIP",

--- a/addons/static/templates/policy_cache_transformer_persona.json
+++ b/addons/static/templates/policy_cache_transformer_persona.json
@@ -408,8 +408,21 @@
       "policyResourceCategory": "ENTITY",
       "policyType": "ACCESS",
       "resources": [
-        "entity:default/*/{entity}*",
+        "entity:default/*/{entity}",
         "entity-type:Persona",
+        "entity-classification:*"
+      ],
+      "actions": [
+        "entity-create",
+        "entity-update",
+        "entity-delete"
+      ]
+    },
+    {
+      "policyResourceCategory": "ENTITY",
+      "policyType": "ACCESS",
+      "resources": [
+        "entity:default/*/{entity}/*",
         "entity-type:AuthPolicy",
         "entity-classification:*"
       ],
@@ -423,7 +436,7 @@
       "policyResourceCategory": "ENTITY",
       "policyType": "ACCESS",
       "resources": [
-        "entity:stakeholderTitle/domain/{entity}/*",
+        "entity:stakeholderTitle/domain/*/{entity}",
         "entity-type:StakeholderTitle",
         "entity-classification:*"
       ],
@@ -569,6 +582,35 @@
         "entity-add-classification",
         "entity-update-classification",
         "entity-remove-classification"
+      ]
+    },
+    {
+      "policyResourceCategory": "ENTITY",
+      "policyType": "ACCESS",
+      "resources": [
+        "entity:default/*/{entity}/*",
+        "entity-type:Persona",
+        "entity-type:AuthPolicy",
+        "entity-classification:*"
+      ],
+      "actions": [
+        "entity-create",
+        "entity-update",
+        "entity-delete"
+      ]
+    },
+    {
+      "policyResourceCategory": "ENTITY",
+      "policyType": "ACCESS",
+      "resources": [
+        "entity:stakeholderTitle/domain/*/{entity}/*domain/*",
+        "entity-type:StakeholderTitle",
+        "entity-classification:*"
+      ],
+      "actions": [
+        "entity-create",
+        "entity-update",
+        "entity-delete"
       ]
     },
     {

--- a/addons/static/templates/policy_cache_transformer_persona.json
+++ b/addons/static/templates/policy_cache_transformer_persona.json
@@ -405,6 +405,35 @@
       ]
     },
     {
+      "policyResourceCategory": "ENTITY",
+      "policyType": "ACCESS",
+      "resources": [
+        "entity:default/*/{entity}*",
+        "entity-type:Persona",
+        "entity-type:AuthPolicy",
+        "entity-classification:*"
+      ],
+      "actions": [
+        "entity-create",
+        "entity-update",
+        "entity-delete"
+      ]
+    },
+    {
+      "policyResourceCategory": "ENTITY",
+      "policyType": "ACCESS",
+      "resources": [
+        "entity:stakeholderTitle/domain/{entity}/*",
+        "entity-type:StakeholderTitle",
+        "entity-classification:*"
+      ],
+      "actions": [
+        "entity-create",
+        "entity-update",
+        "entity-delete"
+      ]
+    },
+    {
       "policyResourceCategory": "RELATIONSHIP",
       "policyType": "ACCESS",
       "description": "Link/unlink any DataDomain, DataProduct OR DataContract to this Domain",

--- a/addons/static/templates/policy_cache_transformer_persona.json
+++ b/addons/static/templates/policy_cache_transformer_persona.json
@@ -438,6 +438,24 @@
       "actions": ["add-relationship", "update-relationship", "remove-relationship"]
     },
     {
+      "policyResourceCategory": "RELATIONSHIP",
+      "policyType": "ACCESS",
+      "description": "Link/unlink any Stakeholder Title to this Domain's Stakeholder",
+
+      "resources": [
+        "relationship-type:*",
+
+        "end-one-entity-type:StakeholderTitle",
+        "end-one-entity-classification:*",
+        "end-one-entity:*",
+
+        "end-two-entity-type:Stakeholder",
+        "end-two-entity-classification:*",
+        "end-two-entity:default/*/{entity}"
+      ],
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+    },
+    {
       "policyResourceCategory": "ENTITY",
       "policyType": "ACCESS",
       "description": "Create Stakeholder Title for this Domain",
@@ -618,6 +636,24 @@
         "end-one-entity-type:DataDomain",
         "end-one-entity-classification:*",
         "end-one-entity:{entity}/*domain/*",
+
+        "end-two-entity-type:Stakeholder",
+        "end-two-entity-classification:*",
+        "end-two-entity:default/*/{entity}/*"
+      ],
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+    },
+    {
+      "policyResourceCategory": "RELATIONSHIP",
+      "policyType": "ACCESS",
+      "description": "Link/unlink any Stakeholder Title to sub-domains's Stakeholder",
+
+      "resources": [
+        "relationship-type:*",
+
+        "end-one-entity-type:StakeholderTitle",
+        "end-one-entity-classification:*",
+        "end-one-entity:*",
 
         "end-two-entity-type:Stakeholder",
         "end-two-entity-classification:*",

--- a/addons/static/templates/policy_cache_transformer_persona.json
+++ b/addons/static/templates/policy_cache_transformer_persona.json
@@ -406,10 +406,11 @@
     },
     {
       "policyResourceCategory": "ENTITY",
+      "description": "Create Stakeholder for this Domain",
       "policyType": "ACCESS",
       "resources": [
         "entity:default/*/{entity}",
-        "entity-type:Persona",
+        "entity-type:Stakeholder",
         "entity-classification:*"
       ],
       "actions": [
@@ -419,22 +420,28 @@
       ]
     },
     {
-      "policyResourceCategory": "ENTITY",
+      "policyResourceCategory": "RELATIONSHIP",
       "policyType": "ACCESS",
+      "description": "Link/unlink any Stakeholder to this Domain",
+
       "resources": [
-        "entity:default/*/{entity}/*",
-        "entity-type:AuthPolicy",
-        "entity-classification:*"
+        "relationship-type:*",
+
+        "end-one-entity-type:DataDomain",
+        "end-one-entity-classification:*",
+        "end-one-entity:{entity}",
+
+        "end-two-entity-type:Stakeholder",
+        "end-two-entity-classification:*",
+        "end-two-entity:default/*/{entity}"
       ],
-      "actions": [
-        "entity-create",
-        "entity-update",
-        "entity-delete"
-      ]
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
     },
     {
       "policyResourceCategory": "ENTITY",
       "policyType": "ACCESS",
+      "description": "Create Stakeholder Title for this Domain",
+
       "resources": [
         "entity:stakeholderTitle/domain/*/{entity}",
         "entity-type:StakeholderTitle",
@@ -587,10 +594,11 @@
     {
       "policyResourceCategory": "ENTITY",
       "policyType": "ACCESS",
+      "description": "Create Stakeholder for Sub Domains",
+
       "resources": [
         "entity:default/*/{entity}/*",
-        "entity-type:Persona",
-        "entity-type:AuthPolicy",
+        "entity-type:Stakeholder",
         "entity-classification:*"
       ],
       "actions": [
@@ -600,8 +608,28 @@
       ]
     },
     {
+      "policyResourceCategory": "RELATIONSHIP",
+      "policyType": "ACCESS",
+      "description": "Link/unlink Stakeholder to Sub Domains",
+
+      "resources": [
+        "relationship-type:*",
+
+        "end-one-entity-type:DataDomain",
+        "end-one-entity-classification:*",
+        "end-one-entity:{entity}/*domain/*",
+
+        "end-two-entity-type:Stakeholder",
+        "end-two-entity-classification:*",
+        "end-two-entity:default/*/{entity}/*"
+      ],
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+    },
+    {
       "policyResourceCategory": "ENTITY",
       "policyType": "ACCESS",
+      "description": "Create Stakeholder Title for Sub Domains",
+
       "resources": [
         "entity:stakeholderTitle/domain/*/{entity}/*domain/*",
         "entity-type:StakeholderTitle",

--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -448,6 +448,7 @@ public final class Constants {
         add(README_ENTITY_TYPE);
         add(LINK_ENTITY_TYPE);
         add(POLICY_ENTITY_TYPE);
+        add(STAKEHOLDER_TITLE_ENTITY_TYPE);
     }};
 
     private Constants() {

--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -141,6 +141,15 @@ public final class Constants {
     public static final String DATA_DOMAIN_ENTITY_TYPE     = "DataDomain";
     public static final String DATA_PRODUCT_ENTITY_TYPE    = "DataProduct";
 
+    public static final String STAKEHOLDER_ENTITY_TYPE       = "Stakeholder";
+    public static final String STAKEHOLDER_TITLE_ENTITY_TYPE = "StakeholderTitle";
+
+    public static final String REL_DOMAIN_TO_DOMAINS  = "parent_domain_sub_domains";
+    public static final String REL_DOMAIN_TO_PRODUCTS = "data_domain_data_products";
+
+    public static final String REL_DOMAIN_TO_STAKEHOLDERS            = "data_domain_stakeholders";
+    public static final String REL_STAKEHOLDER_TITLE_TO_STAKEHOLDERS = "stakeholder_title_stakeholders";
+
 
     /**
      * SQL property keys.
@@ -158,9 +167,6 @@ public final class Constants {
     public static final String PURPOSE_ENTITY_TYPE        = "Purpose";
     public static final String POLICY_ENTITY_TYPE         = "AuthPolicy";
     public static final String SERVICE_ENTITY_TYPE        = "AuthService";
-
-    public static final String STAKEHOLDER_ENTITY_TYPE          = "Stakeholder";
-    public static final String STAKEHOLDER_TITLE_ENTITY_TYPE    = "StakeholderTitle";
 
     /**
      * Resource

--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -158,6 +158,7 @@ public final class Constants {
     public static final String PURPOSE_ENTITY_TYPE        = "Purpose";
     public static final String POLICY_ENTITY_TYPE         = "AuthPolicy";
     public static final String SERVICE_ENTITY_TYPE        = "AuthService";
+    public static final String STAKEHOLDER_ENTITY_TYPE    = "Stakeholder";
 
     /**
      * Resource

--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -431,6 +431,8 @@ public final class Constants {
     public static final Set<String> SKIP_UPDATE_AUTH_CHECK_TYPES = new HashSet<String>() {{
         add(README_ENTITY_TYPE);
         add(LINK_ENTITY_TYPE);
+        add("Persona");
+        add("StakeholderTitle");
     }};
 
     public static final Set<String> SKIP_DELETE_AUTH_CHECK_TYPES = new HashSet<String>() {{

--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -158,7 +158,9 @@ public final class Constants {
     public static final String PURPOSE_ENTITY_TYPE        = "Purpose";
     public static final String POLICY_ENTITY_TYPE         = "AuthPolicy";
     public static final String SERVICE_ENTITY_TYPE        = "AuthService";
-    public static final String STAKEHOLDER_ENTITY_TYPE    = "Stakeholder";
+
+    public static final String STAKEHOLDER_ENTITY_TYPE          = "Stakeholder";
+    public static final String STAKEHOLDER_TITLE_ENTITY_TYPE    = "StakeholderTitle";
 
     /**
      * Resource
@@ -432,8 +434,8 @@ public final class Constants {
     public static final Set<String> SKIP_UPDATE_AUTH_CHECK_TYPES = new HashSet<String>() {{
         add(README_ENTITY_TYPE);
         add(LINK_ENTITY_TYPE);
-        add("Persona");
-        add("StakeholderTitle");
+        add(STAKEHOLDER_ENTITY_TYPE);
+        add(STAKEHOLDER_TITLE_ENTITY_TYPE);
     }};
 
     public static final Set<String> SKIP_DELETE_AUTH_CHECK_TYPES = new HashSet<String>() {{

--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -167,6 +167,7 @@ public final class Constants {
     public static final String PURPOSE_ENTITY_TYPE        = "Purpose";
     public static final String POLICY_ENTITY_TYPE         = "AuthPolicy";
     public static final String SERVICE_ENTITY_TYPE        = "AuthService";
+    public static final String REL_POLICY_TO_ACCESS_CONTROL  = "access_control_policies";
 
     /**
      * Resource

--- a/repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java
@@ -44,6 +44,7 @@ import org.apache.atlas.repository.graphdb.AtlasIndexQuery.Result;
 import org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2;
 import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
 import org.apache.atlas.repository.userprofile.UserProfileService;
+import org.apache.atlas.repository.util.AccessControlUtils;
 import org.apache.atlas.searchlog.ESSearchLogger;
 import org.apache.atlas.service.FeatureFlagStore;
 import org.apache.atlas.stats.StatsClient;
@@ -1146,8 +1147,7 @@ public class EntityDiscoveryService implements AtlasDiscoveryService {
             qualifiedName = params.getPurpose();
         }
 
-        String[] parts = qualifiedName.split("/");
-        String aliasName = parts[parts.length - 1];
+        String aliasName = AccessControlUtils.getESAliasName(qualifiedName);
 
         if (StringUtils.isNotEmpty(aliasName)) {
             if(params.isAccessControlExclusive()) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -59,6 +59,7 @@ import org.apache.atlas.repository.store.graph.v1.RestoreHandlerV1;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.AuthPolicyPreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.ConnectionPreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.contract.ContractPreProcessor;
+import org.apache.atlas.repository.store.graph.v2.preprocessor.datamesh.StakeholderTitlePreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.resource.LinkPreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.accesscontrol.PersonaPreProcessor;
@@ -1849,6 +1850,10 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
 
             case CONTRACT_ENTITY_TYPE:
                 preProcessor = new ContractPreProcessor(graph, typeRegistry, entityRetriever, storeDifferentialAudits, discovery);
+                break;
+
+            case "StakeholderTitle":
+                preProcessor = new StakeholderTitlePreProcessor(graph, typeRegistry, entityRetriever, this);
                 break;
         }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -1857,7 +1857,7 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
                 preProcessor = new ContractPreProcessor(graph, typeRegistry, entityRetriever, storeDifferentialAudits, discovery);
                 break;
 
-            case "StakeholderTitle":
+            case STAKEHOLDER_TITLE_ENTITY_TYPE:
                 preProcessor = new StakeholderTitlePreProcessor(graph, typeRegistry, entityRetriever);
                 break;
         }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -1858,7 +1858,7 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
                 break;
 
             case "StakeholderTitle":
-                preProcessor = new StakeholderTitlePreProcessor(graph, typeRegistry, entityRetriever, this);
+                preProcessor = new StakeholderTitlePreProcessor(graph, typeRegistry, entityRetriever);
                 break;
         }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -58,6 +58,7 @@ import org.apache.atlas.repository.store.graph.v2.AtlasEntityComparator.AtlasEnt
 import org.apache.atlas.repository.store.graph.v1.RestoreHandlerV1;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.AuthPolicyPreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.ConnectionPreProcessor;
+import org.apache.atlas.repository.store.graph.v2.preprocessor.accesscontrol.StakeholderPreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.contract.ContractPreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.datamesh.StakeholderTitlePreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.resource.LinkPreProcessor;
@@ -1834,6 +1835,10 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
 
             case POLICY_ENTITY_TYPE:
                 preProcessor = new AuthPolicyPreProcessor(graph, typeRegistry, entityRetriever);
+                break;
+
+            case STAKEHOLDER_ENTITY_TYPE:
+                preProcessor = new StakeholderPreProcessor(graph, typeRegistry, entityRetriever, this);
                 break;
 
             case CONNECTION_ENTITY_TYPE:

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasRelationshipStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasRelationshipStoreV2.java
@@ -73,6 +73,10 @@ import static org.apache.atlas.repository.Constants.HOME_ID_KEY;
 import static org.apache.atlas.repository.Constants.PROVENANCE_TYPE_KEY;
 import static org.apache.atlas.repository.Constants.RELATIONSHIPTYPE_TAG_PROPAGATION_KEY;
 import static org.apache.atlas.repository.Constants.RELATIONSHIP_GUID_PROPERTY_KEY;
+import static org.apache.atlas.repository.Constants.REL_DOMAIN_TO_DOMAINS;
+import static org.apache.atlas.repository.Constants.REL_DOMAIN_TO_PRODUCTS;
+import static org.apache.atlas.repository.Constants.REL_DOMAIN_TO_STAKEHOLDERS;
+import static org.apache.atlas.repository.Constants.REL_STAKEHOLDER_TITLE_TO_STAKEHOLDERS;
 import static org.apache.atlas.repository.Constants.VERSION_PROPERTY_KEY;
 import static org.apache.atlas.repository.graph.GraphHelper.getTypeName;
 import static org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2.*;
@@ -106,8 +110,10 @@ public class AtlasRelationshipStoreV2 implements AtlasRelationshipStore {
     private static final String ES_DOC_ID_MAP_KEY = "esDocIdMap";
 
     private static Set<String> EXCLUDE_MUTATION_REL_TYPE_NAMES = new HashSet<String>() {{
-        add("parent_domain_sub_domains");
-        add("data_domain_data_products");
+        add(REL_DOMAIN_TO_DOMAINS);
+        add(REL_DOMAIN_TO_PRODUCTS);
+        add(REL_DOMAIN_TO_STAKEHOLDERS);
+        add(REL_STAKEHOLDER_TITLE_TO_STAKEHOLDERS);
     }};
 
     public enum RelationshipMutation {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasRelationshipStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasRelationshipStoreV2.java
@@ -76,6 +76,7 @@ import static org.apache.atlas.repository.Constants.RELATIONSHIP_GUID_PROPERTY_K
 import static org.apache.atlas.repository.Constants.REL_DOMAIN_TO_DOMAINS;
 import static org.apache.atlas.repository.Constants.REL_DOMAIN_TO_PRODUCTS;
 import static org.apache.atlas.repository.Constants.REL_DOMAIN_TO_STAKEHOLDERS;
+import static org.apache.atlas.repository.Constants.REL_POLICY_TO_ACCESS_CONTROL;
 import static org.apache.atlas.repository.Constants.REL_STAKEHOLDER_TITLE_TO_STAKEHOLDERS;
 import static org.apache.atlas.repository.Constants.VERSION_PROPERTY_KEY;
 import static org.apache.atlas.repository.graph.GraphHelper.getTypeName;
@@ -114,6 +115,7 @@ public class AtlasRelationshipStoreV2 implements AtlasRelationshipStore {
         add(REL_DOMAIN_TO_PRODUCTS);
         add(REL_DOMAIN_TO_STAKEHOLDERS);
         add(REL_STAKEHOLDER_TITLE_TO_STAKEHOLDERS);
+        add(REL_POLICY_TO_ACCESS_CONTROL);
     }};
 
     public enum RelationshipMutation {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/AuthPolicyPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/AuthPolicyPreProcessor.java
@@ -24,7 +24,6 @@ import org.apache.atlas.authorize.AtlasAuthorizationUtils;
 import org.apache.atlas.authorize.AtlasEntityAccessRequest;
 import org.apache.atlas.authorize.AtlasPrivilege;
 import org.apache.atlas.exception.AtlasBaseException;
-import org.apache.atlas.featureflag.FeatureFlagStore;
 import org.apache.atlas.model.instance.AtlasEntity;
 import org.apache.atlas.model.instance.AtlasEntity.AtlasEntityWithExtInfo;
 import org.apache.atlas.model.instance.AtlasEntityHeader;
@@ -52,6 +51,7 @@ import java.util.stream.Collectors;
 import static org.apache.atlas.AtlasErrorCode.BAD_REQUEST;
 import static org.apache.atlas.AtlasErrorCode.INSTANCE_BY_UNIQUE_ATTRIBUTE_NOT_FOUND;
 import static org.apache.atlas.AtlasErrorCode.INSTANCE_GUID_NOT_FOUND;
+import static org.apache.atlas.AtlasErrorCode.OPERATION_NOT_SUPPORTED;
 import static org.apache.atlas.AtlasErrorCode.RESOURCE_NOT_FOUND;
 import static org.apache.atlas.AtlasErrorCode.UNAUTHORIZED_CONNECTION_ADMIN;
 import static org.apache.atlas.authorize.AtlasAuthorizationUtils.getCurrentUserName;
@@ -61,6 +61,7 @@ import static org.apache.atlas.model.instance.EntityMutations.EntityOperation.UP
 import static org.apache.atlas.repository.Constants.ATTR_ADMIN_ROLES;
 import static org.apache.atlas.repository.Constants.KEYCLOAK_ROLE_ADMIN;
 import static org.apache.atlas.repository.Constants.QUALIFIED_NAME;
+import static org.apache.atlas.repository.Constants.STAKEHOLDER_ENTITY_TYPE;
 import static org.apache.atlas.repository.util.AccessControlUtils.*;
 import static org.apache.atlas.repository.util.AccessControlUtils.getPolicySubCategory;
 
@@ -105,6 +106,10 @@ public class AuthPolicyPreProcessor implements PreProcessor {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("processCreatePolicy");
         AtlasEntity policy = (AtlasEntity) entity;
 
+        AtlasEntityWithExtInfo parent = getAccessControlEntity(policy);
+        AtlasEntity parentEntity = parent.getEntity();
+        verifyParentTypeName(parentEntity);
+
         String policyCategory = getPolicyCategory(policy);
         if (StringUtils.isEmpty(policyCategory)) {
             throw new AtlasBaseException(BAD_REQUEST, "Please provide attribute " + ATTR_POLICY_CATEGORY);
@@ -114,9 +119,6 @@ public class AuthPolicyPreProcessor implements PreProcessor {
 
         AuthPolicyValidator validator = new AuthPolicyValidator(entityRetriever);
         if (POLICY_CATEGORY_PERSONA.equals(policyCategory)) {
-            AtlasEntityWithExtInfo parent = getAccessControlEntity(policy);
-            AtlasEntity parentEntity = parent.getEntity();
-
             String policySubCategory = getPolicySubCategory(policy);
 
             if (!POLICY_SUB_CATEGORY_DOMAIN.equals(policySubCategory)) {
@@ -139,9 +141,6 @@ public class AuthPolicyPreProcessor implements PreProcessor {
             aliasStore.updateAlias(parent, policy);
 
         } else if (POLICY_CATEGORY_PURPOSE.equals(policyCategory)) {
-            AtlasEntityWithExtInfo parent = getAccessControlEntity(policy);
-            AtlasEntity parentEntity = parent.getEntity();
-
             policy.setAttribute(QUALIFIED_NAME, String.format("%s/%s", getEntityQualifiedName(parentEntity), getUUID()));
 
             validator.validate(policy, null, parentEntity, CREATE);
@@ -319,5 +318,11 @@ public class AuthPolicyPreProcessor implements PreProcessor {
 
         RequestContext.get().endMetricRecord(metricRecorder);
         return ret;
+    }
+
+    private void verifyParentTypeName(AtlasEntity parentEntity) throws AtlasBaseException {
+        if (parentEntity.getTypeName().equals(STAKEHOLDER_ENTITY_TYPE)) {
+            throw new AtlasBaseException(OPERATION_NOT_SUPPORTED, "Updating policies for " + STAKEHOLDER_ENTITY_TYPE);
+        }
     }
 }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/PreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/PreProcessor.java
@@ -11,6 +11,8 @@ import java.util.Set;
 
 import static org.apache.atlas.repository.Constants.ATLAS_GLOSSARY_CATEGORY_ENTITY_TYPE;
 import static org.apache.atlas.repository.Constants.ATLAS_GLOSSARY_TERM_ENTITY_TYPE;
+import static org.apache.atlas.repository.Constants.STAKEHOLDER_ENTITY_TYPE;
+import static org.apache.atlas.repository.Constants.STAKEHOLDER_TITLE_ENTITY_TYPE;
 
 
 public interface PreProcessor {
@@ -18,8 +20,8 @@ public interface PreProcessor {
     Set<String> skipInitialAuthCheckTypes = new HashSet<String>() {{
         add(ATLAS_GLOSSARY_TERM_ENTITY_TYPE);
         add(ATLAS_GLOSSARY_CATEGORY_ENTITY_TYPE);
-        add("Persona");
-        add("StakeholderTitle");
+        add(STAKEHOLDER_ENTITY_TYPE);
+        add(STAKEHOLDER_TITLE_ENTITY_TYPE);
     }};
 
     void processAttributes(AtlasStruct entity, EntityMutationContext context, EntityMutations.EntityOperation operation) throws AtlasBaseException;

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/PreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/PreProcessor.java
@@ -18,6 +18,8 @@ public interface PreProcessor {
     Set<String> skipInitialAuthCheckTypes = new HashSet<String>() {{
         add(ATLAS_GLOSSARY_TERM_ENTITY_TYPE);
         add(ATLAS_GLOSSARY_CATEGORY_ENTITY_TYPE);
+        add("Persona");
+        add("StakeholderTitle");
     }};
 
     void processAttributes(AtlasStruct entity, EntityMutationContext context, EntityMutations.EntityOperation operation) throws AtlasBaseException;

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/PreProcessorUtils.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/PreProcessorUtils.java
@@ -22,11 +22,9 @@ import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
-import static org.apache.atlas.repository.Constants.NAME;
 import static org.apache.atlas.repository.Constants.QUERY_COLLECTION_ENTITY_TYPE;
 import static org.apache.atlas.repository.Constants.QUALIFIED_NAME;
 import static org.apache.atlas.repository.Constants.ENTITY_TYPE_PROPERTY_KEY;
-import static org.apache.atlas.repository.Constants.STAKEHOLDER_ENTITY_TYPE;
 import static org.apache.atlas.repository.util.AtlasEntityUtils.mapOf;
 
 public class PreProcessorUtils {
@@ -48,6 +46,7 @@ public class PreProcessorUtils {
     public static final String DATA_PRODUCT_REL_TYPE = "dataProducts";
     public static final String MIGRATION_CUSTOM_ATTRIBUTE = "isQualifiedNameMigrated";
     public static final String DATA_DOMAIN_REL_TYPE = "dataDomain";
+    public static final String STAKEHOLDER_REL_TYPE = "stakeholders";
 
     public static final String MESH_POLICY_CATEGORY = "datamesh";
 
@@ -179,8 +178,6 @@ public class PreProcessorUtils {
     }
 
     public static void verifyDuplicateAssetByName(String typeName, String assetName, EntityDiscoveryService discovery, String errorMessage) throws AtlasBaseException {
-        boolean exists = false;
-
         List<Map<String, Object>> mustClauseList = new ArrayList();
         mustClauseList.add(mapOf("term", mapOf("__typeName.keyword", typeName)));
         mustClauseList.add(mapOf("term", mapOf("__state", "ACTIVE")));

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/accesscontrol/PersonaPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/accesscontrol/PersonaPreProcessor.java
@@ -19,6 +19,7 @@ package org.apache.atlas.repository.store.graph.v2.preprocessor.accesscontrol;
 
 
 import org.apache.atlas.RequestContext;
+import org.apache.atlas.discovery.EntityDiscoveryService;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.auth.client.keycloak.AtlasKeycloakClient;
 import org.apache.atlas.model.instance.AtlasEntity;

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/accesscontrol/PersonaPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/accesscontrol/PersonaPreProcessor.java
@@ -157,12 +157,13 @@ public class PersonaPreProcessor implements PreProcessor {
                 throw new AtlasBaseException(BAD_REQUEST, "Relation stakeholderTitle not found");
             }
 
-            entity.setAttribute("domainGuid", getGuidFromRelationAttribute(entity, "dataDomain"));
+            String domainQualifiedName = getQualifiedNameFromRelationAttribute(entity, "dataDomain");
+            entity.setAttribute("domainQualifiedName", domainQualifiedName);
             entity.setAttribute("stakeholderTitleGuid", getGuidFromRelationAttribute(entity, "stakeholderTitle"));
 
             String personaQualifiedName = String.format("default/%s/%s",
                     getUUID(),
-                    getQualifiedNameFromRelationAttribute(entity, "dataDomain"));
+                    domainQualifiedName);
 
             entity.setAttribute(QUALIFIED_NAME, personaQualifiedName);
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/accesscontrol/StakeholderPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/accesscontrol/StakeholderPreProcessor.java
@@ -18,69 +18,77 @@
 package org.apache.atlas.repository.store.graph.v2.preprocessor.accesscontrol;
 
 
+import org.apache.atlas.AtlasErrorCode;
+import org.apache.atlas.AtlasException;
 import org.apache.atlas.RequestContext;
-import org.apache.atlas.auth.client.keycloak.AtlasKeycloakClient;
 import org.apache.atlas.authorize.AtlasAuthorizationUtils;
 import org.apache.atlas.authorize.AtlasEntityAccessRequest;
 import org.apache.atlas.authorize.AtlasPrivilege;
+import org.apache.atlas.discovery.EntityDiscoveryService;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.instance.AtlasEntity;
 import org.apache.atlas.model.instance.AtlasEntityHeader;
 import org.apache.atlas.model.instance.AtlasObjectId;
-import org.apache.atlas.model.instance.AtlasRelatedObjectId;
-import org.apache.atlas.model.instance.AtlasRelationship;
 import org.apache.atlas.model.instance.AtlasStruct;
 import org.apache.atlas.model.instance.EntityMutations;
+import org.apache.atlas.repository.graph.GraphHelper;
 import org.apache.atlas.repository.graphdb.AtlasGraph;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
 import org.apache.atlas.repository.store.graph.AtlasEntityStore;
-import org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2;
 import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
 import org.apache.atlas.repository.store.graph.v2.EntityMutationContext;
-import org.apache.atlas.type.AtlasEntityType;
 import org.apache.atlas.type.AtlasTypeRegistry;
 import org.apache.atlas.utils.AtlasPerfMetrics;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
-import org.keycloak.representations.idm.RoleRepresentation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
-import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.apache.atlas.AtlasErrorCode.BAD_REQUEST;
 import static org.apache.atlas.AtlasErrorCode.OPERATION_NOT_SUPPORTED;
 import static org.apache.atlas.repository.Constants.NAME;
-import static org.apache.atlas.repository.Constants.POLICY_ENTITY_TYPE;
 import static org.apache.atlas.repository.Constants.QUALIFIED_NAME;
+import static org.apache.atlas.repository.Constants.STAKEHOLDER_ENTITY_TYPE;
+import static org.apache.atlas.repository.Constants.STAKEHOLDER_TITLE_ENTITY_TYPE;
+import static org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessorUtils.indexSearchPaginated;
+import static org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessorUtils.verifyDuplicateAssetByName;
+import static org.apache.atlas.repository.store.graph.v2.preprocessor.datamesh.StakeholderTitlePreProcessor.ATTR_DOMAIN_QUALIFIED_NAMES;
 import static org.apache.atlas.repository.util.AccessControlUtils.ATTR_ACCESS_CONTROL_ENABLED;
-import static org.apache.atlas.repository.util.AccessControlUtils.ATTR_PERSONA_GROUPS;
 import static org.apache.atlas.repository.util.AccessControlUtils.ATTR_PERSONA_ROLE_ID;
-import static org.apache.atlas.repository.util.AccessControlUtils.ATTR_PERSONA_USERS;
-import static org.apache.atlas.repository.util.AccessControlUtils.ATTR_POLICY_IS_ENABLED;
 import static org.apache.atlas.repository.util.AccessControlUtils.REL_ATTR_POLICIES;
 import static org.apache.atlas.repository.util.AccessControlUtils.getESAliasName;
-import static org.apache.atlas.repository.util.AccessControlUtils.getEntityName;
-import static org.apache.atlas.repository.util.AccessControlUtils.getIsAccessControlEnabled;
-import static org.apache.atlas.repository.util.AccessControlUtils.getPersonaGroups;
 import static org.apache.atlas.repository.util.AccessControlUtils.getPersonaRoleId;
-import static org.apache.atlas.repository.util.AccessControlUtils.getPersonaRoleName;
-import static org.apache.atlas.repository.util.AccessControlUtils.getPersonaUsers;
-import static org.apache.atlas.repository.util.AccessControlUtils.getTenantId;
 import static org.apache.atlas.repository.util.AccessControlUtils.getUUID;
 import static org.apache.atlas.repository.util.AccessControlUtils.validateNoPoliciesAttached;
+import static org.apache.atlas.repository.util.AtlasEntityUtils.mapOf;
 
 public class StakeholderPreProcessor extends PersonaPreProcessor {
     private static final Logger LOG = LoggerFactory.getLogger(StakeholderPreProcessor.class);
+
+    public static final String ATTR_DOMAIN_QUALIFIED_NAME  = "domainQualifiedName";
+    public static final String ATTR_STAKEHOLDER_TITLE_GUID = "stakeholderTitleGuid";
+
+    public static final String REL_ATTR_STAKEHOLDER_TITLE = "stakeholderTitle";
+    public static final String REL_ATTR_STAKEHOLDER_DOMAIN = "dataDomain";
+
+    protected EntityDiscoveryService discovery;
 
     public StakeholderPreProcessor(AtlasGraph graph,
                                    AtlasTypeRegistry typeRegistry,
                                    EntityGraphRetriever entityRetriever,
                                    AtlasEntityStore entityStore) {
         super(graph, typeRegistry, entityRetriever, entityStore);
+
+        try {
+            this.discovery = new EntityDiscoveryService(typeRegistry, graph, null, null, null, null);
+        } catch (AtlasException e) {
+            e.printStackTrace();
+        }
     }
 
     @Override
@@ -133,22 +141,31 @@ public class StakeholderPreProcessor extends PersonaPreProcessor {
 
         validateNoPoliciesAttached(entity);
 
-        if (!entity.hasRelationshipAttribute("stakeholderTitle") || !entity.hasRelationshipAttribute("dataDomain")) {
+        if (!entity.hasRelationshipAttribute(REL_ATTR_STAKEHOLDER_TITLE) || !entity.hasRelationshipAttribute(REL_ATTR_STAKEHOLDER_DOMAIN)) {
             throw new AtlasBaseException(BAD_REQUEST, "Relations stakeholderTitle and dataDomain are mandatory");
         }
 
-        String domainQualifiedName = getQualifiedNameFromRelationAttribute(entity, "dataDomain");
-        entity.setAttribute("domainQualifiedName", domainQualifiedName);
-        entity.setAttribute("stakeholderTitleGuid", getGuidFromRelationAttribute(entity, "stakeholderTitle"));
+        String domainQualifiedName = getQualifiedNameFromRelationAttribute(entity, REL_ATTR_STAKEHOLDER_DOMAIN);
+        String stakeholderTitleGuid = getGuidFromRelationAttribute(entity, REL_ATTR_STAKEHOLDER_TITLE);
+
+        ensureTitleAvailableForDomain(domainQualifiedName, stakeholderTitleGuid);
+
+        //validate Stakeholder & StakeholderTitle pair is unique for this domain
+        verifyDuplicateByDomainAndTitle(domainQualifiedName, stakeholderTitleGuid);
+
+        //validate Name uniqueness for Stakeholders across this domain
+        String name = (String) entity.getAttribute(NAME);
+        verifyDuplicateAssetByName(STAKEHOLDER_ENTITY_TYPE, name, discovery,
+                String.format("Stakeholder with name %s already exists for current domain", name));
+
+        entity.setAttribute(ATTR_DOMAIN_QUALIFIED_NAME, domainQualifiedName);
+        entity.setAttribute(ATTR_STAKEHOLDER_TITLE_GUID, stakeholderTitleGuid);
 
         String personaQualifiedName = String.format("default/%s/%s",
                 getUUID(),
                 domainQualifiedName);
 
         entity.setAttribute(QUALIFIED_NAME, personaQualifiedName);
-
-        //TODO: validate Stakeholder & StakeholderTitle pair is unique
-
 
 
         AtlasAuthorizationUtils.verifyAccess(new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_CREATE, new AtlasEntityHeader(entity)),
@@ -181,12 +198,18 @@ public class StakeholderPreProcessor extends PersonaPreProcessor {
             throw new AtlasBaseException(OPERATION_NOT_SUPPORTED, "Stakeholder not Active");
         }
 
-        String domainGuid = (String) stakeholder.getAttribute("domainGuid");
-        if (StringUtils.isNotEmpty(domainGuid)) {
-            stakeholder.removeAttribute("domainGuid");
-            stakeholder.removeAttribute("stakeholderTitleGuid");
-            stakeholder.getRelationshipAttributes().remove("dataDomain");
-            stakeholder.getRelationshipAttributes().remove("stakeholderTitle");
+        stakeholder.removeAttribute(ATTR_DOMAIN_QUALIFIED_NAME);
+        stakeholder.removeAttribute(ATTR_STAKEHOLDER_TITLE_GUID);
+        stakeholder.getRelationshipAttributes().remove(REL_ATTR_STAKEHOLDER_DOMAIN);
+        stakeholder.getRelationshipAttributes().remove(REL_ATTR_STAKEHOLDER_TITLE);
+
+
+        String currentName = vertex.getProperty(NAME, String.class);
+        String newName = (String) stakeholder.getAttribute(NAME);
+
+        if (!currentName.equals(newName)) {
+            verifyDuplicateAssetByName(STAKEHOLDER_ENTITY_TYPE, newName, discovery,
+                    String.format("Stakeholder with name %s already exists for current domain", newName));
         }
 
         String vertexQName = vertex.getProperty(QUALIFIED_NAME, String.class);
@@ -227,5 +250,59 @@ public class StakeholderPreProcessor extends PersonaPreProcessor {
         }
 
         return qualifiedName;
+    }
+
+    protected void verifyDuplicateByDomainAndTitle(String domainQualifiedName, String stakeholderTitleGuid) throws AtlasBaseException {
+
+        List<Map<String, Object>> mustClauseList = new ArrayList();
+        mustClauseList.add(mapOf("term", mapOf("__typeName.keyword", STAKEHOLDER_ENTITY_TYPE)));
+        mustClauseList.add(mapOf("term", mapOf("__state", "ACTIVE")));
+        mustClauseList.add(mapOf("term", mapOf("domainQualifiedName", domainQualifiedName)));
+        mustClauseList.add(mapOf("term", mapOf("stakeholderTitleGuid", stakeholderTitleGuid)));
+
+
+        Map<String, Object> bool = mapOf("must", mustClauseList);
+
+        Map<String, Object> dsl = mapOf("query", mapOf("bool", bool));
+
+        List<AtlasEntityHeader> assets = indexSearchPaginated(dsl, null, this.discovery);
+
+        if (CollectionUtils.isNotEmpty(assets)) {
+            throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST,
+                    String.format("Stakeholder for provided title & domain combination already exists"));
+        }
+    }
+
+    protected void ensureTitleAvailableForDomain(String domainQualifiedName, String stakeholderTitleGuid) throws AtlasBaseException {
+
+        List<Map<String, Object>> mustClauseList = new ArrayList();
+        mustClauseList.add(mapOf("term", mapOf("__typeName.keyword", STAKEHOLDER_TITLE_ENTITY_TYPE)));
+        mustClauseList.add(mapOf("term", mapOf("__state", "ACTIVE")));
+        mustClauseList.add(mapOf("term", mapOf("__guid", stakeholderTitleGuid)));
+
+        /*List<Map<String, Object>> shouldClauseList = new ArrayList();
+        shouldClauseList.add(mapOf("term", mapOf("domainQualifiedNames", domainQualifiedName)));
+        shouldClauseList.add(mapOf("term", mapOf("domainQualifiedNames", "*")));
+        mustClauseList.add(mapOf("bool", mapOf("should", shouldClauseList)));
+        */
+
+        Map<String, Object> bool = mapOf("must", mustClauseList);
+
+        Map<String, Object> dsl = mapOf("query", mapOf("bool", bool));
+
+        List<AtlasEntityHeader> assets = indexSearchPaginated(dsl, null, this.discovery);
+
+        if (CollectionUtils.isNotEmpty(assets)) {
+            AtlasEntityHeader stakeholderTitleHeader = assets.get(0);
+
+            List<String> domainQualifiedNames = (List<String>) stakeholderTitleHeader.getAttribute(ATTR_DOMAIN_QUALIFIED_NAMES);
+
+            Optional parentDomain = domainQualifiedNames.stream().filter(x -> domainQualifiedName.startsWith(x)).findFirst();
+
+            if (!parentDomain.isPresent()) {
+                throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST,
+                        String.format("Provided StakeholderTitle is not applicable to the domain"));
+            }
+        }
     }
 }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/accesscontrol/StakeholderPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/accesscontrol/StakeholderPreProcessor.java
@@ -45,6 +45,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -290,7 +292,7 @@ public class StakeholderPreProcessor extends PersonaPreProcessor {
 
         Map<String, Object> dsl = mapOf("query", mapOf("bool", bool));
 
-        List<AtlasEntityHeader> assets = indexSearchPaginated(dsl, null, this.discovery);
+        List<AtlasEntityHeader> assets = indexSearchPaginated(dsl, Collections.singleton(ATTR_DOMAIN_QUALIFIED_NAMES), this.discovery);
 
         if (CollectionUtils.isNotEmpty(assets)) {
             AtlasEntityHeader stakeholderTitleHeader = assets.get(0);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/accesscontrol/StakeholderPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/accesscontrol/StakeholderPreProcessor.java
@@ -76,7 +76,7 @@ public class StakeholderPreProcessor extends PersonaPreProcessor {
     public static final String ATTR_STAKEHOLDER_TITLE_GUID = "stakeholderTitleGuid";
 
     public static final String REL_ATTR_STAKEHOLDER_TITLE = "stakeholderTitle";
-    public static final String REL_ATTR_STAKEHOLDER_DOMAIN = "dataDomain";
+    public static final String REL_ATTR_STAKEHOLDER_DOMAIN = "stakeholderDataDomain";
 
     protected EntityDiscoveryService discovery;
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/accesscontrol/StakeholderPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/accesscontrol/StakeholderPreProcessor.java
@@ -268,7 +268,7 @@ public class StakeholderPreProcessor extends PersonaPreProcessor {
 
         if (CollectionUtils.isNotEmpty(assets)) {
             throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST,
-                    format("Stakeholder for provided title & domain combination already exists with name: {}", assets.get(0).getAttribute(NAME)));
+                    format("Stakeholder for provided title & domain combination already exists with name: %s", assets.get(0).getAttribute(NAME)));
         }
     }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/accesscontrol/StakeholderPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/accesscontrol/StakeholderPreProcessor.java
@@ -60,6 +60,7 @@ import static org.apache.atlas.repository.Constants.STAKEHOLDER_TITLE_ENTITY_TYP
 import static org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessorUtils.indexSearchPaginated;
 import static org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessorUtils.verifyDuplicateAssetByName;
 import static org.apache.atlas.repository.store.graph.v2.preprocessor.datamesh.StakeholderTitlePreProcessor.ATTR_DOMAIN_QUALIFIED_NAMES;
+import static org.apache.atlas.repository.store.graph.v2.preprocessor.datamesh.StakeholderTitlePreProcessor.STAR;
 import static org.apache.atlas.repository.util.AccessControlUtils.ATTR_ACCESS_CONTROL_ENABLED;
 import static org.apache.atlas.repository.util.AccessControlUtils.ATTR_PERSONA_ROLE_ID;
 import static org.apache.atlas.repository.util.AccessControlUtils.REL_ATTR_POLICIES;
@@ -259,8 +260,8 @@ public class StakeholderPreProcessor extends PersonaPreProcessor {
         List<Map<String, Object>> mustClauseList = new ArrayList();
         mustClauseList.add(mapOf("term", mapOf("__typeName.keyword", STAKEHOLDER_ENTITY_TYPE)));
         mustClauseList.add(mapOf("term", mapOf("__state", "ACTIVE")));
-        mustClauseList.add(mapOf("term", mapOf("domainQualifiedName", domainQualifiedName)));
-        mustClauseList.add(mapOf("term", mapOf("stakeholderTitleGuid", stakeholderTitleGuid)));
+        mustClauseList.add(mapOf("term", mapOf(ATTR_DOMAIN_QUALIFIED_NAME, domainQualifiedName)));
+        mustClauseList.add(mapOf("term", mapOf(ATTR_STAKEHOLDER_TITLE_GUID, stakeholderTitleGuid)));
 
 
         Map<String, Object> bool = mapOf("must", mustClauseList);
@@ -299,11 +300,13 @@ public class StakeholderPreProcessor extends PersonaPreProcessor {
 
             List<String> domainQualifiedNames = (List<String>) stakeholderTitleHeader.getAttribute(ATTR_DOMAIN_QUALIFIED_NAMES);
 
-            Optional parentDomain = domainQualifiedNames.stream().filter(x -> domainQualifiedName.startsWith(x)).findFirst();
+            if (!domainQualifiedNames.contains(STAR)) {
+                Optional parentDomain = domainQualifiedNames.stream().filter(x -> domainQualifiedName.startsWith(x)).findFirst();
 
-            if (!parentDomain.isPresent()) {
-                throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST,
-                        String.format("Provided StakeholderTitle is not applicable to the domain"));
+                if (!parentDomain.isPresent()) {
+                    throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST,
+                            String.format("Provided StakeholderTitle is not applicable to the domain"));
+                }
             }
         }
     }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/accesscontrol/StakeholderPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/accesscontrol/StakeholderPreProcessor.java
@@ -1,0 +1,231 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas.repository.store.graph.v2.preprocessor.accesscontrol;
+
+
+import org.apache.atlas.RequestContext;
+import org.apache.atlas.auth.client.keycloak.AtlasKeycloakClient;
+import org.apache.atlas.authorize.AtlasAuthorizationUtils;
+import org.apache.atlas.authorize.AtlasEntityAccessRequest;
+import org.apache.atlas.authorize.AtlasPrivilege;
+import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.model.instance.AtlasEntity;
+import org.apache.atlas.model.instance.AtlasEntityHeader;
+import org.apache.atlas.model.instance.AtlasObjectId;
+import org.apache.atlas.model.instance.AtlasRelatedObjectId;
+import org.apache.atlas.model.instance.AtlasRelationship;
+import org.apache.atlas.model.instance.AtlasStruct;
+import org.apache.atlas.model.instance.EntityMutations;
+import org.apache.atlas.repository.graphdb.AtlasGraph;
+import org.apache.atlas.repository.graphdb.AtlasVertex;
+import org.apache.atlas.repository.store.graph.AtlasEntityStore;
+import org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2;
+import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
+import org.apache.atlas.repository.store.graph.v2.EntityMutationContext;
+import org.apache.atlas.type.AtlasEntityType;
+import org.apache.atlas.type.AtlasTypeRegistry;
+import org.apache.atlas.utils.AtlasPerfMetrics;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
+import org.keycloak.representations.idm.RoleRepresentation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.atlas.AtlasErrorCode.BAD_REQUEST;
+import static org.apache.atlas.AtlasErrorCode.OPERATION_NOT_SUPPORTED;
+import static org.apache.atlas.repository.Constants.NAME;
+import static org.apache.atlas.repository.Constants.POLICY_ENTITY_TYPE;
+import static org.apache.atlas.repository.Constants.QUALIFIED_NAME;
+import static org.apache.atlas.repository.util.AccessControlUtils.ATTR_ACCESS_CONTROL_ENABLED;
+import static org.apache.atlas.repository.util.AccessControlUtils.ATTR_PERSONA_GROUPS;
+import static org.apache.atlas.repository.util.AccessControlUtils.ATTR_PERSONA_ROLE_ID;
+import static org.apache.atlas.repository.util.AccessControlUtils.ATTR_PERSONA_USERS;
+import static org.apache.atlas.repository.util.AccessControlUtils.ATTR_POLICY_IS_ENABLED;
+import static org.apache.atlas.repository.util.AccessControlUtils.REL_ATTR_POLICIES;
+import static org.apache.atlas.repository.util.AccessControlUtils.getESAliasName;
+import static org.apache.atlas.repository.util.AccessControlUtils.getEntityName;
+import static org.apache.atlas.repository.util.AccessControlUtils.getIsAccessControlEnabled;
+import static org.apache.atlas.repository.util.AccessControlUtils.getPersonaGroups;
+import static org.apache.atlas.repository.util.AccessControlUtils.getPersonaRoleId;
+import static org.apache.atlas.repository.util.AccessControlUtils.getPersonaRoleName;
+import static org.apache.atlas.repository.util.AccessControlUtils.getPersonaUsers;
+import static org.apache.atlas.repository.util.AccessControlUtils.getTenantId;
+import static org.apache.atlas.repository.util.AccessControlUtils.getUUID;
+import static org.apache.atlas.repository.util.AccessControlUtils.validateNoPoliciesAttached;
+
+public class StakeholderPreProcessor extends PersonaPreProcessor {
+    private static final Logger LOG = LoggerFactory.getLogger(StakeholderPreProcessor.class);
+
+    public StakeholderPreProcessor(AtlasGraph graph,
+                                   AtlasTypeRegistry typeRegistry,
+                                   EntityGraphRetriever entityRetriever,
+                                   AtlasEntityStore entityStore) {
+        super(graph, typeRegistry, entityRetriever, entityStore);
+    }
+
+    @Override
+    public void processAttributes(AtlasStruct entityStruct, EntityMutationContext context,
+                                  EntityMutations.EntityOperation operation) throws AtlasBaseException {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("StakeholderPreProcessor.processAttributes: pre processing {}, {}", entityStruct.getAttribute(QUALIFIED_NAME), operation);
+        }
+
+        AtlasEntity entity = (AtlasEntity) entityStruct;
+
+        switch (operation) {
+            case CREATE:
+                processCreateStakeholder(entity);
+                break;
+            case UPDATE:
+                processUpdateStakeholder(context, entity);
+                break;
+        }
+    }
+
+    @Override
+    public void processDelete(AtlasVertex vertex) throws AtlasBaseException {
+        AtlasEntity.AtlasEntityWithExtInfo entityWithExtInfo = entityRetriever.toAtlasEntityWithExtInfo(vertex);
+        AtlasEntity persona = entityWithExtInfo.getEntity();
+
+        if(!persona.getStatus().equals(AtlasEntity.Status.ACTIVE)) {
+            LOG.info("Persona with guid {} is already deleted/purged", persona.getGuid());
+            return;
+        }
+
+        //delete policies
+        List<AtlasObjectId> policies = (List<AtlasObjectId>) persona.getRelationshipAttribute(REL_ATTR_POLICIES);
+        if (CollectionUtils.isNotEmpty(policies)) {
+            for (AtlasObjectId policyObjectId : policies) {
+                //AtlasVertex policyVertex = entityRetriever.getEntityVertex(policyObjectId.getGuid());
+                entityStore.deleteById(policyObjectId.getGuid());
+            }
+        }
+
+        //remove role
+        keycloakStore.removeRole(getPersonaRoleId(persona));
+
+        //delete ES alias
+        aliasStore.deleteAlias(getESAliasName(persona));
+    }
+
+    private void processCreateStakeholder(AtlasEntity entity) throws AtlasBaseException {
+        AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("processCreateStakeholder");
+
+        validateNoPoliciesAttached(entity);
+
+        if (!entity.hasRelationshipAttribute("stakeholderTitle") || !entity.hasRelationshipAttribute("dataDomain")) {
+            throw new AtlasBaseException(BAD_REQUEST, "Relations stakeholderTitle and dataDomain are mandatory");
+        }
+
+        String domainQualifiedName = getQualifiedNameFromRelationAttribute(entity, "dataDomain");
+        entity.setAttribute("domainQualifiedName", domainQualifiedName);
+        entity.setAttribute("stakeholderTitleGuid", getGuidFromRelationAttribute(entity, "stakeholderTitle"));
+
+        String personaQualifiedName = String.format("default/%s/%s",
+                getUUID(),
+                domainQualifiedName);
+
+        entity.setAttribute(QUALIFIED_NAME, personaQualifiedName);
+
+        //TODO: validate Stakeholder & StakeholderTitle pair is unique
+
+
+
+        AtlasAuthorizationUtils.verifyAccess(new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_CREATE, new AtlasEntityHeader(entity)),
+                "create Stakeholder: ", entity.getAttribute(NAME));
+
+        entity.setAttribute(ATTR_ACCESS_CONTROL_ENABLED, entity.getAttributes().getOrDefault(ATTR_ACCESS_CONTROL_ENABLED, true));
+
+        //create keycloak role
+        String roleId = createKeycloakRole(entity);
+
+        entity.setAttribute(ATTR_PERSONA_ROLE_ID, roleId);
+
+        //create ES alias
+        aliasStore.createAlias(entity);
+
+        RequestContext.get().endMetricRecord(metricRecorder);
+    }
+
+    private void processUpdateStakeholder(EntityMutationContext context, AtlasEntity stakeholder) throws AtlasBaseException {
+        AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("processUpdateStakeholder");
+
+        validateNoPoliciesAttached(stakeholder);
+
+        validateNoPoliciesAttached(stakeholder);
+        AtlasVertex vertex = context.getVertex(stakeholder.getGuid());
+
+        AtlasEntity existingStakeholderEntity = entityRetriever.toAtlasEntityWithExtInfo(vertex).getEntity();
+
+        if (!AtlasEntity.Status.ACTIVE.equals(existingStakeholderEntity.getStatus())) {
+            throw new AtlasBaseException(OPERATION_NOT_SUPPORTED, "Stakeholder not Active");
+        }
+
+        String domainGuid = (String) stakeholder.getAttribute("domainGuid");
+        if (StringUtils.isNotEmpty(domainGuid)) {
+            stakeholder.removeAttribute("domainGuid");
+            stakeholder.removeAttribute("stakeholderTitleGuid");
+            stakeholder.getRelationshipAttributes().remove("dataDomain");
+            stakeholder.getRelationshipAttributes().remove("stakeholderTitle");
+        }
+
+        String vertexQName = vertex.getProperty(QUALIFIED_NAME, String.class);
+        stakeholder.setAttribute(QUALIFIED_NAME, vertexQName);
+        stakeholder.setAttribute(ATTR_PERSONA_ROLE_ID, getPersonaRoleId(existingStakeholderEntity));
+
+        AtlasAuthorizationUtils.verifyAccess(new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_UPDATE, new AtlasEntityHeader(stakeholder)),
+                "update Stakeholder: ", stakeholder.getAttribute(NAME));
+
+        updateKeycloakRole(stakeholder, existingStakeholderEntity);
+
+        RequestContext.get().endMetricRecord(metricRecorder);
+    }
+
+    private String getGuidFromRelationAttribute(AtlasEntity entity, String relationshipAttributeName) throws AtlasBaseException {
+        AtlasObjectId relationObjectId = (AtlasObjectId) entity.getRelationshipAttribute(relationshipAttributeName);
+
+        String guid = relationObjectId.getGuid();
+        if (StringUtils.isEmpty(guid)) {
+            AtlasVertex vertex = entityRetriever.getEntityVertex(relationObjectId);
+            guid = vertex.getProperty("__guid", String.class);
+        }
+
+        return guid;
+    }
+
+    private String getQualifiedNameFromRelationAttribute(AtlasEntity entity, String relationshipAttributeName) throws AtlasBaseException {
+        AtlasObjectId relationObjectId = (AtlasObjectId) entity.getRelationshipAttribute(relationshipAttributeName);
+        String qualifiedName = null;
+
+        if (relationObjectId.getUniqueAttributes() != null) {
+            qualifiedName = (String) relationObjectId.getUniqueAttributes().get(QUALIFIED_NAME);
+        }
+
+        if (StringUtils.isEmpty(qualifiedName)) {
+            AtlasVertex vertex = entityRetriever.getEntityVertex(relationObjectId);
+            qualifiedName = vertex.getProperty(QUALIFIED_NAME, String.class);
+        }
+
+        return qualifiedName;
+    }
+}

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/accesscontrol/StakeholderPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/accesscontrol/StakeholderPreProcessor.java
@@ -72,7 +72,7 @@ import static org.apache.atlas.repository.util.AtlasEntityUtils.mapOf;
 public class StakeholderPreProcessor extends PersonaPreProcessor {
     private static final Logger LOG = LoggerFactory.getLogger(StakeholderPreProcessor.class);
 
-    public static final String ATTR_DOMAIN_QUALIFIED_NAME  = "domainQualifiedName";
+    public static final String ATTR_DOMAIN_QUALIFIED_NAME  = "stakeholderDomainQualifiedName";
     public static final String ATTR_STAKEHOLDER_TITLE_GUID = "stakeholderTitleGuid";
 
     public static final String REL_ATTR_STAKEHOLDER_TITLE = "stakeholderTitle";

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataDomainPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataDomainPreProcessor.java
@@ -104,6 +104,10 @@ public class DataDomainPreProcessor extends AbstractDomainPreProcessor {
             throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST, "Cannot update Domain's subDomains or dataProducts relations");
         }
 
+        if(entity.hasRelationshipAttribute("stakeholders")){
+            throw new AtlasBaseException(AtlasErrorCode.OPERATION_NOT_SUPPORTED, "Managing Stakeholders via Domain update");
+        }
+
         String vertexQnName = vertex.getProperty(QUALIFIED_NAME, String.class);
 
         AtlasEntity storedDomain = entityRetriever.toAtlasEntity(vertex);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataDomainPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataDomainPreProcessor.java
@@ -84,9 +84,7 @@ public class DataDomainPreProcessor extends AbstractDomainPreProcessor {
     private void processCreateDomain(AtlasEntity entity) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("processCreateDomain");
 
-        if(entity.hasRelationshipAttribute(STAKEHOLDER_REL_TYPE)){
-            throw new AtlasBaseException(AtlasErrorCode.OPERATION_NOT_SUPPORTED, "Managing Stakeholders while creating a domain");
-        }
+        validateStakeholderRelationship(entity);
 
         String domainName = (String) entity.getAttribute(NAME);
 
@@ -113,9 +111,7 @@ public class DataDomainPreProcessor extends AbstractDomainPreProcessor {
             throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST, "Cannot update Domain's subDomains or dataProducts relations");
         }
 
-        if(entity.hasRelationshipAttribute(STAKEHOLDER_REL_TYPE)){
-            throw new AtlasBaseException(AtlasErrorCode.OPERATION_NOT_SUPPORTED, "Managing Stakeholders while updating a domain");
-        }
+        validateStakeholderRelationship(entity);
 
         String vertexQnName = vertex.getProperty(QUALIFIED_NAME, String.class);
 
@@ -355,6 +351,12 @@ public class DataDomainPreProcessor extends AbstractDomainPreProcessor {
     private String getOwnQualifiedNameForChild(String childQualifiedName) {
         String[] splitted = childQualifiedName.split("/");
         return String.format("/%s/%s", splitted[splitted.length -2], splitted[splitted.length -1]);
+    }
+
+    private void validateStakeholderRelationship(AtlasEntity entity) throws AtlasBaseException {
+        if(entity.hasRelationshipAttribute(STAKEHOLDER_REL_TYPE)){
+            throw new AtlasBaseException(AtlasErrorCode.OPERATION_NOT_SUPPORTED, "Managing Stakeholders while creating/updating a domain");
+        }
     }
 }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataDomainPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataDomainPreProcessor.java
@@ -83,6 +83,11 @@ public class DataDomainPreProcessor extends AbstractDomainPreProcessor {
 
     private void processCreateDomain(AtlasEntity entity) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("processCreateDomain");
+
+        if(entity.hasRelationshipAttribute(STAKEHOLDER_REL_TYPE)){
+            throw new AtlasBaseException(AtlasErrorCode.OPERATION_NOT_SUPPORTED, "Managing Stakeholders while creating a domain");
+        }
+
         String domainName = (String) entity.getAttribute(NAME);
 
         String parentDomainQualifiedName = (String) entity.getAttribute(PARENT_DOMAIN_QN_ATTR);
@@ -108,8 +113,8 @@ public class DataDomainPreProcessor extends AbstractDomainPreProcessor {
             throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST, "Cannot update Domain's subDomains or dataProducts relations");
         }
 
-        if(entity.hasRelationshipAttribute("stakeholders")){
-            throw new AtlasBaseException(AtlasErrorCode.OPERATION_NOT_SUPPORTED, "Managing Stakeholders via Domain update");
+        if(entity.hasRelationshipAttribute(STAKEHOLDER_REL_TYPE)){
+            throw new AtlasBaseException(AtlasErrorCode.OPERATION_NOT_SUPPORTED, "Managing Stakeholders while updating a domain");
         }
 
         String vertexQnName = vertex.getProperty(QUALIFIED_NAME, String.class);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/StakeholderTitlePreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/StakeholderTitlePreProcessor.java
@@ -78,7 +78,7 @@ public class StakeholderTitlePreProcessor implements PreProcessor {
 
         try {
             if (entity.hasRelationshipAttribute("stakeholders")) {
-                throw new AtlasBaseException(OPERATION_NOT_SUPPORTED, "Can not attach a Stakeholder while creating StakeholderTitle");
+                throw new AtlasBaseException(OPERATION_NOT_SUPPORTED, "Managing Stakeholders while creating StakeholderTitle");
             }
 
             if (RequestContext.get().isSkipAuthorizationCheck()) {
@@ -120,7 +120,7 @@ public class StakeholderTitlePreProcessor implements PreProcessor {
             }
 
             if (entity.hasRelationshipAttribute("stakeholders")) {
-                throw new AtlasBaseException(OPERATION_NOT_SUPPORTED, "Can not attach/detach a Stakeholder while updating StakeholderTitle");
+                throw new AtlasBaseException(OPERATION_NOT_SUPPORTED, "Managing Stakeholders while updating StakeholderTitle");
             }
 
             AtlasVertex vertex = context.getVertex(entity.getGuid());

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/StakeholderTitlePreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/StakeholderTitlePreProcessor.java
@@ -1,0 +1,147 @@
+package org.apache.atlas.repository.store.graph.v2.preprocessor.datamesh;
+
+import org.apache.atlas.AtlasErrorCode;
+import org.apache.atlas.RequestContext;
+import org.apache.atlas.authorize.AtlasAuthorizationUtils;
+import org.apache.atlas.authorize.AtlasEntityAccessRequest;
+import org.apache.atlas.authorize.AtlasPrivilege;
+import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.model.instance.AtlasEntity;
+import org.apache.atlas.model.instance.AtlasEntityHeader;
+import org.apache.atlas.model.instance.AtlasObjectId;
+import org.apache.atlas.model.instance.AtlasRelatedObjectId;
+import org.apache.atlas.model.instance.AtlasRelationship;
+import org.apache.atlas.model.instance.AtlasStruct;
+import org.apache.atlas.model.instance.EntityMutations;
+import org.apache.atlas.repository.graphdb.AtlasGraph;
+import org.apache.atlas.repository.graphdb.AtlasVertex;
+import org.apache.atlas.repository.store.graph.AtlasEntityStore;
+import org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2;
+import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
+import org.apache.atlas.repository.store.graph.v2.EntityMutationContext;
+import org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessor;
+import org.apache.atlas.repository.store.users.KeycloakStore;
+import org.apache.atlas.type.AtlasTypeRegistry;
+import org.apache.atlas.utils.AtlasPerfMetrics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.apache.atlas.AtlasErrorCode.OPERATION_NOT_SUPPORTED;
+import static org.apache.atlas.repository.Constants.NAME;
+import static org.apache.atlas.repository.Constants.QUALIFIED_NAME;
+import static org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessorUtils.getUUID;
+
+public class StakeholderTitlePreProcessor implements PreProcessor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(StakeholderTitlePreProcessor.class);
+
+    private final AtlasGraph graph;
+    private final AtlasTypeRegistry typeRegistry;
+    private final EntityGraphRetriever entityRetriever;
+    private AtlasEntityStore entityStore;
+
+    public StakeholderTitlePreProcessor(AtlasGraph graph,
+                                       AtlasTypeRegistry typeRegistry,
+                                       EntityGraphRetriever entityRetriever,
+                                       AtlasEntityStore entityStore) {
+        this.graph = graph;
+        this.typeRegistry = typeRegistry;
+        this.entityRetriever = entityRetriever;
+        this.entityStore = entityStore;
+    }
+
+    @Override
+    public void processAttributes(AtlasStruct entityStruct, EntityMutationContext context,
+                                  EntityMutations.EntityOperation operation) throws AtlasBaseException {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("StakeholderTitle.processAttributes: pre processing {}, {}", entityStruct.getAttribute(QUALIFIED_NAME), operation);
+        }
+
+        AtlasEntity entity = (AtlasEntity) entityStruct;
+
+        switch (operation) {
+            case CREATE:
+                processCreateStakeholderTitle(entity);
+                break;
+            case UPDATE:
+                processUpdateStakeholderTitle(context, entity);
+                break;
+        }
+    }
+
+    private void processCreateStakeholderTitle(AtlasEntity entity) throws AtlasBaseException {
+        AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("processCreateStakeholderTitle");
+
+        try {
+            if (entity.hasRelationshipAttribute("stakeholders")) {
+                throw new AtlasBaseException(OPERATION_NOT_SUPPORTED, "Can not attach a Stakeholder while creating StakeholderTitle");
+            }
+
+            String qualifiedName;
+
+            String domainGuid = (String) entity.getAttribute("domainGuid");
+            if ("*".equals(domainGuid)) {
+                qualifiedName = String.format("stakeholderTitle/domain/default/%s", getUUID());
+                //TODO: validate name duplication
+            } else {
+
+                AtlasVertex domain = entityRetriever.getEntityVertex(domainGuid);
+                qualifiedName = String.format("stakeholderTitle/domain/%s/%s",
+                        getUUID(),
+                        domain.getProperty(QUALIFIED_NAME, String.class));
+
+                //TODO: validate name duplication
+            }
+
+            entity.setAttribute(QUALIFIED_NAME, qualifiedName);
+
+            AtlasAuthorizationUtils.verifyAccess(new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_CREATE, new AtlasEntityHeader(entity)),
+                    "create StakeholderTitle: ", entity.getAttribute(NAME));
+
+        } finally {
+            RequestContext.get().endMetricRecord(metricRecorder);
+        }
+    }
+
+    private void processUpdateStakeholderTitle(EntityMutationContext context, AtlasEntity entity) throws AtlasBaseException {
+        AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("processUpdateStakeholderTitle");
+
+        try {
+            if (entity.hasRelationshipAttribute("stakeholders")) {
+                throw new AtlasBaseException(OPERATION_NOT_SUPPORTED, "Can not attach/detach a Stakeholder while updating StakeholderTitle");
+            }
+
+            AtlasVertex vertex = context.getVertex(entity.getGuid());
+            String vertexQName = vertex.getProperty(QUALIFIED_NAME, String.class);
+            entity.setAttribute(QUALIFIED_NAME, vertexQName);
+
+            AtlasAuthorizationUtils.verifyAccess(new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_UPDATE, new AtlasEntityHeader(entity)),
+                    "update StakeholderTitle: ", entity.getAttribute(NAME));
+
+        } finally {
+            RequestContext.get().endMetricRecord(metricRecorder);
+        }
+    }
+
+    @Override
+    public void processDelete(AtlasVertex vertex) throws AtlasBaseException {
+        AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("processDeleteStakeholderTitle");
+
+        try {
+            AtlasEntity titleEntity = entityRetriever.toAtlasEntity(vertex);
+            List<AtlasRelatedObjectId> stakeholders = (List<AtlasRelatedObjectId>) titleEntity.getRelationshipAttribute("stakeholders");
+
+            Optional activeStakeholder = stakeholders.stream().filter(x -> x.getRelationshipStatus() == AtlasRelationship.Status.ACTIVE).findFirst();
+            if (activeStakeholder.isPresent()) {
+                throw new AtlasBaseException(OPERATION_NOT_SUPPORTED, "Can not delete StakeholderTitle as it has reference to Active Stakeholder");
+            }
+
+        } finally {
+            RequestContext.get().endMetricRecord(metricRecorder);
+        }
+    }
+}
+

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/StakeholderTitlePreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/StakeholderTitlePreProcessor.java
@@ -48,7 +48,7 @@ public class StakeholderTitlePreProcessor implements PreProcessor {
 
 
     public static final String STAR = "*";
-    public static final String ATTR_DOMAIN_QUALIFIED_NAMES = "domainQualifiedNames";
+    public static final String ATTR_DOMAIN_QUALIFIED_NAMES = "stakeholderTitleDomainQualifiedNames";
 
     public static final String REL_ATTR_STAKEHOLDERS = "stakeholders";
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/StakeholderTitlePreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/StakeholderTitlePreProcessor.java
@@ -1,14 +1,15 @@
 package org.apache.atlas.repository.store.graph.v2.preprocessor.datamesh;
 
 import org.apache.atlas.AtlasErrorCode;
+import org.apache.atlas.AtlasException;
 import org.apache.atlas.RequestContext;
 import org.apache.atlas.authorize.AtlasAuthorizationUtils;
 import org.apache.atlas.authorize.AtlasEntityAccessRequest;
 import org.apache.atlas.authorize.AtlasPrivilege;
+import org.apache.atlas.discovery.EntityDiscoveryService;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.instance.AtlasEntity;
 import org.apache.atlas.model.instance.AtlasEntityHeader;
-import org.apache.atlas.model.instance.AtlasObjectId;
 import org.apache.atlas.model.instance.AtlasRelatedObjectId;
 import org.apache.atlas.model.instance.AtlasRelationship;
 import org.apache.atlas.model.instance.AtlasStruct;
@@ -16,19 +17,19 @@ import org.apache.atlas.model.instance.EntityMutations;
 import org.apache.atlas.repository.graphdb.AtlasGraph;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
 import org.apache.atlas.repository.store.graph.AtlasEntityStore;
-import org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2;
 import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
 import org.apache.atlas.repository.store.graph.v2.EntityMutationContext;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessor;
-import org.apache.atlas.repository.store.users.KeycloakStore;
 import org.apache.atlas.type.AtlasTypeRegistry;
 import org.apache.atlas.utils.AtlasPerfMetrics;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.collections.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.apache.atlas.AtlasErrorCode.BAD_REQUEST;
@@ -36,17 +37,31 @@ import static org.apache.atlas.AtlasErrorCode.OPERATION_NOT_SUPPORTED;
 import static org.apache.atlas.repository.Constants.DATA_DOMAIN_ENTITY_TYPE;
 import static org.apache.atlas.repository.Constants.NAME;
 import static org.apache.atlas.repository.Constants.QUALIFIED_NAME;
+import static org.apache.atlas.repository.Constants.STAKEHOLDER_ENTITY_TYPE;
+import static org.apache.atlas.repository.Constants.STAKEHOLDER_TITLE_ENTITY_TYPE;
 import static org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessorUtils.getUUID;
+import static org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessorUtils.indexSearchPaginated;
+import static org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessorUtils.verifyDuplicateAssetByName;
 import static org.apache.atlas.repository.util.AtlasEntityUtils.mapOf;
 
 public class StakeholderTitlePreProcessor implements PreProcessor {
 
     private static final Logger LOG = LoggerFactory.getLogger(StakeholderTitlePreProcessor.class);
 
+    public static final String PATTERN_QUALIFIED_NAME_ALL_DOMAINS = "stakeholderTitle/domain/default/%s";
+    public static final String PATTERN_QUALIFIED_NAME_DOMAIN = "stakeholderTitle/domain/%s";
+
+
+    public static final String STAR = "*";
+    public static final String ATTR_DOMAIN_QUALIFIED_NAMES = "domainQualifiedNames";
+
+    public static final String REL_ATTR_STAKEHOLDERS = "stakeholders";
+
     private final AtlasGraph graph;
     private final AtlasTypeRegistry typeRegistry;
     private final EntityGraphRetriever entityRetriever;
     private AtlasEntityStore entityStore;
+    protected EntityDiscoveryService discovery;
 
     public StakeholderTitlePreProcessor(AtlasGraph graph,
                                        AtlasTypeRegistry typeRegistry,
@@ -56,6 +71,12 @@ public class StakeholderTitlePreProcessor implements PreProcessor {
         this.typeRegistry = typeRegistry;
         this.entityRetriever = entityRetriever;
         this.entityStore = entityStore;
+
+        try {
+            this.discovery = new EntityDiscoveryService(typeRegistry, graph, null, null, null, null);
+        } catch (AtlasException e) {
+            e.printStackTrace();
+        }
     }
 
     @Override
@@ -81,7 +102,7 @@ public class StakeholderTitlePreProcessor implements PreProcessor {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("processCreateStakeholderTitle");
 
         try {
-            if (entity.hasRelationshipAttribute("stakeholders")) {
+            if (entity.hasRelationshipAttribute(REL_ATTR_STAKEHOLDERS)) {
                 throw new AtlasBaseException(OPERATION_NOT_SUPPORTED, "Managing Stakeholders while creating StakeholderTitle");
             }
 
@@ -89,10 +110,14 @@ public class StakeholderTitlePreProcessor implements PreProcessor {
                 return;
             }
 
+            String name = (String) entity.getAttribute(NAME);
+            verifyDuplicateAssetByName(STAKEHOLDER_TITLE_ENTITY_TYPE, name, discovery,
+                    String.format("Stakeholder title with name %s already exists", name));
+
             List<String> domainQualifiedNames = null;
 
-            if (entity.hasAttribute("domainQualifiedNames")) {
-                domainQualifiedNames = (List<String>) entity.getAttribute("domainQualifiedNames");
+            if (entity.hasAttribute(ATTR_DOMAIN_QUALIFIED_NAMES)) {
+                domainQualifiedNames = (List<String>) entity.getAttribute(ATTR_DOMAIN_QUALIFIED_NAMES);
                 if (domainQualifiedNames.size() == 0) {
                     throw new AtlasBaseException(BAD_REQUEST, "Please pass attribute domainQualifiedNames");
                 }
@@ -101,20 +126,19 @@ public class StakeholderTitlePreProcessor implements PreProcessor {
                 throw new AtlasBaseException(BAD_REQUEST, "Please pass attribute domainQualifiedNames");
             }
 
-            if ((domainQualifiedNames.size() == 1 && "*".equals(domainQualifiedNames.get(0)))
-                    || domainQualifiedNames.contains("*")) {
+            if ((domainQualifiedNames.size() == 1 && STAR.equals(domainQualifiedNames.get(0)))
+                    || domainQualifiedNames.contains(STAR)) {
 
                 AtlasEntityHeader allDomainEntityHeader = new AtlasEntityHeader(DATA_DOMAIN_ENTITY_TYPE, mapOf(QUALIFIED_NAME, "*/super"));
                 AtlasAuthorizationUtils.verifyAccess(new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_CREATE, new AtlasEntityHeader(allDomainEntityHeader)),
                         "create StakeholderTitle for all domains");
 
-                String qualifiedName = String.format("stakeholderTitle/domain/default/%s", getUUID());
+                String qualifiedName = String.format(PATTERN_QUALIFIED_NAME_ALL_DOMAINS, getUUID());
                 entity.setAttribute(QUALIFIED_NAME, qualifiedName);
-                entity.setAttribute("domainQualifiedNames", Collections.singletonList("*"));
+                entity.setAttribute(ATTR_DOMAIN_QUALIFIED_NAMES, Collections.singletonList(STAR));
             } else {
                 for (String domainQualifiedName : domainQualifiedNames) {
-                    //AtlasVertex domainVertex = entityRetriever.getEntityVertex(new AtlasObjectId(DATA_DOMAIN_ENTITY_TYPE, mapOf(QUALIFIED_NAME, domainQualifiedName)));
-                    //AtlasEntityHeader domainHeader = entityRetriever.toAtlasEntityHeader(domainVertex);
+
                     AtlasEntityHeader domainHeader = new AtlasEntityHeader(DATA_DOMAIN_ENTITY_TYPE, mapOf(QUALIFIED_NAME, domainQualifiedName));
                     String qualifiedName = String.format("stakeholderTitle/domain/%s/%s", getUUID(), domainQualifiedName);
 
@@ -124,7 +148,7 @@ public class StakeholderTitlePreProcessor implements PreProcessor {
                             "create StakeholderTitle for domain ", domainQualifiedName);
                 }
 
-                entity.setAttribute(QUALIFIED_NAME, String.format("stakeholderTitle/domain/%s", getUUID()));
+                entity.setAttribute(QUALIFIED_NAME, String.format(PATTERN_QUALIFIED_NAME_DOMAIN, getUUID()));
             }
 
         } finally {
@@ -140,11 +164,19 @@ public class StakeholderTitlePreProcessor implements PreProcessor {
                 return;
             }
 
-            if (entity.hasRelationshipAttribute("stakeholders")) {
+            if (entity.hasRelationshipAttribute(REL_ATTR_STAKEHOLDERS)) {
                 throw new AtlasBaseException(OPERATION_NOT_SUPPORTED, "Managing Stakeholders while updating StakeholderTitle");
             }
 
             AtlasVertex vertex = context.getVertex(entity.getGuid());
+
+            String currentName = vertex.getProperty(NAME, String.class);
+            String newName = (String) entity.getAttribute(NAME);
+            if (!currentName.equals(newName)) {
+                verifyDuplicateAssetByName(STAKEHOLDER_TITLE_ENTITY_TYPE, newName, discovery,
+                        String.format("Stakeholder title with name %s already exists", newName));
+            }
+
             String vertexQName = vertex.getProperty(QUALIFIED_NAME, String.class);
             entity.setAttribute(QUALIFIED_NAME, vertexQName);
 
@@ -162,7 +194,7 @@ public class StakeholderTitlePreProcessor implements PreProcessor {
 
         try {
             AtlasEntity titleEntity = entityRetriever.toAtlasEntity(vertex);
-            List<AtlasRelatedObjectId> stakeholders = (List<AtlasRelatedObjectId>) titleEntity.getRelationshipAttribute("stakeholders");
+            List<AtlasRelatedObjectId> stakeholders = (List<AtlasRelatedObjectId>) titleEntity.getRelationshipAttribute(REL_ATTR_STAKEHOLDERS);
 
             Optional activeStakeholder = stakeholders.stream().filter(x -> x.getRelationshipStatus() == AtlasRelationship.Status.ACTIVE).findFirst();
             if (activeStakeholder.isPresent()) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/StakeholderTitlePreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/StakeholderTitlePreProcessor.java
@@ -166,7 +166,7 @@ public class StakeholderTitlePreProcessor implements PreProcessor {
             }
 
             if (CollectionUtils.isEmpty(domainQualifiedNames)) {
-                domainQualifiedNames = vertex.getListProperty(ATTR_DOMAIN_QUALIFIED_NAMES, String.class);
+                domainQualifiedNames = vertex.getMultiValuedProperty(ATTR_DOMAIN_QUALIFIED_NAMES, String.class);
             }
 
             authorizeDomainAccess(domainQualifiedNames);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/StakeholderTitlePreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/StakeholderTitlePreProcessor.java
@@ -180,9 +180,6 @@ public class StakeholderTitlePreProcessor implements PreProcessor {
             String vertexQName = vertex.getProperty(QUALIFIED_NAME, String.class);
             entity.setAttribute(QUALIFIED_NAME, vertexQName);
 
-            AtlasAuthorizationUtils.verifyAccess(new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_UPDATE, new AtlasEntityHeader(entity)),
-                    "update StakeholderTitle: ", entity.getAttribute(NAME));
-
         } finally {
             RequestContext.get().endMetricRecord(metricRecorder);
         }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/StakeholderTitlePreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/StakeholderTitlePreProcessor.java
@@ -81,28 +81,31 @@ public class StakeholderTitlePreProcessor implements PreProcessor {
                 throw new AtlasBaseException(OPERATION_NOT_SUPPORTED, "Can not attach a Stakeholder while creating StakeholderTitle");
             }
 
-            if (StringUtils.isNotEmpty(RequestContext.getCurrentUser())) {
-                String qualifiedName;
-
-                String domainGuid = (String) entity.getAttribute("domainGuid");
-                if ("*".equals(domainGuid)) {
-                    qualifiedName = String.format("stakeholderTitle/domain/default/%s", getUUID());
-                    //TODO: validate name duplication
-                } else {
-
-                    AtlasVertex domain = entityRetriever.getEntityVertex(domainGuid);
-                    qualifiedName = String.format("stakeholderTitle/domain/%s/%s",
-                            getUUID(),
-                            domain.getProperty(QUALIFIED_NAME, String.class));
-
-                    //TODO: validate name duplication
-                }
-
-                entity.setAttribute(QUALIFIED_NAME, qualifiedName);
-
-                AtlasAuthorizationUtils.verifyAccess(new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_CREATE, new AtlasEntityHeader(entity)),
-                        "create StakeholderTitle: ", entity.getAttribute(NAME));
+            if (RequestContext.get().isSkipAuthorizationCheck()) {
+                return;
             }
+
+            String qualifiedName;
+
+            String domainGuid = (String) entity.getAttribute("domainGuid");
+            if ("*".equals(domainGuid)) {
+                qualifiedName = String.format("stakeholderTitle/domain/default/%s", getUUID());
+                //TODO: validate name duplication
+            } else {
+
+                AtlasVertex domain = entityRetriever.getEntityVertex(domainGuid);
+                qualifiedName = String.format("stakeholderTitle/domain/%s/%s",
+                        getUUID(),
+                        domain.getProperty(QUALIFIED_NAME, String.class));
+
+                //TODO: validate name duplication
+            }
+
+            entity.setAttribute(QUALIFIED_NAME, qualifiedName);
+
+            AtlasAuthorizationUtils.verifyAccess(new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_CREATE, new AtlasEntityHeader(entity)),
+                    "create StakeholderTitle: ", entity.getAttribute(NAME));
+
         } finally {
             RequestContext.get().endMetricRecord(metricRecorder);
         }
@@ -112,6 +115,10 @@ public class StakeholderTitlePreProcessor implements PreProcessor {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("processUpdateStakeholderTitle");
 
         try {
+            if (RequestContext.get().isSkipAuthorizationCheck()) {
+                return;
+            }
+
             if (entity.hasRelationshipAttribute("stakeholders")) {
                 throw new AtlasBaseException(OPERATION_NOT_SUPPORTED, "Can not attach/detach a Stakeholder while updating StakeholderTitle");
             }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/StakeholderTitlePreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/StakeholderTitlePreProcessor.java
@@ -26,21 +26,17 @@ import org.apache.commons.collections.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
+import static java.lang.String.format;
 import static org.apache.atlas.AtlasErrorCode.BAD_REQUEST;
 import static org.apache.atlas.AtlasErrorCode.OPERATION_NOT_SUPPORTED;
 import static org.apache.atlas.repository.Constants.DATA_DOMAIN_ENTITY_TYPE;
 import static org.apache.atlas.repository.Constants.NAME;
 import static org.apache.atlas.repository.Constants.QUALIFIED_NAME;
-import static org.apache.atlas.repository.Constants.STAKEHOLDER_ENTITY_TYPE;
 import static org.apache.atlas.repository.Constants.STAKEHOLDER_TITLE_ENTITY_TYPE;
 import static org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessorUtils.getUUID;
-import static org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessorUtils.indexSearchPaginated;
 import static org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessorUtils.verifyDuplicateAssetByName;
 import static org.apache.atlas.repository.util.AtlasEntityUtils.mapOf;
 
@@ -57,20 +53,15 @@ public class StakeholderTitlePreProcessor implements PreProcessor {
 
     public static final String REL_ATTR_STAKEHOLDERS = "stakeholders";
 
-    private final AtlasGraph graph;
     private final AtlasTypeRegistry typeRegistry;
     private final EntityGraphRetriever entityRetriever;
-    private AtlasEntityStore entityStore;
     protected EntityDiscoveryService discovery;
 
     public StakeholderTitlePreProcessor(AtlasGraph graph,
                                        AtlasTypeRegistry typeRegistry,
-                                       EntityGraphRetriever entityRetriever,
-                                       AtlasEntityStore entityStore) {
-        this.graph = graph;
+                                       EntityGraphRetriever entityRetriever) {
         this.typeRegistry = typeRegistry;
         this.entityRetriever = entityRetriever;
-        this.entityStore = entityStore;
 
         try {
             this.discovery = new EntityDiscoveryService(typeRegistry, graph, null, null, null, null);
@@ -83,7 +74,7 @@ public class StakeholderTitlePreProcessor implements PreProcessor {
     public void processAttributes(AtlasStruct entityStruct, EntityMutationContext context,
                                   EntityMutations.EntityOperation operation) throws AtlasBaseException {
         if (LOG.isDebugEnabled()) {
-            LOG.debug("StakeholderTitle.processAttributes: pre processing {}, {}", entityStruct.getAttribute(QUALIFIED_NAME), operation);
+            LOG.debug("StakeholderTitlePreProcessor.processAttributes: pre processing {}, {}", entityStruct.getAttribute(QUALIFIED_NAME), operation);
         }
 
         AtlasEntity entity = (AtlasEntity) entityStruct;
@@ -102,45 +93,45 @@ public class StakeholderTitlePreProcessor implements PreProcessor {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("processCreateStakeholderTitle");
 
         try {
-            if (entity.hasRelationshipAttribute(REL_ATTR_STAKEHOLDERS)) {
-                throw new AtlasBaseException(OPERATION_NOT_SUPPORTED, "Managing Stakeholders while creating StakeholderTitle");
-            }
+            validateRelations(entity);
 
             if (RequestContext.get().isSkipAuthorizationCheck()) {
+                // To create bootstrap titles with provided aualifiedName
                 return;
             }
 
             String name = (String) entity.getAttribute(NAME);
             verifyDuplicateAssetByName(STAKEHOLDER_TITLE_ENTITY_TYPE, name, discovery,
-                    String.format("Stakeholder title with name %s already exists", name));
+                    format("Stakeholder title with name %s already exists", name));
 
             List<String> domainQualifiedNames = null;
-
             if (entity.hasAttribute(ATTR_DOMAIN_QUALIFIED_NAMES)) {
-                domainQualifiedNames = (List<String>) entity.getAttribute(ATTR_DOMAIN_QUALIFIED_NAMES);
-                if (domainQualifiedNames.size() == 0) {
-                    throw new AtlasBaseException(BAD_REQUEST, "Please pass attribute domainQualifiedNames");
+                Object qNamesAsObject = entity.getAttribute(ATTR_DOMAIN_QUALIFIED_NAMES);
+                if (qNamesAsObject != null) {
+                    domainQualifiedNames = (List<String>) qNamesAsObject;
                 }
+            }
 
-            } else {
-                throw new AtlasBaseException(BAD_REQUEST, "Please pass attribute domainQualifiedNames");
+            if (CollectionUtils.isEmpty(domainQualifiedNames)) {
+                throw new AtlasBaseException(BAD_REQUEST, "Please provide attribute domainQualifiedNames");
             }
 
             if (domainQualifiedNames.contains(STAR)) {
                 if (domainQualifiedNames.size() > 1) {
+
                     domainQualifiedNames.clear();
                     domainQualifiedNames.add(STAR);
                     entity.setAttribute(ATTR_DOMAIN_QUALIFIED_NAMES, domainQualifiedNames);
                 }
 
-                String qualifiedName = String.format(PATTERN_QUALIFIED_NAME_ALL_DOMAINS, getUUID());
+                String qualifiedName = format(PATTERN_QUALIFIED_NAME_ALL_DOMAINS, getUUID());
                 entity.setAttribute(QUALIFIED_NAME, qualifiedName);
 
             } else {
-                entity.setAttribute(QUALIFIED_NAME, String.format(PATTERN_QUALIFIED_NAME_DOMAIN, getUUID()));
+                entity.setAttribute(QUALIFIED_NAME, format(PATTERN_QUALIFIED_NAME_DOMAIN, getUUID()));
             }
 
-            authorizeDomainAccess(domainQualifiedNames, AtlasPrivilege.ENTITY_UPDATE);
+            authorizeDomainAccess(domainQualifiedNames);
 
         } finally {
             RequestContext.get().endMetricRecord(metricRecorder);
@@ -152,12 +143,11 @@ public class StakeholderTitlePreProcessor implements PreProcessor {
 
         try {
             if (RequestContext.get().isSkipAuthorizationCheck()) {
+                // To create bootstrap titles with provided aualifiedName
                 return;
             }
 
-            if (entity.hasRelationshipAttribute(REL_ATTR_STAKEHOLDERS)) {
-                throw new AtlasBaseException(OPERATION_NOT_SUPPORTED, "Managing Stakeholders while updating StakeholderTitle");
-            }
+            validateRelations(entity);
 
             AtlasVertex vertex = context.getVertex(entity.getGuid());
 
@@ -165,17 +155,22 @@ public class StakeholderTitlePreProcessor implements PreProcessor {
             String newName = (String) entity.getAttribute(NAME);
             if (!currentName.equals(newName)) {
                 verifyDuplicateAssetByName(STAKEHOLDER_TITLE_ENTITY_TYPE, newName, discovery,
-                        String.format("Stakeholder title with name %s already exists", newName));
+                        format("StakeholderTitle with name %s already exists", newName));
             }
 
-            List<String> domainQualifiedNames;
+            List<String> domainQualifiedNames = null;
             if (entity.hasAttribute(ATTR_DOMAIN_QUALIFIED_NAMES)) {
-                domainQualifiedNames = (List<String>) entity.getAttribute(ATTR_DOMAIN_QUALIFIED_NAMES);
-            } else {
+                Object qNamesAsObject = entity.getAttribute(ATTR_DOMAIN_QUALIFIED_NAMES);
+                if (qNamesAsObject != null) {
+                    domainQualifiedNames = (List<String>) qNamesAsObject;
+                }
+            }
+
+            if (CollectionUtils.isEmpty(domainQualifiedNames)) {
                 domainQualifiedNames = vertex.getListProperty(ATTR_DOMAIN_QUALIFIED_NAMES, String.class);
             }
 
-            authorizeDomainAccess(domainQualifiedNames, AtlasPrivilege.ENTITY_UPDATE);
+            authorizeDomainAccess(domainQualifiedNames);
 
             String vertexQName = vertex.getProperty(QUALIFIED_NAME, String.class);
             entity.setAttribute(QUALIFIED_NAME, vertexQName);
@@ -191,25 +186,32 @@ public class StakeholderTitlePreProcessor implements PreProcessor {
 
         try {
             AtlasEntity titleEntity = entityRetriever.toAtlasEntity(vertex);
-            List<AtlasRelatedObjectId> stakeholders = (List<AtlasRelatedObjectId>) titleEntity.getRelationshipAttribute(REL_ATTR_STAKEHOLDERS);
 
-            Optional activeStakeholder = stakeholders.stream().filter(x -> x.getRelationshipStatus() == AtlasRelationship.Status.ACTIVE).findFirst();
-            if (activeStakeholder.isPresent()) {
-                throw new AtlasBaseException(OPERATION_NOT_SUPPORTED, "Can not delete StakeholderTitle as it has reference to Active Stakeholder");
+            List<AtlasRelatedObjectId> stakeholders = null;
+            Object stakeholdersAsObject = titleEntity.getRelationshipAttribute(REL_ATTR_STAKEHOLDERS);
+            if (stakeholdersAsObject != null) {
+                stakeholders = (List<AtlasRelatedObjectId>) stakeholdersAsObject;
             }
 
-            List<String> domainQualifiedNames = vertex.getMultiValuedProperty(ATTR_DOMAIN_QUALIFIED_NAMES, String.class);
+            if (CollectionUtils.isNotEmpty(stakeholders)) {
+                Optional activeStakeholder = stakeholders.stream().filter(x -> x.getRelationshipStatus() == AtlasRelationship.Status.ACTIVE).findFirst();
+                if (activeStakeholder.isPresent()) {
+                    throw new AtlasBaseException(OPERATION_NOT_SUPPORTED, "Can not delete StakeholderTitle as it has reference to Active Stakeholder");
+                }
 
-            authorizeDomainAccess(domainQualifiedNames, AtlasPrivilege.ENTITY_UPDATE);
+                List<String> domainQualifiedNames = vertex.getMultiValuedProperty(ATTR_DOMAIN_QUALIFIED_NAMES, String.class);
 
+                authorizeDomainAccess(domainQualifiedNames);
+            }
         } finally {
             RequestContext.get().endMetricRecord(metricRecorder);
         }
     }
 
-    private void authorizeDomainAccess(List<String> domainQualifiedNames, AtlasPrivilege permission) throws AtlasBaseException {
+    private void authorizeDomainAccess(List<String> domainQualifiedNames) throws AtlasBaseException {
         for (String domainQualifiedName: domainQualifiedNames) {
             String domainQualifiedNameToAuth;
+
             if (domainQualifiedNames.contains(STAR)) {
                 domainQualifiedNameToAuth = "*/super";
             } else {
@@ -219,7 +221,13 @@ public class StakeholderTitlePreProcessor implements PreProcessor {
             AtlasEntityHeader domainHeaderToAuth = new AtlasEntityHeader(DATA_DOMAIN_ENTITY_TYPE, mapOf(QUALIFIED_NAME, domainQualifiedNameToAuth));
 
             AtlasAuthorizationUtils.verifyAccess(new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_UPDATE, new AtlasEntityHeader(domainHeaderToAuth)),
-                    "create StakeholderTitle for domain ", domainQualifiedName);
+                    "mutate StakeholderTitle for domain ", domainQualifiedName);
+        }
+    }
+
+    private void validateRelations(AtlasEntity entity) throws AtlasBaseException {
+        if (entity.hasRelationshipAttribute(REL_ATTR_STAKEHOLDERS)) {
+            throw new AtlasBaseException(OPERATION_NOT_SUPPORTED, "Managing Stakeholders while creating/updating StakeholderTitle");
         }
     }
 }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/StakeholderTitlePreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/StakeholderTitlePreProcessor.java
@@ -198,7 +198,7 @@ public class StakeholderTitlePreProcessor implements PreProcessor {
                 throw new AtlasBaseException(OPERATION_NOT_SUPPORTED, "Can not delete StakeholderTitle as it has reference to Active Stakeholder");
             }
 
-            List<String> domainQualifiedNames = vertex.getListProperty(ATTR_DOMAIN_QUALIFIED_NAMES, String.class);
+            List<String> domainQualifiedNames = vertex.getMultiValuedProperty(ATTR_DOMAIN_QUALIFIED_NAMES, String.class);
 
             authorizeDomainAccess(domainQualifiedNames, AtlasPrivilege.ENTITY_UPDATE);
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/StakeholderTitlePreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/StakeholderTitlePreProcessor.java
@@ -16,7 +16,6 @@ import org.apache.atlas.model.instance.AtlasStruct;
 import org.apache.atlas.model.instance.EntityMutations;
 import org.apache.atlas.repository.graphdb.AtlasGraph;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
-import org.apache.atlas.repository.store.graph.AtlasEntityStore;
 import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
 import org.apache.atlas.repository.store.graph.v2.EntityMutationContext;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessor;

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/StakeholderTitlePreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/StakeholderTitlePreProcessor.java
@@ -95,7 +95,7 @@ public class StakeholderTitlePreProcessor implements PreProcessor {
             validateRelations(entity);
 
             if (RequestContext.get().isSkipAuthorizationCheck()) {
-                // To create bootstrap titles with provided aualifiedName
+                // To create bootstrap titles with provided qualifiedName
                 return;
             }
 
@@ -112,7 +112,7 @@ public class StakeholderTitlePreProcessor implements PreProcessor {
             }
 
             if (CollectionUtils.isEmpty(domainQualifiedNames)) {
-                throw new AtlasBaseException(BAD_REQUEST, "Please provide attribute domainQualifiedNames");
+                throw new AtlasBaseException(BAD_REQUEST, "Please provide attribute " + ATTR_DOMAIN_QUALIFIED_NAMES);
             }
 
             if (domainQualifiedNames.contains(STAR)) {

--- a/repository/src/main/java/org/apache/atlas/repository/util/AccessControlUtils.java
+++ b/repository/src/main/java/org/apache/atlas/repository/util/AccessControlUtils.java
@@ -32,6 +32,7 @@ import org.apache.atlas.repository.store.graph.AtlasEntityStore;
 import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
 import org.apache.atlas.util.NanoIdUtils;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -252,19 +253,18 @@ public final class AccessControlUtils {
     }
 
     public static String getPersonaRoleName(AtlasEntity persona) {
-        String qualifiedName = getStringAttribute(persona, QUALIFIED_NAME);
-
-        String[] parts = qualifiedName.split("/");
-
-        return "persona_" + parts[parts.length - 1];
+        return "persona_" + getESAliasName(persona);
     }
 
     public static String getESAliasName(AtlasEntity entity) {
         String qualifiedName = getStringAttribute(entity, QUALIFIED_NAME);
+        return getESAliasName(qualifiedName);
+    }
 
+    public static String getESAliasName(String qualifiedName) {
         String[] parts = qualifiedName.split("/");
 
-        return parts[parts.length - 1];
+        return parts[1];
     }
 
     public static List<AtlasEntity> getPolicies(AtlasEntity.AtlasEntityWithExtInfo accessControl) {

--- a/repository/src/main/java/org/apache/atlas/repository/util/AccessControlUtils.java
+++ b/repository/src/main/java/org/apache/atlas/repository/util/AccessControlUtils.java
@@ -337,7 +337,7 @@ public final class AccessControlUtils {
     public static void validateNoPoliciesAttached(AtlasEntity entity) throws AtlasBaseException {
         List<AtlasObjectId> policies = (List<AtlasObjectId>) entity.getRelationshipAttribute(REL_ATTR_POLICIES);
         if (CollectionUtils.isNotEmpty(policies)) {
-            throw new AtlasBaseException(OPERATION_NOT_SUPPORTED, "Can not attach a policy while creating/updating Persona/Purpose");
+            throw new AtlasBaseException(OPERATION_NOT_SUPPORTED, "Can not attach a policy while creating/updating Persona/Purpose/Stakeholder");
         }
     }
 

--- a/repository/src/main/java/org/apache/atlas/repository/util/AccessControlUtils.java
+++ b/repository/src/main/java/org/apache/atlas/repository/util/AccessControlUtils.java
@@ -18,7 +18,6 @@
 package org.apache.atlas.repository.util;
 
 import org.apache.atlas.exception.AtlasBaseException;
-import org.apache.atlas.featureflag.FeatureFlagStore;
 import org.apache.atlas.model.discovery.IndexSearchParams;
 import org.apache.atlas.model.instance.AtlasEntity;
 import org.apache.atlas.model.instance.AtlasEntityHeader;
@@ -28,11 +27,9 @@ import org.apache.atlas.repository.graphdb.AtlasGraph;
 import org.apache.atlas.repository.graphdb.AtlasIndexQuery;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
 import org.apache.atlas.repository.graphdb.DirectIndexQueryResult;
-import org.apache.atlas.repository.store.graph.AtlasEntityStore;
 import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
 import org.apache.atlas.util.NanoIdUtils;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,7 +41,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.atlas.AtlasErrorCode.ACCESS_CONTROL_ALREADY_EXISTS;
-import static org.apache.atlas.AtlasErrorCode.DISABLED_OPERATION;
 import static org.apache.atlas.AtlasErrorCode.OPERATION_NOT_SUPPORTED;
 import static org.apache.atlas.repository.Constants.*;
 import static org.apache.atlas.repository.util.AtlasEntityUtils.getListAttribute;


### PR DESCRIPTION
## Change description
We want to support Stakeholders for Domain, which will be similar to Personas but more granular Personas.

Overall, the flow would be like:
- The user will 1st create a StakeholderTitle
- Assuming a Domain is already created
- Not users will create Stakeholders for Domain, when Creating Stakeholder, we will pass StakeholderTitle as relationship
- Based on this relationship value, Atlas will populate stakeholderTitleGuid for the Stakeholder asset
  




> Description here

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> https://atlanhq.atlassian.net/browse/DG-1235

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
