### PR TITLE
fix: improve performance of tag cleanup task by fetching all vertices at once

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,7 +25,7 @@ on:
       - beta
       - development
       - master
-      - tagcleanup
+      - lineageondemand
 
 jobs:
   build:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,7 +25,7 @@ on:
       - beta
       - development
       - master
-      - lineageondemand
+      - tagcleanup
 
 jobs:
   build:

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -403,11 +403,9 @@ public final class GraphHelper {
                 }
                 LOG.info("classificationVerticesSet size: {}", classificationVerticesSet.size());
             }
-            return new ArrayList<>(classificationVerticesSet);
         }
-        //
 
-        return IteratorUtils.toList(classificationVertices.iterator());
+        return new ArrayList<>(classificationVerticesSet);
     }
     public static AtlasEdge getClassificationEdge(AtlasVertex entityVertex, AtlasVertex classificationVertex) {
         AtlasEdge ret   = null;

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -384,21 +384,28 @@ public final class GraphHelper {
         return IteratorUtils.toList(vertices.iterator());
     }
 
-    public static List<AtlasVertex> getAllAssetsWithClassificationAttached(AtlasGraph graph, String classificationName, int limit) {
-        AtlasGraphQuery query = graph.query();
-        AtlasGraphQuery hasPropagatedTraitNames = query.createChildQuery().has(PROPAGATED_TRAIT_NAMES_PROPERTY_KEY, classificationName);
-        AtlasGraphQuery hasTraitNames = query.createChildQuery().has(TRAIT_NAMES_PROPERTY_KEY, classificationName);
-        Iterable vertices = query.or(
-                Arrays.asList(
-                        hasPropagatedTraitNames,
-                        hasTraitNames
-                )
-        ).vertices(limit);
-        if (vertices == null) {
+    public static List<AtlasVertex> getAllAssetsWithClassificationAttached(AtlasGraph graph, String classificationName) {
+        Iterable classificationVertices = graph.query().has(TYPE_NAME_PROPERTY_KEY, classificationName).vertices();
+        if (classificationVertices == null) {
             return Collections.emptyList();
         }
+        List<AtlasVertex> classificationVerticesList = IteratorUtils.toList(classificationVertices.iterator());
+        HashSet<AtlasVertex> classificationVerticesSet = new HashSet<>();
+        for (AtlasVertex classificationVertex : classificationVerticesList) {
+            Iterable attachedVertices =  classificationVertex.query()
+                    .direction(AtlasEdgeDirection.IN)
+                    .label(CLASSIFICATION_LABEL).vertices();
+            if (attachedVertices != null) {
+                Iterator<AtlasVertex> attachedVerticesIterator = attachedVertices.iterator();
+                while (attachedVerticesIterator.hasNext()) {
+                    classificationVerticesSet.add(attachedVerticesIterator.next());
+                }
+            }
+            return new ArrayList<>(classificationVerticesSet);
+        }
+        //
 
-        return IteratorUtils.toList(vertices.iterator());
+        return IteratorUtils.toList(classificationVertices.iterator());
     }
     public static AtlasEdge getClassificationEdge(AtlasVertex entityVertex, AtlasVertex classificationVertex) {
         AtlasEdge ret   = null;

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -73,6 +73,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.apache.atlas.AtlasErrorCode.RELATIONSHIP_CREATE_INVALID_PARAMS;
 import static org.apache.atlas.model.instance.AtlasEntity.Status.ACTIVE;
@@ -391,7 +392,7 @@ public final class GraphHelper {
         }
         List<AtlasVertex> classificationVerticesList = IteratorUtils.toList(classificationVertices.iterator());
         LOG.info("classificationVerticesList size: {}", classificationVerticesList.size());
-        HashSet<AtlasVertex> classificationVerticesSet = new HashSet<>();
+        HashSet<AtlasVertex> entityVerticesSet = new HashSet<>();
         for (AtlasVertex classificationVertex : classificationVerticesList) {
             Iterable attachedVertices =  classificationVertex.query()
                     .direction(AtlasEdgeDirection.IN)
@@ -399,13 +400,13 @@ public final class GraphHelper {
             if (attachedVertices != null) {
                 Iterator<AtlasVertex> attachedVerticesIterator = attachedVertices.iterator();
                 while (attachedVerticesIterator.hasNext()) {
-                    classificationVerticesSet.add(attachedVerticesIterator.next());
+                    entityVerticesSet.add(attachedVerticesIterator.next());
                 }
-                LOG.info("classificationVerticesSet size: {}", classificationVerticesSet.size());
+                LOG.info("classificationVerticesSet size: {}", entityVerticesSet.size());
             }
         }
 
-        return new ArrayList<>(classificationVerticesSet);
+        return entityVerticesSet.stream().collect(Collectors.toList());
     }
     public static AtlasEdge getClassificationEdge(AtlasVertex entityVertex, AtlasVertex classificationVertex) {
         AtlasEdge ret   = null;

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -390,6 +390,7 @@ public final class GraphHelper {
             return Collections.emptyList();
         }
         List<AtlasVertex> classificationVerticesList = IteratorUtils.toList(classificationVertices.iterator());
+        LOG.info("classificationVerticesList size: {}", classificationVerticesList.size();
         HashSet<AtlasVertex> classificationVerticesSet = new HashSet<>();
         for (AtlasVertex classificationVertex : classificationVerticesList) {
             Iterable attachedVertices =  classificationVertex.query()
@@ -400,6 +401,7 @@ public final class GraphHelper {
                 while (attachedVerticesIterator.hasNext()) {
                     classificationVerticesSet.add(attachedVerticesIterator.next());
                 }
+                LOG.info("classificationVerticesSet size: {}", classificationVerticesSet.size();
             }
             return new ArrayList<>(classificationVerticesSet);
         }

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -390,7 +390,7 @@ public final class GraphHelper {
             return Collections.emptyList();
         }
         List<AtlasVertex> classificationVerticesList = IteratorUtils.toList(classificationVertices.iterator());
-        LOG.info("classificationVerticesList size: {}", classificationVerticesList.size();
+        LOG.info("classificationVerticesList size: {}", classificationVerticesList.size());
         HashSet<AtlasVertex> classificationVerticesSet = new HashSet<>();
         for (AtlasVertex classificationVertex : classificationVerticesList) {
             Iterable attachedVertices =  classificationVertex.query()
@@ -401,7 +401,7 @@ public final class GraphHelper {
                 while (attachedVerticesIterator.hasNext()) {
                     classificationVerticesSet.add(attachedVerticesIterator.next());
                 }
-                LOG.info("classificationVerticesSet size: {}", classificationVerticesSet.size();
+                LOG.info("classificationVerticesSet size: {}", classificationVerticesSet.size());
             }
             return new ArrayList<>(classificationVerticesSet);
         }

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -391,7 +391,7 @@ public final class GraphHelper {
             return Collections.emptyList();
         }
         List<AtlasVertex> classificationVerticesList = IteratorUtils.toList(classificationVertices.iterator());
-        LOG.info("classificationVerticesList size: {}", classificationVerticesList.size());
+            LOG.info("classificationVerticesList size: {}", classificationVerticesList.size());
         HashSet<AtlasVertex> entityVerticesSet = new HashSet<>();
         for (AtlasVertex classificationVertex : classificationVerticesList) {
             Iterable attachedVertices =  classificationVertex.query()
@@ -402,7 +402,7 @@ public final class GraphHelper {
                 while (attachedVerticesIterator.hasNext()) {
                     entityVerticesSet.add(attachedVerticesIterator.next());
                 }
-                LOG.info("classificationVerticesSet size: {}", entityVerticesSet.size());
+                LOG.info("entityVerticesSet size: {}", entityVerticesSet.size());
             }
         }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -2980,22 +2980,23 @@ public class EntityGraphMapper {
     }
 
     public void cleanUpClassificationPropagation(String classificationName) throws AtlasBaseException {
-        int batchSize = 100;
-        int counter = 0;
-        while (true) {
+        List<AtlasVertex> vertices = GraphHelper.getAllAssetsWithClassificationAttached(graph, classificationName);
+        int batchSize = 2;
+        int totalVertexSize = vertices.size();
+        LOG.info("Clean up tag {} from {} entities", classificationName, totalVertexSize);
+        int toIndex;
+        int offset = 0;
+        do {
+            toIndex = Math.min((offset + batchSize), totalVertexSize);
+            List<AtlasVertex> entityVertices = vertices.subList(offset, toIndex);
+            List<String> impactedGuids = entityVertices.stream().map(GraphHelper::getGuid).collect(Collectors.toList());
             try {
-
-                List<AtlasVertex> vertices = GraphHelper.getAllAssetsWithClassificationAttached(graph, classificationName, batchSize);
-                if (CollectionUtils.isEmpty(vertices)) {
-                    LOG.info("No entities found for classification {}", classificationName);
-                    break;
-                }
-                for(AtlasVertex vertex : vertices) {
+                GraphTransactionInterceptor.lockObjectAndReleasePostCommit(impactedGuids);
+                for (AtlasVertex vertex : entityVertices) {
                     String guid = GraphHelper.getGuid(vertex);
                     GraphTransactionInterceptor.lockObjectAndReleasePostCommit(guid);
                     List<AtlasClassification> deletedClassifications = new ArrayList<>();
                     List<AtlasEdge> classificationEdges = GraphHelper.getClassificationEdges(vertex, null, classificationName);
-
                     for (AtlasEdge edge : classificationEdges) {
                         AtlasClassification classification = entityRetriever.toAtlasClassification(edge.getInVertex());
                         deletedClassifications.add(classification);
@@ -3006,24 +3007,21 @@ public class EntityGraphMapper {
 
                     entityChangeNotifier.onClassificationDeletedFromEntity(entity, deletedClassifications);
 
-                    counter++;
+                    offset += batchSize;
                 }
-            } catch (AtlasBaseException e) {
-                throw e;
             } finally {
                 transactionInterceptHelper.intercept();
-                LOG.info("Processed cleaning up {} entities", counter);
+                LOG.info("Cleaned up {} entities", offset);
             }
 
-            // Fetch all classificationVertex by classificationName and delete them if remaining
-            List<AtlasVertex> classificationVertices = GraphHelper.getAllClassificationVerticesByClassificationName(graph, classificationName);
-            for (AtlasVertex classificationVertex : classificationVertices) {
-                deleteDelegate.getHandler().deleteClassificationVertex(classificationVertex, true);
-            }
-            transactionInterceptHelper.intercept();
-            LOG.info("Completed cleaning up classification {}", classificationName);
-
+        } while (offset < totalVertexSize);
+        // Fetch all classificationVertex by classificationName and delete them if remaining
+        List<AtlasVertex> classificationVertices = GraphHelper.getAllClassificationVerticesByClassificationName(graph, classificationName);
+        for (AtlasVertex classificationVertex : classificationVertices) {
+            deleteDelegate.getHandler().deleteClassificationVertex(classificationVertex, true);
         }
+        transactionInterceptHelper.intercept();
+        LOG.info("Completed cleaning up classification {}", classificationName);
     }
 
     public AtlasEntity repairClassificationMappings(AtlasVertex entityVertex) throws AtlasBaseException {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -2981,13 +2981,12 @@ public class EntityGraphMapper {
 
     public void cleanUpClassificationPropagation(String classificationName) throws AtlasBaseException {
         List<AtlasVertex> vertices = GraphHelper.getAllAssetsWithClassificationAttached(graph, classificationName);
-        int batchSize = 2;
         int totalVertexSize = vertices.size();
         LOG.info("To clean up tag {} from {} entities", classificationName, totalVertexSize);
         int toIndex;
         int offset = 0;
         do {
-            toIndex = Math.min((offset + batchSize), totalVertexSize);
+            toIndex = Math.min((offset + CHUNK_SIZE), totalVertexSize);
             List<AtlasVertex> entityVertices = vertices.subList(offset, toIndex);
             List<String> impactedGuids = entityVertices.stream().map(GraphHelper::getGuid).collect(Collectors.toList());
             try {
@@ -3005,7 +3004,7 @@ public class EntityGraphMapper {
 
                     entityChangeNotifier.onClassificationDeletedFromEntity(entity, deletedClassifications);
                 }
-                offset += batchSize;
+                offset += CHUNK_SIZE;
             } finally {
                 transactionInterceptHelper.intercept();
                 LOG.info("Cleaned up {} entities", offset);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -3007,7 +3007,7 @@ public class EntityGraphMapper {
                 offset += CHUNK_SIZE;
             } finally {
                 transactionInterceptHelper.intercept();
-                LOG.info("Cleaned up {} entities", offset);
+                LOG.info("Cleaned up {} entities for classification {}", offset, classificationName);
             }
 
         } while (offset < totalVertexSize);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -2983,7 +2983,7 @@ public class EntityGraphMapper {
         List<AtlasVertex> vertices = GraphHelper.getAllAssetsWithClassificationAttached(graph, classificationName);
         int batchSize = 2;
         int totalVertexSize = vertices.size();
-        LOG.info("Clean up tag {} from {} entities", classificationName, totalVertexSize);
+        LOG.info("To clean up tag {} from {} entities", classificationName, totalVertexSize);
         int toIndex;
         int offset = 0;
         do {
@@ -2993,8 +2993,6 @@ public class EntityGraphMapper {
             try {
                 GraphTransactionInterceptor.lockObjectAndReleasePostCommit(impactedGuids);
                 for (AtlasVertex vertex : entityVertices) {
-                    String guid = GraphHelper.getGuid(vertex);
-                    GraphTransactionInterceptor.lockObjectAndReleasePostCommit(guid);
                     List<AtlasClassification> deletedClassifications = new ArrayList<>();
                     List<AtlasEdge> classificationEdges = GraphHelper.getClassificationEdges(vertex, null, classificationName);
                     for (AtlasEdge edge : classificationEdges) {
@@ -3006,9 +3004,8 @@ public class EntityGraphMapper {
                     AtlasEntity entity = repairClassificationMappings(vertex);
 
                     entityChangeNotifier.onClassificationDeletedFromEntity(entity, deletedClassifications);
-
-                    offset += batchSize;
                 }
+                offset += batchSize;
             } finally {
                 transactionInterceptHelper.intercept();
                 LOG.info("Cleaned up {} entities", offset);


### PR DESCRIPTION
## Fix tag cleanup task fetch time tombstone issue by traversing all vertices at once

> We are facing a issue in tenant as it keeps cleaning up tag and keep querying later asset fetching getting slower/slower as no of tombstone increasing. We follow same approach in other tasks as well.

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] Enhancement
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
