### PR TITLE
Modified an edge statement such that, when a new lexorank for cat is …

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/PreProcessorUtils.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/PreProcessorUtils.java
@@ -274,7 +274,7 @@ public class PreProcessorUtils {
                 for (AtlasEntityHeader category : categories) {
                     String lexicographicalSortOrder = (String) category.getAttribute(LEXICOGRAPHICAL_SORT_ORDER);
                     if (StringUtils.isNotEmpty(lexicographicalSortOrder)) {
-                        lastLexoRank = lexicographicalSortOrder;
+                        lastLexoRank = getValidLexorank(lexicographicalSortOrder, glossaryQualifiedName, parentQualifiedName, discovery);
                     } else {
                         lastLexoRank = INIT_LEXORANK_OFFSET;
                     }
@@ -291,6 +291,17 @@ public class PreProcessorUtils {
         entity.setAttribute(LEXICOGRAPHICAL_SORT_ORDER, lexoRank);
         lexoRankCache.put(glossaryQualifiedName + "-" + parentQualifiedName, lexoRank);
         RequestContext.get().setLexoRankCache(lexoRankCache);
+    }
+
+    private static String getValidLexorank(String lastLexoRank, String glossaryQualifiedName, String parentQualifiedName, EntityDiscoveryService discovery) {
+        LexoRank parsedLexoRank = LexoRank.parse(lastLexoRank);
+        LexoRank nextLexoRank = parsedLexoRank.genNext().genNext();
+        try {
+            isValidLexoRank(nextLexoRank.toString(), glossaryQualifiedName, parentQualifiedName, discovery);
+            return lastLexoRank;
+        } catch (AtlasBaseException e){
+            return parsedLexoRank.between(nextLexoRank).genPrev().genPrev().toString();
+        }
     }
 
     public static Map<String, Object> createDSLforCheckingPreExistingLexoRank(String lexoRank, String glossaryQualifiedName, String parentQualifiedName) {


### PR DESCRIPTION
…generated, it is not a duplicate of a term in same linear data set

## Change description

> Description here

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
