### PR TITLE
PLT-1665, master, fixed "track_total_hits": false gives an NPE

### DIFF
--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchQuery.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchQuery.java
@@ -445,7 +445,10 @@ public class AtlasElasticsearchQuery implements AtlasIndexQuery<AtlasJanusVertex
         if (hits_0 == null) {
             return result;
         }
-        this.vertexTotals = (Integer) hits_0.get("total").get("value");
+        LinkedHashMap approximateCount = hits_0.get("total");
+        if (approximateCount != null) {
+            this.vertexTotals = (Integer) approximateCount.get("value");
+        }
 
         List<LinkedHashMap> hits_1 = AtlasType.fromJson(AtlasType.toJson(hits_0.get("hits")), List.class);
 


### PR DESCRIPTION
## Change description

> When "track_total_hits" is false, it returns the default value of "approximateCount" that is -1

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [PLT-1665](https://atlanhq.atlassian.net/browse/PLT-1665) 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable


[PLT-1665]: https://atlanhq.atlassian.net/browse/PLT-1665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