### PR TITLE
DISC-378 : Create persona filters on hierachical qualifiedName filters

### DIFF
--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -56,6 +56,7 @@ public final class Constants {
     public static final String GUID_PROPERTY_KEY                = encodePropertyKey(INTERNAL_PROPERTY_KEY_PREFIX + "guid");
     public static final String RELATIONSHIP_GUID_PROPERTY_KEY   = encodePropertyKey(RELATIONSHIP_PROPERTY_KEY_PREFIX + GUID_PROPERTY_KEY);
     public static final String HISTORICAL_GUID_PROPERTY_KEY     = encodePropertyKey(INTERNAL_PROPERTY_KEY_PREFIX + "historicalGuids");
+    public static final String QUALIFIED_NAME_HIERARCHY_PROPERTY_KEY = encodePropertyKey(INTERNAL_PROPERTY_KEY_PREFIX + "qualifiedNameHierarchy");
     public static final String FREETEXT_REQUEST_HANDLER         = "/freetext";
     public static final String TERMS_REQUEST_HANDLER            = "/terms";
     public static final String ES_API_ALIASES                   = "/_aliases";

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphBackedSearchIndexer.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphBackedSearchIndexer.java
@@ -351,6 +351,7 @@ public class GraphBackedSearchIndexer implements SearchIndexer, ActiveStateChang
             // create vertex indexes
             createCommonVertexIndex(management, GUID_PROPERTY_KEY, UniqueKind.GLOBAL_UNIQUE, String.class, SINGLE, true, false, true);
             createCommonVertexIndex(management, HISTORICAL_GUID_PROPERTY_KEY, UniqueKind.GLOBAL_UNIQUE, String.class, SINGLE, true, false);
+            createCommonVertexIndex(management, QUALIFIED_NAME_HIERARCHY_PROPERTY_KEY, UniqueKind.NONE, String.class, SET, false, false, true);
 
             createCommonVertexIndex(management, TYPENAME_PROPERTY_KEY, UniqueKind.GLOBAL_UNIQUE, String.class, SINGLE, true, false);
             createCommonVertexIndex(management, TYPESERVICETYPE_PROPERTY_KEY, UniqueKind.NONE, String.class, SINGLE, true, false);

--- a/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
@@ -210,8 +210,12 @@ public class ESAliasStore implements IndexAliasStore {
                         * This will be dictated by the feature flag ENABLE_PERSONA_HIERARCHY_FILTER
                         */
 
+                        // If asset resource ends with /* then add it in hierarchical filter
+                        boolean isHierarchical = asset.endsWith("/*");
+                        if (isHierarchical) {
+                            asset = asset.substring(0, asset.length() - 2);
+                        }
                         boolean isWildcard = asset.contains("*") || asset.contains("?");
-
                         if (isWildcard) {
                             allowClauseList.add(mapOf("wildcard", mapOf(QUALIFIED_NAME, asset)));
                         } else if (useHierarchicalQualifiedNameFilter) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
@@ -26,6 +26,7 @@ import org.apache.atlas.model.instance.AtlasEntity;
 import org.apache.atlas.repository.graphdb.AtlasGraph;
 import org.apache.atlas.repository.graphdb.janus.AtlasElasticsearchDatabase;
 import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
+import org.apache.atlas.service.FeatureFlagStore;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.elasticsearch.action.admin.indices.alias.get.GetAliasesRequest;
@@ -47,6 +48,7 @@ import static org.apache.atlas.repository.Constants.PROPAGATED_TRAIT_NAMES_PROPE
 import static org.apache.atlas.repository.Constants.QUALIFIED_NAME;
 import static org.apache.atlas.repository.Constants.TRAIT_NAMES_PROPERTY_KEY;
 import static org.apache.atlas.repository.Constants.VERTEX_INDEX_NAME;
+import static org.apache.atlas.repository.Constants.QUALIFIED_NAME_HIERARCHY_PROPERTY_KEY;
 import static org.apache.atlas.repository.util.AccessControlUtils.ACCESS_READ_PERSONA_DOMAIN;
 import static org.apache.atlas.repository.util.AccessControlUtils.ACCESS_READ_PERSONA_METADATA;
 import static org.apache.atlas.repository.util.AccessControlUtils.ACCESS_READ_PERSONA_GLOSSARY;
@@ -68,6 +70,7 @@ import static org.apache.atlas.type.Constants.GLOSSARY_PROPERTY_KEY;
 public class ESAliasStore implements IndexAliasStore {
     private static final Logger LOG = LoggerFactory.getLogger(ESAliasStore.class);
     public static final String NEW_WILDCARD_DOMAIN_SUPER = "default/domain/*/super";
+    public static final String ENABLE_PERSONA_HIERARCHY_FILTER = "enable_persona_hierarchy_filter";
 
     private final AtlasGraph graph;
     private final EntityGraphRetriever entityRetriever;
@@ -160,7 +163,8 @@ public class ESAliasStore implements IndexAliasStore {
             policies.add(policy);
         }
         if (CollectionUtils.isNotEmpty(policies)) {
-            personaPolicyToESDslClauses(policies, allowClauseList);
+            boolean useHierarchicalQualifiedNameFilter =  FeatureFlagStore.evaluate(ENABLE_PERSONA_HIERARCHY_FILTER, "true");
+            personaPolicyToESDslClauses(policies, allowClauseList, useHierarchicalQualifiedNameFilter);
         }
 
         return esClausesToFilter(allowClauseList);
@@ -177,9 +181,10 @@ public class ESAliasStore implements IndexAliasStore {
     }
 
     private void personaPolicyToESDslClauses(List<AtlasEntity> policies,
-                                             List<Map<String, Object>> allowClauseList) throws AtlasBaseException {
+                                             List<Map<String, Object>> allowClauseList, boolean useHierarchicalQualifiedNameFilter) throws AtlasBaseException {
         Set<String> terms = new HashSet<>();
         Set<String> glossaryQualifiedNames =new HashSet<>();
+        Set<String> metadataPolicyQualifiedNames = new HashSet<>();
         
         for (AtlasEntity policy: policies) {
 
@@ -198,16 +203,33 @@ public class ESAliasStore implements IndexAliasStore {
                     }
 
                     for (String asset : assets) {
-                        if (asset.contains("*") || asset.contains("?")) {
-                            //DG-898 Bug fix
+                        /*
+                        * We are introducing a hierarchical filter for qualifiedName.
+                        * This requires a migration of existing data to have a hierarchical qualifiedName.
+                        * So this will only work if migration is done, upon migration completion we will set the feature flag to true
+                        * This will be dictated by the feature flag ENABLE_PERSONA_HIERARCHY_FILTER
+                        */
+
+                        boolean isWildcard = asset.contains("*") || asset.contains("?");
+
+                        if (isWildcard) {
                             allowClauseList.add(mapOf("wildcard", mapOf(QUALIFIED_NAME, asset)));
+                        } else if (useHierarchicalQualifiedNameFilter) {
+                            metadataPolicyQualifiedNames.add(asset);
                         } else {
                             terms.add(asset);
                         }
-                        allowClauseList.add(mapOf("wildcard", mapOf(QUALIFIED_NAME, asset + "/*")));
+
+                        if (!useHierarchicalQualifiedNameFilter || isWildcard) {
+                            allowClauseList.add(mapOf("wildcard", mapOf(QUALIFIED_NAME, asset + "/*")));
+                        }
                     }
 
-                    terms.add(connectionQName);
+                    if (useHierarchicalQualifiedNameFilter) {
+                        metadataPolicyQualifiedNames.add(connectionQName);
+                    } else {
+                        terms.add(connectionQName);
+                    }
 
                 } else if (getPolicyActions(policy).contains(ACCESS_READ_PERSONA_GLOSSARY)) {
                     if (CollectionUtils.isNotEmpty(assets)) {
@@ -250,6 +272,9 @@ public class ESAliasStore implements IndexAliasStore {
         }
 
         allowClauseList.add(mapOf("terms", mapOf(QUALIFIED_NAME, new ArrayList<>(terms))));
+        if (CollectionUtils.isNotEmpty(metadataPolicyQualifiedNames)) {
+            allowClauseList.add(mapOf("terms", mapOf(QUALIFIED_NAME_HIERARCHY_PROPERTY_KEY, new ArrayList<>(metadataPolicyQualifiedNames))));
+        }
         
         if (CollectionUtils.isNotEmpty(glossaryQualifiedNames)) {
             allowClauseList.add(mapOf("terms", mapOf(GLOSSARY_PROPERTY_KEY, new ArrayList<>(glossaryQualifiedNames))));

--- a/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
@@ -225,11 +225,7 @@ public class ESAliasStore implements IndexAliasStore {
                         }
                     }
 
-                    if (useHierarchicalQualifiedNameFilter) {
-                        metadataPolicyQualifiedNames.add(connectionQName);
-                    } else {
-                        terms.add(connectionQName);
-                    }
+                    terms.add(connectionQName);
 
                 } else if (getPolicyActions(policy).contains(ACCESS_READ_PERSONA_GLOSSARY)) {
                     if (CollectionUtils.isNotEmpty(assets)) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -1456,6 +1456,7 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
                         AtlasAuthorizationUtils.verifyAccess(new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_CREATE, new AtlasEntityHeader(entity)),
                                 "create entity: type=", entity.getTypeName());
                     }
+                    createQualifiedNameHierarchyField(entity, context.getVertex(entity.getGuid()));
                 }
             }
             // for existing entities, skip update if incoming entity doesn't have any change
@@ -1475,6 +1476,10 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
                     AtlasEntityDiffResult diffResult   = entityComparator.getDiffResult(entity, storedVertex, !storeDifferentialAudits);
 
                     if (diffResult.hasDifference()) {
+                        if (diffResult.getDiffEntity().hasAttribute(QUALIFIED_NAME)) {
+                            createQualifiedNameHierarchyField(entity, storedVertex);
+                        }
+
                         if (storeDifferentialAudits) {
                             diffResult.getDiffEntity().setGuid(entity.getGuid());
                             reqContext.cacheDifferentialEntity(diffResult.getDiffEntity());
@@ -1801,6 +1806,33 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
         starredDetails.setAttribute(ATTR_ASSET_STARRED_AT, assetStarredAt);
         return starredDetails;
     }
+
+    private void createQualifiedNameHierarchyField(AtlasEntity entity, AtlasVertex vertex) {
+        if (entity.hasAttribute(QUALIFIED_NAME)) {
+            String qualifiedName = (String) entity.getAttribute(QUALIFIED_NAME);
+            if (StringUtils.isNotEmpty(qualifiedName)) {
+                vertex.removeProperty(QUALIFIED_NAME_HIERARCHY_PROPERTY_KEY);
+                String[] parts = qualifiedName.split("/");
+                StringBuilder currentPath = new StringBuilder();
+
+                for (int i = 0; i < parts.length; i++) {
+                    String part = parts[i];
+                    if (StringUtils.isNotEmpty(part)) {
+                        if (i > 0) {
+                            currentPath.append("/");
+                        }
+                        currentPath.append(part);
+                        // i>1 reason: we don't want to add the first part of the qualifiedName as it is the entity name
+                        // Example qualifiedName : default/snowflake/123/db_name we only want `default/snowflake/123` and `default/snowflake/123/db_name`
+                        if (i > 1) {
+                            AtlasGraphUtilsV2.addEncodedProperty(vertex, QUALIFIED_NAME_HIERARCHY_PROPERTY_KEY, currentPath.toString());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
 
     public PreProcessor getPreProcessor(String typeName) {
         PreProcessor preProcessor = null;

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataDomainPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataDomainPreProcessor.java
@@ -196,6 +196,7 @@ public class DataDomainPreProcessor extends AbstractDomainPreProcessor {
         try {
             String domainName = (String) domain.getAttribute(NAME);
             String updatedQualifiedName = "";
+            LinkedHashMap<String, Object> updatedAttributes = new LinkedHashMap<>();
 
             LOG.info("Moving subdomain {} to Domain {}", domainName, targetDomainQualifiedName);
 
@@ -210,6 +211,10 @@ public class DataDomainPreProcessor extends AbstractDomainPreProcessor {
                 domain.setAttribute(PARENT_DOMAIN_QN_ATTR, null);
                 domain.setAttribute(SUPER_DOMAIN_QN_ATTR, null);
                 superDomainQualifiedName = updatedQualifiedName ;
+
+                updatedAttributes.put(QUALIFIED_NAME, updatedQualifiedName);
+                updatedAttributes.put(PARENT_DOMAIN_QN_ATTR, null);
+                updatedAttributes.put(SUPER_DOMAIN_QN_ATTR, null);
             }
             else{
                 if(StringUtils.isEmpty(sourceDomainQualifiedName)){
@@ -221,6 +226,10 @@ public class DataDomainPreProcessor extends AbstractDomainPreProcessor {
                 domain.setAttribute(QUALIFIED_NAME, updatedQualifiedName);
                 domain.setAttribute(PARENT_DOMAIN_QN_ATTR, targetDomainQualifiedName);
                 domain.setAttribute(SUPER_DOMAIN_QN_ATTR, superDomainQualifiedName);
+
+                updatedAttributes.put(QUALIFIED_NAME, updatedQualifiedName);
+                updatedAttributes.put(PARENT_DOMAIN_QN_ATTR, targetDomainQualifiedName);
+                updatedAttributes.put(SUPER_DOMAIN_QN_ATTR, superDomainQualifiedName);
             }
 
             Iterator<AtlasEdge> existingParentEdges = domainVertex.getEdges(AtlasEdgeDirection.IN, DOMAIN_PARENT_EDGE_LABEL).iterator();
@@ -231,6 +240,10 @@ public class DataDomainPreProcessor extends AbstractDomainPreProcessor {
             String currentQualifiedName = domainVertex.getProperty(QUALIFIED_NAME, String.class);
             this.updatedPolicyResources.put("entity:" + currentQualifiedName, "entity:" + updatedQualifiedName);
             this.updatedDomainQualifiedNames.put(currentQualifiedName, updatedQualifiedName);
+
+            for (Map.Entry<String, Object> entry : updatedAttributes.entrySet()) {
+                RequestContext.get().getDifferentialEntitiesMap().get(domain.getGuid()).setAttribute(entry.getKey(), entry.getValue());
+            }
 
             moveChildren(domainVertex, superDomainQualifiedName, updatedQualifiedName, sourceDomainQualifiedName, targetDomainQualifiedName);
             updatePolicies(this.updatedPolicyResources, this.context);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
@@ -190,6 +190,7 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
 
         try {
             String productName = (String) product.getAttribute(NAME);
+            LinkedHashMap<String, Object> updatedAttributes = new LinkedHashMap<>();
 
             LOG.info("Moving dataProduct {} to Domain {}", productName, targetDomainQualifiedName);
 
@@ -206,6 +207,10 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
             product.setAttribute(PARENT_DOMAIN_QN_ATTR, targetDomainQualifiedName);
             product.setAttribute(SUPER_DOMAIN_QN_ATTR, superDomainQualifiedName);
 
+            updatedAttributes.put(QUALIFIED_NAME, updatedQualifiedName);
+            updatedAttributes.put(PARENT_DOMAIN_QN_ATTR, targetDomainQualifiedName);
+            updatedAttributes.put(SUPER_DOMAIN_QN_ATTR, superDomainQualifiedName);
+
             Iterator<AtlasEdge> existingParentEdges = productVertex.getEdges(AtlasEdgeDirection.IN, DATA_PRODUCT_EDGE_LABEL).iterator();
             if (existingParentEdges.hasNext()) {
                 graph.removeEdge(existingParentEdges.next());
@@ -216,7 +221,13 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
             String updatedResource = "entity:"+ updatedQualifiedName;
             this.updatedPolicyResources.put(currentResource, updatedResource);
 
+            for (Map.Entry<String, Object> entry : updatedAttributes.entrySet()) {
+                RequestContext.get().getDifferentialEntitiesMap()
+                        .get(product.getGuid()).setAttribute(entry.getKey(), entry.getValue());
+            }
+
             LOG.info("Moved dataProduct {} to Domain {}", productName, targetDomainQualifiedName);
+
 
         } finally {
             RequestContext.get().endMetricRecord(recorder);


### PR DESCRIPTION
### Hierarchical filters on qualifiedName to eliminate the wildcard persona filters.

> We are creating an internal attributes in ES which will store the hierarchical data of qualifiedName which we will use to filter assets based on hierarchy and get rid of wildcard filters in most of the cases. More details is available on https://www.notion.so/atlanhq/Problem-Statement-Optimizing-Persona-Aliases-in-Elasticsearch-for-Improved-Search-Performance-7840c233e6dd4d96b017dff791c88282?pvs=4 
