### PR TITLE
DG-1462 Fine Tuned Admin access to Super-Domain, by removing default CRUD access to sub-domain.

### DIFF
--- a/addons/policies/bootstrap_entity_policies.json
+++ b/addons/policies/bootstrap_entity_policies.json
@@ -2886,7 +2886,7 @@
                 [
                     "entity-type:DataDomain",
                     "entity-classification:*",
-                    "entity:*"
+                    "entity:default/domain/*/super"
                 ],
                 "policyActions":
                 [


### PR DESCRIPTION
Changed bootstrap policy to allow admins for super domains only , not sub-domains.

## Change description

> Description here

## Type of change
- [ ] New feature (adds functionality)

## Related issues

> Ticket [#1](https://atlanhq.atlassian.net/browse/DG-1462) 
> [TestCases](https://www.notion.so/atlanhq/Fine-Tune-Workspace-Removing-access-of-admin-from-CRUD-for-sub-domains-927093102135423598e92b115fbaad9a?pvs=4)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
