### PR TITLE
DG-1697: Adding endpoint for linking/unlink policy

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,6 +26,7 @@ on:
       - development
       - master
       - lineageondemand
+      - policyendpointsmaster
 
 jobs:
   build:

--- a/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
@@ -113,7 +113,6 @@ public enum AtlasConfiguration {
 
     INDEXSEARCH_ASYNC_SEARCH_KEEP_ALIVE_TIME_IN_SECONDS("atlas.indexsearch.async.search.keep.alive.time.in.seconds", 300),
 
-    POLICY_OPERATIONS_NOTIFICATION_MAX_THREADS("atlas.policy.operations.max.threads", 5),
     ATLAS_MAINTENANCE_MODE("atlas.maintenance.mode", false);
 
 

--- a/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
@@ -113,6 +113,7 @@ public enum AtlasConfiguration {
 
     INDEXSEARCH_ASYNC_SEARCH_KEEP_ALIVE_TIME_IN_SECONDS("atlas.indexsearch.async.search.keep.alive.time.in.seconds", 300),
 
+    POLICY_OPERATIONS_NOTIFICATION_MAX_THREADS("atlas.policy.operations.max.threads", 5),
     ATLAS_MAINTENANCE_MODE("atlas.maintenance.mode", false);
 
 

--- a/intg/src/main/java/org/apache/atlas/model/instance/LinkBusinessPolicyRequest.java
+++ b/intg/src/main/java/org/apache/atlas/model/instance/LinkBusinessPolicyRequest.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas.model.instance;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.io.Serializable;
+import java.util.List;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.PUBLIC_ONLY;
+
+/**
+ * Request to link/unlink policies from asset.
+ */
+@JsonAutoDetect(getterVisibility = PUBLIC_ONLY, setterVisibility = PUBLIC_ONLY, fieldVisibility = NONE)
+@JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.PROPERTY)
+public class LinkBusinessPolicyRequest implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private List<String> linkGuids;
+    private List<String> unlinkGuids;
+
+    public List<String> getLinkGuids() {
+        return linkGuids;
+    }
+
+    public void setLinkGuids(List<String> linkGuids) {
+        this.linkGuids = linkGuids;
+    }
+
+    public List<String> getUnlinkGuids() {
+        return unlinkGuids;
+    }
+
+    public void setUnlinkGuids(List<String> unlinkGuids) {
+        this.unlinkGuids = unlinkGuids;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("LinkBusinessPolicyRequest{");
+        sb.append("linkGuids=").append(linkGuids);
+        sb.append(", unlinkGuids=").append(unlinkGuids);
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasEntityStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasEntityStore.java
@@ -365,4 +365,10 @@ public interface AtlasEntityStore {
 
     void repairAccesscontrolAlias(String guid) throws AtlasBaseException;
 
+
+    void linkBusinessPolicy(String policyId, List<String> linkGuids) throws AtlasBaseException;
+
+
+    void unlinkBusinessPolicy(String policyId, List<String> unlinkGuids) throws AtlasBaseException;
+
 }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AlternateLinkingNotifierImpl.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AlternateLinkingNotifierImpl.java
@@ -1,0 +1,67 @@
+package org.apache.atlas.repository.store.graph.v2;
+
+import org.apache.atlas.RequestContext;
+import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.listener.EntityChangeListenerV2;
+import org.apache.atlas.model.instance.AtlasEntity;
+import org.apache.atlas.model.instance.AtlasEntityHeader;
+import org.apache.atlas.model.instance.EntityMutationResponse;
+import org.apache.atlas.repository.graphdb.AtlasVertex;
+import org.apache.atlas.utils.AtlasPerfMetrics;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.atlas.repository.graph.GraphHelper.*;
+
+
+@Component
+public class AlternateLinkingNotifierImpl implements IAtlasAlternateChangeNotifier {
+
+    private final Set<EntityChangeListenerV2> entityChangeListenersV2;
+
+    @Inject
+    public AlternateLinkingNotifierImpl(Set<EntityChangeListenerV2> entityChangeListenersV2) {
+        this.entityChangeListenersV2 = entityChangeListenersV2;
+
+    }
+
+    @Override
+    public void onEntitiesMutation(final EntityMutationResponse entityMutationResponse, final Map<String, AtlasVertex> entityByGuid) throws AtlasBaseException {
+        AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("onEntitiesMutation");
+        final List<AtlasEntityHeader> updatedEntities = entityMutationResponse.getUpdatedEntities();
+        final List<AtlasEntity> entities = updatedEntities.stream().map(entityHeader -> createAtlasEntity(entityHeader, entityByGuid.get(entityHeader.getGuid()))).collect(Collectors.toList());
+
+        for (EntityChangeListenerV2 listener : entityChangeListenersV2) {
+            listener.onEntitiesUpdated(entities, false);
+        }
+
+        RequestContext.get().endMetricRecord(metricRecorder);
+    }
+
+    private AtlasEntity createAtlasEntity(AtlasEntityHeader entityHeader, AtlasVertex vertex) {
+        AtlasEntity atlasEntity = new AtlasEntity();
+        atlasEntity.setAttributes(entityHeader.getAttributes());
+        atlasEntity.setGuid(entityHeader.getGuid());
+        atlasEntity.setTypeName(entityHeader.getTypeName());
+        atlasEntity.setStatus(entityHeader.getStatus());
+        atlasEntity.setCreatedBy(entityHeader.getCreatedBy());
+        atlasEntity.setUpdatedBy(entityHeader.getUpdatedBy());
+        atlasEntity.setCreateTime(entityHeader.getCreateTime());
+        atlasEntity.setUpdateTime(entityHeader.getUpdateTime());
+        atlasEntity.setIsProxy(entityHeader.getIsIncomplete());
+        atlasEntity.setIsIncomplete(entityHeader.getIsIncomplete());
+        atlasEntity.setProvenanceType(getProvenanceType(vertex));
+        atlasEntity.setCustomAttributes(getCustomAttributes(vertex));
+        atlasEntity.setHomeId(getHomeId(vertex));
+        atlasEntity.setVersion(getVersion(vertex));
+
+        return atlasEntity;
+    }
+
+
+}

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -20,16 +20,12 @@ package org.apache.atlas.repository.store.graph.v2;
 
 
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.atlas.AtlasErrorCode;
-import org.apache.atlas.DeleteType;
-import org.apache.atlas.GraphTransactionInterceptor;
-import org.apache.atlas.RequestContext;
-import org.apache.atlas.AtlasException;
-import org.apache.atlas.AtlasConfiguration;
+import org.apache.atlas.*;
 import org.apache.atlas.annotation.GraphTransaction;
 import org.apache.atlas.authorize.*;
 import org.apache.atlas.authorize.AtlasEntityAccessRequest.AtlasEntityAccessRequestBuilder;
-import org.apache.atlas.authorize.AtlasPrivilege;
+import org.apache.atlas.bulkimport.BulkImportResponse;
+import org.apache.atlas.bulkimport.BulkImportResponse.ImportInfo;
 import org.apache.atlas.discovery.EntityDiscoveryService;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.featureflag.FeatureFlagStore;
@@ -55,40 +51,31 @@ import org.apache.atlas.repository.store.graph.AtlasRelationshipStore;
 import org.apache.atlas.repository.store.graph.EntityGraphDiscovery;
 import org.apache.atlas.repository.store.graph.EntityGraphDiscoveryContext;
 import org.apache.atlas.repository.store.graph.v1.DeleteHandlerDelegate;
-import org.apache.atlas.repository.store.graph.v2.AtlasEntityComparator.AtlasEntityDiffResult;
 import org.apache.atlas.repository.store.graph.v1.RestoreHandlerV1;
+import org.apache.atlas.repository.store.graph.v2.AtlasEntityComparator.AtlasEntityDiffResult;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.AuthPolicyPreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.ConnectionPreProcessor;
-import org.apache.atlas.repository.store.graph.v2.preprocessor.accesscontrol.StakeholderPreProcessor;
-import org.apache.atlas.repository.store.graph.v2.preprocessor.contract.ContractPreProcessor;
-import org.apache.atlas.repository.store.graph.v2.preprocessor.datamesh.StakeholderTitlePreProcessor;
-import org.apache.atlas.repository.store.graph.v2.preprocessor.resource.LinkPreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.accesscontrol.PersonaPreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.accesscontrol.PurposePreProcessor;
-import org.apache.atlas.repository.store.graph.v2.preprocessor.datamesh.DataProductPreProcessor;
+import org.apache.atlas.repository.store.graph.v2.preprocessor.accesscontrol.StakeholderPreProcessor;
+import org.apache.atlas.repository.store.graph.v2.preprocessor.contract.ContractPreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.datamesh.DataDomainPreProcessor;
+import org.apache.atlas.repository.store.graph.v2.preprocessor.datamesh.DataProductPreProcessor;
+import org.apache.atlas.repository.store.graph.v2.preprocessor.datamesh.StakeholderTitlePreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.glossary.CategoryPreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.glossary.GlossaryPreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.glossary.TermPreProcessor;
+import org.apache.atlas.repository.store.graph.v2.preprocessor.resource.LinkPreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.resource.ReadmePreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.sql.QueryCollectionPreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.sql.QueryFolderPreProcessor;
 import org.apache.atlas.repository.store.graph.v2.preprocessor.sql.QueryPreProcessor;
 import org.apache.atlas.repository.store.graph.v2.tasks.MeaningsTask;
 import org.apache.atlas.tasks.TaskManagement;
-import org.apache.atlas.type.AtlasArrayType;
-import org.apache.atlas.type.AtlasBusinessMetadataType;
+import org.apache.atlas.type.*;
 import org.apache.atlas.type.AtlasBusinessMetadataType.AtlasBusinessAttribute;
-import org.apache.atlas.type.AtlasClassificationType;
-import org.apache.atlas.type.AtlasEntityType;
-import org.apache.atlas.type.AtlasEnumType;
 import org.apache.atlas.type.AtlasStructType.AtlasAttribute;
-import org.apache.atlas.type.AtlasType;
-import org.apache.atlas.type.AtlasTypeRegistry;
-import org.apache.atlas.type.AtlasTypeUtil;
-import org.apache.atlas.bulkimport.BulkImportResponse;
-import org.apache.atlas.bulkimport.BulkImportResponse.ImportInfo;
 import org.apache.atlas.util.FileUtils;
 import org.apache.atlas.utils.AtlasEntityUtil;
 import org.apache.atlas.utils.AtlasPerfMetrics;
@@ -111,18 +98,15 @@ import static org.apache.atlas.AtlasConfiguration.STORE_DIFFERENTIAL_AUDITS;
 import static org.apache.atlas.bulkimport.BulkImportResponse.ImportStatus.FAILED;
 import static org.apache.atlas.model.instance.AtlasEntity.Status.ACTIVE;
 import static org.apache.atlas.model.instance.EntityMutations.EntityOperation.*;
+import static org.apache.atlas.repository.Constants.IS_INCOMPLETE_PROPERTY_KEY;
+import static org.apache.atlas.repository.Constants.STATE_PROPERTY_KEY;
 import static org.apache.atlas.repository.Constants.*;
 import static org.apache.atlas.repository.graph.GraphHelper.*;
-import static org.apache.atlas.repository.graph.GraphHelper.getStatus;
 import static org.apache.atlas.repository.store.graph.v2.EntityGraphMapper.validateLabels;
-import static org.apache.atlas.repository.store.graph.v2.tasks.MeaningsTaskFactory.*;
+import static org.apache.atlas.repository.store.graph.v2.tasks.MeaningsTaskFactory.UPDATE_ENTITY_MEANINGS_ON_TERM_HARD_DELETE;
+import static org.apache.atlas.repository.store.graph.v2.tasks.MeaningsTaskFactory.UPDATE_ENTITY_MEANINGS_ON_TERM_SOFT_DELETE;
 import static org.apache.atlas.repository.util.AccessControlUtils.REL_ATTR_POLICIES;
-import static org.apache.atlas.type.Constants.HAS_LINEAGE;
-import static org.apache.atlas.type.Constants.HAS_LINEAGE_VALID;
-import static org.apache.atlas.type.Constants.MEANINGS_TEXT_PROPERTY_KEY;
-import static org.apache.atlas.type.Constants.MEANINGS_PROPERTY_KEY;
-import static org.apache.atlas.type.Constants.MEANING_NAMES_PROPERTY_KEY;
-import static org.apache.atlas.type.Constants.PENDING_TASKS_PROPERTY_KEY;
+import static org.apache.atlas.type.Constants.*;
 
 
 
@@ -151,10 +135,12 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
 
     private final ESAliasStore esAliasStore;
 
+    private final IAtlasAlternateChangeNotifier atlasAlternateChangeNotifier;
     @Inject
     public AtlasEntityStoreV2(AtlasGraph graph, DeleteHandlerDelegate deleteDelegate, RestoreHandlerV1 restoreHandlerV1, AtlasTypeRegistry typeRegistry,
                               IAtlasEntityChangeNotifier entityChangeNotifier, EntityGraphMapper entityGraphMapper, TaskManagement taskManagement,
-                              AtlasRelationshipStore atlasRelationshipStore, FeatureFlagStore featureFlagStore) {
+                              AtlasRelationshipStore atlasRelationshipStore, FeatureFlagStore featureFlagStore,
+                              IAtlasAlternateChangeNotifier atlasAlternateChangeNotifier) {
         this.graph                = graph;
         this.deleteDelegate       = deleteDelegate;
         this.restoreHandlerV1     = restoreHandlerV1;
@@ -168,7 +154,7 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
         this.atlasRelationshipStore = atlasRelationshipStore;
         this.featureFlagStore = featureFlagStore;
         this.esAliasStore = new ESAliasStore(graph, entityRetriever);
-
+        this.atlasAlternateChangeNotifier = atlasAlternateChangeNotifier;
         try {
             this.discovery = new EntityDiscoveryService(typeRegistry, graph, null, null, null, null);
         } catch (AtlasException e) {
@@ -1550,8 +1536,8 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
 
 
             // Notify the change listeners
-           // entityChangeNotifier.onEntitiesMutated(ret, RequestContext.get().isImportInProgress());
-           // atlasRelationshipStore.onRelationshipsMutated(RequestContext.get().getRelationshipMutationMap());
+            entityChangeNotifier.onEntitiesMutated(ret, RequestContext.get().isImportInProgress());
+            atlasRelationshipStore.onRelationshipsMutated(RequestContext.get().getRelationshipMutationMap());
             if (LOG.isDebugEnabled()) {
                 LOG.debug("<== createOrUpdate()");
             }
@@ -2739,21 +2725,51 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
     }
 
     @Override
-    @GraphTransaction
-    public void linkBusinessPolicy(String guid, List<String> linkGuids) {
-        AtlasPerfMetrics.MetricRecorder metric = RequestContext.get().startMetricRecord("linkBusinessPolicy");
-        this.entityGraphMapper.linkBusinessPolicy(guid, linkGuids);
-        RequestContext.get().endMetricRecord(metric);
+    public void linkBusinessPolicy(String guid, List<String> linkGuids) throws AtlasBaseException {
+        processBusinessPolicy(guid, linkGuids, true);
     }
-
 
     @Override
-    @GraphTransaction
-    public void unlinkBusinessPolicy(String guid, List<String> unlinkGuids) {
-        AtlasPerfMetrics.MetricRecorder metric = RequestContext.get().startMetricRecord("linkBusinessPolicy");
-        this.entityGraphMapper.unlinkBusinessPolicy(guid, unlinkGuids);
+    public void unlinkBusinessPolicy(String guid, List<String> unlinkGuids) throws AtlasBaseException {
+        processBusinessPolicy(guid, unlinkGuids, false);
+    }
+
+    private void processBusinessPolicy(String guid, List<String> guids, boolean isLink) throws AtlasBaseException {
+        // Start recording the performance metrics for the operation
+        String operation = isLink ? "linkBusinessPolicy" : "unlinkBusinessPolicy";
+        AtlasPerfMetrics.MetricRecorder metric = RequestContext.get().startMetricRecord(operation);
+
+        // Link or unlink the business policy to/from entities and retrieve the affected vertices
+        List<AtlasVertex> vertices = isLink ? this.entityGraphMapper.linkBusinessPolicy(guid, guids)
+                : this.entityGraphMapper.unlinkBusinessPolicy(guid, guids);
+
+        // If no vertices are returned, exit the method early
+        if (CollectionUtils.isEmpty(vertices)) {
+            return;
+        }
+
+        // Prepare the response for the entity mutations
+        EntityMutationResponse entityMutationResponse = new EntityMutationResponse();
+        for (AtlasVertex vertex : vertices) {
+            // Convert each vertex to an AtlasEntityHeader and add it to the response
+            AtlasEntityHeader entityHeader = entityRetriever.toAtlasEntityHeader(vertex);
+            entityMutationResponse.addEntity(UPDATE, entityHeader);
+        }
+
+        // Collect the vertices into a map for easier access by their GUID property
+        Map<String, AtlasVertex> vertexMap = vertices.stream()
+                .collect(Collectors.toMap(vertex -> vertex.getProperty("__guid", String.class), vertex -> vertex));
+
+        // Notify the policy change notifier about the entities that were mutated
+        this.atlasAlternateChangeNotifier.onEntitiesMutation(entityMutationResponse, vertexMap);
+
+        // End the performance metrics recording
         RequestContext.get().endMetricRecord(metric);
     }
+
+
+
 }
+
 
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -1550,8 +1550,8 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
 
 
             // Notify the change listeners
-            entityChangeNotifier.onEntitiesMutated(ret, RequestContext.get().isImportInProgress());
-            atlasRelationshipStore.onRelationshipsMutated(RequestContext.get().getRelationshipMutationMap());
+           // entityChangeNotifier.onEntitiesMutated(ret, RequestContext.get().isImportInProgress());
+           // atlasRelationshipStore.onRelationshipsMutated(RequestContext.get().getRelationshipMutationMap());
             if (LOG.isDebugEnabled()) {
                 LOG.debug("<== createOrUpdate()");
             }
@@ -2735,6 +2735,23 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
         // Rebuild alias
         this.esAliasStore.updateAlias(accesscontrolEntity, null);
 
+        RequestContext.get().endMetricRecord(metric);
+    }
+
+    @Override
+    @GraphTransaction
+    public void linkBusinessPolicy(String guid, List<String> linkGuids) {
+        AtlasPerfMetrics.MetricRecorder metric = RequestContext.get().startMetricRecord("linkBusinessPolicy");
+        this.entityGraphMapper.linkBusinessPolicy(guid, linkGuids);
+        RequestContext.get().endMetricRecord(metric);
+    }
+
+
+    @Override
+    @GraphTransaction
+    public void unlinkBusinessPolicy(String guid, List<String> unlinkGuids) {
+        AtlasPerfMetrics.MetricRecorder metric = RequestContext.get().startMetricRecord("linkBusinessPolicy");
+        this.entityGraphMapper.unlinkBusinessPolicy(guid, unlinkGuids);
         RequestContext.get().endMetricRecord(metric);
     }
 }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -4514,5 +4514,27 @@ public class EntityGraphMapper {
         }
         RequestContext.get().endMetricRecord(metricRecorder);
     }
+    public void linkBusinessPolicy(String policyId, List<String> linkGuids) {
+        for (String guid : linkGuids) {
+            AtlasVertex ev = AtlasGraphUtilsV2.findByGuid(graph, guid);
+            if (ev != null) {
+                Set<String> existingValues = ev.getMultiValuedSetProperty("assetPolicyGUIDs", String.class);
+                ev.setProperty("assetPolicyGUIDs", policyId);
+                ev.setProperty("assetPoliciesCount", existingValues.size() + 1);
+                updateModificationMetadata(ev);
+            }
+        }
+    }
 
+    public void unlinkBusinessPolicy(String policyId, List<String> unlinkGuids) {
+        for (String guid : unlinkGuids) {
+            AtlasVertex ev = AtlasGraphUtilsV2.findByGuid(graph, guid);
+            if (ev != null) {
+                Set<String> existingValues = ev.getMultiValuedSetProperty("assetPolicyGUIDs", String.class);
+                ev.removePropertyValue("assetPolicyGUIDs", policyId);
+                ev.setProperty("assetPoliciesCount", existingValues.size() - 1);
+                updateModificationMetadata(ev);
+            }
+        }
+    }
 }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/IAtlasAlternateChangeNotifier.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/IAtlasAlternateChangeNotifier.java
