### PR TITLE
DG-1735 | Retry policy download for Atlas service if latest change is not found

### DIFF
--- a/auth-agents-common/src/main/java/org/apache/atlas/plugin/util/PolicyRefresher.java
+++ b/auth-agents-common/src/main/java/org/apache/atlas/plugin/util/PolicyRefresher.java
@@ -322,7 +322,7 @@ public class PolicyRefresher extends Thread {
 
 				svcPolicies = transformer.getPolicies(serviceName,
 						restUtils.getPluginId(serviceName, plugIn.getAppId()),
-						lastUpdatedTiemInMillis);
+						lastUpdatedTiemInMillis, null);
 			} else {
 				svcPolicies = atlasAuthAdminClient.getServicePoliciesIfUpdated(lastUpdatedTiemInMillis);
 			}

--- a/auth-agents-common/src/main/java/org/apache/atlas/policytransformer/CachePolicyTransformerImpl.java
+++ b/auth-agents-common/src/main/java/org/apache/atlas/policytransformer/CachePolicyTransformerImpl.java
@@ -53,15 +53,7 @@ import org.springframework.stereotype.Component;
 import javax.inject.Inject;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -219,12 +211,12 @@ public class CachePolicyTransformerImpl {
                 atlasPolicies = getAtlasPolicies(serviceName, batchSize, latestEditTime);
                 break;
             } catch (AtlasBaseException e) {
-                LOG.error("ERROR in getServicePolicies {}: ", e.getMessage());
+                LOG.error("ES_SYNC_FIX: {}: ERROR in getServicePolicies: {}", serviceName, e.getMessage());
                 TimeUnit.MILLISECONDS.sleep(sleepFor);
                 sleepFor *= 2;
             }
         }
