### PR TITLE
DG- 1380 fix:persona read on super domains

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
@@ -213,7 +213,7 @@ public class ESAliasStore implements IndexAliasStore {
 
                     for (String asset : assets) {
                         terms.add(asset);
-                        allowClauseList.add(mapOf("wildcard", mapOf(QUALIFIED_NAME, asset + "/*")));
+                        allowClauseList.add(mapOf("wildcard", mapOf(QUALIFIED_NAME, asset + "*")));
                     }
 
                 } else if (getPolicyActions(policy).contains(ACCESS_READ_PERSONA_SUB_DOMAIN)) {


### PR DESCRIPTION
## Change description

* We migrated qualifiedName patterns where all super domains will ends with /super
* Since All Domains policies were still sending entity:* instead of entity:*/super, we faces an issue when we search after selecting a Persona which contains All Domains policy
* The ES alias filters were the reason for issue in retrieving "All Domains". It formed "qualifiedName": `*/super/*` instead of "qualifiedName": `*/super*`
* Since ES alias had wildcard clause as */super/*, no super domains were being fetched due to extra / at end before *
* We changed it to */super* so that persona search will fetch super domains as well

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues:
[https://atlanhq.atlassian.net/browse/DG-1380](url)

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
