### PR TITLE
MESH-16 Fine tune admin privileges for subdomains

### DIFF
--- a/addons/policies/bootstrap_entity_policies.json
+++ b/addons/policies/bootstrap_entity_policies.json
@@ -2866,7 +2866,7 @@
             {
                 "name": "CRUD_DATA_MESH_ENTITIES",
                 "qualifiedName": "CRUD_DATA_MESH_ENTITIES",
-                "description": "Allows user to perform create read update operation on data mesh assets",
+                "description": "Allows user to perform crud operation on data mesh assets",
                 "policyCategory": "bootstrap",
                 "policySubCategory": "default",
                 "policyServiceName": "atlas",

--- a/addons/policies/bootstrap_entity_policies.json
+++ b/addons/policies/bootstrap_entity_policies.json
@@ -2864,9 +2864,9 @@
             "typeName": "AuthPolicy",
             "attributes":
             {
-                "name": "CRU_DATA_MESH_ENTITIES",
-                "qualifiedName": "CRU_DATA_MESH_ENTITIES",
-                "description": "Allows user to perform cru operation on data mesh assets",
+                "name": "CRUD_DATA_MESH_ENTITIES",
+                "qualifiedName": "CRUD_DATA_MESH_ENTITIES",
+                "description": "Allows user to perform crud operation on data mesh assets",
                 "policyCategory": "bootstrap",
                 "policySubCategory": "default",
                 "policyServiceName": "atlas",
@@ -2892,7 +2892,8 @@
                 [
                     "entity-create",
                     "entity-read",
-                    "entity-update"
+                    "entity-update",
+                    "entity-delete"
                 ]
             }
         },

--- a/addons/policies/bootstrap_entity_policies.json
+++ b/addons/policies/bootstrap_entity_policies.json
@@ -2864,9 +2864,9 @@
             "typeName": "AuthPolicy",
             "attributes":
             {
-                "name": "CRUD_DATA_MESH_ENTITIES",
-                "qualifiedName": "CRUD_DATA_MESH_ENTITIES",
-                "description": "Allows user to perform crud operation on data mesh assets",
+                "name": "CRU_DATA_MESH_ENTITIES",
+                "qualifiedName": "CRU_DATA_MESH_ENTITIES",
+                "description": "Allows user to perform create read update operation on data mesh assets",
                 "policyCategory": "bootstrap",
                 "policySubCategory": "default",
                 "policyServiceName": "atlas",
@@ -2892,8 +2892,7 @@
                 [
                     "entity-create",
                     "entity-read",
-                    "entity-update",
-                    "entity-delete"
+                    "entity-update"
                 ]
             }
         },

--- a/addons/policies/bootstrap_entity_policies.json
+++ b/addons/policies/bootstrap_entity_policies.json
@@ -2886,7 +2886,7 @@
                 [
                     "entity-type:DataDomain",
                     "entity-classification:*",
-                    "entity:default/domain/*/super"
+                    "entity:*/super"
                 ],
                 "policyActions":
                 [

--- a/addons/policies/bootstrap_entity_policies.json
+++ b/addons/policies/bootstrap_entity_policies.json
@@ -2864,9 +2864,45 @@
             "typeName": "AuthPolicy",
             "attributes":
             {
-                "name": "CRUD_DATA_MESH_ENTITIES",
-                "qualifiedName": "CRUD_DATA_MESH_ENTITIES",
-                "description": "Allows user to perform crud operation on data mesh assets",
+                "name": "CRU_DATA_MESH_ENTITIES",
+                "qualifiedName": "CRU_DATA_MESH_ENTITIES",
+                "description": "Allows user to perform cru operation on data mesh assets",
+                "policyCategory": "bootstrap",
+                "policySubCategory": "default",
+                "policyServiceName": "atlas",
+                "policyType": "allow",
+                "policyPriority": 0,
+                "policyUsers":
+                [],
+                "policyGroups":
+                [],
+                "policyRoles":
+                [
+                    "$admin",
+                    "$api-token-default-access"
+                ],
+                "policyResourceCategory": "ENTITY",
+                "policyResources":
+                [
+                    "entity-type:DataDomain",
+                    "entity-classification:*",
+                    "entity:default/domain/*/super"
+                ],
+                "policyActions":
+                [
+                    "entity-create",
+                    "entity-read",
+                    "entity-delete"
+                ]
+            }
+        },
+        {
+            "typeName": "AuthPolicy",
+            "attributes":
+            {
+                "name": "D_DATA_MESH_ENTITIES",
+                "qualifiedName": "D_DATA_MESH_ENTITIES",
+                "description": "Allows admins to perform delete operation on data mesh assets",
                 "policyCategory": "bootstrap",
                 "policySubCategory": "default",
                 "policyServiceName": "atlas",
@@ -2890,9 +2926,6 @@
                 ],
                 "policyActions":
                 [
-                    "entity-create",
-                    "entity-read",
-                    "entity-update",
                     "entity-delete"
                 ]
             }

--- a/addons/policies/bootstrap_entity_policies.json
+++ b/addons/policies/bootstrap_entity_policies.json
@@ -2892,7 +2892,7 @@
                 [
                     "entity-create",
                     "entity-read",
-                    "entity-delete"
+                    "entity-update"
                 ]
             }
         },

--- a/addons/policies/bootstrap_entity_policies.json
+++ b/addons/policies/bootstrap_entity_policies.json
@@ -2864,8 +2864,8 @@
             "typeName": "AuthPolicy",
             "attributes":
             {
-                "name": "CRU_DATA_MESH_ENTITIES",
-                "qualifiedName": "CRU_DATA_MESH_ENTITIES",
+                "name": "CRUD_DATA_MESH_ENTITIES",
+                "qualifiedName": "CRUD_DATA_MESH_ENTITIES",
                 "description": "Allows user to perform create read update operation on data mesh assets",
                 "policyCategory": "bootstrap",
                 "policySubCategory": "default",
@@ -2892,7 +2892,8 @@
                 [
                     "entity-create",
                     "entity-read",
-                    "entity-update"
+                    "entity-update",
+                    "entity-delete"
                 ]
             }
         },

--- a/addons/policies/bootstrap_entity_policies.json
+++ b/addons/policies/bootstrap_entity_policies.json
@@ -2901,8 +2901,8 @@
             "typeName": "AuthPolicy",
             "attributes":
             {
-                "name": "D_DATA_MESH_ENTITIES",
-                "qualifiedName": "D_DATA_MESH_ENTITIES",
+                "name": "RD_DATA_MESH_ENTITIES",
+                "qualifiedName": "RD_DATA_MESH_ENTITIES",
                 "description": "Allows admins to perform delete operation on data mesh assets",
                 "policyCategory": "bootstrap",
                 "policySubCategory": "default",
@@ -2927,6 +2927,7 @@
                 ],
                 "policyActions":
                 [
+                    "entity-read",
                     "entity-delete"
                 ]
             }


### PR DESCRIPTION
## Change description

> Changed bootstrap policy to allow admins for super domains only , not sub-domains.
> This gives admin , delete permission for all domains, but CRU permissions for superdomains only by default.


## Type of change
- [ ] New improvement (adds functionality)

## Related issues

> Fix [#1](https://atlanhq.atlassian.net/browse/MESH-16) 
> [TestCases](https://www.notion.so/atlanhq/TestCases-4849bd0e61f1473b8101aba0791bce93?pvs=4)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
