### PR TITLE
feat: Fix restriction on prop via lineage

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -3027,7 +3027,7 @@ public class EntityGraphMapper {
                 }
 
                 if (restrictPropagationThroughHierarchy == null) {
-                    classification.setRestrictPropagationThroughLineage(RESTRICT_PROPAGATION_THROUGH_HIERARCHY_DEFAULT);
+                    classification.setRestrictPropagationThroughHierarchy(RESTRICT_PROPAGATION_THROUGH_HIERARCHY_DEFAULT);
                 }
 
                 // set associated entity id to classification


### PR DESCRIPTION
## Wrong propagation mode selected even though propagation through lineage was disabled

> One silly mistake led to selecting wrong propagation mode which was leading to propagation to downstream assets even though we were restricting it. This regression was due to. https://github.com/atlanhq/atlas-metastore/pull/2891

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [https://github.com/atlanhq/atlas-metastore/pull/2891](Addition of restrictPropagationThroughHierarchy flag in classification propagation) 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
