### PR TITLE
Dg 1321 Internal attribute for input/output port relation for filtering.

### DIFF
--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -149,7 +149,8 @@ public final class Constants {
 
     public static final String REL_DOMAIN_TO_STAKEHOLDERS            = "data_domain_stakeholders";
     public static final String REL_STAKEHOLDER_TITLE_TO_STAKEHOLDERS = "stakeholder_title_stakeholders";
-
+    public static final String INPUT_PORT_PRODUCT_EDGE_LABEL = "__Asset.inputPortDataProducts";
+    public static final String OUTPUT_PORT_PRODUCT_EDGE_LABEL = "__Asset.outputPortDataProducts";
 
     /**
      * SQL property keys.

--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -149,6 +149,10 @@ public final class Constants {
 
     public static final String REL_DOMAIN_TO_STAKEHOLDERS            = "data_domain_stakeholders";
     public static final String REL_STAKEHOLDER_TITLE_TO_STAKEHOLDERS = "stakeholder_title_stakeholders";
+
+    public static final String REL_DATA_PRODUCT_TO_OUTPUT_PORTS = "data_products_output_ports";
+    public static final String REL_DATA_PRODUCT_TO_INPUT_PORTS  = "data_products_input_ports";
+
     public static final String INPUT_PORT_PRODUCT_EDGE_LABEL = "__Asset.inputPortDataProducts";
     public static final String OUTPUT_PORT_PRODUCT_EDGE_LABEL = "__Asset.outputPortDataProducts";
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasRelationshipStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasRelationshipStoreV2.java
@@ -68,17 +68,7 @@ import static org.apache.atlas.model.typedef.AtlasRelationshipDef.PropagateTags.
 import static org.apache.atlas.model.typedef.AtlasRelationshipDef.PropagateTags.NONE;
 import static org.apache.atlas.model.typedef.AtlasRelationshipDef.PropagateTags.ONE_TO_TWO;
 import static org.apache.atlas.model.typedef.AtlasRelationshipDef.PropagateTags.TWO_TO_ONE;
-import static org.apache.atlas.repository.Constants.ENTITY_TYPE_PROPERTY_KEY;
-import static org.apache.atlas.repository.Constants.HOME_ID_KEY;
-import static org.apache.atlas.repository.Constants.PROVENANCE_TYPE_KEY;
-import static org.apache.atlas.repository.Constants.RELATIONSHIPTYPE_TAG_PROPAGATION_KEY;
-import static org.apache.atlas.repository.Constants.RELATIONSHIP_GUID_PROPERTY_KEY;
-import static org.apache.atlas.repository.Constants.REL_DOMAIN_TO_DOMAINS;
-import static org.apache.atlas.repository.Constants.REL_DOMAIN_TO_PRODUCTS;
-import static org.apache.atlas.repository.Constants.REL_DOMAIN_TO_STAKEHOLDERS;
-import static org.apache.atlas.repository.Constants.REL_POLICY_TO_ACCESS_CONTROL;
-import static org.apache.atlas.repository.Constants.REL_STAKEHOLDER_TITLE_TO_STAKEHOLDERS;
-import static org.apache.atlas.repository.Constants.VERSION_PROPERTY_KEY;
+import static org.apache.atlas.repository.Constants.*;
 import static org.apache.atlas.repository.graph.GraphHelper.getTypeName;
 import static org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2.*;
 import static org.apache.atlas.repository.store.graph.v2.tasks.ClassificationPropagateTaskFactory.CLASSIFICATION_PROPAGATION_RELATIONSHIP_UPDATE;
@@ -116,6 +106,8 @@ public class AtlasRelationshipStoreV2 implements AtlasRelationshipStore {
         add(REL_DOMAIN_TO_STAKEHOLDERS);
         add(REL_STAKEHOLDER_TITLE_TO_STAKEHOLDERS);
         add(REL_POLICY_TO_ACCESS_CONTROL);
+        add(REL_DATA_PRODUCT_TO_OUTPUT_PORTS);
+        add(REL_DATA_PRODUCT_TO_INPUT_PORTS);
     }};
 
     public enum RelationshipMutation {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -2216,6 +2216,11 @@ public class EntityGraphMapper {
         AtlasVertex toVertex = ctx.getReferringVertex();
         String toVertexType = getTypeName(toVertex);
 
+        if(currentElements.isEmpty() && createdElements.isEmpty() && deletedElements.isEmpty()){
+            RequestContext.get().endMetricRecord(metricRecorder);
+            return;
+        }
+
         if (TYPE_PRODUCT.equals(toVertexType)) {
 
             if(currentElements == null){

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -2242,7 +2242,7 @@ public class EntityGraphMapper {
                 addOrRemoveInternalAttr(toVertex, INPUT_PORT_GUIDS_ATTR, createdElements, currentElements, deletedElements, portGuids);
             }
         }else{
-           throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST, "InternalProductAttribute can only be added to Product entity");
+           throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST, "Can not update product relations while updating any asset");
         }
         RequestContext.get().endMetricRecord(metricRecorder);
     }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -2039,7 +2039,6 @@ public class EntityGraphMapper {
 
         boolean isNewElementsNull = newElements == null;
 
-
         if (isNewElementsNull) {
             newElements = new ArrayList();
         }
@@ -2215,7 +2214,7 @@ public class EntityGraphMapper {
         AtlasVertex toVertex = ctx.getReferringVertex();
         String toVertexType = getTypeName(toVertex);
 
-        if((currentElements.isEmpty() || currentElements == null) && createdElements.isEmpty() && deletedElements.isEmpty()){
+        if((currentElements == null || currentElements.isEmpty()) && createdElements.isEmpty() && deletedElements.isEmpty()){
             RequestContext.get().endMetricRecord(metricRecorder);
             return;
         }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -2128,7 +2128,6 @@ public class EntityGraphMapper {
 
         boolean isNewElementsNull = elementsDeleted == null;
 
-
         if (isNewElementsNull) {
             elementsDeleted = new ArrayList();
         }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -85,7 +85,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
-import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -1908,7 +1907,7 @@ public class EntityGraphMapper {
         AtlasAttribute inverseRefAttribute = attribute.getInverseRefAttribute();
         Cardinality    cardinality         = attribute.getAttributeDef().getCardinality();
         List<AtlasEdge> removedElements    = new ArrayList<>();
-       List<Object>   newElementsCreated  = new ArrayList<>();
+        List<Object>   newElementsCreated  = new ArrayList<>();
         List<Object>   allArrayElements    = null;
         List<Object>   currentElements;
         boolean deleteExistingRelations = shouldDeleteExistingRelations(ctx, attribute);
@@ -2235,7 +2234,7 @@ public class EntityGraphMapper {
             }
 
             if(ctx.getAttribute().getRelationshipEdgeLabel().equals(OUTPUT_PORT_PRODUCT_EDGE_LABEL)){
-                addOrRemoveInternalAttr(toVertex, "OutputPortGuids", createdElements, currentElements, deletedElements);
+                addOrRemoveInternalAttr(toVertex, OUTPUT_PORT_GUIDS_ATTR, createdElements, currentElements, deletedElements);
             }
             if (ctx.getAttribute().getRelationshipEdgeLabel().equals(INPUT_PORT_PRODUCT_EDGE_LABEL)) {
                 addOrRemoveInternalAttr(toVertex, INPUT_PORT_GUIDS_ATTR, createdElements, currentElements, deletedElements);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -2215,7 +2215,6 @@ public class EntityGraphMapper {
         MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("addInternalProductAttrForAppend");
         AtlasVertex toVertex = ctx.getReferringVertex();
         String toVertexType = getTypeName(toVertex);
-        List<String> portGuids = new ArrayList<>();
 
         if (TYPE_PRODUCT.equals(toVertexType)) {
 
@@ -2230,10 +2229,10 @@ public class EntityGraphMapper {
             }
 
             if(ctx.getAttribute().getRelationshipEdgeLabel().equals(OUTPUT_PORT_PRODUCT_EDGE_LABEL)){
-                addOrRemoveInternalAttr(toVertex, OUTPUT_PORT_GUIDS_ATTR, createdElements, currentElements, deletedElements, portGuids);
+                addOrRemoveInternalAttr(toVertex, OUTPUT_PORT_GUIDS_ATTR, createdElements, currentElements, deletedElements);
             }
             if (ctx.getAttribute().getRelationshipEdgeLabel().equals(INPUT_PORT_PRODUCT_EDGE_LABEL)) {
-                addOrRemoveInternalAttr(toVertex, INPUT_PORT_GUIDS_ATTR, createdElements, currentElements, deletedElements, portGuids);
+                addOrRemoveInternalAttr(toVertex, INPUT_PORT_GUIDS_ATTR, createdElements, currentElements, deletedElements);
             }
         }else{
            throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST, "Can not update product relations while updating any asset");
@@ -2241,8 +2240,8 @@ public class EntityGraphMapper {
         RequestContext.get().endMetricRecord(metricRecorder);
     }
 
-    private void addOrRemoveInternalAttr(AtlasVertex toVertex, String internalAttr, List<Object> createdElements, List<Object> currentElements, List<AtlasEdge> deletedElements, List<String> portGuids) {
-        portGuids = toVertex.getMultiValuedProperty(internalAttr, String.class);
+    private void addOrRemoveInternalAttr(AtlasVertex toVertex, String internalAttr, List<Object> createdElements, List<Object> currentElements, List<AtlasEdge> deletedElements) {
+        List<String> portGuids = toVertex.getMultiValuedProperty(internalAttr, String.class);
 
         if (CollectionUtils.isNotEmpty(currentElements) && CollectionUtils.isEmpty(portGuids)) {
             List<String> currentGuids = currentElements.stream()

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -2253,7 +2253,7 @@ public class EntityGraphMapper {
 
         if (CollectionUtils.isNotEmpty(createdElements)) {
             List<String> assetGuids = createdElements.stream().map(x -> ((AtlasEdge) x).getOutVertex().getProperty("__guid", String.class)).collect(Collectors.toList());
-            portGuids.addAll(assetGuids);
+            portGuids = (List<String>) CollectionUtils.union(portGuids, assetGuids);
         }
 
         if (CollectionUtils.isNotEmpty(deletedElements)) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -2225,14 +2225,8 @@ public class EntityGraphMapper {
                 AtlasType      elementType         = arrType.getElementType();
                 boolean        isStructType        = (TypeCategory.STRUCT == elementType.getTypeCategory()) ||
                         (TypeCategory.STRUCT == attribute.getDefinedInType().getTypeCategory());
-                boolean        isReference         = isReference(elementType);
-                boolean        isSoftReference     = ctx.getAttribute().getAttributeDef().isSoftReferenced();
 
-                if (isReference && !isSoftReference) {
-                    currentElements = (List) getCollectionElementsUsingRelationship(ctx.getReferringVertex(), attribute, isStructType);
-                } else {
-                    currentElements = (List) getArrayElementsProperty(elementType, isSoftReference, ctx.getReferringVertex(), ctx.getVertexProperty());
-                }
+                currentElements = (List) getCollectionElementsUsingRelationship(ctx.getReferringVertex(), attribute, isStructType);
             }
 
             if(ctx.getAttribute().getRelationshipEdgeLabel().equals(OUTPUT_PORT_PRODUCT_EDGE_LABEL)){
@@ -2261,20 +2255,16 @@ public class EntityGraphMapper {
         if (CollectionUtils.isNotEmpty(createdElements)) {
             List<String> assetGuids = createdElements.stream().map(x -> ((AtlasEdge) x).getOutVertex().getProperty("__guid", String.class)).collect(Collectors.toList());
             portGuids.addAll(assetGuids);
-            toVertex.removeProperty(internalAttr);
-            if (CollectionUtils.isNotEmpty(portGuids)) {
-                portGuids.forEach(guid -> AtlasGraphUtilsV2.addEncodedProperty(toVertex, internalAttr , guid));
-            }
         }
 
         if (CollectionUtils.isNotEmpty(deletedElements)) {
             List<String> assetGuids = deletedElements.stream().map(x -> x.getOutVertex().getProperty("__guid", String.class)).collect(Collectors.toList());
             portGuids.removeAll(assetGuids);
-            toVertex.removeProperty(internalAttr);
-            if (CollectionUtils.isNotEmpty(portGuids)) {
-                portGuids.forEach(guid -> AtlasGraphUtilsV2.addEncodedProperty(toVertex, internalAttr , guid));
-            }
+        }
 
+        toVertex.removeProperty(internalAttr);
+        if (CollectionUtils.isNotEmpty(portGuids)) {
+            portGuids.forEach(guid -> AtlasGraphUtilsV2.addEncodedProperty(toVertex, internalAttr , guid));
         }
     }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -2170,7 +2170,7 @@ public class EntityGraphMapper {
 
             case INPUT_PORT_PRODUCT_EDGE_LABEL:
             case OUTPUT_PORT_PRODUCT_EDGE_LABEL:
-                addInternalProductAttr(ctx, new ArrayList<>(0) , removedElements, null);
+                addInternalProductAttr(ctx, null , removedElements);
                 break;
         }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -85,6 +85,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
+import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -2216,7 +2217,7 @@ public class EntityGraphMapper {
         AtlasVertex toVertex = ctx.getReferringVertex();
         String toVertexType = getTypeName(toVertex);
 
-        if(currentElements.isEmpty() && createdElements.isEmpty() && deletedElements.isEmpty()){
+        if((currentElements.isEmpty() || currentElements == null) && createdElements.isEmpty() && deletedElements.isEmpty()){
             RequestContext.get().endMetricRecord(metricRecorder);
             return;
         }
@@ -2234,7 +2235,7 @@ public class EntityGraphMapper {
             }
 
             if(ctx.getAttribute().getRelationshipEdgeLabel().equals(OUTPUT_PORT_PRODUCT_EDGE_LABEL)){
-                addOrRemoveInternalAttr(toVertex, OUTPUT_PORT_GUIDS_ATTR, createdElements, currentElements, deletedElements);
+                addOrRemoveInternalAttr(toVertex, "OutputPortGuids", createdElements, currentElements, deletedElements);
             }
             if (ctx.getAttribute().getRelationshipEdgeLabel().equals(INPUT_PORT_PRODUCT_EDGE_LABEL)) {
                 addOrRemoveInternalAttr(toVertex, INPUT_PORT_GUIDS_ATTR, createdElements, currentElements, deletedElements);
@@ -2250,6 +2251,7 @@ public class EntityGraphMapper {
 
         if (CollectionUtils.isNotEmpty(currentElements) && CollectionUtils.isEmpty(portGuids)) {
             List<String> currentGuids = currentElements.stream()
+                    .filter(x -> ((AtlasEdge) x).getProperty(STATE_PROPERTY_KEY, String.class).equals("ACTIVE"))
                     .map(x -> ((AtlasEdge) x).getOutVertex().getProperty("__guid", String.class))
                     .collect(Collectors.toList());
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/PreProcessorUtils.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/PreProcessorUtils.java
@@ -58,6 +58,8 @@ public class PreProcessorUtils {
     public static  final String DAAP_VISIBILITY_ATTR = "daapVisibility";
     public static  final String DAAP_VISIBILITY_USERS_ATTR = "daapVisibilityUsers";
     public static  final String DAAP_VISIBILITY_GROUPS_ATTR = "daapVisibilityGroups";
+    public static final String OUTPUT_PORT_GUIDS_ATTR = "daapOutputPortGuids";
+    public static final String INPUT_PORT_GUIDS_ATTR = "daapInputPortGuids";
 
     //Migration Constants
     public static final String MIGRATION_TYPE_PREFIX = "MIGRATION:";

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
@@ -81,6 +81,9 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
         String productName = (String) entity.getAttribute(NAME);
         String parentDomainQualifiedName = "";
 
+        entity.removeAttribute(OUTPUT_PORT_GUIDS_ATTR);
+        entity.removeAttribute(INPUT_PORT_GUIDS_ATTR);
+
         if (parentDomainObject == null) {
             throw new AtlasBaseException(OPERATION_NOT_SUPPORTED, "Cannot create a Product without a Domain Relationship");
         } else {
@@ -108,6 +111,9 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
 
     private void processUpdateProduct(AtlasEntity entity, AtlasVertex vertex) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("processUpdateProduct");
+
+        entity.removeAttribute(OUTPUT_PORT_GUIDS_ATTR);
+        entity.removeAttribute(INPUT_PORT_GUIDS_ATTR);
 
         if(entity.hasRelationshipAttribute(DATA_DOMAIN_REL_TYPE) && entity.getRelationshipAttribute(DATA_DOMAIN_REL_TYPE) == null){
             throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST, "DataProduct can only be moved to another Domain.");


### PR DESCRIPTION
## Change description

> We are adding two new attributes `daapOutputportGuids` and `daapInputportGuids` to store guids of assets consumed as outputPorts or inputPorts by the Product. The logic is added to maintain this attribute with the relationshipAttributes of Product.


## Type of change
- [x] New feature (adds functionality)

## JIRA Link

[https://atlanhq.atlassian.net/browse/DG-1321](url)

## Results
<img width="1440" alt="Screenshot 2024-06-04 at 7 50 05 PM" src="https://github.com/atlanhq/atlas-metastore/assets/79985042/71e8dd4d-5f1e-4dbb-a3b7-846ae603b837">


<img width="1440" alt="Screenshot 2024-06-04 at 7 51 21 PM" src="https://github.com/atlanhq/atlas-metastore/assets/79985042/ca53b0f6-bf77-420f-a5ec-f2804e259766">


## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
