### PR TITLE
feat: add a way to avoid checks for supertype for tables

### DIFF
--- a/intg/src/main/java/org/apache/atlas/type/AtlasTypeRegistry.java
+++ b/intg/src/main/java/org/apache/atlas/type/AtlasTypeRegistry.java
@@ -44,6 +44,9 @@ public class AtlasTypeRegistry {
     private static final Logger LOG = LoggerFactory.getLogger(AtlasTypeRegistry.class);
     private static final int    DEFAULT_LOCK_MAX_WAIT_TIME_IN_SECONDS = 15;
 
+    public static final ArrayList<String> TYPENAMES_TO_SKIP_SUPER_TYPE_CHECK = new ArrayList<String>() {{
+        add("Table");
+    }};
     protected       RegistryData                   registryData;
     private   final TypeRegistryUpdateSynchronizer updateSynchronizer;
     private   final Set<String>                    missingRelationshipDefs;

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasGraphUtilsV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasGraphUtilsV2.java
@@ -35,8 +35,9 @@ import org.apache.atlas.repository.graphdb.*;
 import org.apache.atlas.type.AtlasEntityType;
 import org.apache.atlas.type.AtlasEnumType;
 import org.apache.atlas.type.AtlasStructType;
-import org.apache.atlas.type.AtlasStructType.AtlasAttribute;
+import org.apache.atlas.type.AtlasTypeRegistry;
 import org.apache.atlas.type.AtlasType;
+import org.apache.atlas.type.AtlasStructType.AtlasAttribute;
 import org.apache.atlas.util.FileUtils;
 import org.apache.atlas.utils.AtlasPerfMetrics;
 import org.apache.atlas.utils.AtlasPerfMetrics.MetricRecorder;
@@ -349,14 +350,14 @@ public class AtlasGraphUtilsV2 {
                 vertex = findByTypeAndUniquePropertyName(graph, typeName, uniqAttrValues);
 
                 // if no instance of given typeName is found, try to find an instance of type's sub-type
-                if (vertex == null && !entitySubTypes.isEmpty()) {
+                if (vertex == null && !entitySubTypes.isEmpty() && !AtlasTypeRegistry.TYPENAMES_TO_SKIP_SUPER_TYPE_CHECK.contains(typeName)) {
                     vertex = findBySuperTypeAndUniquePropertyName(graph, typeName, uniqAttrValues);
                 }
             } else {
                 vertex = findByTypeAndPropertyName(graph, typeName, attrNameValues);
 
                 // if no instance of given typeName is found, try to find an instance of type's sub-type
-                if (vertex == null && !entitySubTypes.isEmpty()) {
+                if (vertex == null && !entitySubTypes.isEmpty() && !AtlasTypeRegistry.TYPENAMES_TO_SKIP_SUPER_TYPE_CHECK.contains(typeName)) {
                     vertex = findBySuperTypeAndPropertyName(graph, typeName, attrNameValues);
                 }
             }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasGraphUtilsV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasGraphUtilsV2.java
@@ -350,6 +350,7 @@ public class AtlasGraphUtilsV2 {
                 vertex = findByTypeAndUniquePropertyName(graph, typeName, uniqAttrValues);
 
                 // if no instance of given typeName is found, try to find an instance of type's sub-type
+                // Added exception for few types to solve https://atlanhq.atlassian.net/browse/PLT-1638
                 if (vertex == null && !entitySubTypes.isEmpty() && !AtlasTypeRegistry.TYPENAMES_TO_SKIP_SUPER_TYPE_CHECK.contains(typeName)) {
                     vertex = findBySuperTypeAndUniquePropertyName(graph, typeName, uniqAttrValues);
                 }
@@ -357,6 +358,7 @@ public class AtlasGraphUtilsV2 {
                 vertex = findByTypeAndPropertyName(graph, typeName, attrNameValues);
 
                 // if no instance of given typeName is found, try to find an instance of type's sub-type
+                // Added exception for few types to solve https://atlanhq.atlassian.net/browse/PLT-1638
                 if (vertex == null && !entitySubTypes.isEmpty() && !AtlasTypeRegistry.TYPENAMES_TO_SKIP_SUPER_TYPE_CHECK.contains(typeName)) {
                     vertex = findBySuperTypeAndPropertyName(graph, typeName, attrNameValues);
                 }


### PR DESCRIPTION
## Skip supertype check for Table entity meaning if table type is passed it will not check if it has entity with subtypes
> There was an issue in customer tenant regarding dynamic table and table creation, where customer was trying to create table with same name as dynamic table but it was updating existing dynamic table instead of creating. Wanted to change the behaviour just by adding a check during diff calculation.


## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [https://atlanhq.atlassian.net/browse/PLT-1638](Table getting cataloged as DynamicTable)

## Test cases
<img width="737" alt="image" src="https://github.com/atlanhq/atlas-metastore/assets/59254445/b9d4a304-12da-4ddf-bc80-d807f603207d">
https://docs.google.com/spreadsheets/d/1N6cp-nYxFcFfyXW4q3zuqbw8vk2F7R3CgWzZLBPAzzA/edit?usp=sharing

### Development

- [ ] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
