### PR TITLE
GRC-25 Remove MEDIUM severity from trivy code scanning alerts

### DIFF
--- a/.github/workflows/trivy-docker-scan.yml
+++ b/.github/workflows/trivy-docker-scan.yml
@@ -29,7 +29,7 @@ jobs:
           output: 'trivy-results-docker.sarif'
           exit-code: '1'
           #ignore-unfixed: true
-          severity: 'CRITICAL,HIGH,MEDIUM'
+          severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy Docker Scan Results To GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2


### PR DESCRIPTION
## Change description

> We're focusing on Critical and High severity vulnerabilities across the org, and hence removing the MEDIUM severity vulnerabilities from creating alerts. We will re-enable them once we have tackled the critical and high severity ones. 

## Type of change
- [x] Bug fix (fixes an issue)
- [] New feature (adds functionality)

## Related issues

> Fix https://github.com/atlanhq/atlas-metastore/security/code-scanning/15

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
