### PR TITLE
MESH-40 Fixed the TODOs left by previous part of the task.

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/AuthPolicyPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/AuthPolicyPreProcessor.java
@@ -125,11 +125,9 @@ public class AuthPolicyPreProcessor implements PreProcessor {
             if (!POLICY_SUB_CATEGORY_DOMAIN.equals(policySubCategory)) {
                 validator.validate(policy, null, parentEntity, CREATE);
                 validateConnectionAdmin(policy);
+            } else {
+                validateAndReduce(policy);
             }
-            // TODO : uncomment after FE release
-//            else {
-//                validateAndReduce(policy);
-//            }
 
             policy.setAttribute(QUALIFIED_NAME, String.format("%s/%s", getEntityQualifiedName(parentEntity), getUUID()));
 
@@ -173,11 +171,11 @@ public class AuthPolicyPreProcessor implements PreProcessor {
         boolean hasAllDomainPattern = resources.stream().anyMatch(resource ->
                 resource.equals("entity:*") ||
                         resource.equals("entity:*/super") ||
-                        resource.equals("entity:default/domain/*/super")
+                        resource.equals(ENTITY_DEFAULT_DOMAIN_SUPER)
         );
 
         if (hasAllDomainPattern) {
-            policy.setAttribute(ATTR_POLICY_RESOURCES, Collections.singletonList("entity:default/domain/*/super"));
+            policy.setAttribute(ATTR_POLICY_RESOURCES, Collections.singletonList(ENTITY_DEFAULT_DOMAIN_SUPER));
         }
     }
 
@@ -199,11 +197,9 @@ public class AuthPolicyPreProcessor implements PreProcessor {
             if (!POLICY_SUB_CATEGORY_DOMAIN.equals(policySubCategory)) {
                 validator.validate(policy, existingPolicy, parentEntity, UPDATE);
                 validateConnectionAdmin(policy);
+            } else {
+                validateAndReduce(policy);
             }
-            // TODO : uncomment after FE release
-//            else {
-//                validateAndReduce(policy);
-//            }
 
             String qName = getEntityQualifiedName(existingPolicy);
             policy.setAttribute(QUALIFIED_NAME, qName);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/StakeholderTitlePreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/StakeholderTitlePreProcessor.java
@@ -117,15 +117,12 @@ public class StakeholderTitlePreProcessor implements PreProcessor {
             }
             if (domainQualifiedNames.contains(NEW_STAR) || domainQualifiedNames.contains(STAR)) {
                 if (domainQualifiedNames.size() > 1) {
-
                     domainQualifiedNames.clear();
-                    // TODO : convert this to NEW_STAR after FE release
-                    domainQualifiedNames.add(STAR);
+                    domainQualifiedNames.add(NEW_STAR);
                     entity.setAttribute(ATTR_DOMAIN_QUALIFIED_NAMES, domainQualifiedNames);
-                } // TODO : uncomment this after FE release
-//                else {
-//                    domainQualifiedNames.replaceAll(s -> s.equals(STAR) ? NEW_STAR : s);
-//                }
+                }else {
+                    domainQualifiedNames.replaceAll(s -> s.equals(STAR) ? NEW_STAR : s);
+                }
 
                 String qualifiedName = format(PATTERN_QUALIFIED_NAME_ALL_DOMAINS, getUUID());
                 entity.setAttribute(QUALIFIED_NAME, qualifiedName);
@@ -216,8 +213,7 @@ public class StakeholderTitlePreProcessor implements PreProcessor {
             String domainQualifiedNameToAuth;
 
             if (domainQualifiedNames.contains(STAR) || domainQualifiedNames.contains(NEW_STAR)) {
-                //TODO : Convert this to NEW_STAR
-                domainQualifiedNameToAuth = STAR;
+                domainQualifiedNameToAuth = NEW_STAR;
             } else {
                 domainQualifiedNameToAuth = domainQualifiedName;
             }


### PR DESCRIPTION
## Change description

> Whenever creating/updating a policy, if policyResources contains an all domains pattern, these steps would happen:

> Convert this old pattern to new pattern i.e default/domain/*super
> Remove any specific domain access to be removed, i.e If the resources have a. All Domains b. Some Domain QN, -> that specific domain will be taken out of the list, as its redundant.
> Changing the domain wildcard alias also fixed a bug where , old pattern was getting stakeholder entities as well as domain entities, where we are only supposed to get domain entities.
## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] Code Improvement 

## Related issues

> Fix [#1](https://atlanhq.atlassian.net/browse/MESH-40) 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
