### PR TITLE
DG-1370 Write Mesh parent attributes in server

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/AbstractDomainPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/AbstractDomainPreProcessor.java
@@ -226,7 +226,7 @@ public abstract class AbstractDomainPreProcessor implements PreProcessor {
         mustClauseList.add(mapOf("term", mapOf("__state", "ACTIVE")));
         mustClauseList.add(mapOf("term", mapOf("name.keyword", assetName)));
         List<Map<String, Object>> mustNotClauseList = new ArrayList();
-        if(Objects.nonNull(guid) && StringUtils.isNotEmpty(guid)){
+        if(StringUtils.isNotEmpty(guid)){
             mustNotClauseList.add(mapOf("term", mapOf("__guid", guid)));
         }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/AbstractDomainPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/AbstractDomainPreProcessor.java
@@ -218,26 +218,29 @@ public abstract class AbstractDomainPreProcessor implements PreProcessor {
         }
     }
 
-    protected void exists(String assetType, String assetName, String parentDomainQualifiedName) throws AtlasBaseException {
+    protected void exists(String assetType, String assetName, String parentDomainQualifiedName, String guid) throws AtlasBaseException {
         boolean exists = false;
 
         List<Map<String, Object>> mustClauseList = new ArrayList();
         mustClauseList.add(mapOf("term", mapOf("__typeName.keyword", assetType)));
         mustClauseList.add(mapOf("term", mapOf("__state", "ACTIVE")));
         mustClauseList.add(mapOf("term", mapOf("name.keyword", assetName)));
-
+        List<Map<String, Object>> mustNotClauseList = new ArrayList();
+        if(Objects.nonNull(guid) && StringUtils.isNotEmpty(guid)){
+            mustNotClauseList.add(mapOf("term", mapOf("__guid", guid)));
+        }
 
         Map<String, Object> bool = new HashMap<>();
         if (StringUtils.isNotEmpty(parentDomainQualifiedName)) {
             mustClauseList.add(mapOf("term", mapOf("parentDomainQualifiedName", parentDomainQualifiedName)));
         } else {
-            List<Map<String, Object>> mustNotClauseList = new ArrayList();
             mustNotClauseList.add(mapOf("exists", mapOf("field", "parentDomainQualifiedName")));
-            bool.put("must_not", mustNotClauseList);
         }
 
         bool.put("must", mustClauseList);
-
+        if(!mustNotClauseList.isEmpty()) {
+            bool.put("must_not", mustNotClauseList);
+        }
         Map<String, Object> dsl = mapOf("query", mapOf("bool", bool));
 
         List<AtlasEntityHeader> assets = indexSearchPaginated(dsl, null, this.discovery);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataDomainPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataDomainPreProcessor.java
@@ -118,7 +118,7 @@ public class DataDomainPreProcessor extends AbstractDomainPreProcessor {
 
         entity.setCustomAttributes(customAttributes);
 
-        domainExists(domainName, parentDomainQualifiedName);
+        domainExists(domainName, parentDomainQualifiedName, null);
 
         RequestContext.get().endMetricRecord(metricRecorder);
     }
@@ -167,7 +167,7 @@ public class DataDomainPreProcessor extends AbstractDomainPreProcessor {
             //Auth check
             isAuthorized(currentParentDomainHeader, newParentDomainHeader);
 
-            processMoveSubDomainToAnotherDomain(entity, vertex, currentParentDomainQualifiedName, newParentDomainQualifiedName, vertexQnName, newSuperDomainQualifiedName);
+            processMoveSubDomainToAnotherDomain(entity, vertex, currentParentDomainQualifiedName, newParentDomainQualifiedName, vertexQnName, newSuperDomainQualifiedName, storedDomain.getGuid());
 
         } else {
             String domainCurrentName = vertex.getProperty(NAME, String.class);
@@ -177,7 +177,7 @@ public class DataDomainPreProcessor extends AbstractDomainPreProcessor {
             entity.removeAttribute(SUPER_DOMAIN_QN_ATTR);
 
             if (!domainCurrentName.equals(domainNewName)) {
-                domainExists(domainNewName, currentParentDomainQualifiedName);
+                domainExists(domainNewName, currentParentDomainQualifiedName, storedDomain.getGuid());
             }
             entity.setAttribute(QUALIFIED_NAME, vertexQnName);
         }
@@ -190,7 +190,8 @@ public class DataDomainPreProcessor extends AbstractDomainPreProcessor {
                                                       String sourceDomainQualifiedName,
                                                       String targetDomainQualifiedName,
                                                       String currentDomainQualifiedName,
-                                                      String superDomainQualifiedName) throws AtlasBaseException {
+                                                      String superDomainQualifiedName,
+                                                      String guid) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder recorder = RequestContext.get().startMetricRecord("processMoveSubDomainToAnotherDomain");
 
         try {
@@ -199,7 +200,7 @@ public class DataDomainPreProcessor extends AbstractDomainPreProcessor {
 
             LOG.info("Moving subdomain {} to Domain {}", domainName, targetDomainQualifiedName);
 
-            domainExists(domainName, targetDomainQualifiedName);
+            domainExists(domainName, targetDomainQualifiedName, guid);
 
             if(targetDomainQualifiedName.isEmpty()){
                 //Moving subDomain to make it Super Domain
@@ -356,10 +357,10 @@ public class DataDomainPreProcessor extends AbstractDomainPreProcessor {
         return getParent(objectId, PARENT_ATTRIBUTES);
     }
 
-    private void domainExists(String domainName, String parentDomainQualifiedName) throws AtlasBaseException {
+    private void domainExists(String domainName, String parentDomainQualifiedName,String guid) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("domainExists");
         try {
-            exists(DATA_DOMAIN_ENTITY_TYPE, domainName, parentDomainQualifiedName);
+            exists(DATA_DOMAIN_ENTITY_TYPE, domainName, parentDomainQualifiedName, guid);
 
         } finally {
             RequestContext.get().endMetricRecord(metricRecorder);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataDomainPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataDomainPreProcessor.java
@@ -97,6 +97,14 @@ public class DataDomainPreProcessor extends AbstractDomainPreProcessor {
         if(parentDomainObject != null ){
             parentDomain = retrieverNoRelation.getEntityVertex(parentDomainObject);
             parentDomainQualifiedName = parentDomain.getProperty(QUALIFIED_NAME, String.class);
+            if(StringUtils.isNotEmpty(parentDomainQualifiedName)) {
+                entity.setAttribute(PARENT_DOMAIN_QN_ATTR, parentDomainQualifiedName);
+                String superDomainQualifiedName = parentDomain.getProperty(SUPER_DOMAIN_QN_ATTR, String.class);
+                if(StringUtils.isEmpty(parentDomain.getProperty(SUPER_DOMAIN_QN_ATTR, String.class))) {
+                    superDomainQualifiedName = parentDomainQualifiedName;
+                }
+                entity.setAttribute(SUPER_DOMAIN_QN_ATTR, superDomainQualifiedName);
+            }
         } else {
             entity.removeAttribute(PARENT_DOMAIN_QN_ATTR);
             entity.removeAttribute(SUPER_DOMAIN_QN_ATTR);
@@ -104,17 +112,6 @@ public class DataDomainPreProcessor extends AbstractDomainPreProcessor {
 
         entity.setAttribute(QUALIFIED_NAME, createQualifiedName(parentDomainQualifiedName));
 
-        if(StringUtils.isNotEmpty(parentDomainQualifiedName)) {
-            entity.setAttribute(PARENT_DOMAIN_QN_ATTR, parentDomainQualifiedName);
-            String superDomainQualifiedName = "";
-            if(StringUtils.isEmpty(parentDomain.getProperty(SUPER_DOMAIN_QN_ATTR, String.class))){
-                superDomainQualifiedName = parentDomainQualifiedName;
-            }
-            else {
-                superDomainQualifiedName =  parentDomain.getProperty(SUPER_DOMAIN_QN_ATTR, String.class);
-            }
-            entity.setAttribute(SUPER_DOMAIN_QN_ATTR, superDomainQualifiedName);
-        }
 
         entity.setCustomAttributes(customAttributes);
 
@@ -169,7 +166,7 @@ public class DataDomainPreProcessor extends AbstractDomainPreProcessor {
             //Auth check
             isAuthorized(currentParentDomainHeader, newParentDomainHeader);
 
-            processMoveSubDomainToAnotherDomain(entity, vertex, currentParentDomainQualifiedName, newParentDomainQualifiedName, vertexQnName, newSuperDomainQualifiedName, storedDomain.getGuid());
+            processMoveSubDomainToAnotherDomain(entity, vertex, currentParentDomainQualifiedName, newParentDomainQualifiedName, vertexQnName, newSuperDomainQualifiedName);
 
         } else {
             String domainCurrentName = vertex.getProperty(NAME, String.class);
@@ -192,8 +189,7 @@ public class DataDomainPreProcessor extends AbstractDomainPreProcessor {
                                                       String sourceDomainQualifiedName,
                                                       String targetDomainQualifiedName,
                                                       String currentDomainQualifiedName,
-                                                      String superDomainQualifiedName,
-                                                      String guid) throws AtlasBaseException {
+                                                      String superDomainQualifiedName) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder recorder = RequestContext.get().startMetricRecord("processMoveSubDomainToAnotherDomain");
 
         try {
@@ -202,7 +198,7 @@ public class DataDomainPreProcessor extends AbstractDomainPreProcessor {
 
             LOG.info("Moving subdomain {} to Domain {}", domainName, targetDomainQualifiedName);
 
-            domainExists(domainName, targetDomainQualifiedName, guid);
+            domainExists(domainName, targetDomainQualifiedName, domain.getGuid());
 
             if(targetDomainQualifiedName.isEmpty()){
                 //Moving subDomain to make it Super Domain

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataDomainPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataDomainPreProcessor.java
@@ -211,8 +211,7 @@ public class DataDomainPreProcessor extends AbstractDomainPreProcessor {
             }
             else{
                 if(StringUtils.isEmpty(sourceDomainQualifiedName)){
-                    String[] arr = currentDomainQualifiedName.split("/");
-                    updatedQualifiedName = targetDomainQualifiedName + "/domain/" + arr[arr.length - 1];
+                    updatedQualifiedName = createQualifiedName(targetDomainQualifiedName);
                 }else {
                     updatedQualifiedName = currentDomainQualifiedName.replace(sourceDomainQualifiedName, targetDomainQualifiedName);
                 }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataDomainPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataDomainPreProcessor.java
@@ -158,7 +158,6 @@ public class DataDomainPreProcessor extends AbstractDomainPreProcessor {
 
         if (!newParentDomainQualifiedName.equals(currentParentDomainQualifiedName) && entity.hasRelationshipAttribute(PARENT_DOMAIN_REL_TYPE)) {
             if(storedDomain.getRelationshipAttribute(PARENT_DOMAIN_REL_TYPE) == null &&
-                    Objects.isNull(storedDomain.getAttribute(PARENT_DOMAIN_QN_ATTR)) &&
                     StringUtils.isEmpty( (String) storedDomain.getAttribute(PARENT_DOMAIN_QN_ATTR))){
                 throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST, "Cannot move Super Domain inside another domain");
             }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataDomainPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataDomainPreProcessor.java
@@ -160,7 +160,9 @@ public class DataDomainPreProcessor extends AbstractDomainPreProcessor {
         }
 
         if (!newParentDomainQualifiedName.equals(currentParentDomainQualifiedName) && entity.hasRelationshipAttribute(PARENT_DOMAIN_REL_TYPE)) {
-            if(storedDomain.getRelationshipAttribute(PARENT_DOMAIN_REL_TYPE) == null){
+            if(storedDomain.getRelationshipAttribute(PARENT_DOMAIN_REL_TYPE) == null &&
+                    Objects.isNull(storedDomain.getAttribute(PARENT_DOMAIN_QN_ATTR)) &&
+                    StringUtils.isEmpty( (String) storedDomain.getAttribute(PARENT_DOMAIN_QN_ATTR))){
                 throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST, "Cannot move Super Domain inside another domain");
             }
 
@@ -213,7 +215,13 @@ public class DataDomainPreProcessor extends AbstractDomainPreProcessor {
                 superDomainQualifiedName = updatedQualifiedName ;
             }
             else{
-                updatedQualifiedName = currentDomainQualifiedName.replace(sourceDomainQualifiedName, targetDomainQualifiedName);
+                if(StringUtils.isEmpty(sourceDomainQualifiedName)){
+                    String[] arr = currentDomainQualifiedName.split("/");
+                    updatedQualifiedName = targetDomainQualifiedName + "/domain/" + arr[arr.length - 1];
+                }else {
+                    updatedQualifiedName = currentDomainQualifiedName.replace(sourceDomainQualifiedName, targetDomainQualifiedName);
+                }
+
                 domain.setAttribute(QUALIFIED_NAME, updatedQualifiedName);
                 domain.setAttribute(PARENT_DOMAIN_QN_ATTR, targetDomainQualifiedName);
                 domain.setAttribute(SUPER_DOMAIN_QN_ATTR, superDomainQualifiedName);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
@@ -95,7 +95,7 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
             entity.setAttribute(SUPER_DOMAIN_QN_ATTR, superDomainQualifiedName);
         }
 
-        productExists(productName, parentDomainQualifiedName);
+        productExists(productName, parentDomainQualifiedName, null);
 
         createDaapVisibilityPolicy(entity, vertex);
 
@@ -144,7 +144,7 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
                 newSuperDomainQualifiedName = newParentDomainQualifiedName;
             }
 
-            processMoveDataProductToAnotherDomain(entity, currentParentDomainQualifiedName, newParentDomainQualifiedName, vertexQnName, newSuperDomainQualifiedName);
+            processMoveDataProductToAnotherDomain(entity, currentParentDomainQualifiedName, newParentDomainQualifiedName, vertexQnName, newSuperDomainQualifiedName, storedProduct.getGuid());
 
             updatePolicies(this.updatedPolicyResources, this.context);
 
@@ -159,7 +159,7 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
             String productNewName = (String) entity.getAttribute(NAME);
 
             if (!productCurrentName.equals(productNewName)) {
-                productExists(productNewName, currentParentDomainQualifiedName);
+                productExists(productNewName, currentParentDomainQualifiedName, storedProduct.getGuid());
             }
             entity.setAttribute(QUALIFIED_NAME, vertexQnName);
         }
@@ -179,7 +179,8 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
                                                        String sourceDomainQualifiedName,
                                                        String targetDomainQualifiedName,
                                                        String currentDataProductQualifiedName,
-                                                       String superDomainQualifiedName) throws AtlasBaseException {
+                                                       String superDomainQualifiedName,
+                                                       String guid) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder recorder = RequestContext.get().startMetricRecord("processMoveDataProductToAnotherDomain");
 
         try {
@@ -187,7 +188,7 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
 
             LOG.info("Moving dataProduct {} to Domain {}", productName, targetDomainQualifiedName);
 
-            productExists(productName, targetDomainQualifiedName);
+            productExists(productName, targetDomainQualifiedName, guid);
 
             String updatedQualifiedName;
             if(StringUtils.isEmpty(sourceDomainQualifiedName)){
@@ -221,11 +222,11 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
         return getParent(relationshipAttribute, PARENT_ATTRIBUTES);
     }
 
-    private void productExists(String productName, String parentDomainQualifiedName) throws AtlasBaseException {
+    private void productExists(String productName, String parentDomainQualifiedName, String guid) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("domainExists");
 
         try {
-            exists(DATA_PRODUCT_ENTITY_TYPE, productName, parentDomainQualifiedName);
+            exists(DATA_PRODUCT_ENTITY_TYPE, productName, parentDomainQualifiedName, guid);
 
         } finally {
             RequestContext.get().endMetricRecord(metricRecorder);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
@@ -192,7 +192,8 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
 
             String updatedQualifiedName;
             if(StringUtils.isEmpty(sourceDomainQualifiedName)){
-                updatedQualifiedName = targetDomainQualifiedName + "/" + product.getAttribute(QUALIFIED_NAME);
+                String[] arr = product.getAttribute(QUALIFIED_NAME).toString().split("/");
+                updatedQualifiedName = targetDomainQualifiedName + "/product/" + arr[ arr.length - 1];
             } else {
                 updatedQualifiedName = currentDataProductQualifiedName.replace(sourceDomainQualifiedName, targetDomainQualifiedName);
             }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
@@ -151,9 +151,6 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
         } else {
             entity.removeAttribute(PARENT_DOMAIN_QN_ATTR);
             entity.removeAttribute(SUPER_DOMAIN_QN_ATTR);
-            if(Objects.isNull(currentParentDomainQualifiedName)) {
-                currentParentDomainQualifiedName = "";
-            }
             String productCurrentName = vertex.getProperty(NAME, String.class);
             String productNewName = (String) entity.getAttribute(NAME);
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
@@ -187,8 +187,7 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
 
             String updatedQualifiedName;
             if(StringUtils.isEmpty(sourceDomainQualifiedName)){
-                String[] arr = product.getAttribute(QUALIFIED_NAME).toString().split("/");
-                updatedQualifiedName = targetDomainQualifiedName + "/product/" + arr[ arr.length - 1];
+                updatedQualifiedName = createQualifiedName(targetDomainQualifiedName);
             } else {
                 updatedQualifiedName = currentDataProductQualifiedName.replace(sourceDomainQualifiedName, targetDomainQualifiedName);
             }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
@@ -91,6 +91,9 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
             entity.setAttribute(PARENT_DOMAIN_QN_ATTR, parentDomainQualifiedName);
 
             String superDomainQualifiedName = parentDomain.getProperty(SUPER_DOMAIN_QN_ATTR, String.class);
+            if(StringUtils.isEmpty(superDomainQualifiedName)) {
+                superDomainQualifiedName = parentDomainQualifiedName;
+            }
             entity.setAttribute(SUPER_DOMAIN_QN_ATTR, superDomainQualifiedName);
         }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
+import static org.apache.atlas.AtlasErrorCode.OPERATION_NOT_SUPPORTED;
 import static org.apache.atlas.repository.Constants.*;
 import static org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessorUtils.*;
 import static org.apache.atlas.repository.util.AccessControlUtils.*;
@@ -81,7 +82,7 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
         String parentDomainQualifiedName = "";
 
         if (parentDomainObject == null) {
-            throw new AtlasBaseException("Cannot create a Product without a Domain Relationship");
+            throw new AtlasBaseException(OPERATION_NOT_SUPPORTED, "Cannot create a Product without a Domain Relationship");
         } else {
             AtlasVertex parentDomain = retrieverNoRelation.getEntityVertex(parentDomainObject);
             parentDomainQualifiedName = parentDomain.getProperty(QUALIFIED_NAME, String.class);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
@@ -81,8 +81,7 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
         String parentDomainQualifiedName = "";
 
         if (parentDomainObject == null) {
-            entity.removeAttribute(PARENT_DOMAIN_QN_ATTR);
-            entity.removeAttribute(SUPER_DOMAIN_QN_ATTR);
+            throw new AtlasBaseException("Cannot create a Product without a Domain Relationship");
         } else {
             AtlasVertex parentDomain = retrieverNoRelation.getEntityVertex(parentDomainObject);
             parentDomainQualifiedName = parentDomain.getProperty(QUALIFIED_NAME, String.class);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
@@ -79,7 +79,6 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
         AtlasObjectId parentDomainObject = (AtlasObjectId) entity.getRelationshipAttribute(DATA_DOMAIN_REL_TYPE);
         String productName = (String) entity.getAttribute(NAME);
         String parentDomainQualifiedName = "";
-        entity.setAttribute(QUALIFIED_NAME, createQualifiedName(parentDomainQualifiedName));
 
         if (parentDomainObject == null) {
             entity.removeAttribute(PARENT_DOMAIN_QN_ATTR);
@@ -94,6 +93,8 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
             String superDomainQualifiedName = parentDomain.getProperty(SUPER_DOMAIN_QN_ATTR, String.class);
             entity.setAttribute(SUPER_DOMAIN_QN_ATTR, superDomainQualifiedName);
         }
+
+        entity.setAttribute(QUALIFIED_NAME, createQualifiedName(parentDomainQualifiedName));
 
         productExists(productName, parentDomainQualifiedName, null);
 


### PR DESCRIPTION
## Change description

When a user creates a Domain or Product, attributed parentDomainQualfiedName and SuperDomainQualifiedName can be abused by request, thus leading to inconsistency between actual relationships vs these denormalized attributes

With this change, we never write de-normalized attributes received from the client & the server will rewrite them as per need based on actual relationships passed. This eliminates abusing these couple of denormalized attributes.

Also,
Since we never enforced parent relationships to map parents for the Domain or Product, we ran into a tech debt on a tenant JPMC:
They had Products with de-normalized super & parent references but not the relationship with the parent Domain.
They had sub-domains with de-normalized super & parent references but not the relationship with the parent Domain.

Since we support moving Domains/Products, we tried to move these orphan children into their parent Domain which failed due to a couple of issues:
1. Name duplicate check
2. Super domain can not be moved inside another domain

This change includes enabling the moving of such orphan Products/Domains as well as fixing them.

Testing details - https://atlanhq.atlassian.net/browse/DG-1370?focusedCommentId=113454

## Type of change
- [x] Bug fix (fixes an issue)

## Related issues

> https://atlanhq.atlassian.net/browse/DG-1370