-        LOG.info("Moving to transform policies, size: {}", atlasPolicies.size());
+        LOG.info("ES_SYNC_FIX: {}: Moving to transform policies, size: {}", serviceName, atlasPolicies.size());
         if (CollectionUtils.isNotEmpty(atlasPolicies)) {
             //transform policies
             servicePolicies = transformAtlasPoliciesToRangerPolicies(atlasPolicies, serviceType, serviceName);
@@ -523,31 +515,32 @@ public class CachePolicyTransformerImpl {
                 List<AtlasEntityHeader> headers = discoveryService.directIndexSearch(indexSearchParams).getEntities();
                 if (headers != null) {
                     ret.addAll(headers);
-                    LOG.info("======= Found result with {} policies", headers.size());
+                    LOG.info("ES_SYNC_FIX: {}: ======= Found result with {} policies", serviceName, headers.size());
                 } else {
                     found = false;
-                    LOG.info("======= Found result with null policies");
+                    LOG.info("ES_SYNC_FIX: {}: ======= Found result with null policies", serviceName);
                 }
 
                 from += size;
 
             } while (found && ret.size() % size == 0);
-
-            boolean latestEditFound = false;
-            Date latestEditTimeAvailable = null;
-            for (AtlasEntityHeader entity : ret) {
-                LOG.info("Looping on returned policies: {}, size: {}", entity.getDisplayText(), ret.size());
-                if (latestEditTime == null || entity.getUpdateTime().compareTo(latestEditTime) >= 0) {
-                    LOG.info("Found latest policy: {}, latestEditTime: {}, found policy time: {}", entity.getDisplayText(), latestEditTime, entity.getUpdateTime());
-                    latestEditFound = true;
-                    break;
+            if (Objects.equals(serviceName, "atlas")) {
+                boolean latestEditFound = false;
+                Date latestEditTimeAvailable = null;
+                for (AtlasEntityHeader entity : ret) {
+                    // LOG.info("ES_SYNC_FIX: {}: Looping on returned policies: {}, size: {}", serviceName, entity.getDisplayText(), ret.size());
+                    if (latestEditTime == null || entity.getUpdateTime().compareTo(latestEditTime) >= 0) {
+                        LOG.info("ES_SYNC_FIX: {}: Found latest policy: {}, latestEditTime: {}, found policy time: {}", serviceName, entity.getDisplayText(), latestEditTime, entity.getUpdateTime());
+                        latestEditFound = true;
+                        break;
+                    }
+                    latestEditTimeAvailable = entity.getUpdateTime();
+                    // LOG.info("ES_SYNC_FIX: {}: Checked for latest edit, entity: {}, latestEditTimeAvailable: {}", serviceName, entity.getDisplayText(), latestEditTimeAvailable);
                 }
-                latestEditTimeAvailable = entity.getUpdateTime();
-                LOG.info("Checked for latest edit, entity: {}, latestEditTimeAvailable: {}", entity.getDisplayText(),  latestEditTimeAvailable);
-            }
-            if (latestEditTime != null && !latestEditFound) {
-                LOG.info("Latest edit not found yet, policies: {}, latestEditTime: {}, latestEditTimeAvailable: {}", ret.size(), latestEditTime,  latestEditTimeAvailable);
-                throw new AtlasBaseException("Latest edit not found yet");
+                if (latestEditTime != null && !latestEditFound) {
+                    LOG.info("ES_SYNC_FIX: {}: Latest edit not found yet, policies: {}, latestEditTime: {}, latestEditTimeAvailable: {}", serviceName, ret.size(), latestEditTime, latestEditTimeAvailable);
+                    throw new AtlasBaseException("Latest edit not found yet");
+                }
             }
 
         } finally {

--- a/auth-agents-common/src/main/java/org/apache/atlas/policytransformer/CachePolicyTransformerImpl.java
+++ b/auth-agents-common/src/main/java/org/apache/atlas/policytransformer/CachePolicyTransformerImpl.java
@@ -213,6 +213,9 @@ public class CachePolicyTransformerImpl {
             } catch (AtlasBaseException e) {
                 LOG.error("ES_SYNC_FIX: {}: ERROR in getServicePolicies: {}", serviceName, e.getMessage());
                 TimeUnit.MILLISECONDS.sleep(sleepFor);
+                if (attempt == maxAttempts) {
+                    throw e;
+                }
                 sleepFor *= 2;
             }
         }

--- a/auth-agents-common/src/main/java/org/apache/atlas/policytransformer/CachePolicyTransformerImpl.java
+++ b/auth-agents-common/src/main/java/org/apache/atlas/policytransformer/CachePolicyTransformerImpl.java
@@ -206,7 +206,7 @@ public class CachePolicyTransformerImpl {
 
         int maxAttempts = 5;
         int sleepFor = 500;
-        for (int attempt = 0; attempt < maxAttempts; attempt++) {
+        for (int attempt = 0; attempt <= maxAttempts; attempt++) {
             try {
                 atlasPolicies = getAtlasPolicies(serviceName, batchSize, latestEditTime);
                 break;

--- a/intg/src/main/java/org/apache/atlas/model/audit/EntityAuditEventV2.java
+++ b/intg/src/main/java/org/apache/atlas/model/audit/EntityAuditEventV2.java
@@ -32,10 +32,7 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.io.Serializable;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.PUBLIC_ONLY;
@@ -118,6 +115,11 @@ public class EntityAuditEventV2 implements Serializable, Clearable {
             }
 
             throw new IllegalArgumentException("No enum constant " + EntityAuditActionV2.class.getCanonicalName() + "." + strValue);
+        }
+
+        public static List<EntityAuditActionV2> getDeleteActions() {
+            return Arrays.asList(ENTITY_DELETE, ENTITY_PURGE, ENTITY_IMPORT_DELETE, CLASSIFICATION_DELETE,
+                    PROPAGATED_CLASSIFICATION_DELETE, TERM_DELETE, LABEL_DELETE);
         }
     }
 

--- a/webapp/src/main/java/org/apache/atlas/web/rest/AuthREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/AuthREST.java
@@ -157,7 +157,10 @@ public class AuthREST {
 
             ServicePolicies ret = policyTransformer.getPolicies(serviceName, pluginId, lastUpdatedTime, new Date(latestEditTime));
 
-            updateLastSync(serviceName);
+            // check if ret contains any policies other than tagPolicies
+            if (ret != null && ret.getPolicies() != null && !ret.getPolicies().isEmpty()) {
+                updateLastSync(serviceName);
+            }
 
             return ret;
         } finally {

--- a/webapp/src/main/java/org/apache/atlas/web/rest/AuthREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/AuthREST.java
@@ -198,12 +198,12 @@ public class AuthREST {
         mustClauseList.add(getMap("terms", getMap("typeName", entityUpdateToWatch)));
 
         lastUpdatedTime = lastUpdatedTime == -1 ? 0 : lastUpdatedTime;
-        mustClauseList.add(getMap("range", getMap("timestamp", getMap("gte", lastUpdatedTime))));
+        mustClauseList.add(getMap("range", getMap("created", getMap("gte", lastUpdatedTime))));
 
         dsl.put("query", getMap("bool", getMap("must", mustClauseList)));
 
         List<Map<String, Object>> sortList = new ArrayList<>();
-        sortList.add(getMap("timestamp", "desc"));
+        sortList.add(getMap("created", "desc"));
         dsl.put("sort", sortList);
 
         parameters.setDsl(dsl);
@@ -217,7 +217,7 @@ public class AuthREST {
                     if (!EntityAuditEventV2.EntityAuditActionV2.getDeleteActions().contains(lastAuditLog.getAction())) {
                         lastEditTime = lastAuditLog.getTimestamp();
                     } else {
-                        LOG.info("found delete action, so ignoring the last edit time: {}", lastAuditLog.getTimestamp());
+                        LOG.info("ES_SYNC_FIX: {}: found delete action, so ignoring the last edit time: {}", serviceName, lastAuditLog.getTimestamp());
                     }
                 } else {
                     lastEditTime = null; // no edits found

--- a/webapp/src/main/java/org/apache/atlas/web/rest/AuthREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/AuthREST.java
@@ -157,10 +157,7 @@ public class AuthREST {
 
             ServicePolicies ret = policyTransformer.getPolicies(serviceName, pluginId, lastUpdatedTime, new Date(latestEditTime));
 
-            // check if ret contains any policies other than tagPolicies
-            if (ret != null && ret.getPolicies() != null && !ret.getPolicies().isEmpty()) {
-                updateLastSync(serviceName);
-            }
+            updateLastSync(serviceName);
 
             return ret;
         } finally {

--- a/webapp/src/main/java/org/apache/atlas/web/rest/AuthREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/AuthREST.java
@@ -216,6 +216,8 @@ public class AuthREST {
                     EntityAuditEventV2 lastAuditLog = result.getEntityAudits().get(0);
                     if (!EntityAuditEventV2.EntityAuditActionV2.getDeleteActions().contains(lastAuditLog.getAction())) {
                         lastEditTime = lastAuditLog.getTimestamp();
+                    } else {
+                        LOG.info("found delete action, so ignoring the last edit time: {}", lastAuditLog.getTimestamp());
                     }
                 } else {
                     lastEditTime = null; // no edits found
@@ -223,7 +225,6 @@ public class AuthREST {
             }
         } catch (AtlasBaseException e) {
             LOG.error("ERROR in getPoliciesIfUpdated while fetching entity audits {}: ", e.getMessage());
-            return lastEditTime;
         } finally {
             RequestContext.get().endMetricRecord(recorder);
             LOG.info("Last edit time for service {} is {}, dsl: {}", serviceName, lastEditTime, dsl);

--- a/webapp/src/main/java/org/apache/atlas/web/rest/AuthREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/AuthREST.java
@@ -51,10 +51,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.apache.atlas.policytransformer.CachePolicyTransformerImpl.ATTR_SERVICE_LAST_SYNC;
 import static org.apache.atlas.repository.Constants.PERSONA_ENTITY_TYPE;
@@ -152,11 +149,13 @@ public class AuthREST {
                 perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "AuthREST.downloadPolicies(serviceName="+serviceName+", pluginId="+pluginId+", lastUpdatedTime="+lastUpdatedTime+")");
             }
 
+            Date latestEditTime = null; // TODO: get latest edit time from audit logs
+
             if (!isPolicyUpdated(serviceName, lastUpdatedTime)) {
                 return null;
             }
 
-            ServicePolicies ret = policyTransformer.getPolicies(serviceName, pluginId, lastUpdatedTime);
+            ServicePolicies ret = policyTransformer.getPolicies(serviceName, pluginId, lastUpdatedTime, latestEditTime);
 
             updateLastSync(serviceName);
 


### PR DESCRIPTION
## Change description

There were few cases reported where changes shown in audit logs for the policies created on a new connection creation where not reflecting while policies were fetched. This adds retries attempt with some delay to incorporate possible delay in ES sync with Cassandra.

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
