### PR TITLE
DISC-367 : Deduplicate the glossary and qualifiedName in terms query

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
@@ -178,7 +178,7 @@ public class ESAliasStore implements IndexAliasStore {
 
     private void personaPolicyToESDslClauses(List<AtlasEntity> policies,
                                              List<Map<String, Object>> allowClauseList) throws AtlasBaseException {
-        List<String> terms = new ArrayList<>();
+        Set<String> terms = new HashSet<>();
         Set<String> glossaryQualifiedNames =new HashSet<>();
         
         for (AtlasEntity policy: policies) {
@@ -249,8 +249,8 @@ public class ESAliasStore implements IndexAliasStore {
             }
         }
 
-        allowClauseList.add(mapOf("terms", mapOf(QUALIFIED_NAME, terms)));
-
+        allowClauseList.add(mapOf("terms", mapOf(QUALIFIED_NAME, new ArrayList<>(terms))));
+        
         if (CollectionUtils.isNotEmpty(glossaryQualifiedNames)) {
             allowClauseList.add(mapOf("terms", mapOf(GLOSSARY_PROPERTY_KEY, new ArrayList<>(glossaryQualifiedNames))));
         }

--- a/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
@@ -179,6 +179,7 @@ public class ESAliasStore implements IndexAliasStore {
     private void personaPolicyToESDslClauses(List<AtlasEntity> policies,
                                              List<Map<String, Object>> allowClauseList) throws AtlasBaseException {
         List<String> terms = new ArrayList<>();
+        Set<String> glossaryQualifiedNames =new HashSet<>();
         
         for (AtlasEntity policy: policies) {
 
@@ -211,7 +212,7 @@ public class ESAliasStore implements IndexAliasStore {
                 } else if (getPolicyActions(policy).contains(ACCESS_READ_PERSONA_GLOSSARY)) {
                     if (CollectionUtils.isNotEmpty(assets)) {
                         terms.addAll(assets);
-                        allowClauseList.add(mapOf("terms", mapOf(GLOSSARY_PROPERTY_KEY, assets)));
+                        glossaryQualifiedNames.addAll(assets);
                     }
                 } else if (getPolicyActions(policy).contains(ACCESS_READ_PERSONA_DOMAIN)) {
                     for (String asset : assets) {
@@ -249,6 +250,10 @@ public class ESAliasStore implements IndexAliasStore {
         }
 
         allowClauseList.add(mapOf("terms", mapOf(QUALIFIED_NAME, terms)));
+
+        if (CollectionUtils.isNotEmpty(glossaryQualifiedNames)) {
+            allowClauseList.add(mapOf("terms", mapOf(GLOSSARY_PROPERTY_KEY, new ArrayList<>(glossaryQualifiedNames))));
+        }
     }
 
     private boolean isAllDomain(String asset) {


### PR DESCRIPTION
## Deduplicate the glossary and qualifiedName in terms query

> There was an issue in previous PR that if we had multiple Glossary policy it would create multiple glossary query which is unnecessary, so making the alias filter neat and clean

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
