### PR TITLE
PLT-1759 | Refactor to use AtlasTypeRegistry to check for Duplicate Business Metadata Names

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasBusinessMetadataDefStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasBusinessMetadataDefStoreV2.java
@@ -81,15 +81,6 @@ public class AtlasBusinessMetadataDefStoreV2 extends AtlasAbstractDefStoreV2<Atl
             throw new AtlasBaseException(AtlasErrorCode.TYPE_ALREADY_EXISTS, businessMetadataDef.getName());
         }
 
-        //validate uniqueness of display name for BM
-        if (type.getTypeCategory() == TypeCategory.BUSINESS_METADATA) {
-            ret = typeDefStore.findTypeVertexByDisplayName(
-                    businessMetadataDef.getDisplayName(), DataTypes.TypeCategory.BUSINESS_METADATA);
-            if (ret != null) {
-                throw new AtlasBaseException(AtlasErrorCode.TYPE_WITH_DISPLAY_NAME_ALREADY_EXISTS, businessMetadataDef.getDisplayName());
-            }
-        }
-
         ret = typeDefStore.createTypeVertex(businessMetadataDef);
 
         updateVertexPreCreate(businessMetadataDef, (AtlasBusinessMetadataType) type, ret);
@@ -107,10 +98,9 @@ public class AtlasBusinessMetadataDefStoreV2 extends AtlasAbstractDefStoreV2<Atl
         AtlasBusinessMetadataDef businessMetadataDef = (AtlasBusinessMetadataDef) typeDef;
 
         //validate uniqueness of display name for BM
-        AtlasVertex ret = typeDefStore.findTypeVertexByDisplayName(
-                businessMetadataDef.getDisplayName(), DataTypes.TypeCategory.BUSINESS_METADATA);
-        if (ret != null && (
-                businessMetadataDef.getGuid() == null || !businessMetadataDef.getGuid().equals(ret.getProperty(Constants.GUID_PROPERTY_KEY, String.class)))) {
+        AtlasBusinessMetadataType ret = typeRegistry.getBusinessMetadataTypeByDisplayName(businessMetadataDef.getDisplayName());
+        if ((ret != null && ret.getBusinessMetadataDef().getGuid() != null) && (
+                businessMetadataDef.getGuid() == null || !businessMetadataDef.getGuid().equals(ret.getBusinessMetadataDef().getGuid()))) {
             throw new AtlasBaseException(AtlasErrorCode.TYPE_WITH_DISPLAY_NAME_ALREADY_EXISTS, businessMetadataDef.getDisplayName());
         }
 


### PR DESCRIPTION
There was a performance issue identified on one of the Customer calls that creation of Custom Metadata was slow and adding Attributes to the Metadata was overshooting the allocated 30 seconds timeout on UI.

This led to investigation on identifying performance bottleneck for
1. Creating Custom Business Metadata (Ueer defined typedef)
2. Adding Attributes to existing Business Metadata.

The postmortem of the above is available here:
https://www.notion.so/atlanhq/Postmortem-Atlas-slowness-for-Custom-metadata-2b80ea2464044d4a95b66e92a6eeb433?pvs=4

One of the alternatives to solve this was suggested by @mehtaanshul to use AtlasTypeRegistry rather than traversing un-indexed graph store.

