### PR TITLE
DG-1357 Custom metadata access for mesh assets

### DIFF
--- a/addons/static/templates/policy_cache_transformer_persona.json
+++ b/addons/static/templates/policy_cache_transformer_persona.json
@@ -480,7 +480,19 @@
       "actions": ["add-relationship", "update-relationship", "remove-relationship"]
     }
   ],
-
+  "persona-domain-business-update-metadata": [
+    {
+      "policyType": "ACCESS",
+      "policyResourceCategory": "ENTITY",
+      "resources": [
+        "entity:{entity}",
+        "entity-type:DataDomain",
+        "entity-classification:*",
+        "entity-business-metadata:*"
+      ],
+      "actions": ["entity-update-business-metadata"]
+    }
+  ],
 
   "persona-domain-sub-domain-read": [
     {
@@ -587,6 +599,19 @@
         "entity-classification:*"
       ],
       "actions": ["entity-delete"]
+    }
+  ],
+  "persona-domain-sub-domain-business-update-metadata": [
+    {
+      "policyType": "ACCESS",
+      "policyResourceCategory": "ENTITY",
+      "resources": [
+        "entity:{entity}/*domain/*",
+        "entity-type:DataDomain",
+        "entity-classification:*",
+        "entity-business-metadata:*"
+      ],
+      "actions": ["entity-update-business-metadata"]
     }
   ],
 
@@ -719,8 +744,19 @@
       "actions": ["entity-delete"]
     }
   ],
-
-
+  "persona-domain-product-business-update-metadata": [
+    {
+      "policyType": "ACCESS",
+      "policyResourceCategory": "ENTITY",
+      "resources": [
+        "entity:{entity}/*product/*",
+        "entity-type:DataProduct",
+        "entity-classification:*",
+        "entity-business-metadata:*"
+      ],
+      "actions": ["entity-update-business-metadata"]
+    }
+  ],
 
   "select": [
     {


### PR DESCRIPTION
## Change description

> The users successfully updated CM on a sub-domain without requiring the persona-domain-sub-domain-business-update-metadata permission. The PR includes policy adjustments for access control regarding custom metadata.

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
