### PR TITLE
DG-1720 Added Lineage support for DataProducts <> Assets

### DIFF
--- a/repository/src/main/java/org/apache/atlas/discovery/AtlasLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/AtlasLineageService.java
@@ -71,7 +71,7 @@ public interface AtlasLineageService {
      * @param lineageOnDemandRequest lineage on demand request object
      * @return AtlasLineageInfo
      */
-    AtlasLineageOnDemandInfo getAtlasLineageInfo(String entityGuid, LineageOnDemandRequest lineageOnDemandRequest) throws AtlasBaseException;
+    AtlasLineageOnDemandInfo getAtlasLineageInfo(String entityGuid, LineageOnDemandRequest lineageOnDemandRequest, String lineageType) throws AtlasBaseException;
 
     /**
      * @param entityGuid unique ID of the entity

--- a/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
@@ -221,11 +221,10 @@ public class EntityLineageService implements AtlasLineageService {
         }
         HashMap<String, Boolean> dataTypeMap = new HashMap<>();
         boolean isProcess = entityType.getTypeAndAllSuperTypes().contains(PROCESS_SUPER_TYPE);
-        boolean isDataProduct = entityType.getTypeAndAllSuperTypes().contains(DATA_PRODUCT_ENTITY_TYPE);
+        boolean isDataProduct = entityType.getTypeName().equals(DATA_PRODUCT_ENTITY_TYPE);
         dataTypeMap.put(IS_DATA_PRODUCT, isDataProduct);
         dataTypeMap.put(IS_DATASET, !isProcess);
         if (!isProcess) {
-            //TODO : Check product is an asset super
             boolean isDataSet = entityType.getTypeAndAllSuperTypes().contains(DATA_SET_SUPER_TYPE);
             if (!isDataSet) {
                 throw new AtlasBaseException(AtlasErrorCode.INVALID_LINEAGE_ENTITY_TYPE, guid, typeName);

--- a/webapp/src/main/java/org/apache/atlas/web/rest/LineageREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/LineageREST.java
@@ -93,7 +93,7 @@ public class LineageREST {
     @Consumes(Servlets.JSON_MEDIA_TYPE)
     @Produces(Servlets.JSON_MEDIA_TYPE)
     @Timed
-    public AtlasLineageOnDemandInfo getLineageGraph(@PathParam("guid") String guid,
+    public AtlasLineageOnDemandInfo getLineageGraph(@PathParam("guid") String guid,@QueryParam("lineageType") String lineageType,
                                                     LineageOnDemandRequest lineageOnDemandRequest) throws AtlasBaseException {
         if (!AtlasConfiguration.LINEAGE_ON_DEMAND_ENABLED.getBoolean()) {
             LOG.warn("LineageREST: "+ AtlasErrorCode.LINEAGE_ON_DEMAND_NOT_ENABLED.getFormattedErrorMessage(AtlasConfiguration.LINEAGE_ON_DEMAND_ENABLED.getPropertyName()));
@@ -110,7 +110,7 @@ public class LineageREST {
                 perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "LineageREST.getOnDemandLineageGraph(" + guid + "," + lineageOnDemandRequest + ")");
             }
 
-            return atlasLineageService.getAtlasLineageInfo(guid, lineageOnDemandRequest);
+            return atlasLineageService.getAtlasLineageInfo(guid, lineageOnDemandRequest, lineageType);
         } finally {
             AtlasPerfTracer.log(perf);
         }


### PR DESCRIPTION
## Change description

> DataProduct when connected with Assets through input/output Ports will provide lineage through `/lineage/{guid}` api
> through a query param flag called `lineageType=ProductAssetLineage`
>
> Example URL : 
>```
> http://localhost:21000/api/meta/lineage/61adac14-b226-4fd3-97fa-ff0fb255dadb?lineageType=ProductAssetLineage
> ```

## Type of change
- [ ] New feature (adds functionality)

## Related issues

> Ticket [#1](https://atlanhq.atlassian.net/browse/DG-1720) 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
