### PR TITLE
DG-1384 Daap visibility issue when Products are not created using UI

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -1808,7 +1808,7 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
                 break;
 
             case DATA_PRODUCT_ENTITY_TYPE:
-                preProcessor = new DataProductPreProcessor(typeRegistry, entityRetriever, graph);
+                preProcessor = new DataProductPreProcessor(typeRegistry, entityRetriever, graph, this);
                 break;
 
             case QUERY_ENTITY_TYPE:

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/PreProcessorUtils.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/PreProcessorUtils.java
@@ -53,7 +53,9 @@ public class PreProcessorUtils {
 
     public static final String PARENT_DOMAIN_QN_ATTR = "parentDomainQualifiedName";
     public static final String SUPER_DOMAIN_QN_ATTR = "superDomainQualifiedName";
-
+    public static  final String DAAP_VISIBILITY = "daapVisibility";
+    public static  final String DAAP_VISIBILITY_USERS = "daapVisibilityUsers";
+    public static  final String DAAP_VISIBILITY_GROUPS = "daapVisibilityGroups";
 
     //Migration Constants
     public static final String MIGRATION = "MIGRATION:";

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/PreProcessorUtils.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/PreProcessorUtils.java
@@ -53,9 +53,9 @@ public class PreProcessorUtils {
 
     public static final String PARENT_DOMAIN_QN_ATTR = "parentDomainQualifiedName";
     public static final String SUPER_DOMAIN_QN_ATTR = "superDomainQualifiedName";
-    public static  final String DAAP_VISIBILITY = "daapVisibility";
-    public static  final String DAAP_VISIBILITY_USERS = "daapVisibilityUsers";
-    public static  final String DAAP_VISIBILITY_GROUPS = "daapVisibilityGroups";
+    public static  final String DAAP_VISIBILITY_ATTR = "daapVisibility";
+    public static  final String DAAP_VISIBILITY_USERS_ATTR = "daapVisibilityUsers";
+    public static  final String DAAP_VISIBILITY_GROUPS_ATTR = "daapVisibilityGroups";
 
     //Migration Constants
     public static final String MIGRATION = "MIGRATION:";

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
@@ -11,7 +11,7 @@ import org.apache.atlas.repository.store.graph.v2.AtlasEntityStream;
 import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
 import org.apache.atlas.repository.store.graph.v2.EntityMutationContext;
 import org.apache.atlas.repository.store.graph.v2.EntityStream;
-import org.apache.atlas.repository.util.AccessControlUtils;
+import org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessorUtils;
 import org.apache.atlas.type.AtlasTypeRegistry;
 import org.apache.atlas.utils.AtlasPerfMetrics;
 import org.apache.commons.collections.CollectionUtils;
@@ -24,10 +24,14 @@ import java.util.*;
 import static org.apache.atlas.repository.Constants.*;
 import static org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessorUtils.*;
 import static org.apache.atlas.repository.util.AccessControlUtils.*;
-import static org.apache.atlas.repository.util.AtlasEntityUtils.mapOf;
 
 public class DataProductPreProcessor extends AbstractDomainPreProcessor {
     private static final Logger LOG = LoggerFactory.getLogger(DataProductPreProcessor.class);
+    private static final String PRIVATE = "Private";
+    private static final String PROTECTED = "Protected";
+    private static final String PUBLIC = "Public";
+
+
 
     private EntityMutationContext context;
     private AtlasEntityStore entityStore;
@@ -78,42 +82,7 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
 
         productExists(productName, parentDomainQualifiedName);
 
-        String productGuid = vertex.getProperty("__guid", String.class);
-
-        AtlasEntity policy = new AtlasEntity();
-        policy.setTypeName(POLICY_ENTITY_TYPE);
-        policy.setAttribute(NAME,entity.getAttribute(NAME));
-        policy.setAttribute(QUALIFIED_NAME, productGuid+"/read-policy");
-        policy.setAttribute(AccessControlUtils.ATTR_POLICY_ACTIONS, Arrays.asList("entity-read"));
-        policy.setAttribute(ATTR_POLICY_CATEGORY,"datamesh");
-        policy.setAttribute(ATTR_POLICY_TYPE,POLICY_TYPE_ALLOW);
-        policy.setAttribute(ATTR_POLICY_RESOURCES, Arrays.asList("entity:"+entity.getAttribute(QUALIFIED_NAME)));
-        policy.setAttribute("accessControlPolicyCategory",POLICY_CATEGORY_PERSONA);
-        policy.setAttribute(ATTR_POLICY_RESOURCES_CATEGORY,"entity");
-        policy.setAttribute(ATTR_POLICY_SERVICE_NAME,"atlas");
-        policy.setAttribute(ATTR_POLICY_SUB_CATEGORY,"dataProduct");
-
-        switch ((String) entity.getAttribute("daapVisibility")) {
-            case "Private":
-                // do nothing for private daapVisibility
-                break;
-            case "Protected":
-                // create policy for policyUsers and policyGroups
-                policy.setAttribute(ATTR_POLICY_USERS, entity.getAttribute("daapVisibilityUsers"));
-                policy.setAttribute(ATTR_POLICY_GROUPS, entity.getAttribute("daapVisibilityGroups"));
-                break;
-            case "Public":
-                // set empty user list
-                policy.setAttribute(ATTR_POLICY_USERS, Arrays.asList());
-                // set user groups oto public to allow access for all
-                policy.setAttribute(ATTR_POLICY_GROUPS, Arrays.asList("Public"));
-                break;
-        }
-
-        AtlasEntity.AtlasEntitiesWithExtInfo policiesExtInfo = new AtlasEntity.AtlasEntitiesWithExtInfo();
-        policiesExtInfo.addEntity(policy);
-        EntityStream entityStream = new AtlasEntityStream(policiesExtInfo);
-        entityStore.createOrUpdate(entityStream, false); // adding new policy
+        createDaapVisibilityPolicy(entity,vertex);
 
         RequestContext.get().endMetricRecord(metricRecorder);
     }
@@ -168,65 +137,13 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
         }
 
         // check for daapVisibility change
-        String currentProductDaapVisibility = storedProduct.getAttribute("daapVisibility").toString();
-        String newProductDaapVisibility = (String) entity.getAttribute(NAME);
+        String currentProductDaapVisibility = storedProduct.getAttribute(DAAP_VISIBILITY).toString();
+        String newProductDaapVisibility = (String) entity.getAttribute(DAAP_VISIBILITY);
 
         if (newProductDaapVisibility != null && !newProductDaapVisibility.equals(currentProductDaapVisibility)) {
-
-            AtlasEntity policy = new AtlasEntity();
-            policy.setTypeName(POLICY_ENTITY_TYPE);
-            policy.setAttribute(NAME,entity.getAttribute(NAME));
-            policy.setAttribute(QUALIFIED_NAME,storedProduct.getGuid()+"/read-policy");
-
-            switch (currentProductDaapVisibility) {
-                case "Private":
-                    switch (newProductDaapVisibility) {
-                        case "Protected":
-                            // create policy for policyUsers and policyGroups
-                            policy.setAttribute(ATTR_POLICY_USERS, entity.getAttribute("daapVisibilityUsers"));
-                            policy.setAttribute(ATTR_POLICY_GROUPS, entity.getAttribute("daapVisibilityGroups"));
-                            break;
-                        case "Public":
-                            // set empty user list
-                            policy.setAttribute(ATTR_POLICY_USERS, Arrays.asList());
-                            // set user groups oto public to allow access for all
-                            policy.setAttribute(ATTR_POLICY_GROUPS, Arrays.asList("Public"));
-                    }
-                    break;
-                case "Protected":
-                    switch (newProductDaapVisibility) {
-                        case "Private":
-                            // create policy for policyUsers and policyGroups
-                            policy.setAttribute(ATTR_POLICY_USERS,Arrays.asList());
-                            policy.setAttribute(ATTR_POLICY_GROUPS,Arrays.asList());
-                            break;
-                        case "Public":
-                            // set empty user list
-                            policy.setAttribute(ATTR_POLICY_USERS, Arrays.asList());
-                            // set user groups oto public to allow access for all
-                            policy.setAttribute(ATTR_POLICY_GROUPS, Arrays.asList("Public"));
-                    }
-                    break;
-                case "Public":
-                    switch (newProductDaapVisibility) {
-                        case "Private":
-                            // create policy for policyUsers and policyGroups
-                            policy.setAttribute(ATTR_POLICY_USERS,Arrays.asList());
-                            policy.setAttribute(ATTR_POLICY_GROUPS,Arrays.asList());
-                            break;
-                        case "Protected":
-                            // create policy for policyUsers and policyGroups
-                            policy.setAttribute(ATTR_POLICY_USERS, entity.getAttribute("daapVisibilityUsers"));
-                            policy.setAttribute(ATTR_POLICY_GROUPS, entity.getAttribute("daapVisibilityGroups"));
-                            break;
-                    }
-                    break;
-            }
-            AtlasEntity.AtlasEntitiesWithExtInfo policiesExtInfo = new AtlasEntity.AtlasEntitiesWithExtInfo();
-            policiesExtInfo.addEntity(policy);
-            EntityStream entityStream = new AtlasEntityStream(policiesExtInfo);
-            entityStore.createOrUpdate(entityStream, false); // adding new policy
+            updateDaapVisibilityPolicy(entity, storedProduct, currentProductDaapVisibility,newProductDaapVisibility);
         }
+
         RequestContext.get().endMetricRecord(metricRecorder);
     }
 