@@ -1,0 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas.repository.store.graph.v2;
+
+import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.model.instance.*;
+import org.apache.atlas.repository.graphdb.AtlasVertex;
+
+import java.util.Map;
+
+public interface IAtlasAlternateChangeNotifier {
+    void onEntitiesMutation(final EntityMutationResponse entityMutationResponse, final Map<String, AtlasVertex> entityByGuid) throws AtlasBaseException;
+}

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/bulkimport/MigrationImport.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/bulkimport/MigrationImport.java
@@ -129,7 +129,7 @@ public class MigrationImport extends ImportStrategy {
                 graph, relationshipStore, entityChangeNotifier, getInstanceConverter(graph), fullTextMapperV2, null, null);
         AtlasRelationshipStoreV2 atlasRelationshipStoreV2 = new AtlasRelationshipStoreV2(graph, typeRegistry, deleteDelegate, entityChangeNotifier);
 
-        return new AtlasEntityStoreV2(graph, deleteDelegate, restoreHandlerV1, typeRegistry, entityChangeNotifier, entityGraphMapper, null, atlasRelationshipStoreV2, null);
+        return new AtlasEntityStoreV2(graph, deleteDelegate, restoreHandlerV1, typeRegistry, entityChangeNotifier, entityGraphMapper, null, atlasRelationshipStoreV2, null, null);
     }
 
     private void shutdownEntityCreationManager(EntityCreationManager creationManager) {

--- a/server-api/src/main/java/org/apache/atlas/RequestContext.java
+++ b/server-api/src/main/java/org/apache/atlas/RequestContext.java
@@ -93,7 +93,7 @@ public class RequestContext {
     private String      currentTypePatchAction = "";
     private AtlasTask   currentTask;
     private String traceId;
-    private final Map<AtlasObjectId, Object> relationshipEndToVertexIdMap = new HashMap<>();
+    private  Map<AtlasObjectId, Object> relationshipEndToVertexIdMap = new HashMap<>();
     private boolean     allowDuplicateDisplayName;
     private MetricsRegistry metricsRegistry;
     private boolean skipAuthorizationCheck = false;
@@ -105,9 +105,81 @@ public class RequestContext {
     private Map<AtlasClassification, Collection<Object>> deletedClassificationAndVertices = new HashMap<>();
     private Map<AtlasClassification, Collection<Object>> addedClassificationAndVertices = new HashMap<>();
 
+    private boolean isCloned = false;
+    private boolean alternatePath  = false;
+
 
     private RequestContext() {
+
     }
+
+    private RequestContext(RequestContext other) {
+        this.user = other.user;
+        this.userGroups = other.userGroups != null ? new HashSet<>(other.userGroups) : null;
+        this.clientIPAddress = other.clientIPAddress;
+        this.forwardedAddresses = other.forwardedAddresses != null ? new ArrayList<>(other.forwardedAddresses) : null;
+        this.deleteType = other.deleteType;
+        this.isPurgeRequested = other.isPurgeRequested;
+        this.maxAttempts = other.maxAttempts;
+        this.attemptCount = other.attemptCount;
+        this.isImportInProgress = other.isImportInProgress;
+        this.isInNotificationProcessing = other.isInNotificationProcessing;
+        this.isInTypePatching = other.isInTypePatching;
+        this.createShellEntityForNonExistingReference = other.createShellEntityForNonExistingReference;
+        this.skipFailedEntities = other.skipFailedEntities;
+        this.allowDeletedRelationsIndexsearch = other.allowDeletedRelationsIndexsearch;
+        this.includeMeanings = other.includeMeanings;
+        this.includeClassifications = other.includeClassifications;
+        this.includeClassificationNames = other.includeClassificationNames;
+        this.currentTypePatchAction = other.currentTypePatchAction;
+        this.currentTask = other.currentTask;
+        this.traceId = other.traceId;
+        this.relationshipEndToVertexIdMap = new HashMap<>(other.relationshipEndToVertexIdMap);
+        this.allowDuplicateDisplayName = other.allowDuplicateDisplayName;
+        this.metricsRegistry = other.metricsRegistry;
+        this.skipAuthorizationCheck = other.skipAuthorizationCheck;
+        this.deletedEdgesIdsForResetHasLineage = new HashSet<>(other.deletedEdgesIdsForResetHasLineage);
+        this.requestUri = other.requestUri;
+        this.cacheEnabled = other.cacheEnabled;
+        this.delayTagNotifications = other.delayTagNotifications;
+        this.deletedClassificationAndVertices = new HashMap<>(other.deletedClassificationAndVertices);
+        this.addedClassificationAndVertices = new HashMap<>(other.addedClassificationAndVertices);
+
+        this.updatedEntities.putAll(other.updatedEntities);
+        this.deletedEntities.putAll(other.deletedEntities);
+        this.restoreEntities.putAll(other.restoreEntities);
+        this.entityCache.putAll(other.entityCache);
+        this.entityHeaderCache.putAll(other.entityHeaderCache);
+        this.entityExtInfoCache.putAll(other.entityExtInfoCache);
+        this.diffEntityCache.putAll(other.diffEntityCache);
+        this.addedPropagations.putAll(other.addedPropagations);
+        this.removedPropagations.putAll(other.removedPropagations);
+        this.requestContextHeaders.putAll(other.requestContextHeaders);
+        this.deletedEdgesIds.addAll(other.deletedEdgesIds);
+        this.processGuidIds.addAll(other.processGuidIds);
+        this.entitiesToSkipUpdate.addAll(other.entitiesToSkipUpdate);
+        this.onlyCAUpdateEntities.addAll(other.onlyCAUpdateEntities);
+        this.onlyBAUpdateEntities.addAll(other.onlyBAUpdateEntities);
+        this.queuedTasks.addAll(other.queuedTasks);
+        this.relationAttrsForSearch.addAll(other.relationAttrsForSearch);
+        this.removedElementsMap.putAll(other.removedElementsMap);
+        this.newElementsCreatedMap.putAll(other.newElementsCreatedMap);
+        this.relationshipMutationMap.putAll(other.relationshipMutationMap);
+    }
+
+
+    public static RequestContext cloneCurrentContext() {
+        RequestContext currentContext = get();
+        RequestContext requestContext = new RequestContext(currentContext);
+        requestContext.isCloned = true;
+        return requestContext;
+    }
+
+    public static void set(RequestContext context) {
+        CURRENT_CONTEXT.set(context);
+    }
+
+
 
     //To handle gets from background threads where createContext() is not called
     //createContext called for every request in the filter
@@ -787,5 +859,17 @@ public class RequestContext {
 
     public Map<String, Set<AtlasRelationship>> getRelationshipMutationMap() {
         return relationshipMutationMap;
+    }
+
+    public boolean isCloned() {
+        return isCloned;
+    }
+
+    public boolean isAlternatePath() {
+        return alternatePath;
+    }
+
+    public void setAlternatePath(boolean alternatePath) {
+        this.alternatePath = alternatePath;
     }
 }

--- a/webapp/src/main/java/org/apache/atlas/notification/EntityNotificationSender.java
+++ b/webapp/src/main/java/org/apache/atlas/notification/EntityNotificationSender.java
@@ -18,6 +18,7 @@
 package org.apache.atlas.notification;
 
 import org.apache.atlas.GraphTransactionInterceptor;
+import org.apache.atlas.RequestContext;
 import org.apache.atlas.model.notification.EntityNotification;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.configuration.Configuration;
@@ -95,10 +96,12 @@ public class EntityNotificationSender<T> {
                 notificationHook = new PostCommitNotificationHook(operationType, notifications);
                 postCommitNotificationHooks.set(notificationHook);
             } else {
-                if (isRelationshipEvent(operationType))
-                    notificationHook.addRelationshipNotifications(notifications);
-                else
-                    notificationHook.addNotifications(notifications);
+                if (isRelationshipEvent(operationType)) notificationHook.addRelationshipNotifications(notifications);
+                else notificationHook.addNotifications(notifications);
+            }
+
+            if (RequestContext.get().isAlternatePath()) {
+                notificationHook.onComplete(true);
             }
         }
 

--- a/webapp/src/main/java/org/apache/atlas/web/rest/AlternateREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/AlternateREST.java
@@ -1,0 +1,116 @@
+package org.apache.atlas.web.rest;
+
+import org.apache.atlas.AtlasErrorCode;
+import org.apache.atlas.RequestContext;
+import org.apache.atlas.annotation.Timed;
+import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.model.instance.LinkBusinessPolicyRequest;
+import org.apache.atlas.repository.store.graph.AtlasEntityStore;
+import org.apache.atlas.utils.AtlasPerfTracer;
+import org.apache.atlas.web.util.Servlets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+
+import static org.apache.atlas.repository.util.AccessControlUtils.ARGO_SERVICE_USER_NAME;
+
+@Path("alternate")
+@Singleton
+@Service
+@Consumes({Servlets.JSON_MEDIA_TYPE, MediaType.APPLICATION_JSON})
+@Produces({Servlets.JSON_MEDIA_TYPE, MediaType.APPLICATION_JSON})
+public class AlternateREST {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AlternateREST.class);
+    private static final Logger PERF_LOG = AtlasPerfTracer.getPerfLogger("rest.AlternateREST");
+
+    private final AtlasEntityStore entitiesStore;
+
+    @Inject
+    public AlternateREST(AtlasEntityStore entitiesStore) {
+        this.entitiesStore = entitiesStore;
+    }
+
+    /**
+     * Links a business policy to entities.
+     *
+     * @param policyId the ID of the policy to be linked
+     * @param request  the request containing the GUIDs of the assets to link the policy to
+     * @throws AtlasBaseException if there is an error during the linking process
+     */
+    @POST
+    @Path("/{policyId}/link-business-policy")
+    @Timed
+    public void linkBusinessPolicy(@PathParam("policyId") final String policyId, final LinkBusinessPolicyRequest request) throws AtlasBaseException {
+        // Ensure the current user is authorized to link policies
+        if (!ARGO_SERVICE_USER_NAME.equals(RequestContext.getCurrentUser())) {
+            throw new AtlasBaseException(AtlasErrorCode.UNAUTHORIZED_ACCESS, RequestContext.getCurrentUser(), "Policy linking");
+        }
+
+        // Set request context parameters
+        RequestContext.get().setAlternatePath(true);
+        RequestContext.get().setIncludeClassifications(false);
+        RequestContext.get().setIncludeMeanings(false);
+
+        AtlasPerfTracer perf = null;
+        try {
+            // Start performance tracing if enabled
+            if (AtlasPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
+                perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "AlternateREST.linkBusinessPolicy(" + policyId + ")");
+            }
+
+            // Link the business policy to the specified entities
+            entitiesStore.linkBusinessPolicy(policyId, request.getLinkGuids());
+        } catch (AtlasBaseException abe) {
+            LOG.error("Error in policy linking: ", abe);
+            throw new AtlasBaseException(AtlasErrorCode.INTERNAL_ERROR, "During Policy linking");
+        } finally {
+            // Log performance metrics
+            AtlasPerfTracer.log(perf);
+        }
+    }
+
+    /**
+     * Unlinks a business policy from entities.
+     *
+     * @param policyId the ID of the policy to be unlinked
+     * @param request  the request containing the GUIDs of the assets to unlink the policy from
+     * @throws AtlasBaseException if there is an error during the unlinking process
+     */
+    @POST
+    @Path("/{policyId}/unlink-business-policy")
+    @Timed
+    public void unlinkBusinessPolicy(@PathParam("policyId") final String policyId, final LinkBusinessPolicyRequest request) throws AtlasBaseException {
+        // Ensure the current user is authorized to unlink policies
+        if (!ARGO_SERVICE_USER_NAME.equals(RequestContext.getCurrentUser())) {
+            throw new AtlasBaseException(AtlasErrorCode.UNAUTHORIZED_ACCESS, RequestContext.getCurrentUser(), "Policy unlinking");
+        }
+
+        // Set request context parameters
+        RequestContext.get().setAlternatePath(true);
+        RequestContext.get().setIncludeClassifications(false);
+        RequestContext.get().setIncludeMeanings(false);
+
+        AtlasPerfTracer perf = null;
+        try {
+            // Start performance tracing if enabled
+            if (AtlasPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
+                perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "AlternateREST.unlinkBusinessPolicy(" + policyId + ")");
+            }
+
+            // Unlink the business policy from the specified entities
+            entitiesStore.unlinkBusinessPolicy(policyId, request.getUnlinkGuids());
+        } catch (AtlasBaseException abe) {
+            LOG.error("Error in policy unlinking: ", abe);
+            throw new AtlasBaseException(AtlasErrorCode.INTERNAL_ERROR, "During Policy unlinking");
+        } finally {
+            // Log performance metrics
+            AtlasPerfTracer.log(perf);
+        }
+    }
+}

