### PR TITLE
DG-1671 Set archival status on delete

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/PreProcessorUtils.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/PreProcessorUtils.java
@@ -60,6 +60,8 @@ public class PreProcessorUtils {
     public static  final String DAAP_VISIBILITY_GROUPS_ATTR = "daapVisibilityGroups";
     public static final String OUTPUT_PORT_GUIDS_ATTR = "daapOutputPortGuids";
     public static final String INPUT_PORT_GUIDS_ATTR = "daapInputPortGuids";
+    public static final String DAAP_STATUS_ATTR = "daapStatus";
+    public static final String DAAP_ARCHIVED_STATUS = "Archived";
 
     //Migration Constants
     public static final String MIGRATION_TYPE_PREFIX = "MIGRATION:";

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
@@ -427,6 +427,7 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
 
         try{
             if(RequestContext.get().getDeleteType() != DeleteType.SOFT){
+                vertex.setProperty(DAAP_STATUS_ATTR, DAAP_ARCHIVED_STATUS);
                 String productGuid = vertex.getProperty("__guid", String.class);
                 AtlasObjectId atlasObjectId = new AtlasObjectId();
                 atlasObjectId.setTypeName(POLICY_ENTITY_TYPE);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
@@ -427,7 +427,6 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
 
         try{
             if(RequestContext.get().getDeleteType() != DeleteType.SOFT){
-                vertex.setProperty(DAAP_STATUS_ATTR, DAAP_ARCHIVED_STATUS);
                 String productGuid = vertex.getProperty("__guid", String.class);
                 AtlasObjectId atlasObjectId = new AtlasObjectId();
                 atlasObjectId.setTypeName(POLICY_ENTITY_TYPE);
@@ -442,6 +441,9 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
                         throw exp;
                     }
                 }
+            }
+            if(RequestContext.get().getDeleteType() == DeleteType.SOFT){
+                vertex.setProperty(DAAP_STATUS_ATTR, DAAP_ARCHIVED_STATUS);
             }
         }
         finally {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
@@ -442,7 +442,7 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
                     }
                 }
             }
-            if(RequestContext.get().getDeleteType() == DeleteType.SOFT){
+            if(RequestContext.get().getDeleteType() == DeleteType.SOFT || RequestContext.get().getDeleteType() == DeleteType.DEFAULT){
                 vertex.setProperty(DAAP_STATUS_ATTR, DAAP_ARCHIVED_STATUS);
             }
         }


### PR DESCRIPTION
## Change description

>  If we archive a daap using any other client other than Atlan UI the attribute `daapStatus` remains as it is either Active or Sunset. Added a fix to set attribute `daapStatus` to be updated to relevant state.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