@@ -291,7 +208,113 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
         if (StringUtils.isEmpty(parentDomainQualifiedName)) {
             throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST, "Parent Domain Qualified Name cannot be empty or null");
         }
-        return parentDomainQualifiedName + "/product/" + getUUID();
+        return parentDomainQualifiedName + "/product/" + PreProcessorUtils.getUUID();
 
+    }
+
+    private void createDaapVisibilityPolicy(AtlasEntity entity,AtlasVertex vertex) throws AtlasBaseException {
+        String productGuid = vertex.getProperty("__guid", String.class);
+
+        AtlasEntity policy = new AtlasEntity();
+        policy.setTypeName(POLICY_ENTITY_TYPE);
+        policy.setAttribute(NAME, entity.getAttribute(NAME));
+        policy.setAttribute(QUALIFIED_NAME, productGuid + "/read-policy");
+        policy.setAttribute(ATTR_POLICY_ACTIONS, Arrays.asList("entity-read"));
+        policy.setAttribute(ATTR_POLICY_CATEGORY, MESH_POLICY_CATEGORY);
+        policy.setAttribute(ATTR_POLICY_TYPE, POLICY_TYPE_ALLOW);
+        policy.setAttribute(ATTR_POLICY_RESOURCES, Arrays.asList("entity:" + entity.getAttribute(QUALIFIED_NAME)));
+        policy.setAttribute(ATTR_POLICY_RESOURCES_CATEGORY, POLICY_RESOURCE_CATEGORY_PERSONA_ENTITY);
+        policy.setAttribute(ATTR_POLICY_SERVICE_NAME, "atlas");
+        policy.setAttribute(ATTR_POLICY_SUB_CATEGORY, DATA_PRODUCT_ENTITY_TYPE);
+
+        switch ((String) entity.getAttribute(DAAP_VISIBILITY)) {
+            case PRIVATE:
+                // do nothing for private daapVisibility
+                break;
+            case PROTECTED:
+                // create policy for policyUsers and policyGroups
+                policy.setAttribute(ATTR_POLICY_USERS, entity.getAttribute(DAAP_VISIBILITY_USERS));
+                policy.setAttribute(ATTR_POLICY_GROUPS, entity.getAttribute(DAAP_VISIBILITY_GROUPS));
+                break;
+            case PUBLIC:
+                // set empty user list
+                policy.setAttribute(ATTR_POLICY_USERS, Arrays.asList());
+                // set user groups oto public to allow access for all
+                policy.setAttribute(ATTR_POLICY_GROUPS, Arrays.asList("public"));
+                break;
+        }
+
+        try {
+            RequestContext.get().setSkipAuthorizationCheck(true);
+            AtlasEntity.AtlasEntitiesWithExtInfo policiesExtInfo = new AtlasEntity.AtlasEntitiesWithExtInfo();
+            policiesExtInfo.addEntity(policy);
+            EntityStream entityStream = new AtlasEntityStream(policiesExtInfo);
+            entityStore.createOrUpdate(entityStream, false); // adding new policy
+        } finally {
+            RequestContext.get().setSkipAuthorizationCheck(false);
+        }
+    }
+
+    private void updateDaapVisibilityPolicy(AtlasEntity newEntity, AtlasEntity currentEntity,  String currentProductDaapVisibility, String newProductDaapVisibility) throws AtlasBaseException{
+
+        AtlasEntity policy = new AtlasEntity();
+        policy.setTypeName(POLICY_ENTITY_TYPE);
+        policy.setAttribute(NAME,newEntity.getAttribute(NAME));
+        policy.setAttribute(QUALIFIED_NAME,currentEntity.getGuid()+"/read-policy");
+
+        switch (currentProductDaapVisibility) {
+            case PRIVATE:
+                switch (newProductDaapVisibility) {
+                    case PROTECTED:
+                        // create policy for policyUsers and policyGroups
+                        policy.setAttribute(ATTR_POLICY_USERS, newEntity.getAttribute(DAAP_VISIBILITY_USERS));
+                        policy.setAttribute(ATTR_POLICY_GROUPS, newEntity.getAttribute(DAAP_VISIBILITY_GROUPS));
+                        break;
+                    case PUBLIC:
+                        // set empty user list
+                        policy.setAttribute(ATTR_POLICY_USERS, Arrays.asList());
+                        // set user groups to public to allow access for all
+                        policy.setAttribute(ATTR_POLICY_GROUPS, Arrays.asList("public"));
+                }
+                break;
+            case PROTECTED:
+                switch (newProductDaapVisibility) {
+                    case PRIVATE:
+                        // create policy for policyUsers and policyGroups
+                        policy.setAttribute(ATTR_POLICY_USERS,Arrays.asList());
+                        policy.setAttribute(ATTR_POLICY_GROUPS,Arrays.asList());
+                        break;
+                    case PUBLIC:
+                        // set empty user list
+                        policy.setAttribute(ATTR_POLICY_USERS, Arrays.asList());
+                        // set user groups to public to allow access for all
+                        policy.setAttribute(ATTR_POLICY_GROUPS, Arrays.asList("public"));
+                }
+                break;
+            case PUBLIC:
+                switch (newProductDaapVisibility) {
+                    case PRIVATE:
+                        // create policy for policyUsers and policyGroups
+                        policy.setAttribute(ATTR_POLICY_USERS,Arrays.asList());
+                        policy.setAttribute(ATTR_POLICY_GROUPS,Arrays.asList());
+                        break;
+                    case PROTECTED:
+                        // create policy for policyUsers and policyGroups
+                        policy.setAttribute(ATTR_POLICY_USERS, newEntity.getAttribute(DAAP_VISIBILITY_USERS));
+                        policy.setAttribute(ATTR_POLICY_GROUPS, newEntity.getAttribute(DAAP_VISIBILITY_GROUPS));
+                        break;
+                }
+                break;
+        }
+
+        try {
+            RequestContext.get().setSkipAuthorizationCheck(true);
+            AtlasEntity.AtlasEntitiesWithExtInfo policiesExtInfo = new AtlasEntity.AtlasEntitiesWithExtInfo();
+            policiesExtInfo.addEntity(policy);
+            EntityStream entityStream = new AtlasEntityStream(policiesExtInfo);
+            entityStore.createOrUpdate(entityStream, false); // adding new policy
+        } finally {
+            RequestContext.get().setSkipAuthorizationCheck(false);
+        }
     }
 }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