--- a/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
@@ -75,7 +75,9 @@ import java.util.*;
 
 import static org.apache.atlas.AtlasErrorCode.BAD_REQUEST;
 import static org.apache.atlas.AtlasErrorCode.DEPRECATED_API;
+import static org.apache.atlas.authorize.AtlasAuthorizationUtils.getCurrentUserName;
 import static org.apache.atlas.authorize.AtlasPrivilege.*;
+import static org.apache.atlas.repository.util.AccessControlUtils.ARGO_SERVICE_USER_NAME;
 
 
 /**
@@ -1952,7 +1954,47 @@ public class EntityREST {
        } finally {
               AtlasPerfTracer.log(perf);
        }
+    }
 
 
+    @POST
+    @Path("/{policyId}/link-business-policy")
+    @Produces(Servlets.JSON_MEDIA_TYPE)
+    @Consumes(Servlets.JSON_MEDIA_TYPE)
+    @Timed
+    public void linkBusinessPolicy(@PathParam("policyId") final String policyId, final LinkBusinessPolicyRequest request) throws AtlasBaseException {
+        if (ARGO_SERVICE_USER_NAME.equals(RequestContext.getCurrentUser())) {
+            throw new AtlasBaseException(AtlasErrorCode.UNAUTHORIZED_ACCESS, RequestContext.getCurrentUser(), "Policy linking");
+        }
+        AtlasPerfTracer perf = null;
+        try {
+            if (AtlasPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
+                perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "EntityREST.linkBusinessPolicy(" + policyId + ")");
+            }
+            entitiesStore.linkBusinessPolicy(policyId, request.getLinkGuids());
+        } finally {
+            AtlasPerfTracer.log(perf);
+        }
+    }
+
+
+    @POST
+    @Path("/{policyId}/unlink-business-policy")
+    @Produces(Servlets.JSON_MEDIA_TYPE)
+    @Consumes(Servlets.JSON_MEDIA_TYPE)
+    @Timed
+    public void unlinkBusinessPolicy(@PathParam("policyId") final String policyId, final LinkBusinessPolicyRequest request) throws AtlasBaseException {
+        if (ARGO_SERVICE_USER_NAME.equals(RequestContext.getCurrentUser())) {
+            throw new AtlasBaseException(AtlasErrorCode.UNAUTHORIZED_ACCESS, RequestContext.getCurrentUser(), "Policy unlinking");
+        }
+        AtlasPerfTracer perf = null;
+        try {
+            if (AtlasPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
+                perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "EntityREST.unlinkBusinessPolicy(" + policyId + ")");
+            }
+            entitiesStore.unlinkBusinessPolicy(policyId, request.getUnlinkGuids());
+        } finally {
+            AtlasPerfTracer.log(perf);
+        }
     }
 }

--- a/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
@@ -1955,46 +1955,4 @@ public class EntityREST {
               AtlasPerfTracer.log(perf);
        }
     }
-
-
-    @POST
-    @Path("/{policyId}/link-business-policy")
-    @Produces(Servlets.JSON_MEDIA_TYPE)
-    @Consumes(Servlets.JSON_MEDIA_TYPE)
-    @Timed
-    public void linkBusinessPolicy(@PathParam("policyId") final String policyId, final LinkBusinessPolicyRequest request) throws AtlasBaseException {
-        if (ARGO_SERVICE_USER_NAME.equals(RequestContext.getCurrentUser())) {
-            throw new AtlasBaseException(AtlasErrorCode.UNAUTHORIZED_ACCESS, RequestContext.getCurrentUser(), "Policy linking");
-        }
-        AtlasPerfTracer perf = null;
-        try {
-            if (AtlasPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
-                perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "EntityREST.linkBusinessPolicy(" + policyId + ")");
-            }
-            entitiesStore.linkBusinessPolicy(policyId, request.getLinkGuids());
-        } finally {
-            AtlasPerfTracer.log(perf);
-        }
-    }
-
-
-    @POST
-    @Path("/{policyId}/unlink-business-policy")
-    @Produces(Servlets.JSON_MEDIA_TYPE)
-    @Consumes(Servlets.JSON_MEDIA_TYPE)
-    @Timed
-    public void unlinkBusinessPolicy(@PathParam("policyId") final String policyId, final LinkBusinessPolicyRequest request) throws AtlasBaseException {
-        if (ARGO_SERVICE_USER_NAME.equals(RequestContext.getCurrentUser())) {
-            throw new AtlasBaseException(AtlasErrorCode.UNAUTHORIZED_ACCESS, RequestContext.getCurrentUser(), "Policy unlinking");
-        }
-        AtlasPerfTracer perf = null;
-        try {
-            if (AtlasPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
-                perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "EntityREST.unlinkBusinessPolicy(" + policyId + ")");
-            }
-            entitiesStore.unlinkBusinessPolicy(policyId, request.getUnlinkGuids());
-        } finally {
-            AtlasPerfTracer.log(perf);
-        }
-    }
 }


### PR DESCRIPTION
## Change description

Created two new endpoints in the metastore:
1. Unlink Policies

```
Endpoint: POST entity/{policy-id}/unlink-business-policy
Body: {"unlinkGuids":["assetId1", "assetId2"]}
```

2 Link Policies

```
Endpoint: POST entity/{policy-id}/link-business-policy
Body: {"linkGuids":["assetId1", "assetId2"]}
```
These endpoints link or unlink policies from a set of asset IDs with minimal operations:

1. Verify if the request is from a service account.
2. Loop through all assets.
3. Load each asset.
4. Link or unlink the policy.
5. Increment or decrement the asset policies count.

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues



## Checklists

### Development

- [ ] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
