### PR TITLE
fix: make all glossary queries at once

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
@@ -179,6 +179,7 @@ public class ESAliasStore implements IndexAliasStore {
     private void personaPolicyToESDslClauses(List<AtlasEntity> policies,
                                              List<Map<String, Object>> allowClauseList) throws AtlasBaseException {
         List<String> terms = new ArrayList<>();
+        Set<String> glossaryQualifiedNames =new HashSet<>();
         
         for (AtlasEntity policy: policies) {
 
@@ -211,7 +212,7 @@ public class ESAliasStore implements IndexAliasStore {
                 } else if (getPolicyActions(policy).contains(ACCESS_READ_PERSONA_GLOSSARY)) {
                     if (CollectionUtils.isNotEmpty(assets)) {
                         terms.addAll(assets);
-                        allowClauseList.add(mapOf("terms", mapOf(GLOSSARY_PROPERTY_KEY, assets)));
+                        glossaryQualifiedNames.addAll(assets);
                     }
                 } else if (getPolicyActions(policy).contains(ACCESS_READ_PERSONA_DOMAIN)) {
                     for (String asset : assets) {
@@ -249,6 +250,10 @@ public class ESAliasStore implements IndexAliasStore {
         }
 
         allowClauseList.add(mapOf("terms", mapOf(QUALIFIED_NAME, terms)));
+
+        if (CollectionUtils.isNotEmpty(glossaryQualifiedNames)) {
+            allowClauseList.add(mapOf("terms", mapOf(GLOSSARY_PROPERTY_KEY, new ArrayList<>(glossaryQualifiedNames))));
+        }
     }
 
     private boolean isAllDomain(String asset) {


### PR DESCRIPTION
### fix: make all glossary queries at once