@@ -89,9 +89,9 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
         policy.setAttribute(ATTR_POLICY_TYPE,POLICY_TYPE_ALLOW);
         policy.setAttribute(ATTR_POLICY_RESOURCES, Arrays.asList("entity:"+entity.getAttribute(QUALIFIED_NAME)));
         policy.setAttribute("accessControlPolicyCategory",POLICY_CATEGORY_PERSONA);
-        policy.setAttribute("policyResourceCategory","entity");
-        policy.setAttribute("policyServiceName","atlas");
-        policy.setAttribute("policySubCategory","dataProduct");
+        policy.setAttribute(ATTR_POLICY_RESOURCES_CATEGORY,"entity");
+        policy.setAttribute(ATTR_POLICY_SERVICE_NAME,"atlas");
+        policy.setAttribute(ATTR_POLICY_SUB_CATEGORY,"dataProduct");
 
         switch ((String) entity.getAttribute("daapVisibility")) {
             case "Private":

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
@@ -236,31 +236,19 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
 
         switch ((String) entity.getAttribute(DAAP_VISIBILITY_ATTR)) {
             case PRIVATE:
-                policy.setAttribute(ATTR_POLICY_USERS,Arrays.asList());
-                policy.setAttribute(ATTR_POLICY_GROUPS,Arrays.asList());
+                setPolicyAttributes(policy, Arrays.asList(), Arrays.asList());
                 break;
             case PROTECTED:
-                // create policy for policyUsers and policyGroups
-                policy.setAttribute(ATTR_POLICY_USERS, entity.getAttribute(DAAP_VISIBILITY_USERS_ATTR));
-                policy.setAttribute(ATTR_POLICY_GROUPS, entity.getAttribute(DAAP_VISIBILITY_GROUPS_ATTR));
+                setPolicyAttributes(policy,
+                        (List<String>) entity.getAttribute(DAAP_VISIBILITY_USERS_ATTR),
+                        (List<String>) entity.getAttribute(DAAP_VISIBILITY_GROUPS_ATTR)
+                );
                 break;
             case PUBLIC:
-                // set empty user list
-                policy.setAttribute(ATTR_POLICY_USERS, Arrays.asList());
-                // set user groups oto public to allow access for all
-                policy.setAttribute(ATTR_POLICY_GROUPS, Arrays.asList("public"));
+                setPolicyAttributes(policy, Arrays.asList(), Arrays.asList("public"));
                 break;
         }
-
-        try {
-            RequestContext.get().setSkipAuthorizationCheck(true);
-            AtlasEntity.AtlasEntitiesWithExtInfo policiesExtInfo = new AtlasEntity.AtlasEntitiesWithExtInfo();
-            policiesExtInfo.addEntity(policy);
-            EntityStream entityStream = new AtlasEntityStream(policiesExtInfo);
-            entityStore.createOrUpdate(entityStream, false); // adding new policy
-        } finally {
-            RequestContext.get().setSkipAuthorizationCheck(false);
-        }
+        createOrUpdatePolicy(policy);
     }
 
     private void updateDaapVisibilityPolicy(AtlasEntity newEntity, AtlasEntity currentEntity,  String currentProductDaapVisibility, String newProductDaapVisibility) throws AtlasBaseException{
@@ -275,46 +263,42 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
                 switch (newProductDaapVisibility) {
                     case PROTECTED:
                         // create policy for policyUsers and policyGroups
-                        policy.setAttribute(ATTR_POLICY_USERS, newEntity.getAttribute(DAAP_VISIBILITY_USERS_ATTR));
-                        policy.setAttribute(ATTR_POLICY_GROUPS, newEntity.getAttribute(DAAP_VISIBILITY_GROUPS_ATTR));
+                        setPolicyAttributes(policy,
+                                (List<String>) newEntity.getAttribute(DAAP_VISIBILITY_USERS_ATTR),
+                                (List<String>) newEntity.getAttribute(DAAP_VISIBILITY_GROUPS_ATTR)
+                        );
                         break;
                     case PUBLIC:
-                        // set empty user list
-                        policy.setAttribute(ATTR_POLICY_USERS, Arrays.asList());
-                        // set user groups to public to allow access for all
-                        policy.setAttribute(ATTR_POLICY_GROUPS, Arrays.asList("public"));
+                        setPolicyAttributes(policy, Arrays.asList(), Arrays.asList("public"));
                 }
                 break;
             case PROTECTED:
                 switch (newProductDaapVisibility) {
                     case PRIVATE:
-                        // create policy for policyUsers and policyGroups
-                        policy.setAttribute(ATTR_POLICY_USERS,Arrays.asList());
-                        policy.setAttribute(ATTR_POLICY_GROUPS,Arrays.asList());
+                        setPolicyAttributes(policy, Arrays.asList(), Arrays.asList());
                         break;
                     case PUBLIC:
-                        // set empty user list
-                        policy.setAttribute(ATTR_POLICY_USERS, Arrays.asList());
-                        // set user groups to public to allow access for all
-                        policy.setAttribute(ATTR_POLICY_GROUPS, Arrays.asList("public"));
+                        setPolicyAttributes(policy, Arrays.asList(), Arrays.asList("public"));
                 }
                 break;
             case PUBLIC:
                 switch (newProductDaapVisibility) {
                     case PRIVATE:
-                        // create policy for policyUsers and policyGroups
-                        policy.setAttribute(ATTR_POLICY_USERS,Arrays.asList());
-                        policy.setAttribute(ATTR_POLICY_GROUPS,Arrays.asList());
+                        setPolicyAttributes(policy, Arrays.asList(), Arrays.asList());
                         break;
                     case PROTECTED:
-                        // create policy for policyUsers and policyGroups
-                        policy.setAttribute(ATTR_POLICY_USERS, newEntity.getAttribute(DAAP_VISIBILITY_USERS_ATTR));
-                        policy.setAttribute(ATTR_POLICY_GROUPS, newEntity.getAttribute(DAAP_VISIBILITY_GROUPS_ATTR));
+                        setPolicyAttributes(policy,
+                                (List<String>) newEntity.getAttribute(DAAP_VISIBILITY_USERS_ATTR),
+                                (List<String>) newEntity.getAttribute(DAAP_VISIBILITY_GROUPS_ATTR)
+                        );
                         break;
                 }
                 break;
         }
