### PR TITLE
LIN-749: New finishTime attribute in lineage graph API

### DIFF
--- a/intg/src/main/java/org/apache/atlas/model/instance/AtlasEntityHeader.java
+++ b/intg/src/main/java/org/apache/atlas/model/instance/AtlasEntityHeader.java
@@ -73,6 +73,7 @@ public class AtlasEntityHeader extends AtlasStruct implements Serializable {
     private String                          deleteHandler       = null;
     private Integer                         depth               = null;
     private Integer                         traversalOrder      = null;
+    private Integer                         finishTime          = null;
 
     private Map<String, AtlasSearchResult>  collapse    = null;
 
@@ -161,6 +162,14 @@ public class AtlasEntityHeader extends AtlasStruct implements Serializable {
     public Integer getTraversalOrder() { return traversalOrder; }
 
     public void setTraversalOrder(Integer traversalOrder) { this.traversalOrder = traversalOrder; }
+
+    public Integer getFinishTime() {
+        return finishTime;
+    }
+
+    public void setFinishTime(Integer finishTime) {
+        this.finishTime = finishTime;
+    }
 
     public AtlasEntity.Status getStatus() {
         return status;

--- a/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
@@ -302,8 +302,7 @@ public class EntityLineageService implements AtlasLineageService {
             if (direction == AtlasLineageOnDemandInfo.LineageDirection.OUTPUT || direction == AtlasLineageOnDemandInfo.LineageDirection.BOTH)
                 traverseEdgesOnDemand(datasetVertex, false, depth, level, new HashSet<>(), atlasLineageOnDemandContext, ret, guid, outputEntitiesTraversed, traversalOrder);
             AtlasEntityHeader baseEntityHeader = entityRetriever.toAtlasEntityHeader(datasetVertex, atlasLineageOnDemandContext.getAttributes());
-            baseEntityHeader.setDepth(level);
-            baseEntityHeader.setTraversalOrder(0);
+            setGraphTraversalMetadata(level, traversalOrder, baseEntityHeader);
             ret.getGuidEntityMap().put(guid, baseEntityHeader);
         } else  {
             AtlasVertex processVertex = AtlasGraphUtilsV2.findByGuid(this.graph, guid);
@@ -319,6 +318,12 @@ public class EntityLineageService implements AtlasLineageService {
         }
         RequestContext.get().endMetricRecord(metricRecorder);
         return ret;
+    }
+
+    private static void setGraphTraversalMetadata(int level, AtomicInteger traversalOrder, AtlasEntityHeader baseEntityHeader) {
+        baseEntityHeader.setDepth(level);
+        baseEntityHeader.setTraversalOrder(0);
+        baseEntityHeader.setFinishTime(traversalOrder.get());
     }
 
     private void traverseEdgesOnDemand(Iterator<AtlasEdge> processEdges, boolean isInput, int depth, int level, AtlasLineageOnDemandContext atlasLineageOnDemandContext, AtlasLineageOnDemandInfo ret, AtlasVertex processVertex, String baseGuid, AtomicInteger entitiesTraversed, AtomicInteger traversalOrder) throws AtlasBaseException {

--- a/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
@@ -427,8 +427,8 @@ public class EntityLineageService implements AtlasLineageService {
                     }
                     if (entityVertex != null && !visitedVertices.contains(getId(entityVertex))) {
                         traverseEdgesOnDemand(entityVertex, isInput, depth - 1, nextLevel, visitedVertices, atlasLineageOnDemandContext, ret, baseGuid, entitiesTraversed, traversalOrder); // execute inner depth
-                        AtlasEntityHeader baseEntity = ret.getGuidEntityMap().get(baseGuid);
-                        baseEntity.setFinishTime(traversalOrder.get());
+                        AtlasEntityHeader traversedEntity = ret.getGuidEntityMap().get(AtlasGraphUtilsV2.getIdFromVertex(entityVertex));
+                        traversedEntity.setFinishTime(traversalOrder.get());
                     }
                 }
             }

--- a/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
@@ -427,6 +427,8 @@ public class EntityLineageService implements AtlasLineageService {
                     }
                     if (entityVertex != null && !visitedVertices.contains(getId(entityVertex))) {
                         traverseEdgesOnDemand(entityVertex, isInput, depth - 1, nextLevel, visitedVertices, atlasLineageOnDemandContext, ret, baseGuid, entitiesTraversed, traversalOrder); // execute inner depth
+                        AtlasEntityHeader baseEntity = ret.getGuidEntityMap().get(baseGuid);
+                        baseEntity.setFinishTime(traversalOrder.get());
                     }
                 }
             }


### PR DESCRIPTION
## Change description

> Added a new attribute in lineage Graph API called "finishTime". This denotes the finish time when backtracking for each node. This is required to improve graph render time in the product, it will help reduce FE computations.

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues
[https://atlanhq.atlassian.net/browse/LIN-749](url)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
