### PR TITLE
DG-1530 Changing the wildcard pattern for indexsearch to be more efficient

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
@@ -40,7 +40,6 @@ import org.springframework.stereotype.Component;
 import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -213,9 +212,10 @@ public class ESAliasStore implements IndexAliasStore {
                 } else if (getPolicyActions(policy).contains(ACCESS_READ_PERSONA_DOMAIN)) {
 
                     for (String asset : assets) {
-                        asset = validateAndConvertAsset(asset);
-                        if(!asset.equals(NEW_WILDCARD_DOMAIN_SUPER)) {
+                        if(!isAllDomain(asset)) {
                             terms.add(asset);
+                        } else {
+                            asset = NEW_WILDCARD_DOMAIN_SUPER;
                         }
                         allowClauseList.add(mapOf("wildcard", mapOf(QUALIFIED_NAME, asset + "*")));
                     }
@@ -248,10 +248,8 @@ public class ESAliasStore implements IndexAliasStore {
         allowClauseList.add(mapOf("terms", mapOf(QUALIFIED_NAME, terms)));
     }
 
-    private String validateAndConvertAsset(String asset) {
-        if(asset.equals("*/super") || asset.equals("*"))
-            asset = NEW_WILDCARD_DOMAIN_SUPER;
-        return asset;
+    private boolean isAllDomain(String asset) {
+        return asset.equals("*/super") || asset.equals("*") || asset.equals(NEW_WILDCARD_DOMAIN_SUPER);
     }
     private Map<String, Object> esClausesToFilter(List<Map<String, Object>> allowClauseList) {
         if (CollectionUtils.isNotEmpty(allowClauseList)) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
@@ -70,6 +70,7 @@ import static org.apache.atlas.repository.util.AtlasEntityUtils.mapOf;
 @Component
 public class ESAliasStore implements IndexAliasStore {
     private static final Logger LOG = LoggerFactory.getLogger(ESAliasStore.class);
+    public static final String NEW_WILDCARD_DOMAIN_SUPER = "default/domain/*/super";
 
     private final AtlasGraph graph;
     private final EntityGraphRetriever entityRetriever;
@@ -213,7 +214,7 @@ public class ESAliasStore implements IndexAliasStore {
 
                     for (String asset : assets) {
                         asset = validateAndConvertAsset(asset);
-                        if(!asset.equals("default/domain/*/super")) {
+                        if(!asset.equals(NEW_WILDCARD_DOMAIN_SUPER)) {
                             terms.add(asset);
                         }
                         allowClauseList.add(mapOf("wildcard", mapOf(QUALIFIED_NAME, asset + "*")));
@@ -249,7 +250,7 @@ public class ESAliasStore implements IndexAliasStore {
 
     private String validateAndConvertAsset(String asset) {
         if(asset.equals("*/super") || asset.equals("*"))
-            asset = "default/domain/*/super";
+            asset = NEW_WILDCARD_DOMAIN_SUPER;
         return asset;
     }
     private Map<String, Object> esClausesToFilter(List<Map<String, Object>> allowClauseList) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
@@ -213,7 +213,9 @@ public class ESAliasStore implements IndexAliasStore {
 
                     for (String asset : assets) {
                         asset = validateAndConvertAsset(asset);
-                        terms.add(asset);
+                        if(!asset.equals("default/domain/*/super")) {
+                            terms.add(asset);
+                        }
                         allowClauseList.add(mapOf("wildcard", mapOf(QUALIFIED_NAME, asset + "*")));
                     }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
@@ -212,6 +212,7 @@ public class ESAliasStore implements IndexAliasStore {
                 } else if (getPolicyActions(policy).contains(ACCESS_READ_PERSONA_DOMAIN)) {
 
                     for (String asset : assets) {
+                        asset = validateAndConvertAsset(asset);
                         terms.add(asset);
                         allowClauseList.add(mapOf("wildcard", mapOf(QUALIFIED_NAME, asset + "*")));
                     }
@@ -244,6 +245,11 @@ public class ESAliasStore implements IndexAliasStore {
         allowClauseList.add(mapOf("terms", mapOf(QUALIFIED_NAME, terms)));
     }
 
+    private String validateAndConvertAsset(String asset) {
+        if(asset.equals("*/super"))
+            asset = "default/domain/*/super";
+        return asset;
+    }
     private Map<String, Object> esClausesToFilter(List<Map<String, Object>> allowClauseList) {
         if (CollectionUtils.isNotEmpty(allowClauseList)) {
             return mapOf("bool", mapOf("should", allowClauseList));

--- a/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
@@ -246,7 +246,7 @@ public class ESAliasStore implements IndexAliasStore {
     }
 
     private String validateAndConvertAsset(String asset) {
-        if(asset.equals("*/super"))
+        if(asset.equals("*/super") || asset.equals("*"))
             asset = "default/domain/*/super";
         return asset;
     }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/AuthPolicyPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/AuthPolicyPreProcessor.java
@@ -211,6 +211,8 @@ public class AuthPolicyPreProcessor implements PreProcessor {
             if (!POLICY_SUB_CATEGORY_DOMAIN.equals(policySubCategory)) {
                 validator.validate(policy, existingPolicy, parentEntity, UPDATE);
                 validateConnectionAdmin(policy);
+            } else {
+                validateAndReduce(policy);
             }
 
             String qName = getEntityQualifiedName(existingPolicy);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/AuthPolicyPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/AuthPolicyPreProcessor.java
@@ -64,6 +64,7 @@ import static org.apache.atlas.repository.util.AccessControlUtils.getPolicySubCa
 
 public class AuthPolicyPreProcessor implements PreProcessor {
     private static final Logger LOG = LoggerFactory.getLogger(AuthPolicyPreProcessor.class);
+    public static final String ENTITY_DEFAULT_DOMAIN_SUPER = "entity:default/domain/*/super";
 
     private final AtlasGraph graph;
     private final AtlasTypeRegistry typeRegistry;
@@ -187,7 +188,7 @@ public class AuthPolicyPreProcessor implements PreProcessor {
                     i--;
                 }
             }
-            resources.add("entity:default/domain/*/super");
+            resources.add(ENTITY_DEFAULT_DOMAIN_SUPER);
         }
 
         policy.setAttribute(ATTR_POLICY_RESOURCES, resources);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/AuthPolicyPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/AuthPolicyPreProcessor.java
@@ -187,7 +187,7 @@ public class AuthPolicyPreProcessor implements PreProcessor {
                     i--;
                 }
             }
-            resources.add("default/domain/*/super");
+            resources.add("entity:default/domain/*/super");
         }
 
         policy.setAttribute(ATTR_POLICY_RESOURCES, resources);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/AuthPolicyPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/AuthPolicyPreProcessor.java
@@ -125,9 +125,11 @@ public class AuthPolicyPreProcessor implements PreProcessor {
             if (!POLICY_SUB_CATEGORY_DOMAIN.equals(policySubCategory)) {
                 validator.validate(policy, null, parentEntity, CREATE);
                 validateConnectionAdmin(policy);
-            } else {
-                validateAndReduce(policy);
             }
+            // TODO : uncomment after FE release
+//            else {
+//                validateAndReduce(policy);
+//            }
 
             policy.setAttribute(QUALIFIED_NAME, String.format("%s/%s", getEntityQualifiedName(parentEntity), getUUID()));
 
@@ -197,9 +199,11 @@ public class AuthPolicyPreProcessor implements PreProcessor {
             if (!POLICY_SUB_CATEGORY_DOMAIN.equals(policySubCategory)) {
                 validator.validate(policy, existingPolicy, parentEntity, UPDATE);
                 validateConnectionAdmin(policy);
-            } else {
-                validateAndReduce(policy);
             }
+            // TODO : uncomment after FE release
+//            else {
+//                validateAndReduce(policy);
+//            }
 
             String qName = getEntityQualifiedName(existingPolicy);
             policy.setAttribute(QUALIFIED_NAME, qName);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/accesscontrol/StakeholderPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/accesscontrol/StakeholderPreProcessor.java
@@ -58,8 +58,7 @@ import static org.apache.atlas.repository.Constants.QUALIFIED_NAME;
 import static org.apache.atlas.repository.Constants.STAKEHOLDER_ENTITY_TYPE;
 import static org.apache.atlas.repository.Constants.STAKEHOLDER_TITLE_ENTITY_TYPE;
 import static org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessorUtils.indexSearchPaginated;
-import static org.apache.atlas.repository.store.graph.v2.preprocessor.datamesh.StakeholderTitlePreProcessor.ATTR_DOMAIN_QUALIFIED_NAMES;
-import static org.apache.atlas.repository.store.graph.v2.preprocessor.datamesh.StakeholderTitlePreProcessor.STAR;
+import static org.apache.atlas.repository.store.graph.v2.preprocessor.datamesh.StakeholderTitlePreProcessor.*;
 import static org.apache.atlas.repository.util.AccessControlUtils.ATTR_ACCESS_CONTROL_ENABLED;
 import static org.apache.atlas.repository.util.AccessControlUtils.ATTR_PERSONA_ROLE_ID;
 import static org.apache.atlas.repository.util.AccessControlUtils.REL_ATTR_POLICIES;
@@ -290,7 +289,7 @@ public class StakeholderPreProcessor extends PersonaPreProcessor {
 
             List<String> domainQualifiedNames = (List<String>) stakeholderTitleHeader.getAttribute(ATTR_DOMAIN_QUALIFIED_NAMES);
 
-            if (!domainQualifiedNames.contains(STAR)) {
+            if (!domainQualifiedNames.contains(STAR) && !domainQualifiedNames.contains(NEW_STAR)) {
                 Optional parentDomain = domainQualifiedNames.stream().filter(x -> domainQualifiedName.startsWith(x)).findFirst();
 
                 if (!parentDomain.isPresent()) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/StakeholderTitlePreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/StakeholderTitlePreProcessor.java
@@ -48,6 +48,7 @@ public class StakeholderTitlePreProcessor implements PreProcessor {
 
 
     public static final String STAR = "*/super";
+    public static final String NEW_STAR = "default/domain/*/super";
     public static final String ATTR_DOMAIN_QUALIFIED_NAMES = "stakeholderTitleDomainQualifiedNames";
 
     public static final String REL_ATTR_STAKEHOLDERS = "stakeholders";
@@ -114,12 +115,12 @@ public class StakeholderTitlePreProcessor implements PreProcessor {
             if (CollectionUtils.isEmpty(domainQualifiedNames)) {
                 throw new AtlasBaseException(BAD_REQUEST, "Please provide attribute " + ATTR_DOMAIN_QUALIFIED_NAMES);
             }
-
-            if (domainQualifiedNames.contains(STAR)) {
+            domainQualifiedNames.replaceAll(s -> s.equals(STAR) ? NEW_STAR : s);
+            if (domainQualifiedNames.contains(NEW_STAR)) {
                 if (domainQualifiedNames.size() > 1) {
 
                     domainQualifiedNames.clear();
-                    domainQualifiedNames.add(STAR);
+                    domainQualifiedNames.add(NEW_STAR);
                     entity.setAttribute(ATTR_DOMAIN_QUALIFIED_NAMES, domainQualifiedNames);
                 }
 
@@ -211,8 +212,8 @@ public class StakeholderTitlePreProcessor implements PreProcessor {
         for (String domainQualifiedName: domainQualifiedNames) {
             String domainQualifiedNameToAuth;
 
-            if (domainQualifiedNames.contains(STAR)) {
-                domainQualifiedNameToAuth = "*/super";
+            if (domainQualifiedNames.contains(STAR) || domainQualifiedNames.contains(NEW_STAR)) {
+                domainQualifiedNameToAuth = NEW_STAR;
             } else {
                 domainQualifiedNameToAuth = domainQualifiedName;
             }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/StakeholderTitlePreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/StakeholderTitlePreProcessor.java
@@ -119,11 +119,13 @@ public class StakeholderTitlePreProcessor implements PreProcessor {
                 if (domainQualifiedNames.size() > 1) {
 
                     domainQualifiedNames.clear();
-                    domainQualifiedNames.add(NEW_STAR);
+                    // TODO : convert this to NEW_STAR after FE release
+                    domainQualifiedNames.add(STAR);
                     entity.setAttribute(ATTR_DOMAIN_QUALIFIED_NAMES, domainQualifiedNames);
-                } else {
-                    domainQualifiedNames.replaceAll(s -> s.equals(STAR) ? NEW_STAR : s);
-                }
+                } // TODO : uncomment this after FE release
+//                else {
+//                    domainQualifiedNames.replaceAll(s -> s.equals(STAR) ? NEW_STAR : s);
+//                }
 
                 String qualifiedName = format(PATTERN_QUALIFIED_NAME_ALL_DOMAINS, getUUID());
                 entity.setAttribute(QUALIFIED_NAME, qualifiedName);
@@ -214,7 +216,8 @@ public class StakeholderTitlePreProcessor implements PreProcessor {
             String domainQualifiedNameToAuth;
 
             if (domainQualifiedNames.contains(STAR) || domainQualifiedNames.contains(NEW_STAR)) {
-                domainQualifiedNameToAuth = NEW_STAR;
+                //TODO : Convert this to NEW_STAR
+                domainQualifiedNameToAuth = STAR;
             } else {
                 domainQualifiedNameToAuth = domainQualifiedName;
             }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/StakeholderTitlePreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/StakeholderTitlePreProcessor.java
@@ -115,13 +115,14 @@ public class StakeholderTitlePreProcessor implements PreProcessor {
             if (CollectionUtils.isEmpty(domainQualifiedNames)) {
                 throw new AtlasBaseException(BAD_REQUEST, "Please provide attribute " + ATTR_DOMAIN_QUALIFIED_NAMES);
             }
-            domainQualifiedNames.replaceAll(s -> s.equals(STAR) ? NEW_STAR : s);
-            if (domainQualifiedNames.contains(NEW_STAR)) {
+            if (domainQualifiedNames.contains(NEW_STAR) || domainQualifiedNames.contains(STAR)) {
                 if (domainQualifiedNames.size() > 1) {
 
                     domainQualifiedNames.clear();
                     domainQualifiedNames.add(NEW_STAR);
                     entity.setAttribute(ATTR_DOMAIN_QUALIFIED_NAMES, domainQualifiedNames);
+                } else {
+                    domainQualifiedNames.replaceAll(s -> s.equals(STAR) ? NEW_STAR : s);
                 }
 
                 String qualifiedName = format(PATTERN_QUALIFIED_NAME_ALL_DOMAINS, getUUID());


### PR DESCRIPTION
## Change description

> Whenever creating/updating a policy, if policyResources contains an `all domains` pattern, these steps would happen:
> - Convert this old pattern to new pattern i.e `default/domain/*super`
> - Remove any specific domain access to be removed, i.e If the resources have a. All Domains b. Some Domain QN, -> that specific domain will be taken out of the list, as its redundant.

> Changing the domain wildcard alias also fixed a bug where , old pattern was getting stakeholder entities as well as domain entities, where we are only supposed to get domain entities.
> This is the pre-FE release PR for this feature. Will be resolving multiple TODOs added in this PR in the next PR(post FE release)

## Type of change
- [ ] Bug fix (fixes an issue)

## Related issues

> Fix [#1](https://atlanhq.atlassian.net/browse/DG-1530) 
> TestCases considered and tested on [here](https://www.notion.so/atlanhq/Test-Cases-for-IndexSearch-Wildcard-pattern-change-fc36dfa30bcf4ddb81881980b3d4f89a)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