+        createOrUpdatePolicy(policy);
+    }
 
+    private void createOrUpdatePolicy(AtlasEntity policy) throws AtlasBaseException{
         try {
             RequestContext.get().setSkipAuthorizationCheck(true);
             AtlasEntity.AtlasEntitiesWithExtInfo policiesExtInfo = new AtlasEntity.AtlasEntitiesWithExtInfo();
@@ -324,5 +308,11 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
         } finally {
             RequestContext.get().setSkipAuthorizationCheck(false);
         }
+    }
+
+    // Helper method to set policy attributes
+    private void setPolicyAttributes(AtlasEntity policy, List<String> users, List<String> groups) {
+        policy.setAttribute(ATTR_POLICY_USERS, users);
+        policy.setAttribute(ATTR_POLICY_GROUPS, groups);
     }
 }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
@@ -113,7 +113,16 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
             newParentDomainQualifiedName = (String) newParentDomainHeader.getAttribute(QUALIFIED_NAME);
         }
 
+        // check for daapVisibility change
+        String currentProductDaapVisibility = storedProduct.getAttribute(DAAP_VISIBILITY).toString();
+        String newProductDaapVisibility = (String) entity.getAttribute(DAAP_VISIBILITY);
+
         if (newParentDomainQualifiedName != null && !newParentDomainQualifiedName.equals(currentParentDomainQualifiedName)) {
+
+            if (newProductDaapVisibility != null && !newProductDaapVisibility.equals(currentProductDaapVisibility)){
+                throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST, "Moving the product to another domain, along with the change in Dapp visibility, is not allowed");
+            }
+
             //Auth check
             isAuthorized(currentParentDomainHeader, newParentDomainHeader);
 
@@ -135,10 +144,6 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
             }
             entity.setAttribute(QUALIFIED_NAME, vertexQnName);
         }
-
-        // check for daapVisibility change
-        String currentProductDaapVisibility = storedProduct.getAttribute(DAAP_VISIBILITY).toString();
-        String newProductDaapVisibility = (String) entity.getAttribute(DAAP_VISIBILITY);
 
         if (newProductDaapVisibility != null && !newProductDaapVisibility.equals(currentProductDaapVisibility)) {
             updateDaapVisibilityPolicy(entity, storedProduct, currentProductDaapVisibility,newProductDaapVisibility);


### PR DESCRIPTION
## Change description
- Currently we are managing Daap visibility policies via UI
- This caused an issue where UI were sending stale qualifirdNames for daap visibility policy
- Also Products which are not managed by UI, meeses up visibility as they do not have policy at all
- We decided to handle it from BE completely
- This release will need UI changes to remove policy bulk calls & send users & groups list when protected visibility is selected

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> https://atlanhq.atlassian.net/browse/DG-1384

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
