### PR TITLE
DG-1735 | Fix for policy updates getting missed by PolicyRefresher

### DIFF
--- a/auth-agents-common/src/main/java/org/apache/atlas/plugin/util/PolicyRefresher.java
+++ b/auth-agents-common/src/main/java/org/apache/atlas/plugin/util/PolicyRefresher.java
@@ -322,7 +322,7 @@ public class PolicyRefresher extends Thread {
 
 				svcPolicies = transformer.getPolicies(serviceName,
 						restUtils.getPluginId(serviceName, plugIn.getAppId()),
-						lastUpdatedTiemInMillis);
+						lastUpdatedTiemInMillis, null);
 			} else {
 				svcPolicies = atlasAuthAdminClient.getServicePoliciesIfUpdated(lastUpdatedTiemInMillis);
 			}

--- a/intg/src/main/java/org/apache/atlas/model/audit/EntityAuditEventV2.java
+++ b/intg/src/main/java/org/apache/atlas/model/audit/EntityAuditEventV2.java
@@ -32,10 +32,7 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.io.Serializable;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.PUBLIC_ONLY;
@@ -118,6 +115,11 @@ public class EntityAuditEventV2 implements Serializable, Clearable {
             }
 
             throw new IllegalArgumentException("No enum constant " + EntityAuditActionV2.class.getCanonicalName() + "." + strValue);
+        }
+
+        public static List<EntityAuditActionV2> getDeleteActions() {
+            return Arrays.asList(ENTITY_DELETE, ENTITY_PURGE, ENTITY_IMPORT_DELETE, CLASSIFICATION_DELETE,
+                    PROPAGATED_CLASSIFICATION_DELETE, TERM_DELETE, LABEL_DELETE);
         }
     }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/contract/DataContract.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/contract/DataContract.java
@@ -45,12 +45,12 @@ public class DataContract {
     public String                               dataset;
     public DatasetType                          type;
     public String                               description;
-    public List<String>                         owners;
+    public Object                               owners;
     public List<BusinessTag>                    tags;
     public String                               certificate;
     @Valid
     public List<Column>                         columns;
-    private final Map<String, Object>            unknownFields = new HashMap<>();
+    private final Map<String, Object>           unknownFields = new HashMap<>();
 
     public enum Status {
         @JsonProperty("DRAFT") DRAFT,
@@ -146,7 +146,7 @@ public class DataContract {
         }
     }
 
-    public void setOwners(List<String> owners) {
+    public void setOwners(Object owners) {
         this.owners = owners;
     }
 

--- a/webapp/src/main/java/org/apache/atlas/web/rest/AuthREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/AuthREST.java
@@ -216,6 +216,8 @@ public class AuthREST {
                     EntityAuditEventV2 lastAuditLog = result.getEntityAudits().get(0);
                     if (!EntityAuditEventV2.EntityAuditActionV2.getDeleteActions().contains(lastAuditLog.getAction())) {
                         lastEditTime = lastAuditLog.getTimestamp();
+                    } else {
+                        LOG.info("found delete action, so ignoring the last edit time: {}", lastAuditLog.getTimestamp());
                     }
                 } else {
                     lastEditTime = null; // no edits found
@@ -223,7 +225,6 @@ public class AuthREST {
             }
         } catch (AtlasBaseException e) {
             LOG.error("ERROR in getPoliciesIfUpdated while fetching entity audits {}: ", e.getMessage());
-            return lastEditTime;
         } finally {
             RequestContext.get().endMetricRecord(recorder);
             LOG.info("Last edit time for service {} is {}, dsl: {}", serviceName, lastEditTime, dsl);

--- a/webapp/src/main/java/org/apache/atlas/web/rest/AuthREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/AuthREST.java
@@ -51,10 +51,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.apache.atlas.policytransformer.CachePolicyTransformerImpl.ATTR_SERVICE_LAST_SYNC;
 import static org.apache.atlas.repository.Constants.PERSONA_ENTITY_TYPE;
@@ -152,11 +149,13 @@ public class AuthREST {
                 perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "AuthREST.downloadPolicies(serviceName="+serviceName+", pluginId="+pluginId+", lastUpdatedTime="+lastUpdatedTime+")");
             }
 
+            Date latestEditTime = null; // TODO: get latest edit time from audit logs
+
             if (!isPolicyUpdated(serviceName, lastUpdatedTime)) {
                 return null;
             }
 
-            ServicePolicies ret = policyTransformer.getPolicies(serviceName, pluginId, lastUpdatedTime);
+            ServicePolicies ret = policyTransformer.getPolicies(serviceName, pluginId, lastUpdatedTime, latestEditTime);
 
             updateLastSync(serviceName);
 


### PR DESCRIPTION
## Change description

Currently, the `PolicyRefresher` fetches policies if it finds audit logs after last updated timestamp and then updates it's last updated time to current time. This PR adds a check on fetched data to check if it has the latest edited policies, otherwise try again. And don't update the last updated timestamp if latest data is not found.

Things to note:
- I'm ignoring the delete events for now and only capturing the T1 for other updates
- I'm checking for last policy update time (T2) after pulling all the policies. If sort by timestamp desc, risk is if more policies are added in the meantime, we won't get them and if no. of policies is large, ES might sync by the time we pull last page and if we sort in descending, we'll not get to take advantage of this.
- Anyway, this can be changed if required

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
