### PR TITLE
Dg 1637 Empty Filter for Persona without any policy

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
@@ -170,12 +170,6 @@ public class ESAliasStore implements IndexAliasStore {
         return esClausesToFilter(allowClauseList);
     }
 
-//    private Map<String, Object> getFilterForPersona (AtlasEntity persona) throws AtlasBaseException {
-//        Map<String, Object> matchAll = mapOf("match_all", Collections.emptyMap());
-//        Map<String, Object> mustNot = mapOf("must_not", matchAll);
-//        return mapOf("bool", mustNot);
-//    }
-
     private void personaPolicyToESDslClauses(List<AtlasEntity> policies,
                                              List<Map<String, Object>> allowClauseList) throws AtlasBaseException {
         List<String> terms = new ArrayList<>();

--- a/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
@@ -124,6 +124,9 @@ public class ESAliasStore implements IndexAliasStore {
 
         if (PERSONA_ENTITY_TYPE.equals(accessControl.getEntity().getTypeName())) {
             filter = getFilterForPersona(accessControl, policy);
+            if (filter == null || filter.isEmpty()) {
+                filter = getEmptyFilter();
+            }
         } else {
             filter = getFilterForPurpose(accessControl.getEntity());
         }

--- a/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
@@ -38,12 +38,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static org.apache.atlas.ESAliasRequestBuilder.ESAliasAction.ADD;
 import static org.apache.atlas.repository.Constants.PERSONA_ENTITY_TYPE;
@@ -90,7 +85,7 @@ public class ESAliasStore implements IndexAliasStore {
         ESAliasRequestBuilder requestBuilder = new ESAliasRequestBuilder();
 
         if (PERSONA_ENTITY_TYPE.equals(entity.getTypeName())) {
-            requestBuilder.addAction(ADD, new AliasAction(getIndexNameFromAliasIfExists(VERTEX_INDEX_NAME), aliasName));
+            requestBuilder.addAction(ADD, new AliasAction(getIndexNameFromAliasIfExists(VERTEX_INDEX_NAME), aliasName, getFilterForPersona(null, null)));
         } else {
             requestBuilder.addAction(ADD, new AliasAction(getIndexNameFromAliasIfExists(VERTEX_INDEX_NAME), aliasName, getFilterForPurpose(entity)));
         }
@@ -150,6 +145,10 @@ public class ESAliasStore implements IndexAliasStore {
     private Map<String, Object> getFilterForPersona(AtlasEntity.AtlasEntityWithExtInfo persona, AtlasEntity policy) throws AtlasBaseException {
         List<Map<String, Object>> allowClauseList = new ArrayList<>();
 
+        if (policy == null && persona == null){
+            return getEmptyFilter();
+        }
+
         List<AtlasEntity> policies = getPolicies(persona);
         if (policy != null) {
             policies.add(policy);
@@ -170,6 +169,12 @@ public class ESAliasStore implements IndexAliasStore {
 
         return esClausesToFilter(allowClauseList);
     }
+
+//    private Map<String, Object> getFilterForPersona (AtlasEntity persona) throws AtlasBaseException {
+//        Map<String, Object> matchAll = mapOf("match_all", Collections.emptyMap());
+//        Map<String, Object> mustNot = mapOf("must_not", matchAll);
+//        return mapOf("bool", mustNot);
+//    }
 
     private void personaPolicyToESDslClauses(List<AtlasEntity> policies,
                                              List<Map<String, Object>> allowClauseList) throws AtlasBaseException {


### PR DESCRIPTION
## Change description

### Preconditions:
   -  Create a Persona, add yourself in to users list.
   - Do not create any policy or,   
   - Any existing persona that do not have any policy due to either never added any policy or deleted all existing policies

 ### Steps:

  - Go to Assets page, select Persona
  - Go to Assets page, select Persona, go to Glossary page

### Actual Result:

  - On both Assets & Glossary page, no asset should be visible

### Expected Result:

  - All assets or GCTs are listed 

### Root Cause:

  - When we create a Persona, we create ES alias without filters
  - When deleted any policy in Persona, we simply reform ES alias filters & overrride


### Solution:

  - When creating a new Persona, we should create ES alias with filter in such a way that it does not return anything
  - When deleting a policy, check if filters is empty, if yes add filter that it does not return anything
  - We have simply used `match_none ` for empty filters.

## Jira Link:

[https://atlanhq.atlassian.net/browse/DG-1637](url)

## Test-Case Doc
[https://www.notion.so/atlanhq/Test-Case-Doc-For-DG-1637-7853efb87dca437992b9288c59d93568](url)

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
