### PR TITLE
feature: Added support for "search_after" in elasticsearch queries

### DIFF
--- a/graphdb/api/src/main/java/org/apache/atlas/repository/graphdb/AtlasIndexQuery.java
+++ b/graphdb/api/src/main/java/org/apache/atlas/repository/graphdb/AtlasIndexQuery.java
@@ -26,7 +26,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
+import java.util.ArrayList;
 /**
  * A graph query that runs directly against a particular index.
  *
@@ -103,7 +103,7 @@ public interface AtlasIndexQuery<V, E> {
         DirectIndexQueryResult<V, E> getCollapseVertices(String key);
 
         Map<String, List<String>> getHighLights();
-
+        ArrayList<Object> getSort();
     }
 
 }

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchQuery.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchQuery.java
@@ -544,6 +544,11 @@ public class AtlasElasticsearchQuery implements AtlasIndexQuery<AtlasJanusVertex
         public Map<String, List<String>> getHighLights() {
             return new HashMap<>();
         }
+
+        @Override
+        public ArrayList<Object> getSort() {
+            return new ArrayList<>();
+        }
     }
 
 
@@ -608,6 +613,15 @@ public class AtlasElasticsearchQuery implements AtlasIndexQuery<AtlasJanusVertex
                 return (Map<String, List<String>>) highlight;
             }
             return new HashMap<>();
+        }
+
+        @Override
+        public ArrayList<Object> getSort() {
+            Object sort = this.hit.get("sort");
+            if (Objects.nonNull(sort) && sort instanceof List) {
+                return (ArrayList<Object>) sort;
+            }
+            return new ArrayList<>();
         }
     }
 

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusIndexQuery.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusIndexQuery.java
@@ -153,5 +153,10 @@ public class AtlasJanusIndexQuery implements AtlasIndexQuery<AtlasJanusVertex, A
         public Map<String, List<String>> getHighLights() {
             return new HashMap<>();
         }
+
+        @Override
+        public ArrayList<Object> getSort() {
+            return new ArrayList<>();
+        }
     }
 }

--- a/intg/src/main/java/org/apache/atlas/model/discovery/AtlasSearchResult.java
+++ b/intg/src/main/java/org/apache/atlas/model/discovery/AtlasSearchResult.java
@@ -37,6 +37,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.LinkedHashMap;
 
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.PUBLIC_ONLY;
@@ -59,7 +60,7 @@ public class AtlasSearchResult implements Serializable {
     private Map<String, Object>            aggregations;
     private Map<String,Double>             searchScore;
 
-    private Map<String, ElasticsearchMetadata>   searchMetadata;
+    private LinkedHashMap<String, ElasticsearchMetadata> searchMetadata;
 
 
 
@@ -162,11 +163,24 @@ public class AtlasSearchResult implements Serializable {
 
     public void addHighlights(String guid, Map<String, List<String>> highlights) {
         if(MapUtils.isEmpty(this.searchMetadata)) {
-            this.searchMetadata = new HashMap<>();
+            this.searchMetadata = new LinkedHashMap<>();
         }
         ElasticsearchMetadata v = this.searchMetadata.getOrDefault(guid, new ElasticsearchMetadata());
         v.addHighlights(highlights);
         this.searchMetadata.put(guid, v);
+    }
+
+    public void addSort(String guid, ArrayList sort) {
+        if(MapUtils.isEmpty(this.searchMetadata)) {
+            this.searchMetadata = new LinkedHashMap<>();
+        }
+        ElasticsearchMetadata v = this.searchMetadata.getOrDefault(guid, new ElasticsearchMetadata());
+        v.addSort(sort);
+        if (this.searchMetadata.containsKey(guid)) {
+           this.searchMetadata.replace(guid, v);
+        } else {
+            this.searchMetadata.put(guid, v);
+        }
     }
 
     @Override

--- a/intg/src/main/java/org/apache/atlas/model/discovery/AtlasSearchResult.java
+++ b/intg/src/main/java/org/apache/atlas/model/discovery/AtlasSearchResult.java
@@ -174,12 +174,12 @@ public class AtlasSearchResult implements Serializable {
         if(MapUtils.isEmpty(this.searchMetadata)) {
             this.searchMetadata = new LinkedHashMap<>();
         }
-        ElasticsearchMetadata v = this.searchMetadata.getOrDefault(guid, new ElasticsearchMetadata());
-        v.addSort(sort);
+        ElasticsearchMetadata sortMetadata = this.searchMetadata.getOrDefault(guid, new ElasticsearchMetadata());
+        sortMetadata.addSort(sort);
         if (this.searchMetadata.containsKey(guid)) {
-           this.searchMetadata.replace(guid, v);
+           this.searchMetadata.replace(guid, sortMetadata);
         } else {
-            this.searchMetadata.put(guid, v);
+            this.searchMetadata.put(guid, sortMetadata);
         }
     }
 

--- a/intg/src/main/java/org/apache/atlas/model/discovery/ElasticsearchMetadata.java
+++ b/intg/src/main/java/org/apache/atlas/model/discovery/ElasticsearchMetadata.java
@@ -5,10 +5,12 @@ import org.apache.commons.collections.MapUtils;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.ArrayList;
 
 public class ElasticsearchMetadata {
 
     private Map<String, List<String>> highlights;
+    private ArrayList<Object> sort;
 
     public Map<String, List<String>> getHighlights() {
         return highlights;
@@ -23,6 +25,17 @@ public class ElasticsearchMetadata {
         }
     }
 
+    public Object getSort() { return sort; }
+
+    public void addSort(ArrayList<Object> sort) {
+
+        if(!sort.isEmpty()) {
+            if (MapUtils.isEmpty(this.highlights)) {
+                this.sort = new ArrayList<>();
+            }
+            this.sort = sort;
+        }
+    }
 
     @Override
     public String toString() {

--- a/intg/src/main/java/org/apache/atlas/model/discovery/ElasticsearchMetadata.java
+++ b/intg/src/main/java/org/apache/atlas/model/discovery/ElasticsearchMetadata.java
@@ -1,5 +1,6 @@
 package org.apache.atlas.model.discovery;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.apache.commons.collections.MapUtils;
 
 import java.util.HashMap;
@@ -10,6 +11,8 @@ import java.util.ArrayList;
 public class ElasticsearchMetadata {
 
     private Map<String, List<String>> highlights;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private ArrayList<Object> sort;
 
     public Map<String, List<String>> getHighlights() {

--- a/intg/src/main/java/org/apache/atlas/model/discovery/ElasticsearchMetadata.java
+++ b/intg/src/main/java/org/apache/atlas/model/discovery/ElasticsearchMetadata.java
@@ -31,13 +31,7 @@ public class ElasticsearchMetadata {
     public Object getSort() { return sort; }
 
     public void addSort(ArrayList<Object> sort) {
-
-        if(!sort.isEmpty()) {
-            if (MapUtils.isEmpty(this.highlights)) {
-                this.sort = new ArrayList<>();
-            }
-            this.sort = sort;
-        }
+        this.sort = sort;
     }
 
     @Override

--- a/intg/src/main/java/org/apache/atlas/model/discovery/ElasticsearchMetadata.java
+++ b/intg/src/main/java/org/apache/atlas/model/discovery/ElasticsearchMetadata.java
@@ -31,7 +31,11 @@ public class ElasticsearchMetadata {
     public Object getSort() { return sort; }
 
     public void addSort(ArrayList<Object> sort) {
-        this.sort = sort;
+        if (sort.isEmpty()) {
+            this.sort = null;
+        } else {
+            this.sort = sort;
+        }
     }
 
     @Override

--- a/intg/src/main/java/org/apache/atlas/model/discovery/SearchParams.java
+++ b/intg/src/main/java/org/apache/atlas/model/discovery/SearchParams.java
@@ -26,6 +26,8 @@ public class SearchParams {
     Async async = new Async();
     boolean showHighlights;
 
+    boolean showSearchMetadata;
+
     public String getQuery() {
         return getQuery();
     }
@@ -154,8 +156,12 @@ public class SearchParams {
         return this.requestMetadata.getSearchInput();
     }
 
-    public boolean isShowHighlights() {
+    public boolean getShowHighlights() {
         return showHighlights;
+    }
+
+    public boolean getShowSearchMetadata() {
+        return showSearchMetadata;
     }
 
 

--- a/repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java
@@ -1098,10 +1098,11 @@ public class EntityDiscoveryService implements AtlasDiscoveryService {
                         header.setCollapse(collapse);
                     }
                 }
-
-                if (searchParams.isShowHighlights()) {
+                if (searchParams.getShowSearchMetadata()) {
                     ret.addHighlights(header.getGuid(), result.getHighLights());
                     ret.addSort(header.getGuid(), result.getSort());
+                } else if (searchParams.getShowHighlights()) {
+                    ret.addHighlights(header.getGuid(), result.getHighLights());
                 }
 
                 ret.addEntity(header);

--- a/repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java
@@ -1101,6 +1101,7 @@ public class EntityDiscoveryService implements AtlasDiscoveryService {
 
                 if (searchParams.isShowHighlights()) {
                     ret.addHighlights(header.getGuid(), result.getHighLights());
+                    ret.addSort(header.getGuid(), result.getSort());
                 }
 
                 ret.addEntity(header);


### PR DESCRIPTION
## Change description

> Description here
- In searchMetadata field adding the sort field from elasticsearch response with same datatypes.
- This will help implement search_after pagination usecase in indexsearch queries.
- Earlier we used to use from pagination which is not performant when we want to paginate over large number of documents. [doc](https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#paginate-search-results)

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
