### PR TITLE
DG-1720 Support Product lineage with current lineage APIs

### DIFF
--- a/intg/src/main/java/org/apache/atlas/model/lineage/LineageListRequest.java
+++ b/intg/src/main/java/org/apache/atlas/model/lineage/LineageListRequest.java
@@ -26,6 +26,9 @@ public class LineageListRequest {
     private Boolean                         excludeMeanings;
     private Boolean                         excludeClassifications;
 
+
+    private String                         lineageType = "DatasetProcessLineage";
+
     public enum LineageDirection {INPUT, OUTPUT}
 
     public LineageListRequest() {
@@ -80,6 +83,13 @@ public class LineageListRequest {
 
     public void setDepth(Integer depth) {
         this.depth = depth;
+    }
+    public String getLineageType() {
+        return lineageType;
+    }
+
+    public void setLineageType(String lineageType) {
+        this.lineageType = lineageType;
     }
 
     public LineageDirection getDirection() {

--- a/intg/src/main/java/org/apache/atlas/model/lineage/LineageOnDemandRequest.java
+++ b/intg/src/main/java/org/apache/atlas/model/lineage/LineageOnDemandRequest.java
@@ -22,6 +22,7 @@ public class LineageOnDemandRequest {
     private Set<String>                             attributes;
     private Set<String>                             relationAttributes;
     private LineageOnDemandBaseParams               defaultParams;
+    private String                                  lineageType = "DatasetProcessLineage";
 
     public LineageOnDemandRequest() {
         this.attributes = new HashSet<>();
@@ -64,6 +65,13 @@ public class LineageOnDemandRequest {
         this.relationshipTraversalFilters = relationshipTraversalFilters;
     }
 
+    public String getLineageType() {
+        return lineageType;
+    }
+
+    public void setLineageType(String lineageType) {
+        this.lineageType = lineageType;
+    }
     public Set<String> getAttributes() {
         return attributes;
     }

--- a/repository/src/main/java/org/apache/atlas/discovery/AtlasLineageListContext.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/AtlasLineageListContext.java
@@ -23,6 +23,7 @@ public final class AtlasLineageListContext {
     private int                                 currentEntityCounter;
     private boolean                             depthLimitReached;
     private boolean                             hasMoreUpdated;
+    private String                              lineageType = "DatasetProcessLineage";
 
     public AtlasLineageListContext(LineageListRequest lineageListRequest, AtlasTypeRegistry typeRegistry) {
         this.guid = lineageListRequest.getGuid();
@@ -34,6 +35,7 @@ public final class AtlasLineageListContext {
         this.vertexTraversalPredicate = constructInMemoryPredicate(typeRegistry, lineageListRequest.getEntityTraversalFilters());
         this.edgeTraversalPredicate = constructInMemoryPredicate(typeRegistry, lineageListRequest.getRelationshipTraversalFilters());
         this.attributes = lineageListRequest.getAttributes();
+        this.lineageType = lineageListRequest.getLineageType();
         this.relationAttributes = lineageListRequest.getRelationAttributes();
     }
 
@@ -127,6 +129,14 @@ public final class AtlasLineageListContext {
 
     public void setCurrentFromCounter(int currentFromCounter) {
         this.currentFromCounter = currentFromCounter;
+    }
+
+    public String getLineageType() {
+        return lineageType;
+    }
+
+    public void setLineageType(String lineageType) {
+        this.lineageType = lineageType;
     }
 
     public int getCurrentEntityCounter() {

--- a/repository/src/main/java/org/apache/atlas/discovery/AtlasLineageOnDemandContext.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/AtlasLineageOnDemandContext.java
@@ -24,6 +24,9 @@ public class AtlasLineageOnDemandContext {
     private Set<String>                             relationAttributes;
     private LineageOnDemandBaseParams               defaultParams;
 
+
+    private String                                  lineageType = "DatasetProcessLineage";
+
     public AtlasLineageOnDemandContext(LineageOnDemandRequest lineageOnDemandRequest, AtlasTypeRegistry typeRegistry) {
         this.constraints        = lineageOnDemandRequest.getConstraints();
         this.attributes         = lineageOnDemandRequest.getAttributes();
@@ -31,6 +34,7 @@ public class AtlasLineageOnDemandContext {
         this.defaultParams      = lineageOnDemandRequest.getDefaultParams();
         this.vertexPredicate    = constructInMemoryPredicate(typeRegistry, lineageOnDemandRequest.getEntityTraversalFilters());
         this.edgePredicate      = constructInMemoryPredicate(typeRegistry, lineageOnDemandRequest.getRelationshipTraversalFilters());
+        this.lineageType        = lineageOnDemandRequest.getLineageType();
     }
 
     public Map<String, LineageOnDemandConstraints> getConstraints() {
@@ -55,6 +59,13 @@ public class AtlasLineageOnDemandContext {
 
     public void setEdgePredicate(Predicate edgePredicate) {
         this.edgePredicate = edgePredicate;
+    }
+    public String getLineageType() {
+        return lineageType;
+    }
+
+    public void setLineageType(String lineageType) {
+        this.lineageType = lineageType;
     }
 
     public Set<String> getAttributes() {

--- a/repository/src/main/java/org/apache/atlas/discovery/AtlasLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/AtlasLineageService.java
@@ -71,7 +71,7 @@ public interface AtlasLineageService {
      * @param lineageOnDemandRequest lineage on demand request object
      * @return AtlasLineageInfo
      */
-    AtlasLineageOnDemandInfo getAtlasLineageInfo(String entityGuid, LineageOnDemandRequest lineageOnDemandRequest) throws AtlasBaseException;
+    AtlasLineageOnDemandInfo getAtlasLineageInfo(String entityGuid, LineageOnDemandRequest lineageOnDemandRequest, String lineageType) throws AtlasBaseException;
 
     /**
      * @param entityGuid unique ID of the entity

--- a/repository/src/main/java/org/apache/atlas/discovery/AtlasLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/AtlasLineageService.java
@@ -71,13 +71,13 @@ public interface AtlasLineageService {
      * @param lineageOnDemandRequest lineage on demand request object
      * @return AtlasLineageInfo
      */
-    AtlasLineageOnDemandInfo getAtlasLineageInfo(String entityGuid, LineageOnDemandRequest lineageOnDemandRequest, String lineageType) throws AtlasBaseException;
+    AtlasLineageOnDemandInfo getAtlasLineageInfo(String entityGuid, LineageOnDemandRequest lineageOnDemandRequest) throws AtlasBaseException;
 
     /**
      * @param entityGuid unique ID of the entity
      * @param lineageListRequest lineage list request object
      * @return AtlasLineageListInfo
      */
-    AtlasLineageListInfo getLineageListInfoOnDemand(String entityGuid, LineageListRequest lineageListRequest, String lineageType) throws AtlasBaseException;
+    AtlasLineageListInfo getLineageListInfoOnDemand(String entityGuid, LineageListRequest lineageListRequest) throws AtlasBaseException;
 
 }

--- a/repository/src/main/java/org/apache/atlas/discovery/AtlasLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/AtlasLineageService.java
@@ -78,6 +78,6 @@ public interface AtlasLineageService {
      * @param lineageListRequest lineage list request object
      * @return AtlasLineageListInfo
      */
-    AtlasLineageListInfo getLineageListInfoOnDemand(String entityGuid, LineageListRequest lineageListRequest) throws AtlasBaseException;
+    AtlasLineageListInfo getLineageListInfoOnDemand(String entityGuid, LineageListRequest lineageListRequest, String lineageType) throws AtlasBaseException;
 
 }

--- a/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
@@ -100,7 +100,7 @@ public class EntityLineageService implements AtlasLineageService {
     private static final int     LINEAGE_ON_DEMAND_DEFAULT_DEPTH      = 3;
     private static final String  SEPARATOR                            = "->";
     public static final String IS_DATA_PRODUCT = "isDataProduct";
-    public static final String IS_DATASET = "isProcess";
+    public static final String IS_DATASET = "isDataset";
     public static final String PRODUCT_ASSET_LINEAGE = "ProductAssetLineage";
     public static final String DATASET_PROCESS_LINEAGE = "DatasetProcessLineage";
 

--- a/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
@@ -202,13 +202,13 @@ public class EntityLineageService implements AtlasLineageService {
 
     @Override
     @GraphTransaction
-    public AtlasLineageListInfo getLineageListInfoOnDemand(String guid, LineageListRequest lineageListRequest) throws AtlasBaseException {
+    public AtlasLineageListInfo getLineageListInfoOnDemand(String guid, LineageListRequest lineageListRequest, String lineageType) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("getLineageListInfoOnDemand");
 
         AtlasLineageListInfo ret = new AtlasLineageListInfo(new ArrayList<>());
         RequestContext.get().setRelationAttrsForSearch(lineageListRequest.getRelationAttributes());
 
-        traverseEdgesUsingBFS(guid, new AtlasLineageListContext(lineageListRequest, atlasTypeRegistry), ret);
+        traverseEdgesUsingBFS(guid, new AtlasLineageListContext(lineageListRequest, atlasTypeRegistry), ret, lineageType);
         ret.setSearchParameters(lineageListRequest);
 
         RequestContext.get().endMetricRecord(metricRecorder);
@@ -479,7 +479,7 @@ public class EntityLineageService implements AtlasLineageService {
             ret.setDownstreamEntityLimitReached(true);
     }
 
-    private void traverseEdgesUsingBFS(String baseGuid, AtlasLineageListContext lineageListContext, AtlasLineageListInfo ret) throws AtlasBaseException {
+    private void traverseEdgesUsingBFS(String baseGuid, AtlasLineageListContext lineageListContext, AtlasLineageListInfo ret, String lineageType) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("traverseEdgesUsingBFS");
 
         Set<String> visitedVertices = new HashSet<>();
@@ -488,16 +488,22 @@ public class EntityLineageService implements AtlasLineageService {
         Queue<String> traversalQueue = new LinkedList<>();
 
         AtlasVertex baseVertex = AtlasGraphUtilsV2.findByGuid(this.graph, baseGuid);
-        boolean isBaseNodeDataset = validateAndGetEntityTypeMap(baseGuid).get(IS_DATASET);
-        enqueueNeighbours(baseVertex, isBaseNodeDataset, lineageListContext, traversalQueue, visitedVertices, skippedVertices);
+        HashMap<String, Boolean> dataTypeMap = validateAndGetEntityTypeMap(baseGuid);
+        if (StringUtils.isEmpty(lineageType)){
+            lineageType = DATASET_PROCESS_LINEAGE;
+        }
+        boolean isNotConnecterVertex =  lineageType.equals(PRODUCT_ASSET_LINEAGE)
+                ? dataTypeMap.get(IS_DATA_PRODUCT)
+                : dataTypeMap.get(IS_DATASET);
+        enqueueNeighbours(baseVertex, dataTypeMap, lineageListContext, traversalQueue, visitedVertices, skippedVertices, lineageType);
         int currentDepth = 0;
-        int currentLevel = isBaseNodeDataset? 0: 1;
+        int currentLevel = isNotConnecterVertex? 0: 1;
 
         while (!traversalQueue.isEmpty() && !lineageListContext.isEntityLimitReached() && currentDepth < lineageListContext.getDepth()) {
             currentDepth++;
 
             // update level at every alternate depth
-            if ((isBaseNodeDataset && currentDepth % 2 != 0) || (!isBaseNodeDataset && currentDepth % 2 == 0))
+            if ((isNotConnecterVertex && currentDepth % 2 != 0) || (!isNotConnecterVertex && currentDepth % 2 == 0))
                 currentLevel++;
 
             int entitiesInCurrentDepth = traversalQueue.size();
@@ -510,20 +516,20 @@ public class EntityLineageService implements AtlasLineageService {
                 if (Objects.isNull(currentVertex))
                     throw new AtlasBaseException("Found null vertex during lineage graph traversal for guid: " + currentGUID);
 
-                boolean isDataset = validateAndGetEntityTypeMap(currentGUID).get(IS_DATASET);
+                HashMap<String, Boolean> currentEntityDataTypeMap = validateAndGetEntityTypeMap(currentGUID);
                 if (!lineageListContext.evaluateVertexFilter(currentVertex)) {
-                    enqueueNeighbours(currentVertex, isDataset, lineageListContext, traversalQueue, visitedVertices, skippedVertices);
+                    enqueueNeighbours(currentVertex, currentEntityDataTypeMap, lineageListContext, traversalQueue, visitedVertices, skippedVertices, lineageType);
                     continue;
                 }
                 if (checkOffsetAndSkipEntity(lineageListContext, ret)) {
                     skippedVertices.add(currentGUID);
-                    enqueueNeighbours(currentVertex, isDataset, lineageListContext, traversalQueue, visitedVertices, skippedVertices);
+                    enqueueNeighbours(currentVertex, currentEntityDataTypeMap, lineageListContext, traversalQueue, visitedVertices, skippedVertices, lineageType);
                     continue;
                 }
 
                 lineageListContext.incrementEntityCount();
                 appendToResult(currentVertex, lineageListContext, ret, currentLevel);
-                enqueueNeighbours(currentVertex, isDataset, lineageListContext, traversalQueue, visitedVertices, skippedVertices);
+                enqueueNeighbours(currentVertex, currentEntityDataTypeMap, lineageListContext, traversalQueue, visitedVertices, skippedVertices, lineageType);
                 if (isLastEntityInLastDepth(lineageListContext.getDepth(), currentDepth, entitiesInCurrentDepth, i)) {
                     ret.setHasMore(false);
                     lineageListContext.setHasMoreUpdated(true);
@@ -537,14 +543,18 @@ public class EntityLineageService implements AtlasLineageService {
         RequestContext.get().endMetricRecord(metricRecorder);
     }
 
-    private void enqueueNeighbours(AtlasVertex currentVertex, boolean isDataset, AtlasLineageListContext lineageListContext,
-                                   Queue<String> traversalQueue, Set<String> visitedVertices, Set<String> skippedVertices) {
+    private void enqueueNeighbours(AtlasVertex currentVertex, HashMap<String, Boolean> dataTypeMap, AtlasLineageListContext lineageListContext,
+                                   Queue<String> traversalQueue, Set<String> visitedVertices, Set<String> skippedVertices,String lineageType) {
         AtlasPerfMetrics.MetricRecorder traverseEdgesOnDemandGetEdges = RequestContext.get().startMetricRecord("traverseEdgesOnDemandGetEdges");
         Iterator<AtlasEdge> edges;
-        if (isDataset)
-            edges = currentVertex.getEdges(IN, isInputDirection(lineageListContext) ? PROCESS_OUTPUTS_EDGE : PROCESS_INPUTS_EDGE).iterator();
+        boolean isConnecterVertex =  lineageType.equals(PRODUCT_ASSET_LINEAGE)
+                ? !dataTypeMap.get(IS_DATA_PRODUCT)
+                : !dataTypeMap.get(IS_DATASET);
+        String[] edgeDirectionLabels = LINEAGE_MAP.get(lineageType);
+        if (!isConnecterVertex)
+            edges = currentVertex.getEdges(IN, isInputDirection(lineageListContext) ? edgeDirectionLabels[1] : edgeDirectionLabels[0]).iterator();
         else
-            edges = currentVertex.getEdges(OUT, isInputDirection(lineageListContext) ? PROCESS_INPUTS_EDGE : PROCESS_OUTPUTS_EDGE).iterator();
+            edges = currentVertex.getEdges(OUT, isInputDirection(lineageListContext) ? edgeDirectionLabels[0] : edgeDirectionLabels[1]).iterator();
         RequestContext.get().endMetricRecord(traverseEdgesOnDemandGetEdges);
 
         while (edges.hasNext()) {
@@ -552,7 +562,7 @@ public class EntityLineageService implements AtlasLineageService {
             if (!lineageListContext.evaluateTraversalFilter(currentEdge))
                 continue;
             AtlasVertex neighbourVertex;
-            if (isDataset)
+            if (!isConnecterVertex)
                 neighbourVertex = currentEdge.getOutVertex();
             else
                 neighbourVertex = currentEdge.getInVertex();

--- a/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
@@ -69,11 +69,10 @@ import java.util.stream.Collectors;
 
 import static org.apache.atlas.AtlasClient.DATA_SET_SUPER_TYPE;
 import static org.apache.atlas.AtlasClient.PROCESS_SUPER_TYPE;
-import static org.apache.atlas.AtlasErrorCode.INSTANCE_LINEAGE_QUERY_FAILED;
+import static org.apache.atlas.AtlasErrorCode.*;
 import static org.apache.atlas.model.instance.AtlasEntity.Status.DELETED;
 import static org.apache.atlas.model.lineage.AtlasLineageInfo.LineageDirection.*;
-import static org.apache.atlas.repository.Constants.ACTIVE_STATE_VALUE;
-import static org.apache.atlas.repository.Constants.RELATIONSHIP_GUID_PROPERTY_KEY;
+import static org.apache.atlas.repository.Constants.*;
 import static org.apache.atlas.repository.graph.GraphHelper.*;
 import static org.apache.atlas.repository.graphdb.AtlasEdgeDirection.IN;
 import static org.apache.atlas.repository.graphdb.AtlasEdgeDirection.OUT;
@@ -85,11 +84,25 @@ public class EntityLineageService implements AtlasLineageService {
 
     private static final String PROCESS_INPUTS_EDGE = "__Process.inputs";
     private static final String PROCESS_OUTPUTS_EDGE = "__Process.outputs";
+    private static final String OUTPUT_PORT_EDGE = "__Asset.outputPortDataProducts";
+    private static final String INPUT_PORT_EDGE = "__Asset.inputPortDataProducts";
+
+    /**
+    * String[] => [Input edge Label, Output Edge Label]
+    */
+    public static final HashMap<String, String[]> LINEAGE_MAP = new HashMap<String, String[]>(){{
+        put(DATASET_PROCESS_LINEAGE, new String[]{PROCESS_INPUTS_EDGE, PROCESS_OUTPUTS_EDGE});
+        put(PRODUCT_ASSET_LINEAGE, new String[]{INPUT_PORT_EDGE, OUTPUT_PORT_EDGE});
+    }};
     private static final String COLUMNS = "columns";
     private static final boolean LINEAGE_USING_GREMLIN = AtlasConfiguration.LINEAGE_USING_GREMLIN.getBoolean();
     private static final Integer DEFAULT_LINEAGE_MAX_NODE_COUNT       = 9000;
     private static final int     LINEAGE_ON_DEMAND_DEFAULT_DEPTH      = 3;
     private static final String  SEPARATOR                            = "->";
+    public static final String IS_DATA_PRODUCT = "isDataProduct";
+    public static final String IS_DATASET = "isProcess";
+    public static final String PRODUCT_ASSET_LINEAGE = "ProductAssetLineage";
+    public static final String DATASET_PROCESS_LINEAGE = "DatasetProcessLineage";
 
     private final AtlasGraph graph;
     private final AtlasGremlinQueryProvider gremlinQueryProvider;
@@ -171,13 +184,13 @@ public class EntityLineageService implements AtlasLineageService {
 
     @Override
     @GraphTransaction
-    public AtlasLineageOnDemandInfo getAtlasLineageInfo(String guid, LineageOnDemandRequest lineageOnDemandRequest) throws AtlasBaseException {
+    public AtlasLineageOnDemandInfo getAtlasLineageInfo(String guid, LineageOnDemandRequest lineageOnDemandRequest, String lineageType) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("getAtlasLineageInfo");
 
         RequestContext.get().setRelationAttrsForSearch(lineageOnDemandRequest.getRelationAttributes());
         AtlasLineageOnDemandContext atlasLineageOnDemandContext = new AtlasLineageOnDemandContext(lineageOnDemandRequest, atlasTypeRegistry);
-        boolean isDataSet = validateEntityTypeAndCheckIfDataSet(guid);
-        AtlasLineageOnDemandInfo ret = getLineageInfoOnDemand(guid, atlasLineageOnDemandContext, isDataSet);
+        HashMap<String, Boolean> dataTypeMap = validateAndGetEntityTypeMap(guid);
+        AtlasLineageOnDemandInfo ret = getLineageInfoOnDemand(guid, atlasLineageOnDemandContext, dataTypeMap, lineageType);
         appendLineageOnDemandPayload(ret, lineageOnDemandRequest);
         // filtering out on-demand relations which has input & output nodes within the limit
         cleanupRelationsOnDemand(ret);
@@ -202,20 +215,25 @@ public class EntityLineageService implements AtlasLineageService {
         return ret;
     }
 
-    private boolean validateEntityTypeAndCheckIfDataSet(String guid) throws AtlasBaseException {
+    private HashMap<String, Boolean> validateAndGetEntityTypeMap(String guid) throws AtlasBaseException {
         String  typeName = entityRetriever.getEntityVertex(guid).getProperty(Constants.TYPE_NAME_PROPERTY_KEY, String.class);
         AtlasEntityType entityType = atlasTypeRegistry.getEntityTypeByName(typeName);
         if (entityType == null) {
             throw new AtlasBaseException(AtlasErrorCode.TYPE_NAME_NOT_FOUND, typeName);
         }
+        HashMap<String, Boolean> dataTypeMap = new HashMap<>();
         boolean isProcess = entityType.getTypeAndAllSuperTypes().contains(PROCESS_SUPER_TYPE);
+        boolean isDataProduct = entityType.getTypeAndAllSuperTypes().contains(DATA_PRODUCT_ENTITY_TYPE);
+        dataTypeMap.put(IS_DATA_PRODUCT, isDataProduct);
+        dataTypeMap.put(IS_DATASET, !isProcess);
         if (!isProcess) {
+            //TODO : Check product is an asset super
             boolean isDataSet = entityType.getTypeAndAllSuperTypes().contains(DATA_SET_SUPER_TYPE);
             if (!isDataSet) {
                 throw new AtlasBaseException(AtlasErrorCode.INVALID_LINEAGE_ENTITY_TYPE, guid, typeName);
             }
         }
-        return !isProcess;
+        return dataTypeMap;
     }
 
     private LineageOnDemandConstraints getLineageConstraints(String guid, LineageOnDemandBaseParams defaultParams) {
@@ -280,8 +298,10 @@ public class EntityLineageService implements AtlasLineageService {
         }
     }
 
-    private AtlasLineageOnDemandInfo getLineageInfoOnDemand(String guid, AtlasLineageOnDemandContext atlasLineageOnDemandContext, boolean isDataSet) throws AtlasBaseException {
+    private AtlasLineageOnDemandInfo getLineageInfoOnDemand(String guid, AtlasLineageOnDemandContext atlasLineageOnDemandContext, HashMap<String, Boolean> dataTypeMap, String lineageType) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("getLineageInfoOnDemand");
+        if(StringUtils.isEmpty(lineageType))
+            lineageType = DATASET_PROCESS_LINEAGE;
 
         LineageOnDemandConstraints lineageConstraintsByGuid = getAndValidateLineageConstraintsByGuid(guid, atlasLineageOnDemandContext);
         AtlasLineageOnDemandInfo.LineageDirection direction = lineageConstraintsByGuid.getDirection();
@@ -297,27 +317,35 @@ public class EntityLineageService implements AtlasLineageService {
         AtomicInteger inputEntitiesTraversed = new AtomicInteger(0);
         AtomicInteger outputEntitiesTraversed = new AtomicInteger(0);
         AtomicInteger traversalOrder = new AtomicInteger(1);
-        if (isDataSet) {
-            AtlasVertex datasetVertex = AtlasGraphUtilsV2.findByGuid(this.graph, guid);
-            if (direction == AtlasLineageOnDemandInfo.LineageDirection.INPUT || direction == AtlasLineageOnDemandInfo.LineageDirection.BOTH)
-                traverseEdgesOnDemand(datasetVertex, true, depth, level, new HashSet<>(), atlasLineageOnDemandContext, ret, guid, inputEntitiesTraversed, traversalOrder);
-            if (direction == AtlasLineageOnDemandInfo.LineageDirection.OUTPUT || direction == AtlasLineageOnDemandInfo.LineageDirection.BOTH)
-                traverseEdgesOnDemand(datasetVertex, false, depth, level, new HashSet<>(), atlasLineageOnDemandContext, ret, guid, outputEntitiesTraversed, traversalOrder);
-            AtlasEntityHeader baseEntityHeader = entityRetriever.toAtlasEntityHeader(datasetVertex, atlasLineageOnDemandContext.getAttributes());
-            setGraphTraversalMetadata(level, traversalOrder, baseEntityHeader);
-            ret.getGuidEntityMap().put(guid, baseEntityHeader);
-        } else  {
-            AtlasVertex processVertex = AtlasGraphUtilsV2.findByGuid(this.graph, guid);
-            // make one hop to the next dataset vertices from process vertex and traverse with 'depth = depth - 1'
-            if (direction == AtlasLineageOnDemandInfo.LineageDirection.INPUT || direction == AtlasLineageOnDemandInfo.LineageDirection.BOTH) {
-                Iterator<AtlasEdge> processEdges = processVertex.getEdges(AtlasEdgeDirection.OUT, PROCESS_INPUTS_EDGE).iterator();
-                traverseEdgesOnDemand(processEdges, true, depth, level, atlasLineageOnDemandContext, ret, processVertex, guid, inputEntitiesTraversed, traversalOrder);
+        String[] lineageEdgeLabels = LINEAGE_MAP.get(lineageType);
+        boolean isConnecterVertex;
+
+
+        isConnecterVertex =  lineageType.equals(PRODUCT_ASSET_LINEAGE)
+                ? !dataTypeMap.get(IS_DATA_PRODUCT)
+                : !dataTypeMap.get(IS_DATASET);
+
+        if (!isConnecterVertex) {
+                AtlasVertex datasetVertex = AtlasGraphUtilsV2.findByGuid(this.graph, guid);
+                if (direction == AtlasLineageOnDemandInfo.LineageDirection.INPUT || direction == AtlasLineageOnDemandInfo.LineageDirection.BOTH)
+                    traverseEdgesOnDemand(datasetVertex, true, depth, level, new HashSet<>(), atlasLineageOnDemandContext, ret, guid, inputEntitiesTraversed, traversalOrder, lineageType);
+                if (direction == AtlasLineageOnDemandInfo.LineageDirection.OUTPUT || direction == AtlasLineageOnDemandInfo.LineageDirection.BOTH)
+                    traverseEdgesOnDemand(datasetVertex, false, depth, level, new HashSet<>(), atlasLineageOnDemandContext, ret, guid, outputEntitiesTraversed, traversalOrder, lineageType);
+                AtlasEntityHeader baseEntityHeader = entityRetriever.toAtlasEntityHeader(datasetVertex, atlasLineageOnDemandContext.getAttributes());
+                setGraphTraversalMetadata(level, traversalOrder, baseEntityHeader);
+                ret.getGuidEntityMap().put(guid, baseEntityHeader);
+            } else {
+                AtlasVertex processVertex = AtlasGraphUtilsV2.findByGuid(this.graph, guid);
+                // make one hop to the next dataset vertices from process vertex and traverse with 'depth = depth - 1'
+                if (direction == AtlasLineageOnDemandInfo.LineageDirection.INPUT || direction == AtlasLineageOnDemandInfo.LineageDirection.BOTH) {
+                    Iterator<AtlasEdge> processEdges = processVertex.getEdges(AtlasEdgeDirection.OUT, lineageEdgeLabels[0]).iterator();
+                    traverseEdgesOnDemand(processEdges, true, depth, level, atlasLineageOnDemandContext, ret, processVertex, guid, inputEntitiesTraversed, traversalOrder, lineageType);
+                }
+                if (direction == AtlasLineageOnDemandInfo.LineageDirection.OUTPUT || direction == AtlasLineageOnDemandInfo.LineageDirection.BOTH) {
+                    Iterator<AtlasEdge> processEdges = processVertex.getEdges(AtlasEdgeDirection.OUT, lineageEdgeLabels[1]).iterator();
+                    traverseEdgesOnDemand(processEdges, false, depth, level, atlasLineageOnDemandContext, ret, processVertex, guid, outputEntitiesTraversed, traversalOrder, lineageType);
+                }
             }
-            if (direction == AtlasLineageOnDemandInfo.LineageDirection.OUTPUT || direction == AtlasLineageOnDemandInfo.LineageDirection.BOTH) {
-                Iterator<AtlasEdge> processEdges = processVertex.getEdges(AtlasEdgeDirection.OUT, PROCESS_OUTPUTS_EDGE).iterator();
-                traverseEdgesOnDemand(processEdges, false, depth, level, atlasLineageOnDemandContext, ret, processVertex, guid, outputEntitiesTraversed, traversalOrder);
-            }
-        }
         RequestContext.get().endMetricRecord(metricRecorder);
         return ret;
     }
@@ -328,7 +356,7 @@ public class EntityLineageService implements AtlasLineageService {
         baseEntityHeader.setFinishTime(traversalOrder.get());
     }
 
-    private void traverseEdgesOnDemand(Iterator<AtlasEdge> processEdges, boolean isInput, int depth, int level, AtlasLineageOnDemandContext atlasLineageOnDemandContext, AtlasLineageOnDemandInfo ret, AtlasVertex processVertex, String baseGuid, AtomicInteger entitiesTraversed, AtomicInteger traversalOrder) throws AtlasBaseException {
+    private void traverseEdgesOnDemand(Iterator<AtlasEdge> processEdges, boolean isInput, int depth, int level, AtlasLineageOnDemandContext atlasLineageOnDemandContext, AtlasLineageOnDemandInfo ret, AtlasVertex processVertex, String baseGuid, AtomicInteger entitiesTraversed, AtomicInteger traversalOrder, String lineageType) throws AtlasBaseException {
         AtlasLineageOnDemandInfo.LineageDirection direction = isInput ? AtlasLineageOnDemandInfo.LineageDirection.INPUT : AtlasLineageOnDemandInfo.LineageDirection.OUTPUT;
         int nextLevel = isInput ? level - 1: level + 1;
 
@@ -359,11 +387,11 @@ public class EntityLineageService implements AtlasLineageService {
                 ret.getRelationsOnDemand().put(inGuid, new LineageInfoOnDemand(inGuidLineageConstrains));
             }
 
-            traverseEdgesOnDemand(datasetVertex, isInput, depth - 1, nextLevel, new HashSet<>(), atlasLineageOnDemandContext, ret, baseGuid, entitiesTraversed, traversalOrder);
+            traverseEdgesOnDemand(datasetVertex, isInput, depth - 1, nextLevel, new HashSet<>(), atlasLineageOnDemandContext, ret, baseGuid, entitiesTraversed, traversalOrder, lineageType);
         }
     }
 
-    private void traverseEdgesOnDemand(AtlasVertex datasetVertex, boolean isInput, int depth, int level, Set<String> visitedVertices, AtlasLineageOnDemandContext atlasLineageOnDemandContext, AtlasLineageOnDemandInfo ret, String baseGuid, AtomicInteger entitiesTraversed, AtomicInteger traversalOrder) throws AtlasBaseException {
+    private void traverseEdgesOnDemand(AtlasVertex datasetVertex, boolean isInput, int depth, int level, Set<String> visitedVertices, AtlasLineageOnDemandContext atlasLineageOnDemandContext, AtlasLineageOnDemandInfo ret, String baseGuid, AtomicInteger entitiesTraversed, AtomicInteger traversalOrder, String lineageType) throws AtlasBaseException {
         if (isEntityTraversalLimitReached(entitiesTraversed))
             return;
         if (depth != 0) { // base condition of recursion for depth
@@ -372,16 +400,17 @@ public class EntityLineageService implements AtlasLineageService {
             int nextLevel = isInput ? level - 1: level + 1;
             // keep track of visited vertices to avoid circular loop
             visitedVertices.add(getId(datasetVertex));
-
+            String[] edgeDirections = LINEAGE_MAP.get(lineageType);
             AtlasPerfMetrics.MetricRecorder traverseEdgesOnDemandGetEdgesIn = RequestContext.get().startMetricRecord("traverseEdgesOnDemandGetEdgesIn");
-            Iterator<AtlasEdge> incomingEdges = datasetVertex.getEdges(IN, isInput ? PROCESS_OUTPUTS_EDGE : PROCESS_INPUTS_EDGE).iterator();
+
+            Iterator<AtlasEdge> incomingEdges = datasetVertex.getEdges(IN, isInput ? edgeDirections[1] : edgeDirections[0]).iterator();
             RequestContext.get().endMetricRecord(traverseEdgesOnDemandGetEdgesIn);
 
             while (incomingEdges.hasNext()) {
                 AtlasEdge incomingEdge = incomingEdges.next();
-                AtlasVertex processVertex = incomingEdge.getOutVertex();
+                AtlasVertex connecterVertex = incomingEdge.getOutVertex();
 
-                if (!vertexMatchesEvaluation(processVertex, atlasLineageOnDemandContext) || !edgeMatchesEvaluation(incomingEdge, atlasLineageOnDemandContext)) {
+                if (!vertexMatchesEvaluation(connecterVertex, atlasLineageOnDemandContext) || !edgeMatchesEvaluation(incomingEdge, atlasLineageOnDemandContext)) {
                     continue;
                 }
 
@@ -402,7 +431,7 @@ public class EntityLineageService implements AtlasLineageService {
                 }
 
                 AtlasPerfMetrics.MetricRecorder traverseEdgesOnDemandGetEdgesOut = RequestContext.get().startMetricRecord("traverseEdgesOnDemandGetEdgesOut");
-                Iterator<AtlasEdge> outgoingEdges = processVertex.getEdges(OUT, isInput ? PROCESS_INPUTS_EDGE : PROCESS_OUTPUTS_EDGE).iterator();
+                Iterator<AtlasEdge> outgoingEdges = connecterVertex.getEdges(OUT, isInput ? edgeDirections[0] : edgeDirections[1]).iterator();
                 RequestContext.get().endMetricRecord(traverseEdgesOnDemandGetEdgesOut);
 
                 while (outgoingEdges.hasNext()) {
@@ -413,11 +442,11 @@ public class EntityLineageService implements AtlasLineageService {
                         continue;
                     }
 
-                    if (checkForOffset(outgoingEdge, processVertex, atlasLineageOnDemandContext, ret)) {
+                    if (checkForOffset(outgoingEdge, connecterVertex, atlasLineageOnDemandContext, ret)) {
                         continue;
                     }
                     if (incrementAndCheckIfRelationsLimitReached(outgoingEdge, isInput, atlasLineageOnDemandContext, ret, depth, entitiesTraversed, direction, visitedVertices)) {
-                        String processGuid = AtlasGraphUtilsV2.getIdFromVertex(processVertex);
+                        String processGuid = AtlasGraphUtilsV2.getIdFromVertex(connecterVertex);
                         LineageInfoOnDemand entityOnDemandInfo = ret.getRelationsOnDemand().get(processGuid);
                         if (entityOnDemandInfo == null)
                             continue;
@@ -433,7 +462,7 @@ public class EntityLineageService implements AtlasLineageService {
                             setEntityLimitReachedFlag(isInput, ret);
                     }
                     if (entityVertex != null && !visitedVertices.contains(getId(entityVertex))) {
-                        traverseEdgesOnDemand(entityVertex, isInput, depth - 1, nextLevel, visitedVertices, atlasLineageOnDemandContext, ret, baseGuid, entitiesTraversed, traversalOrder); // execute inner depth
+                        traverseEdgesOnDemand(entityVertex, isInput, depth - 1, nextLevel, visitedVertices, atlasLineageOnDemandContext, ret, baseGuid, entitiesTraversed, traversalOrder, lineageType); // execute inner depth
                         AtlasEntityHeader traversedEntity = ret.getGuidEntityMap().get(AtlasGraphUtilsV2.getIdFromVertex(entityVertex));
                         traversedEntity.setFinishTime(traversalOrder.get());
                     }
@@ -460,7 +489,7 @@ public class EntityLineageService implements AtlasLineageService {
         Queue<String> traversalQueue = new LinkedList<>();
 
         AtlasVertex baseVertex = AtlasGraphUtilsV2.findByGuid(this.graph, baseGuid);
-        boolean isBaseNodeDataset = validateEntityTypeAndCheckIfDataSet(baseGuid);
+        boolean isBaseNodeDataset = validateAndGetEntityTypeMap(baseGuid).get(IS_DATASET);
         enqueueNeighbours(baseVertex, isBaseNodeDataset, lineageListContext, traversalQueue, visitedVertices, skippedVertices);
         int currentDepth = 0;
         int currentLevel = isBaseNodeDataset? 0: 1;
@@ -482,7 +511,7 @@ public class EntityLineageService implements AtlasLineageService {
                 if (Objects.isNull(currentVertex))
                     throw new AtlasBaseException("Found null vertex during lineage graph traversal for guid: " + currentGUID);
 
-                boolean isDataset = validateEntityTypeAndCheckIfDataSet(currentGUID);
+                boolean isDataset = validateAndGetEntityTypeMap(currentGUID).get(IS_DATASET);
                 if (!lineageListContext.evaluateVertexFilter(currentVertex)) {
                     enqueueNeighbours(currentVertex, isDataset, lineageListContext, traversalQueue, visitedVertices, skippedVertices);
                     continue;

--- a/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
@@ -186,8 +186,10 @@ public class EntityLineageService implements AtlasLineageService {
     @GraphTransaction
     public AtlasLineageOnDemandInfo getAtlasLineageInfo(String guid, LineageOnDemandRequest lineageOnDemandRequest) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("getAtlasLineageInfo");
-
         RequestContext.get().setRelationAttrsForSearch(lineageOnDemandRequest.getRelationAttributes());
+        RequestContext.get().setLineageInputLabel(LINEAGE_MAP.get(lineageOnDemandRequest.getLineageType())[0]);
+        RequestContext.get().setLineageOutputLabel(LINEAGE_MAP.get(lineageOnDemandRequest.getLineageType())[1]);
+
         AtlasLineageOnDemandContext atlasLineageOnDemandContext = new AtlasLineageOnDemandContext(lineageOnDemandRequest, atlasTypeRegistry);
         HashMap<String, Boolean> dataTypeMap = validateAndGetEntityTypeMap(guid);
         AtlasLineageOnDemandInfo ret = getLineageInfoOnDemand(guid, atlasLineageOnDemandContext, dataTypeMap);
@@ -204,7 +206,8 @@ public class EntityLineageService implements AtlasLineageService {
     @GraphTransaction
     public AtlasLineageListInfo getLineageListInfoOnDemand(String guid, LineageListRequest lineageListRequest) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("getLineageListInfoOnDemand");
-
+        RequestContext.get().setLineageInputLabel(LINEAGE_MAP.get(lineageListRequest.getLineageType())[0]);
+        RequestContext.get().setLineageOutputLabel(LINEAGE_MAP.get(lineageListRequest.getLineageType())[1]);
         AtlasLineageListInfo ret = new AtlasLineageListInfo(new ArrayList<>());
         RequestContext.get().setRelationAttrsForSearch(lineageListRequest.getRelationAttributes());
 
@@ -299,9 +302,9 @@ public class EntityLineageService implements AtlasLineageService {
 
     private AtlasLineageOnDemandInfo getLineageInfoOnDemand(String guid, AtlasLineageOnDemandContext atlasLineageOnDemandContext, HashMap<String, Boolean> dataTypeMap) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("getLineageInfoOnDemand");
-        String lineageType = RequestContext.get().getLineageType();
-        if(StringUtils.isEmpty(lineageType))
-            lineageType = DATASET_PROCESS_LINEAGE;
+        String lineageInputLabel = RequestContext.get().getLineageInputLabel();
+        String lineageOutputLabel = RequestContext.get().getLineageOutputLabel();
+        String lineageType = atlasLineageOnDemandContext.getLineageType();
 
         LineageOnDemandConstraints lineageConstraintsByGuid = getAndValidateLineageConstraintsByGuid(guid, atlasLineageOnDemandContext);
         AtlasLineageOnDemandInfo.LineageDirection direction = lineageConstraintsByGuid.getDirection();
@@ -317,7 +320,7 @@ public class EntityLineageService implements AtlasLineageService {
         AtomicInteger inputEntitiesTraversed = new AtomicInteger(0);
         AtomicInteger outputEntitiesTraversed = new AtomicInteger(0);
         AtomicInteger traversalOrder = new AtomicInteger(1);
-        String[] lineageEdgeLabels = LINEAGE_MAP.get(lineageType);
+
         boolean isConnecterVertex;
 
 
@@ -338,11 +341,11 @@ public class EntityLineageService implements AtlasLineageService {
                 AtlasVertex processVertex = AtlasGraphUtilsV2.findByGuid(this.graph, guid);
                 // make one hop to the next dataset vertices from process vertex and traverse with 'depth = depth - 1'
                 if (direction == AtlasLineageOnDemandInfo.LineageDirection.INPUT || direction == AtlasLineageOnDemandInfo.LineageDirection.BOTH) {
-                    Iterator<AtlasEdge> processEdges = processVertex.getEdges(AtlasEdgeDirection.OUT, lineageEdgeLabels[0]).iterator();
+                    Iterator<AtlasEdge> processEdges = processVertex.getEdges(AtlasEdgeDirection.OUT, lineageInputLabel).iterator();
                     traverseEdgesOnDemand(processEdges, true, depth, level, atlasLineageOnDemandContext, ret, processVertex, guid, inputEntitiesTraversed, traversalOrder);
                 }
                 if (direction == AtlasLineageOnDemandInfo.LineageDirection.OUTPUT || direction == AtlasLineageOnDemandInfo.LineageDirection.BOTH) {
-                    Iterator<AtlasEdge> processEdges = processVertex.getEdges(AtlasEdgeDirection.OUT, lineageEdgeLabels[1]).iterator();
+                    Iterator<AtlasEdge> processEdges = processVertex.getEdges(AtlasEdgeDirection.OUT, lineageOutputLabel).iterator();
                     traverseEdgesOnDemand(processEdges, false, depth, level, atlasLineageOnDemandContext, ret, processVertex, guid, outputEntitiesTraversed, traversalOrder);
                 }
             }
@@ -358,8 +361,8 @@ public class EntityLineageService implements AtlasLineageService {
 
     private void traverseEdgesOnDemand(Iterator<AtlasEdge> processEdges, boolean isInput, int depth, int level, AtlasLineageOnDemandContext atlasLineageOnDemandContext, AtlasLineageOnDemandInfo ret, AtlasVertex processVertex, String baseGuid, AtomicInteger entitiesTraversed, AtomicInteger traversalOrder) throws AtlasBaseException {
         AtlasLineageOnDemandInfo.LineageDirection direction = isInput ? AtlasLineageOnDemandInfo.LineageDirection.INPUT : AtlasLineageOnDemandInfo.LineageDirection.OUTPUT;
+        String lineageInputLabel = RequestContext.get().getLineageInputLabel();
         int nextLevel = isInput ? level - 1: level + 1;
-        String lineageType = RequestContext.get().getLineageType();
         while (processEdges.hasNext()) {
             AtlasEdge processEdge = processEdges.next();
             AtlasVertex datasetVertex = processEdge.getInVertex();
@@ -372,7 +375,7 @@ public class EntityLineageService implements AtlasLineageService {
                 continue;
             }
 
-            boolean isInputEdge  = processEdge.getLabel().equalsIgnoreCase(LINEAGE_MAP.get(lineageType)[0]);
+            boolean isInputEdge  = processEdge.getLabel().equalsIgnoreCase(lineageInputLabel);
             if (incrementAndCheckIfRelationsLimitReached(processEdge, isInputEdge, atlasLineageOnDemandContext, ret, depth, entitiesTraversed, direction, new HashSet<>())) {
                 break;
             } else {
@@ -394,17 +397,17 @@ public class EntityLineageService implements AtlasLineageService {
     private void traverseEdgesOnDemand(AtlasVertex datasetVertex, boolean isInput, int depth, int level, Set<String> visitedVertices, AtlasLineageOnDemandContext atlasLineageOnDemandContext, AtlasLineageOnDemandInfo ret, String baseGuid, AtomicInteger entitiesTraversed, AtomicInteger traversalOrder) throws AtlasBaseException {
         if (isEntityTraversalLimitReached(entitiesTraversed))
             return;
-        String lineageType = RequestContext.get().getLineageType();
         if (depth != 0) { // base condition of recursion for depth
             AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("traverseEdgesOnDemand");
             AtlasLineageOnDemandInfo.LineageDirection direction = isInput ? AtlasLineageOnDemandInfo.LineageDirection.INPUT : AtlasLineageOnDemandInfo.LineageDirection.OUTPUT;
+            String lineageInputLabel = RequestContext.get().getLineageInputLabel();
+            String lineageOutputLabel = RequestContext.get().getLineageOutputLabel();
             int nextLevel = isInput ? level - 1: level + 1;
             // keep track of visited vertices to avoid circular loop
             visitedVertices.add(getId(datasetVertex));
-            String[] edgeDirections = LINEAGE_MAP.get(lineageType);
             AtlasPerfMetrics.MetricRecorder traverseEdgesOnDemandGetEdgesIn = RequestContext.get().startMetricRecord("traverseEdgesOnDemandGetEdgesIn");
 
-            Iterator<AtlasEdge> incomingEdges = datasetVertex.getEdges(IN, isInput ? edgeDirections[1] : edgeDirections[0]).iterator();
+            Iterator<AtlasEdge> incomingEdges = datasetVertex.getEdges(IN, isInput ? lineageOutputLabel : lineageInputLabel).iterator();
             RequestContext.get().endMetricRecord(traverseEdgesOnDemandGetEdgesIn);
 
             while (incomingEdges.hasNext()) {
@@ -432,7 +435,7 @@ public class EntityLineageService implements AtlasLineageService {
                 }
 
                 AtlasPerfMetrics.MetricRecorder traverseEdgesOnDemandGetEdgesOut = RequestContext.get().startMetricRecord("traverseEdgesOnDemandGetEdgesOut");
-                Iterator<AtlasEdge> outgoingEdges = connecterVertex.getEdges(OUT, isInput ? edgeDirections[0] : edgeDirections[1]).iterator();
+                Iterator<AtlasEdge> outgoingEdges = connecterVertex.getEdges(OUT, isInput ? lineageInputLabel : lineageOutputLabel).iterator();
                 RequestContext.get().endMetricRecord(traverseEdgesOnDemandGetEdgesOut);
 
                 while (outgoingEdges.hasNext()) {
@@ -483,7 +486,7 @@ public class EntityLineageService implements AtlasLineageService {
 
     private void traverseEdgesUsingBFS(String baseGuid, AtlasLineageListContext lineageListContext, AtlasLineageListInfo ret) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("traverseEdgesUsingBFS");
-        String lineageType = RequestContext.get().getLineageType();
+        String lineageType = lineageListContext.getLineageType();
         Set<String> visitedVertices = new HashSet<>();
         visitedVertices.add(baseGuid);
         Set<String> skippedVertices = new HashSet<>();
@@ -491,9 +494,7 @@ public class EntityLineageService implements AtlasLineageService {
 
         AtlasVertex baseVertex = AtlasGraphUtilsV2.findByGuid(this.graph, baseGuid);
         HashMap<String, Boolean> dataTypeMap = validateAndGetEntityTypeMap(baseGuid);
-        if (StringUtils.isEmpty(lineageType)){
-            lineageType = DATASET_PROCESS_LINEAGE;
-        }
+
         boolean isNotConnecterVertex =  lineageType.equals(PRODUCT_ASSET_LINEAGE)
                 ? dataTypeMap.get(IS_DATA_PRODUCT)
                 : dataTypeMap.get(IS_DATASET);
@@ -549,15 +550,16 @@ public class EntityLineageService implements AtlasLineageService {
                                    Queue<String> traversalQueue, Set<String> visitedVertices, Set<String> skippedVertices) {
         AtlasPerfMetrics.MetricRecorder traverseEdgesOnDemandGetEdges = RequestContext.get().startMetricRecord("traverseEdgesOnDemandGetEdges");
         Iterator<AtlasEdge> edges;
-        String lineageType = RequestContext.get().getLineageType();
+        String lineageInputLabel = RequestContext.get().getLineageInputLabel();
+        String lineageOutputLabel = RequestContext.get().getLineageOutputLabel();
+        String lineageType = lineageListContext.getLineageType();
         boolean isConnecterVertex =  lineageType.equals(PRODUCT_ASSET_LINEAGE)
                 ? !dataTypeMap.get(IS_DATA_PRODUCT)
                 : !dataTypeMap.get(IS_DATASET);
-        String[] edgeDirectionLabels = LINEAGE_MAP.get(lineageType);
         if (!isConnecterVertex)
-            edges = currentVertex.getEdges(IN, isInputDirection(lineageListContext) ? edgeDirectionLabels[1] : edgeDirectionLabels[0]).iterator();
+            edges = currentVertex.getEdges(IN, isInputDirection(lineageListContext) ? lineageOutputLabel : lineageInputLabel).iterator();
         else
-            edges = currentVertex.getEdges(OUT, isInputDirection(lineageListContext) ? edgeDirectionLabels[0] : edgeDirectionLabels[1]).iterator();
+            edges = currentVertex.getEdges(OUT, isInputDirection(lineageListContext) ? lineageInputLabel : lineageOutputLabel).iterator();
         RequestContext.get().endMetricRecord(traverseEdgesOnDemandGetEdges);
 
         while (edges.hasNext()) {
@@ -693,8 +695,8 @@ public class EntityLineageService implements AtlasLineageService {
     }
 
     private void setHasDownstream(AtlasLineageOnDemandContext atlasLineageOnDemandContext, AtlasVertex inVertex, LineageInfoOnDemand inLineageInfo) {
-        String lineageType = RequestContext.get().getLineageType();
-        List<AtlasEdge> filteredEdges = getFilteredAtlasEdges(inVertex, IN, LINEAGE_MAP.get(lineageType)[0], atlasLineageOnDemandContext);
+        String lineageInputLabel = RequestContext.get().getLineageInputLabel();
+        List<AtlasEdge> filteredEdges = getFilteredAtlasEdges(inVertex, IN, lineageInputLabel, atlasLineageOnDemandContext);
         if (!filteredEdges.isEmpty()) {
             inLineageInfo.setHasDownstream(true);
         }
@@ -702,8 +704,8 @@ public class EntityLineageService implements AtlasLineageService {
     }
 
     private void setHasUpstream(AtlasLineageOnDemandContext atlasLineageOnDemandContext, AtlasVertex outVertex, LineageInfoOnDemand outLineageInfo) {
-        String lineageType = RequestContext.get().getLineageType();
-        List<AtlasEdge> filteredEdges = getFilteredAtlasEdges(outVertex, IN, LINEAGE_MAP.get(lineageType)[1], atlasLineageOnDemandContext);
+        String lineageOutputLabel = RequestContext.get().getLineageOutputLabel();
+        List<AtlasEdge> filteredEdges = getFilteredAtlasEdges(outVertex, IN, lineageOutputLabel, atlasLineageOnDemandContext);
         if (!filteredEdges.isEmpty()) {
             outLineageInfo.setHasUpstream(true);
         }
@@ -862,7 +864,8 @@ public class EntityLineageService implements AtlasLineageService {
 
     private AtlasLineageInfo getLineageInfoV2(AtlasLineageContext lineageContext) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder metric = RequestContext.get().startMetricRecord("getLineageInfoV2");
-        String lineageType = RequestContext.get().getLineageType();
+        String lineageInputLabel = RequestContext.get().getLineageInputLabel();
+        String lineageOutputLabel = RequestContext.get().getLineageOutputLabel();
         int depth = lineageContext.getDepth();
         String guid = lineageContext.getGuid();
         LineageDirection direction = lineageContext.getDirection();
@@ -889,7 +892,7 @@ public class EntityLineageService implements AtlasLineageService {
 
             // make one hop to the next dataset vertices from process vertex and traverse with 'depth = depth - 1'
             if (direction == INPUT || direction == BOTH) {
-                Iterator<AtlasEdge> processEdges = vertexEdgeCache.getEdges(processVertex, OUT, LINEAGE_MAP.get(lineageType)[0]).iterator();
+                Iterator<AtlasEdge> processEdges = vertexEdgeCache.getEdges(processVertex, OUT, lineageInputLabel).iterator();
 
                 List<AtlasEdge> qualifyingEdges = getQualifyingProcessEdges(processEdges, lineageContext);
                 ret.setHasChildrenForDirection(getGuid(processVertex), new LineageChildrenInfo(INPUT, hasMoreChildren(qualifyingEdges)));
@@ -904,7 +907,7 @@ public class EntityLineageService implements AtlasLineageService {
             }
 
             if (direction == OUTPUT || direction == BOTH) {
-                Iterator<AtlasEdge> processEdges = vertexEdgeCache.getEdges(processVertex, OUT, LINEAGE_MAP.get(lineageType)[1]).iterator();
+                Iterator<AtlasEdge> processEdges = vertexEdgeCache.getEdges(processVertex, OUT, lineageOutputLabel).iterator();
 
                 List<AtlasEdge> qualifyingEdges = getQualifyingProcessEdges(processEdges, lineageContext);
                 ret.setHasChildrenForDirection(getGuid(processVertex), new LineageChildrenInfo(OUTPUT, hasMoreChildren(qualifyingEdges)));
@@ -954,13 +957,13 @@ public class EntityLineageService implements AtlasLineageService {
     }
 
     private String getEdgeLabel(AtlasEdge edge) {
-        String lineageType = RequestContext.get().getLineageType();
+        String lineageInputLabel = RequestContext.get().getLineageInputLabel();
         AtlasVertex inVertex     = edge.getInVertex();
         AtlasVertex outVertex    = edge.getOutVertex();
         String      inGuid       = AtlasGraphUtilsV2.getIdFromVertex(inVertex);
         String      outGuid      = AtlasGraphUtilsV2.getIdFromVertex(outVertex);
         String      relationGuid = AtlasGraphUtilsV2.getEncodedProperty(edge, RELATIONSHIP_GUID_PROPERTY_KEY, String.class);
-        boolean     isInputEdge  = edge.getLabel().equalsIgnoreCase(LINEAGE_MAP.get(lineageType)[0]);
+        boolean     isInputEdge  = edge.getLabel().equalsIgnoreCase(lineageInputLabel);
 
         if (isLineageOnDemandEnabled()) {
             return getEdgeLabelFromGuids(isInputEdge, inGuid, outGuid);
@@ -1131,10 +1134,11 @@ public class EntityLineageService implements AtlasLineageService {
                 lineageContext.getIgnoredProcesses().contains(processVertex.getProperty(Constants.ENTITY_TYPE_PROPERTY_KEY, String.class))) {
             return Collections.emptyList();
         }
-        String lineageType = RequestContext.get().getLineageType();
+        String lineageInputLabel = RequestContext.get().getLineageInputLabel();
+        String lineageOutputLabel = RequestContext.get().getLineageOutputLabel();
         List<Pair<AtlasEdge, String>> unvisitedProcessEdgesWithOutputVertexIds = new ArrayList<>();
 
-        Iterable<AtlasEdge> outgoingEdges = vertexEdgeCache.getEdges(processVertex, OUT, isInput ? LINEAGE_MAP.get(lineageType)[0] : LINEAGE_MAP.get(lineageType)[1]);
+        Iterable<AtlasEdge> outgoingEdges = vertexEdgeCache.getEdges(processVertex, OUT, isInput ? lineageInputLabel : lineageOutputLabel);
 
         for (AtlasEdge outgoingEdge : outgoingEdges) {
             AtlasVertex outputVertex = outgoingEdge.getInVertex();
@@ -1221,8 +1225,9 @@ public class EntityLineageService implements AtlasLineageService {
     }
 
     private void processLastLevel(AtlasVertex currentVertex, boolean isInput, AtlasLineageInfo ret, AtlasLineageContext lineageContext) {
-        String lineageType = RequestContext.get().getLineageType();
-        List<AtlasEdge> processEdges = vertexEdgeCache.getEdges(currentVertex, IN, isInput ? LINEAGE_MAP.get(lineageType)[1] : LINEAGE_MAP.get(lineageType)[0]);
+        String lineageInputLabel = RequestContext.get().getLineageInputLabel();
+        String lineageOutputLabel = RequestContext.get().getLineageOutputLabel();
+        List<AtlasEdge> processEdges = vertexEdgeCache.getEdges(currentVertex, IN, isInput ? lineageOutputLabel : lineageInputLabel);
 
         // Filter lineages based on ignored process types
         processEdges = CollectionUtils.isNotEmpty(lineageContext.getIgnoredProcesses()) ?
@@ -1243,9 +1248,10 @@ public class EntityLineageService implements AtlasLineageService {
 
     private boolean childHasOnlySelfCycle(AtlasVertex processVertex, AtlasVertex currentVertex, boolean isInput) {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("childHasSelfCycle");
-        String lineageType = RequestContext.get().getLineageType();
+        String lineageInputLabel = RequestContext.get().getLineageInputLabel();
+        String lineageOutputLabel = RequestContext.get().getLineageOutputLabel();
         Iterator<AtlasEdge> processEdgeIterator;
-        processEdgeIterator = processVertex.getEdges(OUT, isInput ? LINEAGE_MAP.get(lineageType)[0] : LINEAGE_MAP.get(lineageType)[1]).iterator();
+        processEdgeIterator = processVertex.getEdges(OUT, isInput ? lineageInputLabel : lineageOutputLabel).iterator();
         Set<AtlasEdge> processOutputEdges = new HashSet<>();
         while (processEdgeIterator.hasNext()) {
             processOutputEdges.add(processEdgeIterator.next());
@@ -1261,8 +1267,9 @@ public class EntityLineageService implements AtlasLineageService {
                 lineageContext.getIgnoredProcesses().contains(processVertex.getProperty(Constants.ENTITY_TYPE_PROPERTY_KEY, String.class))) {
             return Collections.emptyList();
         }
-        String lineageType = RequestContext.get().getLineageType();
-        return vertexEdgeCache.getEdges(processVertex, OUT, isInput ? LINEAGE_MAP.get(lineageType)[0] : LINEAGE_MAP.get(lineageType)[1])
+        String lineageInputLabel = RequestContext.get().getLineageInputLabel();
+        String lineageOutputLabel = RequestContext.get().getLineageOutputLabel();
+        return vertexEdgeCache.getEdges(processVertex, OUT, isInput ? lineageInputLabel : lineageOutputLabel)
                 .stream()
                 .filter(edge -> shouldProcessEdge(lineageContext, edge) && vertexMatchesEvaluation(edge.getInVertex(), lineageContext))
                 .sorted(Comparator.comparing(edge -> edge.getProperty("_r__guid", String.class)))
@@ -1287,9 +1294,10 @@ public class EntityLineageService implements AtlasLineageService {
     }
 
     private List<AtlasEdge> getEdgesOfCurrentVertex(AtlasVertex currentVertex, boolean isInput, AtlasLineageContext lineageContext) {
-        String lineageType = RequestContext.get().getLineageType();
+        String lineageInputLabel = RequestContext.get().getLineageInputLabel();
+        String lineageOutputLabel = RequestContext.get().getLineageOutputLabel();
         return vertexEdgeCache
-                .getEdges(currentVertex, IN, isInput ? LINEAGE_MAP.get(lineageType)[1] : LINEAGE_MAP.get(lineageType)[0])
+                .getEdges(currentVertex, IN, isInput ? lineageOutputLabel : lineageInputLabel)
                 .stream()
                 .sorted(Comparator.comparing(edge -> edge.getProperty("_r__guid", String.class)))
                 .filter(edge -> shouldProcessEdge(lineageContext, edge))
@@ -1378,7 +1386,7 @@ public class EntityLineageService implements AtlasLineageService {
                                        AtlasLineageContext lineageContext) throws AtlasBaseException {
         final Map<String, AtlasEntityHeader> entities = lineageInfo.getGuidEntityMap();
         final Set<LineageRelation> relations = lineageInfo.getRelations();
-        String lineageType = RequestContext.get().getLineageType();
+        String lineageInputLabel = RequestContext.get().getLineageInputLabel();
         AtlasVertex inVertex = incomingEdge.getInVertex();
         AtlasVertex outVertex = outgoingEdge.getInVertex();
         AtlasVertex processVertex = outgoingEdge.getOutVertex();
@@ -1386,7 +1394,7 @@ public class EntityLineageService implements AtlasLineageService {
         String outGuid = AtlasGraphUtilsV2.getIdFromVertex(outVertex);
         String processGuid = AtlasGraphUtilsV2.getIdFromVertex(processVertex);
         String relationGuid = null;
-        boolean isInputEdge = incomingEdge.getLabel().equalsIgnoreCase(LINEAGE_MAP.get(lineageType)[0]);
+        boolean isInputEdge = incomingEdge.getLabel().equalsIgnoreCase(lineageInputLabel);
 
         if (!entities.containsKey(inGuid)) {
             AtlasEntityHeader entityHeader = entityRetriever.toAtlasEntityHeader(inVertex, lineageContext.getAttributes());
@@ -1417,7 +1425,7 @@ public class EntityLineageService implements AtlasLineageService {
     private void processEdges(final AtlasEdge incomingEdge, AtlasEdge outgoingEdge, AtlasLineageInfo lineageInfo,
                               AtlasLineageContext lineageContext) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder metric = RequestContext.get().startMetricRecord("processEdges");
-        String lineageType = RequestContext.get().getLineageType();
+        String lineageInputLabel = RequestContext.get().getLineageInputLabel();
         final Map<String, AtlasEntityHeader> entities = lineageInfo.getGuidEntityMap();
         final Set<LineageRelation> relations = lineageInfo.getRelations();
 
@@ -1445,14 +1453,14 @@ public class EntityLineageService implements AtlasLineageService {
         }
 
         String relationGuid = AtlasGraphUtilsV2.getEncodedProperty(incomingEdge, RELATIONSHIP_GUID_PROPERTY_KEY, String.class);
-        if (incomingEdge.getLabel().equalsIgnoreCase(LINEAGE_MAP.get(lineageType)[0])) {
+        if (incomingEdge.getLabel().equalsIgnoreCase(lineageInputLabel)) {
             relations.add(new LineageRelation(leftGuid, processGuid, relationGuid));
         } else {
             relations.add(new LineageRelation(processGuid, leftGuid, relationGuid));
         }
 
         relationGuid = AtlasGraphUtilsV2.getEncodedProperty(outgoingEdge, RELATIONSHIP_GUID_PROPERTY_KEY, String.class);
-        if (outgoingEdge.getLabel().equalsIgnoreCase(LINEAGE_MAP.get(lineageType)[0])) {
+        if (outgoingEdge.getLabel().equalsIgnoreCase(lineageInputLabel)) {
             relations.add(new LineageRelation(rightGuid, processGuid, relationGuid));
         } else {
             relations.add(new LineageRelation(processGuid, rightGuid, relationGuid));
@@ -1463,16 +1471,16 @@ public class EntityLineageService implements AtlasLineageService {
     private void processEdge(final AtlasEdge edge, AtlasLineageInfo lineageInfo,
                              AtlasLineageContext lineageContext) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder metric = RequestContext.get().startMetricRecord("processEdge");
-        String lineageType = RequestContext.get().getLineageType();
+
         final Map<String, AtlasEntityHeader> entities = lineageInfo.getGuidEntityMap();
         final Set<LineageRelation> relations = lineageInfo.getRelations();
-
+        String lineageInputLabel = RequestContext.get().getLineageInputLabel();
         AtlasVertex inVertex = edge.getInVertex();
         AtlasVertex outVertex = edge.getOutVertex();
         String inGuid = AtlasGraphUtilsV2.getIdFromVertex(inVertex);
         String outGuid = AtlasGraphUtilsV2.getIdFromVertex(outVertex);
         String relationGuid = AtlasGraphUtilsV2.getEncodedProperty(edge, RELATIONSHIP_GUID_PROPERTY_KEY, String.class);
-        boolean isInputEdge = edge.getLabel().equalsIgnoreCase(LINEAGE_MAP.get(lineageType)[0]);
+        boolean isInputEdge = edge.getLabel().equalsIgnoreCase(lineageInputLabel);
 
         if (!entities.containsKey(inGuid)) {
             AtlasEntityHeader entityHeader = entityRetriever.toAtlasEntityHeaderWithClassifications(inVertex, lineageContext.getAttributes());
@@ -1495,13 +1503,13 @@ public class EntityLineageService implements AtlasLineageService {
     private void processEdge(final AtlasEdge edge, final Map<String, AtlasEntityHeader> entities,
                              final Set<LineageRelation> relations, AtlasLineageContext lineageContext) throws AtlasBaseException {
         //Backward compatibility method
-        String lineageType = RequestContext.get().getLineageType();
+        String lineageInputLabel = RequestContext.get().getLineageInputLabel();
         AtlasVertex inVertex = edge.getInVertex();
         AtlasVertex outVertex = edge.getOutVertex();
         String inGuid = AtlasGraphUtilsV2.getIdFromVertex(inVertex);
         String outGuid = AtlasGraphUtilsV2.getIdFromVertex(outVertex);
         String relationGuid = AtlasGraphUtilsV2.getEncodedProperty(edge, RELATIONSHIP_GUID_PROPERTY_KEY, String.class);
-        boolean isInputEdge = edge.getLabel().equalsIgnoreCase(LINEAGE_MAP.get(lineageType)[0]);
+        boolean isInputEdge = edge.getLabel().equalsIgnoreCase(lineageInputLabel);
 
         if (!entities.containsKey(inGuid)) {
             AtlasEntityHeader entityHeader = entityRetriever.toAtlasEntityHeaderWithClassifications(inVertex, lineageContext.getAttributes());
@@ -1526,10 +1534,10 @@ public class EntityLineageService implements AtlasLineageService {
 
     private void processEdge(final AtlasEdge edge, final Map<String, AtlasEntityHeader> entities, final Set<AtlasLineageOnDemandInfo.LineageRelation> relations, final Set<String> visitedEdges, final Set<String> attributes, int level, AtomicInteger traversalOrder) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("processEdge");
-        String lineageType = RequestContext.get().getLineageType();
+
         AtlasVertex inVertex     = edge.getInVertex();
         AtlasVertex outVertex    = edge.getOutVertex();
-
+        String lineageInputLabel = RequestContext.get().getLineageInputLabel();
         String inTypeName = AtlasGraphUtilsV2.getTypeName(inVertex);
         AtlasEntityType inEntityType = atlasTypeRegistry.getEntityTypeByName(inTypeName);
         if (inEntityType == null) {
@@ -1540,7 +1548,7 @@ public class EntityLineageService implements AtlasLineageService {
         String      inGuid       = AtlasGraphUtilsV2.getIdFromVertex(inVertex);
         String      outGuid      = AtlasGraphUtilsV2.getIdFromVertex(outVertex);
         String      relationGuid = AtlasGraphUtilsV2.getEncodedProperty(edge, RELATIONSHIP_GUID_PROPERTY_KEY, String.class);
-        boolean     isInputEdge  = edge.getLabel().equalsIgnoreCase(LINEAGE_MAP.get(lineageType)[0]);
+        boolean     isInputEdge  = edge.getLabel().equalsIgnoreCase(lineageInputLabel);
 
         if (!entities.containsKey(inGuid)) {
             AtlasEntityHeader entityHeader = entityRetriever.toAtlasEntityHeader(inVertex, attributes);
@@ -1587,13 +1595,14 @@ public class EntityLineageService implements AtlasLineageService {
         String incomingFrom = null;
         String outgoingTo = null;
         String ret;
-        String lineageType = RequestContext.get().getLineageType();
+        String lineageInputLabel = RequestContext.get().getLineageInputLabel();
+        String lineageOutputLabel = RequestContext.get().getLineageOutputLabel();
         if (direction.equals(INPUT)) {
-            incomingFrom = LINEAGE_MAP.get(lineageType)[1];
-            outgoingTo = LINEAGE_MAP.get(lineageType)[0];
+            incomingFrom = lineageOutputLabel;
+            outgoingTo = lineageInputLabel;
         } else if (direction.equals(OUTPUT)) {
-            incomingFrom = LINEAGE_MAP.get(lineageType)[0];
-            outgoingTo = LINEAGE_MAP.get(lineageType)[1];
+            incomingFrom = lineageInputLabel;
+            outgoingTo = lineageOutputLabel;
         }
 
         bindings.put("guid", entityGuid);

--- a/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
@@ -223,11 +223,10 @@ public class EntityLineageService implements AtlasLineageService {
         }
         HashMap<String, Boolean> dataTypeMap = new HashMap<>();
         boolean isProcess = entityType.getTypeAndAllSuperTypes().contains(PROCESS_SUPER_TYPE);
-        boolean isDataProduct = entityType.getTypeAndAllSuperTypes().contains(DATA_PRODUCT_ENTITY_TYPE);
+        boolean isDataProduct = entityType.getTypeName().equals(DATA_PRODUCT_ENTITY_TYPE);
         dataTypeMap.put(IS_DATA_PRODUCT, isDataProduct);
         dataTypeMap.put(IS_DATASET, !isProcess);
         if (!isProcess) {
-            //TODO : Check product is an asset super
             boolean isDataSet = entityType.getTypeAndAllSuperTypes().contains(DATA_SET_SUPER_TYPE);
             if (!isDataSet) {
                 throw new AtlasBaseException(AtlasErrorCode.INVALID_LINEAGE_ENTITY_TYPE, guid, typeName);

--- a/server-api/src/main/java/org/apache/atlas/RequestContext.java
+++ b/server-api/src/main/java/org/apache/atlas/RequestContext.java
@@ -90,6 +90,9 @@ public class RequestContext {
     private boolean     includeClassifications = true;
 
     private boolean     includeClassificationNames = false;
+
+
+    private String     lineageType = "DatasetProcessLineage";
     private String      currentTypePatchAction = "";
     private AtlasTask   currentTask;
     private String traceId;
@@ -192,6 +195,13 @@ public class RequestContext {
         this.applicationMetrics.add(metric);
     }
 
+    public String getLineageType() {
+        return lineageType;
+    }
+
+    public void setLineageType(String lineageType) {
+        this.lineageType = lineageType;
+    }
     public void clearEntityCache() {
         this.entityCache.clear();
     }

--- a/server-api/src/main/java/org/apache/atlas/RequestContext.java
+++ b/server-api/src/main/java/org/apache/atlas/RequestContext.java
@@ -92,7 +92,9 @@ public class RequestContext {
     private boolean     includeClassificationNames = false;
 
 
-    private String     lineageType = "DatasetProcessLineage";
+
+    private String     lineageInputLabel = "";
+    private String     lineageOutputLabel = "";
     private String      currentTypePatchAction = "";
     private AtlasTask   currentTask;
     private String traceId;
@@ -195,13 +197,6 @@ public class RequestContext {
         this.applicationMetrics.add(metric);
     }
 
-    public String getLineageType() {
-        return lineageType;
-    }
-
-    public void setLineageType(String lineageType) {
-        this.lineageType = lineageType;
-    }
     public void clearEntityCache() {
         this.entityCache.clear();
     }
@@ -220,6 +215,21 @@ public class RequestContext {
         return removedElementsMap;
     }
 
+    public String getLineageInputLabel() {
+        return lineageInputLabel;
+    }
+
+    public void setLineageInputLabel(String lineageInputLabel) {
+        this.lineageInputLabel = lineageInputLabel;
+    }
+
+    public String getLineageOutputLabel() {
+        return lineageOutputLabel;
+    }
+
+    public void setLineageOutputLabel(String lineageOutputLabel) {
+        this.lineageOutputLabel = lineageOutputLabel;
+    }
     public Map<String, List<Object>> getNewElementsCreatedMap() {
         return newElementsCreatedMap;
     }

--- a/webapp/src/main/java/org/apache/atlas/web/rest/LineageREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/LineageREST.java
@@ -93,7 +93,7 @@ public class LineageREST {
     @Consumes(Servlets.JSON_MEDIA_TYPE)
     @Produces(Servlets.JSON_MEDIA_TYPE)
     @Timed
-    public AtlasLineageOnDemandInfo getLineageGraph(@PathParam("guid") String guid,
+    public AtlasLineageOnDemandInfo getLineageGraph(@PathParam("guid") String guid,@QueryParam("lineageType") String lineageType,
                                                     LineageOnDemandRequest lineageOnDemandRequest) throws AtlasBaseException {
         if (!AtlasConfiguration.LINEAGE_ON_DEMAND_ENABLED.getBoolean()) {
             LOG.warn("LineageREST: "+ AtlasErrorCode.LINEAGE_ON_DEMAND_NOT_ENABLED.getFormattedErrorMessage(AtlasConfiguration.LINEAGE_ON_DEMAND_ENABLED.getPropertyName()));
@@ -110,7 +110,7 @@ public class LineageREST {
                 perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "LineageREST.getOnDemandLineageGraph(" + guid + "," + lineageOnDemandRequest + ")");
             }
 
-            return atlasLineageService.getAtlasLineageInfo(guid, lineageOnDemandRequest);
+            return atlasLineageService.getAtlasLineageInfo(guid, lineageOnDemandRequest, lineageType);
         } finally {
             AtlasPerfTracer.log(perf);
         }

--- a/webapp/src/main/java/org/apache/atlas/web/rest/LineageREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/LineageREST.java
@@ -48,6 +48,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * REST interface for an entity's lineage information
@@ -109,8 +110,10 @@ public class LineageREST {
             if (AtlasPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
                 perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "LineageREST.getOnDemandLineageGraph(" + guid + "," + lineageOnDemandRequest + ")");
             }
-
-            return atlasLineageService.getAtlasLineageInfo(guid, lineageOnDemandRequest, lineageType);
+            if(Objects.nonNull(lineageType)) {
+                RequestContext.get().setLineageType(lineageType);
+            }
+            return atlasLineageService.getAtlasLineageInfo(guid, lineageOnDemandRequest);
         } finally {
             AtlasPerfTracer.log(perf);
         }
@@ -141,8 +144,10 @@ public class LineageREST {
         try {
             if (AtlasPerfTracer.isPerfTraceEnabled(PERF_LOG))
                 perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "LineageREST.getLineageList(" + guid + "," + lineageListRequest + ")");
-
-            return atlasLineageService.getLineageListInfoOnDemand(guid, lineageListRequest, lineageType);
+            if(Objects.nonNull(lineageType)) {
+                RequestContext.get().setLineageType(lineageType);
+            }
+            return atlasLineageService.getLineageListInfoOnDemand(guid, lineageListRequest);
         } finally {
             AtlasPerfTracer.log(perf);
         }

--- a/webapp/src/main/java/org/apache/atlas/web/rest/LineageREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/LineageREST.java
@@ -94,7 +94,7 @@ public class LineageREST {
     @Consumes(Servlets.JSON_MEDIA_TYPE)
     @Produces(Servlets.JSON_MEDIA_TYPE)
     @Timed
-    public AtlasLineageOnDemandInfo getLineageGraph(@PathParam("guid") String guid,@QueryParam("lineageType") String lineageType,
+    public AtlasLineageOnDemandInfo getLineageGraph(@PathParam("guid") String guid,
                                                     LineageOnDemandRequest lineageOnDemandRequest) throws AtlasBaseException {
         if (!AtlasConfiguration.LINEAGE_ON_DEMAND_ENABLED.getBoolean()) {
             LOG.warn("LineageREST: "+ AtlasErrorCode.LINEAGE_ON_DEMAND_NOT_ENABLED.getFormattedErrorMessage(AtlasConfiguration.LINEAGE_ON_DEMAND_ENABLED.getPropertyName()));
@@ -109,9 +109,6 @@ public class LineageREST {
         try {
             if (AtlasPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
                 perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "LineageREST.getOnDemandLineageGraph(" + guid + "," + lineageOnDemandRequest + ")");
-            }
-            if(Objects.nonNull(lineageType)) {
-                RequestContext.get().setLineageType(lineageType);
             }
             return atlasLineageService.getAtlasLineageInfo(guid, lineageOnDemandRequest);
         } finally {
@@ -131,7 +128,7 @@ public class LineageREST {
     @Consumes(Servlets.JSON_MEDIA_TYPE)
     @Produces(Servlets.JSON_MEDIA_TYPE)
     @Timed
-    public AtlasLineageListInfo getLineageList(@QueryParam("lineageType") String lineageType, LineageListRequest lineageListRequest) throws AtlasBaseException {
+    public AtlasLineageListInfo getLineageList(LineageListRequest lineageListRequest) throws AtlasBaseException {
         lineageListRequestValidator.validate(lineageListRequest);
 
         String guid = lineageListRequest.getGuid();
@@ -144,9 +141,7 @@ public class LineageREST {
         try {
             if (AtlasPerfTracer.isPerfTraceEnabled(PERF_LOG))
                 perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "LineageREST.getLineageList(" + guid + "," + lineageListRequest + ")");
-            if(Objects.nonNull(lineageType)) {
-                RequestContext.get().setLineageType(lineageType);
-            }
+
             return atlasLineageService.getLineageListInfoOnDemand(guid, lineageListRequest);
         } finally {
             AtlasPerfTracer.log(perf);

--- a/webapp/src/main/java/org/apache/atlas/web/rest/LineageREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/LineageREST.java
@@ -128,7 +128,7 @@ public class LineageREST {
     @Consumes(Servlets.JSON_MEDIA_TYPE)
     @Produces(Servlets.JSON_MEDIA_TYPE)
     @Timed
-    public AtlasLineageListInfo getLineageList(LineageListRequest lineageListRequest) throws AtlasBaseException {
+    public AtlasLineageListInfo getLineageList(@QueryParam("lineageType") String lineageType, LineageListRequest lineageListRequest) throws AtlasBaseException {
         lineageListRequestValidator.validate(lineageListRequest);
 
         String guid = lineageListRequest.getGuid();
@@ -142,7 +142,7 @@ public class LineageREST {
             if (AtlasPerfTracer.isPerfTraceEnabled(PERF_LOG))
                 perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "LineageREST.getLineageList(" + guid + "," + lineageListRequest + ")");
 
-            return atlasLineageService.getLineageListInfoOnDemand(guid, lineageListRequest);
+            return atlasLineageService.getLineageListInfoOnDemand(guid, lineageListRequest, lineageType);
         } finally {
             AtlasPerfTracer.log(perf);
         }


### PR DESCRIPTION
## Change description
>
> URL 1: 
>```
> http://localhost:21000/api/meta/lineage/list
> ```
> URL 2: 
>```
> http://localhost:21000/api/meta/lineage/61adac14-b226-4fd3-97fa-ff0fb255dadb
> ```
> DataProduct when connected with Assets through input/output Ports will provide lineage through `/lineage/{guid}` api and `/lineage/list` api
> through a request body attribute flag called `lineageType : ProductAssetLineage`
```
{
    "lineageType": "ProductAssetLineage",
    ....
}
```
## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> Fix [#1](https://atlanhq.atlassian.net/browse/DG-1720)
> [TestCases](https://www.notion.so/atlanhq/Dev-Testing-0143bf8cbbab428b8159211a61541f73)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
