### PR TITLE
feat: rebuild ES aliases required for accesscontrol like persona/purpose 

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
@@ -141,23 +141,6 @@ public class ESAliasStore implements IndexAliasStore {
         return true;
     }
 
-    public void rebuildAlias(AtlasEntity.AtlasEntityWithExtInfo accessControl) throws AtlasBaseException {
-        String aliasName = getAliasName(accessControl.getEntity());
-
-        Map<String, Object> filter;
-
-        if (PERSONA_ENTITY_TYPE.equals(accessControl.getEntity().getTypeName())) {
-            filter = getFilterForPersona(accessControl);
-        } else {
-            filter = getFilterForPurpose(accessControl.getEntity());
-        }
-
-        ESAliasRequestBuilder requestBuilder = new ESAliasRequestBuilder();
-        requestBuilder.addAction(ADD, new AliasAction(getIndexNameFromAliasIfExists(VERTEX_INDEX_NAME), aliasName, filter));
-
-        graph.createOrUpdateESAlias(requestBuilder);
-    }
-
     @Override
     public boolean deleteAlias(String aliasName) throws AtlasBaseException {
         graph.deleteESAlias(getIndexNameFromAliasIfExists(VERTEX_INDEX_NAME), aliasName);
@@ -171,17 +154,6 @@ public class ESAliasStore implements IndexAliasStore {
         if (policy != null) {
             policies.add(policy);
         }
-        if (CollectionUtils.isNotEmpty(policies)) {
-            personaPolicyToESDslClauses(policies, allowClauseList);
-        }
-
-        return esClausesToFilter(allowClauseList);
-    }
-
-    private Map<String, Object> getFilterForPersona(AtlasEntity.AtlasEntityWithExtInfo persona) throws AtlasBaseException {
-        List<Map<String, Object>> allowClauseList = new ArrayList<>();
-
-        List<AtlasEntity> policies = getPolicies(persona);
         if (CollectionUtils.isNotEmpty(policies)) {
             personaPolicyToESDslClauses(policies, allowClauseList);
         }

--- a/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
@@ -141,6 +141,23 @@ public class ESAliasStore implements IndexAliasStore {
         return true;
     }
 
+    public void rebuildAlias(AtlasEntity.AtlasEntityWithExtInfo accessControl) throws AtlasBaseException {
+        String aliasName = getAliasName(accessControl.getEntity());
+
+        Map<String, Object> filter;
+
+        if (PERSONA_ENTITY_TYPE.equals(accessControl.getEntity().getTypeName())) {
+            filter = getFilterForPersona(accessControl);
+        } else {
+            filter = getFilterForPurpose(accessControl.getEntity());
+        }
+
+        ESAliasRequestBuilder requestBuilder = new ESAliasRequestBuilder();
+        requestBuilder.addAction(ADD, new AliasAction(getIndexNameFromAliasIfExists(VERTEX_INDEX_NAME), aliasName, filter));
+
+        graph.createOrUpdateESAlias(requestBuilder);
+    }
+
     @Override
     public boolean deleteAlias(String aliasName) throws AtlasBaseException {
         graph.deleteESAlias(getIndexNameFromAliasIfExists(VERTEX_INDEX_NAME), aliasName);
@@ -154,6 +171,17 @@ public class ESAliasStore implements IndexAliasStore {
         if (policy != null) {
             policies.add(policy);
         }
+        if (CollectionUtils.isNotEmpty(policies)) {
+            personaPolicyToESDslClauses(policies, allowClauseList);
+        }
+
+        return esClausesToFilter(allowClauseList);
+    }
+
+    private Map<String, Object> getFilterForPersona(AtlasEntity.AtlasEntityWithExtInfo persona) throws AtlasBaseException {
+        List<Map<String, Object>> allowClauseList = new ArrayList<>();
+
+        List<AtlasEntity> policies = getPolicies(persona);
         if (CollectionUtils.isNotEmpty(policies)) {
             personaPolicyToESDslClauses(policies, allowClauseList);
         }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasEntityStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasEntityStore.java
@@ -25,7 +25,6 @@ import org.apache.atlas.model.instance.*;
 import org.apache.atlas.model.instance.AtlasEntity.AtlasEntitiesWithExtInfo;
 import org.apache.atlas.model.instance.AtlasEntity.AtlasEntityWithExtInfo;
 import org.apache.atlas.model.instance.AtlasEntityHeader;
-import org.apache.atlas.model.instance.AtlasEntityHeaders;
 import org.apache.atlas.model.instance.AtlasObjectId;
 import org.apache.atlas.model.instance.AtlasHasLineageRequests;
 import org.apache.atlas.model.instance.EntityMutationResponse;
@@ -364,6 +363,6 @@ public interface AtlasEntityStore {
 
     void repairMeaningAttributeForTerms(List<String> termGuids) throws AtlasBaseException;
 
-    public void repairAlias(String guid) throws AtlasBaseException;
+    void repairAccesscontrolAlias(String guid) throws AtlasBaseException;
 
 }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasEntityStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasEntityStore.java
@@ -364,4 +364,6 @@ public interface AtlasEntityStore {
 
     void repairMeaningAttributeForTerms(List<String> termGuids) throws AtlasBaseException;
 
+    public void repairAlias(String guid) throws AtlasBaseException;
+
 }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -49,6 +49,7 @@ import org.apache.atlas.repository.graphdb.AtlasGraph;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
 import org.apache.atlas.repository.patches.PatchContext;
 import org.apache.atlas.repository.patches.ReIndexPatch;
+import org.apache.atlas.repository.store.aliasstore.ESAliasStore;
 import org.apache.atlas.repository.store.graph.AtlasEntityStore;
 import org.apache.atlas.repository.store.graph.AtlasRelationshipStore;
 import org.apache.atlas.repository.store.graph.EntityGraphDiscovery;
@@ -147,6 +148,8 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
     private final AtlasRelationshipStore atlasRelationshipStore;
     private final FeatureFlagStore featureFlagStore;
 
+    private final ESAliasStore esAliasStore;
+
     @Inject
     public AtlasEntityStoreV2(AtlasGraph graph, DeleteHandlerDelegate deleteDelegate, RestoreHandlerV1 restoreHandlerV1, AtlasTypeRegistry typeRegistry,
                               IAtlasEntityChangeNotifier entityChangeNotifier, EntityGraphMapper entityGraphMapper, TaskManagement taskManagement,
@@ -163,6 +166,7 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
         this.taskManagement = taskManagement;
         this.atlasRelationshipStore = atlasRelationshipStore;
         this.featureFlagStore = featureFlagStore;
+        this.esAliasStore = new ESAliasStore(graph, entityRetriever);
 
         try {
             this.discovery = new EntityDiscoveryService(typeRegistry, graph, null, null, null, null);
@@ -2702,6 +2706,12 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
             LOG.info("Updated asset {}  with term {} ",  getGuid(assetVertex) ,  StringUtils.join(termNameList, ","));
         }
 
+    }
+    @Override
+    public void repairAlias(String guid) throws AtlasBaseException {
+        // Fetch entity with extenfo
+        AtlasEntity.AtlasEntityWithExtInfo entity = entityRetriever.toAtlasEntityWithExtInfo(guid);
+        this.esAliasStore.rebuildAlias(entity);
     }
 }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -2709,8 +2709,25 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
     }
     @Override
     public void repairAlias(String guid) throws AtlasBaseException {
-        // Fetch entity with extenfo
+        // Fetch entity with extInfo
         AtlasEntity.AtlasEntityWithExtInfo entity = entityRetriever.toAtlasEntityWithExtInfo(guid);
+
+        if (entity == null) {
+            throw new AtlasBaseException(AtlasErrorCode.INSTANCE_GUID_NOT_FOUND, guid);
+        }
+
+        // Validate entity status
+        if (entity.getEntity().getStatus() != ACTIVE) {
+            throw new AtlasBaseException(AtlasErrorCode.INSTANCE_GUID_DELETED, guid);
+        }
+
+        // Validate entity type
+        String entityType = entity.getEntity().getTypeName();
+        if (!PERSONA_ENTITY_TYPE.equals(entityType)) {
+            throw new AtlasBaseException(AtlasErrorCode.INVALID_OBJECT_ID, entityType);
+        }
+
+        // Rebuild alias
         this.esAliasStore.rebuildAlias(entity);
     }
 }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -2716,10 +2716,6 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
 
         AtlasAuthorizationUtils.verifyAccess(new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_UPDATE, new AtlasEntityHeader(accesscontrolEntity.getEntity())));
 
-        if (accesscontrolEntity == null) {
-            throw new AtlasBaseException(AtlasErrorCode.INSTANCE_GUID_NOT_FOUND, guid);
-        }
-
         // Validate accesscontrolEntity status
         if (accesscontrolEntity.getEntity().getStatus() != ACTIVE) {
             throw new AtlasBaseException(AtlasErrorCode.INSTANCE_GUID_DELETED, guid);
@@ -2728,7 +2724,7 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
         // Validate accesscontrolEntity type
         String entityType = accesscontrolEntity.getEntity().getTypeName();
         if (!PERSONA_ENTITY_TYPE.equals(entityType)) {
-            throw new AtlasBaseException(AtlasErrorCode.INVALID_OBJECT_ID, entityType);
+            throw new AtlasBaseException(AtlasErrorCode.OPERATION_NOT_SUPPORTED, entityType);
         }
 
         List<AtlasObjectId> policies = (List<AtlasObjectId>) accesscontrolEntity.getEntity().getRelationshipAttribute(REL_ATTR_POLICIES);
@@ -2737,7 +2733,7 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
         }
 
         // Rebuild alias
-        this.esAliasStore.rebuildAlias(accesscontrolEntity);
+        this.esAliasStore.updateAlias(accesscontrolEntity, null);
 
         RequestContext.get().endMetricRecord(metric);
     }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -2709,7 +2709,7 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
 
     }
     @Override
-    public void repairAlias(String guid) throws AtlasBaseException {
+    public void repairAccesscontrolAlias(String guid) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder metric = RequestContext.get().startMetricRecord("repairAlias");
         // Fetch accesscontrolEntity with extInfo
         AtlasEntity.AtlasEntityWithExtInfo accesscontrolEntity = entityRetriever.toAtlasEntityWithExtInfo(guid);

--- a/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
@@ -1932,9 +1932,27 @@ public class EntityREST {
     }
 
     @POST
-    @Path("/repairalias/{guid}")
+    @Path("/repairAccesscontrolAlias/{guid}")
     @Timed
-    public void repairAlias(@PathParam("guid") String guid) throws AtlasBaseException {
-        entitiesStore.repairAlias(guid);
+    public void repairAccessControlAlias(@PathParam("guid") String guid) throws AtlasBaseException {
+        Servlets.validateQueryParamLength("guid", guid);
+
+        AtlasPerfTracer perf = null;
+
+
+       try {
+           if (AtlasPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
+               perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "EntityREST.repairAccessControlAlias");
+           }
+
+           entitiesStore.repairAccesscontrolAlias(guid);
+
+           LOG.info("Repaired access control alias for entity with guid {}", guid);
+
+       } finally {
+              AtlasPerfTracer.log(perf);
+       }
+
+
     }
 }

--- a/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
@@ -1930,4 +1930,11 @@ public class EntityREST {
             AtlasPerfTracer.log(perf);
         }
     }
+
+    @POST
+    @Path("/repairalias/{guid}")
+    @Timed
+    public void repairAlias(@PathParam("guid") String guid) throws AtlasBaseException {
+        entitiesStore.repairAlias(guid);
+    }
 }

--- a/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
@@ -1932,7 +1932,7 @@ public class EntityREST {
     }
 
     @POST
-    @Path("/repairAccesscontrolAlias/{guid}")
+    @Path("/repair/accesscontrolAlias/{guid}")
     @Timed
     public void repairAccessControlAlias(@PathParam("guid") String guid) throws AtlasBaseException {
         Servlets.validateQueryParamLength("guid", guid);


### PR DESCRIPTION
## Create an endpoint to rebuild the aliases in ES for the accesscontrol entity i.e Persona, Purpose

>  Remove unnecessary beginning wildcard filters in persona aliases. So for that we created this rebuild API to make the persona state better.

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
