### PR TITLE
DG-1533 Only check create permission on source/target domains

### DIFF
--- a/addons/static/templates/policy_cache_transformer_persona.json
+++ b/addons/static/templates/policy_cache_transformer_persona.json
@@ -692,24 +692,6 @@
         "end-two-entity:{entity}/*domain/*"
       ],
       "actions": ["add-relationship", "update-relationship", "remove-relationship"]
-    },
-    {
-      "policyResourceCategory": "RELATIONSHIP",
-      "policyType": "ACCESS",
-      "description": "Unlink any domain-sub-domain relationship in within this DataDomain",
-      "resources": [
-        "relationship-type:parent_domain_sub_domains",
-
-        "end-one-entity:{entity}/*",
-        "end-one-entity:{entity}",
-        "end-one-entity-type:DataDomain",
-        "end-one-entity-classification:*",
-
-        "end-two-entity:*",
-        "end-two-entity-type:DataDomain",
-        "end-two-entity-classification:*"
-      ],
-      "actions": ["update-relationship", "remove-relationship"]
     }
   ],
   "persona-domain-sub-domain-delete": [

--- a/addons/static/templates/policy_cache_transformer_persona.json
+++ b/addons/static/templates/policy_cache_transformer_persona.json
@@ -692,6 +692,24 @@
         "end-two-entity:{entity}/*domain/*"
       ],
       "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+    },
+    {
+      "policyResourceCategory": "RELATIONSHIP",
+      "policyType": "ACCESS",
+      "description": "Unlink any domain-sub-domain relationship in within this DataDomain",
+      "resources": [
+        "relationship-type:parent_domain_sub_domains",
+
+        "end-one-entity:{entity}/*",
+        "end-one-entity:{entity}",
+        "end-one-entity-type:DataDomain",
+        "end-one-entity-classification:*",
+
+        "end-two-entity:*",
+        "end-two-entity-type:DataDomain",
+        "end-two-entity-classification:*"
+      ],
+      "actions": ["update-relationship", "remove-relationship"]
     }
   ],
   "persona-domain-sub-domain-delete": [

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/AbstractDomainPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/AbstractDomainPreProcessor.java
@@ -93,19 +93,11 @@ public abstract class AbstractDomainPreProcessor implements PreProcessor {
     protected void isAuthorized(AtlasEntityHeader sourceDomain, AtlasEntityHeader targetDomain) throws AtlasBaseException {
 
        if(sourceDomain != null){
-           // source -> CREATE + UPDATE + DELETE
-           AtlasAuthorizationUtils.verifyAccess(new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_CREATE, sourceDomain),
-                   "create on source Domain: ", sourceDomain.getAttribute(NAME));
-
            AtlasAuthorizationUtils.verifyAccess(new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_UPDATE, sourceDomain),
                    "update on source Domain: ", sourceDomain.getAttribute(NAME));
        }
 
        if(targetDomain != null){
-           // target -> CREATE + UPDATE + DELETE
-           AtlasAuthorizationUtils.verifyAccess(new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_CREATE, targetDomain),
-                   "create on target Domain: ", targetDomain.getAttribute(NAME));
-
            AtlasAuthorizationUtils.verifyAccess(new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_UPDATE, targetDomain),
                    "update on target Domain: ", targetDomain.getAttribute(NAME));
        }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/AbstractDomainPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/AbstractDomainPreProcessor.java
@@ -60,6 +60,7 @@ public abstract class AbstractDomainPreProcessor implements PreProcessor {
     private static final Logger LOG = LoggerFactory.getLogger(AbstractDomainPreProcessor.class);
 
 
+    protected final AtlasGraph graph;
     protected final AtlasTypeRegistry typeRegistry;
     protected final EntityGraphRetriever entityRetriever;
     protected EntityGraphRetriever entityRetrieverNoRelations;
@@ -78,6 +79,7 @@ public abstract class AbstractDomainPreProcessor implements PreProcessor {
     }
 
     AbstractDomainPreProcessor(AtlasTypeRegistry typeRegistry, EntityGraphRetriever entityRetriever, AtlasGraph graph) {
+        this.graph = graph;
         this.entityRetriever = entityRetriever;
         this.typeRegistry = typeRegistry;
         this.preProcessor = new AuthPolicyPreProcessor(graph, typeRegistry, entityRetriever);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/AbstractDomainPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/AbstractDomainPreProcessor.java
@@ -90,16 +90,27 @@ public abstract class AbstractDomainPreProcessor implements PreProcessor {
         }
     }
 
-    protected void isAuthorized(AtlasEntityHeader sourceDomain, AtlasEntityHeader targetDomain) throws AtlasBaseException {
+    protected void isAuthorizedToMove(String typeName, AtlasEntityHeader sourceDomain, AtlasEntityHeader targetDomain) throws AtlasBaseException {
 
-       if(sourceDomain != null){
-           AtlasAuthorizationUtils.verifyAccess(new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_UPDATE, sourceDomain),
-                   "update on source Domain: ", sourceDomain.getAttribute(NAME));
+        String qualifiedNameToAuthSuffix = DATA_DOMAIN_ENTITY_TYPE.equals(typeName) ? "/*domain/*" : "/*product/*";
+        AtlasEntityHeader headerToAuth = new AtlasEntityHeader(typeName);
+
+        if (sourceDomain != null) {
+           //Update sub-domains/product on source parent
+           String qualifiedNameToAuth = sourceDomain.getAttribute(QUALIFIED_NAME) + qualifiedNameToAuthSuffix;
+           headerToAuth.setAttribute(QUALIFIED_NAME, qualifiedNameToAuth);
+
+           AtlasAuthorizationUtils.verifyAccess(new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_UPDATE, headerToAuth),
+                   AtlasPrivilege.ENTITY_UPDATE.name(), " " , typeName, " : ", qualifiedNameToAuth);
        }
 
-       if(targetDomain != null){
-           AtlasAuthorizationUtils.verifyAccess(new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_UPDATE, targetDomain),
-                   "update on target Domain: ", targetDomain.getAttribute(NAME));
+       if (targetDomain != null) {
+           //Create sub-domains/product on target parent
+           String qualifiedNameToAuth = targetDomain.getAttribute(QUALIFIED_NAME) + qualifiedNameToAuthSuffix;
+           headerToAuth.setAttribute(QUALIFIED_NAME, qualifiedNameToAuth);
+
+           AtlasAuthorizationUtils.verifyAccess(new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_CREATE, headerToAuth),
+                   AtlasPrivilege.ENTITY_CREATE.name(), " " , typeName, " : ", qualifiedNameToAuth);
        }
     }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataDomainPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataDomainPreProcessor.java
@@ -28,6 +28,8 @@ import org.apache.atlas.model.instance.AtlasRelatedObjectId;
 import org.apache.atlas.model.instance.AtlasStruct;
 import org.apache.atlas.model.instance.EntityMutations;
 import org.apache.atlas.repository.graph.GraphHelper;
+import org.apache.atlas.repository.graphdb.AtlasEdge;
+import org.apache.atlas.repository.graphdb.AtlasEdgeDirection;
 import org.apache.atlas.repository.graphdb.AtlasGraph;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
 import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
@@ -219,6 +221,11 @@ public class DataDomainPreProcessor extends AbstractDomainPreProcessor {
                 domain.setAttribute(QUALIFIED_NAME, updatedQualifiedName);
                 domain.setAttribute(PARENT_DOMAIN_QN_ATTR, targetDomainQualifiedName);
                 domain.setAttribute(SUPER_DOMAIN_QN_ATTR, superDomainQualifiedName);
+            }
+
+            Iterator<AtlasEdge> existingParentEdges = domainVertex.getEdges(AtlasEdgeDirection.IN, DOMAIN_PARENT_EDGE_LABEL).iterator();
+            if (existingParentEdges.hasNext()) {
+                graph.removeEdge(existingParentEdges.next());
             }
 
             String currentQualifiedName = domainVertex.getProperty(QUALIFIED_NAME, String.class);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataDomainPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataDomainPreProcessor.java
@@ -163,7 +163,7 @@ public class DataDomainPreProcessor extends AbstractDomainPreProcessor {
             }
 
             //Auth check
-            isAuthorized(currentParentDomainHeader, newParentDomainHeader);
+            isAuthorizedToMove(DATA_DOMAIN_ENTITY_TYPE, currentParentDomainHeader, newParentDomainHeader);
 
             processMoveSubDomainToAnotherDomain(entity, vertex, currentParentDomainQualifiedName, newParentDomainQualifiedName, vertexQnName, newSuperDomainQualifiedName);
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
@@ -5,7 +5,6 @@ import org.apache.atlas.DeleteType;
 import org.apache.atlas.RequestContext;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.instance.*;
-import org.apache.atlas.repository.graph.GraphHelper;
 import org.apache.atlas.repository.graphdb.AtlasEdge;
 import org.apache.atlas.repository.graphdb.AtlasEdgeDirection;
 import org.apache.atlas.repository.graphdb.AtlasGraph;

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
@@ -18,7 +18,6 @@ import org.apache.atlas.type.AtlasEntityType;
 import org.apache.atlas.type.AtlasTypeRegistry;
 import org.apache.atlas.utils.AtlasPerfMetrics;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -141,7 +140,7 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
             }
 
             //Auth check
-            isAuthorized(currentParentDomainHeader, newParentDomainHeader);
+            isAuthorizedToMove(DATA_PRODUCT_ENTITY_TYPE, currentParentDomainHeader, newParentDomainHeader);
 
             String newSuperDomainQualifiedName = (String) newParentDomainHeader.getAttribute(SUPER_DOMAIN_QN_ATTR);
             if(StringUtils.isEmpty(newSuperDomainQualifiedName)){

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
@@ -5,6 +5,9 @@ import org.apache.atlas.DeleteType;
 import org.apache.atlas.RequestContext;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.instance.*;
+import org.apache.atlas.repository.graph.GraphHelper;
+import org.apache.atlas.repository.graphdb.AtlasEdge;
+import org.apache.atlas.repository.graphdb.AtlasEdgeDirection;
 import org.apache.atlas.repository.graphdb.AtlasGraph;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
 import org.apache.atlas.repository.store.graph.AtlasEntityStore;
@@ -35,8 +38,6 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
     private static final String PROTECTED = "Protected";
     private static final String PUBLIC = "Public";
     private static final String DATA_PRODUCT = "dataProduct";
-
-
 
     private EntityMutationContext context;
     private AtlasEntityStore entityStore;
@@ -147,7 +148,7 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
                 newSuperDomainQualifiedName = newParentDomainQualifiedName;
             }
 
-            processMoveDataProductToAnotherDomain(entity, currentParentDomainQualifiedName, newParentDomainQualifiedName, vertexQnName, newSuperDomainQualifiedName);
+            processMoveDataProductToAnotherDomain(entity, vertex, currentParentDomainQualifiedName, newParentDomainQualifiedName, vertexQnName, newSuperDomainQualifiedName);
 
             updatePolicies(this.updatedPolicyResources, this.context);
 
@@ -175,6 +176,7 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
     }
 
     private void processMoveDataProductToAnotherDomain(AtlasEntity product,
+                                                       AtlasVertex productVertex,
                                                        String sourceDomainQualifiedName,
                                                        String targetDomainQualifiedName,
                                                        String currentDataProductQualifiedName,
@@ -198,6 +200,11 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
             product.setAttribute(QUALIFIED_NAME, updatedQualifiedName);
             product.setAttribute(PARENT_DOMAIN_QN_ATTR, targetDomainQualifiedName);
             product.setAttribute(SUPER_DOMAIN_QN_ATTR, superDomainQualifiedName);
+
+            Iterator<AtlasEdge> existingParentEdges = productVertex.getEdges(AtlasEdgeDirection.IN, DATA_PRODUCT_EDGE_LABEL).iterator();
+            if (existingParentEdges.hasNext()) {
+                graph.removeEdge(existingParentEdges.next());
+            }
 
             //Store domainPolicies and resources to be updated
             String currentResource = "entity:"+ currentDataProductQualifiedName;


### PR DESCRIPTION
## Change description

Currently we check for entity-create & entity-update permissions of current parent & target parent.
We found a bug where moving is failed to member user since via Persona domain policy we do not provide create domain permission, this check does not make any sense.



Solution:
when moving a Domain, check whether the user have the following permissions:
* entity-update permission on the Domain which is being moved
* Update sub-domains on source parent
* Create sub-domains on the target parent

when moving a Product, check whether the user have the following permissions
* entity-update permission on the Product which is being moved
* Update products on source parent
* Create products on target parent
        
e.g.
Assume a couple of super domains Sales & Marketing as the following hierarchy.

> Sales → domain_0 -> domain_1
> Marketing

Case 1 - Moving domain_0 from Sales to Marketing must check 
* entity-update on Sales
* Update sub-domains on Sales 
* Create sub-domains in Marketing 

Case 2 - Moving domain_1 from Sales to Marketing must check
* entity-update on domain_0 Sales
* Update sub-domains on domain_0 
* Create sub-domains in Marketing 


Testing - https://www.notion.so/atlanhq/DG-1533-Move-domain-CREATE-permission-Latest-de3e0a9204d945af91631e8cdb210122#8ab647163544405abb5e94c78a66046e

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> https://atlanhq.atlassian.net/browse/DG-1533

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
