### PR TITLE
LIN-1079 immediate downstream and upstream assets in impact report

### DIFF
--- a/intg/src/main/java/org/apache/atlas/model/instance/AtlasEntityHeader.java
+++ b/intg/src/main/java/org/apache/atlas/model/instance/AtlasEntityHeader.java
@@ -77,6 +77,9 @@ public class AtlasEntityHeader extends AtlasStruct implements Serializable {
 
     private Map<String, AtlasSearchResult>  collapse    = null;
 
+    private List<String> immediateUpstream;  // New field
+    private List<String> immediateDownstream;  // New field
+
 
     public AtlasEntityHeader() {
         this(null, null);
@@ -344,6 +347,22 @@ public class AtlasEntityHeader extends AtlasStruct implements Serializable {
 
     public void setMeanings(final List<AtlasTermAssignmentHeader> meanings) {
         this.meanings = meanings;
+    }
+
+    public List<String> getImmediateUpstream() {
+        return immediateUpstream;
+    }
+
+    public void setImmediateUpstream(List<String> immediateUpstream) {
+        this.immediateUpstream = immediateUpstream;
+    }
+
+    public List<String> getImmediateDownstream() {
+        return immediateDownstream;
+    }
+
+    public void setImmediateDownstream(List<String> immediateDownstream) {
+        this.immediateDownstream = immediateDownstream;
     }
 
     /**

--- a/intg/src/main/java/org/apache/atlas/model/instance/AtlasEntityHeader.java
+++ b/intg/src/main/java/org/apache/atlas/model/instance/AtlasEntityHeader.java
@@ -77,8 +77,8 @@ public class AtlasEntityHeader extends AtlasStruct implements Serializable {
 
     private Map<String, AtlasSearchResult>  collapse    = null;
 
-    private List<String> immediateUpstream;  // New field
-    private List<String> immediateDownstream;  // New field
+    private List<List<String>> immediateUpstream;  // New field
+    private List<List<String>> immediateDownstream;  // New field
 
 
     public AtlasEntityHeader() {
@@ -349,19 +349,19 @@ public class AtlasEntityHeader extends AtlasStruct implements Serializable {
         this.meanings = meanings;
     }
 
-    public List<String> getImmediateUpstream() {
+    public List<List<String>> getImmediateUpstream() {
         return immediateUpstream;
     }
 
-    public void setImmediateUpstream(List<String> immediateUpstream) {
+    public void setImmediateUpstream(List<List<String>> immediateUpstream) {
         this.immediateUpstream = immediateUpstream;
     }
 
-    public List<String> getImmediateDownstream() {
+    public List<List<String>> getImmediateDownstream() {
         return immediateDownstream;
     }
 
-    public void setImmediateDownstream(List<String> immediateDownstream) {
+    public void setImmediateDownstream(List<List<String>> immediateDownstream) {
         this.immediateDownstream = immediateDownstream;
     }
 

--- a/intg/src/main/java/org/apache/atlas/model/instance/AtlasEntityHeader.java
+++ b/intg/src/main/java/org/apache/atlas/model/instance/AtlasEntityHeader.java
@@ -77,8 +77,8 @@ public class AtlasEntityHeader extends AtlasStruct implements Serializable {
 
     private Map<String, AtlasSearchResult>  collapse    = null;
 
-    private List<List<String>> immediateUpstream;  // New field
-    private List<List<String>> immediateDownstream;  // New field
+    private List<Map<String,String>> immediateUpstream;  // New field
+    private List<Map<String,String>> immediateDownstream;  // New field
 
 
     public AtlasEntityHeader() {
@@ -349,19 +349,19 @@ public class AtlasEntityHeader extends AtlasStruct implements Serializable {
         this.meanings = meanings;
     }
 
-    public List<List<String>> getImmediateUpstream() {
+    public List<Map<String,String>> getImmediateUpstream() {
         return immediateUpstream;
     }
 
-    public void setImmediateUpstream(List<List<String>> immediateUpstream) {
+    public void setImmediateUpstream(List<Map<String,String>> immediateUpstream) {
         this.immediateUpstream = immediateUpstream;
     }
 
-    public List<List<String>> getImmediateDownstream() {
+    public List<Map<String,String>> getImmediateDownstream() {
         return immediateDownstream;
     }
 
-    public void setImmediateDownstream(List<List<String>> immediateDownstream) {
+    public void setImmediateDownstream(List<Map<String,String>> immediateDownstream) {
         this.immediateDownstream = immediateDownstream;
     }
 

--- a/intg/src/main/java/org/apache/atlas/model/lineage/LineageListRequest.java
+++ b/intg/src/main/java/org/apache/atlas/model/lineage/LineageListRequest.java
@@ -25,7 +25,7 @@ public class LineageListRequest {
     private Set<String>                     relationAttributes;
     private Boolean                         excludeMeanings;
     private Boolean                         excludeClassifications;
-    private Boolean                         immediateNeighbours;
+    private Boolean                         immediateNeighbours=false;
 
     public Boolean getImmediateNeighbours() {
         return immediateNeighbours;

--- a/intg/src/main/java/org/apache/atlas/model/lineage/LineageListRequest.java
+++ b/intg/src/main/java/org/apache/atlas/model/lineage/LineageListRequest.java
@@ -25,6 +25,15 @@ public class LineageListRequest {
     private Set<String>                     relationAttributes;
     private Boolean                         excludeMeanings;
     private Boolean                         excludeClassifications;
+    private Boolean                         immediateNeighbours;
+
+    public Boolean getImmediateNeighbours() {
+        return immediateNeighbours;
+    }
+
+    public void setImmediateNeighbours(Boolean immediateNeighbours) {
+        this.immediateNeighbours = immediateNeighbours;
+    }
 
     public enum LineageDirection {INPUT, OUTPUT}
 

--- a/repository/src/main/java/org/apache/atlas/discovery/AtlasLineageListContext.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/AtlasLineageListContext.java
@@ -23,6 +23,7 @@ public final class AtlasLineageListContext {
     private int                                 currentEntityCounter;
     private boolean                             depthLimitReached;
     private boolean                             hasMoreUpdated;
+    private Boolean                             immediateNeighbours;
 
     public AtlasLineageListContext(LineageListRequest lineageListRequest, AtlasTypeRegistry typeRegistry) {
         this.guid = lineageListRequest.getGuid();
@@ -35,6 +36,7 @@ public final class AtlasLineageListContext {
         this.edgeTraversalPredicate = constructInMemoryPredicate(typeRegistry, lineageListRequest.getRelationshipTraversalFilters());
         this.attributes = lineageListRequest.getAttributes();
         this.relationAttributes = lineageListRequest.getRelationAttributes();
+        this.immediateNeighbours = lineageListRequest.getImmediateNeighbours();
     }
 
     public String getGuid() {
@@ -189,5 +191,13 @@ public final class AtlasLineageListContext {
 
     public void setHasMoreUpdated(boolean hasMoreUpdated) {
         this.hasMoreUpdated = hasMoreUpdated;
+    }
+
+    public Boolean getImmediateNeighbours() {
+        return immediateNeighbours;
+    }
+
+    public void setImmediateNeighbours(Boolean immediateNeighbours) {
+        this.immediateNeighbours = immediateNeighbours;
     }
 }

--- a/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
@@ -578,7 +578,7 @@ public class EntityLineageService implements AtlasLineageService {
                 // Get the list of AtlasVertex from the map
                 List<String> parentNodes = parentMapForNeighbours.get(entity.getGuid());
 
-                List<List<String>> parentNodesOfParentWithDetails = new ArrayList<>();
+                List<Map<String,String>> parentNodesOfParentWithDetails = new ArrayList<>();
                 for (String parentNode : parentNodes) {
                     List<String> parentsOfParentNodes = parentMapForNeighbours.get(parentNode);
                     for (String parentOfParent : parentsOfParentNodes) {
@@ -598,7 +598,7 @@ public class EntityLineageService implements AtlasLineageService {
                 // Get the list of AtlasVertex from the map
                 List<String> childrenNodes = childrenMapForNeighbours.get(entity.getGuid());
 
-                List<List<String>> childrenNodesOfChildrenWithDetails = new ArrayList<>();
+                List<Map<String,String>> childrenNodesOfChildrenWithDetails = new ArrayList<>();
                 for (String childNode : childrenNodes) {
                     // Add all children for the current childNode
                     List<String> childrenOfChildNode = childrenMapForNeighbours.get(childNode);

--- a/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
@@ -579,12 +579,17 @@ public class EntityLineageService implements AtlasLineageService {
             if (lineageParentsForEntityMap.containsKey(entity.getGuid())) {
                 // Get the list of AtlasVertex from the map
                 List<String> parentNodes = lineageParentsForEntityMap.get(entity.getGuid());
-
+                Set<String> seenGuids = new HashSet<>();
                 List<Map<String,String>> parentNodesOfParentWithDetails = new ArrayList<>();
                 for (String parentNode : parentNodes) {
                     List<String> parentsOfParentNodes = lineageParentsForEntityMap.get(parentNode);
                     for (String parentOfParent : parentsOfParentNodes) {
-                        parentNodesOfParentWithDetails.add(fetchAttributes(AtlasGraphUtilsV2.findByGuid(this.graph, parentOfParent), FETCH_ENTITY_ATTRIBUTES));
+                        Map<String, String> details = fetchAttributes(AtlasGraphUtilsV2.findByGuid(this.graph, parentOfParent), FETCH_ENTITY_ATTRIBUTES);
+                        // Check if the guid is already in the set
+                        if (!seenGuids.contains(parentOfParent)) {
+                            parentNodesOfParentWithDetails.add(details);
+                            seenGuids.add(parentOfParent); // Add the guid to the set
+                        }
                     }
                 }
 
@@ -599,13 +604,17 @@ public class EntityLineageService implements AtlasLineageService {
             if (lineageChildrenForEntityMap.containsKey(entity.getGuid())) {
                 // Get the list of AtlasVertex from the map
                 List<String> childrenNodes = lineageChildrenForEntityMap.get(entity.getGuid());
-
+                Set<String> seenGuids = new HashSet<>();
                 List<Map<String,String>> childrenNodesOfChildrenWithDetails = new ArrayList<>();
                 for (String childNode : childrenNodes) {
                     // Add all children for the current childNode
                     List<String> childrenOfChildNode = lineageChildrenForEntityMap.get(childNode);
                     for (String childOfChild : childrenOfChildNode) {
-                        childrenNodesOfChildrenWithDetails.add(fetchAttributes(AtlasGraphUtilsV2.findByGuid(this.graph, childOfChild), FETCH_ENTITY_ATTRIBUTES));
+                        Map<String, String> details = fetchAttributes(AtlasGraphUtilsV2.findByGuid(this.graph, childOfChild), FETCH_ENTITY_ATTRIBUTES);
+                        if (!seenGuids.contains(childOfChild)) {
+                            childrenNodesOfChildrenWithDetails.add(details);
+                            seenGuids.add(childOfChild); // Add the guid to the set
+                        }
                     }
                 }
 

--- a/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
@@ -585,16 +585,18 @@ public class EntityLineageService implements AtlasLineageService {
                             Set<String> seenGuids = new HashSet<>();
                             List<Map<String,String>> parentNodesOfParentWithDetails = new ArrayList<>();
                             for (String parentNode : parentNodes) {
-                                List<String> parentsOfParentNodes = lineageParentsForEntityMap.get(parentNode);
-                                if (parentsOfParentNodes != null){
-                                    for (String parentOfParent : parentsOfParentNodes) {
-                                        AtlasVertex vertex = AtlasGraphUtilsV2.findByGuid(this.graph, parentOfParent);
-                                        if (vertex != null) {
-                                            Map<String, String> details = fetchAttributes(vertex, FETCH_ENTITY_ATTRIBUTES);
-                                            // Check if the guid is already in the set
-                                            if (!seenGuids.contains(parentOfParent)) {
-                                                parentNodesOfParentWithDetails.add(details);
-                                                seenGuids.add(parentOfParent); // Add the guid to the set
+                                if(lineageParentsForEntityMap.containsKey(parentNode)){
+                                    List<String> parentsOfParentNodes = lineageParentsForEntityMap.get(parentNode);
+                                    if (parentsOfParentNodes != null){
+                                        for (String parentOfParent : parentsOfParentNodes) {
+                                            AtlasVertex vertex = AtlasGraphUtilsV2.findByGuid(this.graph, parentOfParent);
+                                            if (vertex != null) {
+                                                Map<String, String> details = fetchAttributes(vertex, FETCH_ENTITY_ATTRIBUTES);
+                                                // Check if the guid is already in the set
+                                                if (!seenGuids.contains(parentOfParent)) {
+                                                    parentNodesOfParentWithDetails.add(details);
+                                                    seenGuids.add(parentOfParent); // Add the guid to the set
+                                                }
                                             }
                                         }
                                     }
@@ -617,16 +619,18 @@ public class EntityLineageService implements AtlasLineageService {
                             Set<String> seenGuids = new HashSet<>();
                             List<Map<String,String>> childrenNodesOfChildrenWithDetails = new ArrayList<>();
                             for (String childNode : childrenNodes) {
-                                // Add all children for the current childNode
-                                List<String> childrenOfChildNode = lineageChildrenForEntityMap.get(childNode);
-                                if (childrenOfChildNode != null){
-                                    for (String childOfChild : childrenOfChildNode) {
-                                        AtlasVertex vertex = AtlasGraphUtilsV2.findByGuid(this.graph, childOfChild);
-                                        if (vertex != null) {
-                                            Map<String, String> details = fetchAttributes(vertex, FETCH_ENTITY_ATTRIBUTES);
-                                            if (!seenGuids.contains(childOfChild)) {
-                                                childrenNodesOfChildrenWithDetails.add(details);
-                                                seenGuids.add(childOfChild); // Add the guid to the set
+                                if(lineageChildrenForEntityMap.containsKey(childNode)){
+                                    // Add all children for the current childNode
+                                    List<String> childrenOfChildNode = lineageChildrenForEntityMap.get(childNode);
+                                    if (childrenOfChildNode != null){
+                                        for (String childOfChild : childrenOfChildNode) {
+                                            AtlasVertex vertex = AtlasGraphUtilsV2.findByGuid(this.graph, childOfChild);
+                                            if (vertex != null) {
+                                                Map<String, String> details = fetchAttributes(vertex, FETCH_ENTITY_ATTRIBUTES);
+                                                if (!seenGuids.contains(childOfChild)) {
+                                                    childrenNodesOfChildrenWithDetails.add(details);
+                                                    seenGuids.add(childOfChild); // Add the guid to the set
+                                                }
                                             }
                                         }
                                     }

--- a/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
@@ -514,8 +514,10 @@ public class EntityLineageService implements AtlasLineageService {
             }
         }
 
-        // update parents for each entity
-        updateParentNodesForEachEntity(lineageListContext, ret, parentMapForNeighbours, childrenMapForNeighbours);
+        if(lineageListContext.getImmediateNeighbours()){
+            // update parents for each entity
+            updateParentNodesForEachEntity(lineageListContext, ret, parentMapForNeighbours, childrenMapForNeighbours);
+        }
 
         if (currentDepth > lineageListContext.getDepth())
             lineageListContext.setDepthLimitReached(true);
@@ -556,13 +558,16 @@ public class EntityLineageService implements AtlasLineageService {
                 traversalQueue.add(vertexGuid);
                 addEntitiesToCache(neighbourVertex);
             }
-            String vertexDisplayName = getQalifiedName(neighbourVertex);
-            parentMapForNeighbours
-                    .computeIfAbsent(vertexDisplayName, k -> new ArrayList<>())
-                    .add(getQalifiedName(currentVertex));
-            childrenMapForNeighbours
-                    .computeIfAbsent(getQalifiedName(currentVertex), k -> new ArrayList<>())
-                    .add(vertexDisplayName);
+
+            if(lineageListContext.getImmediateNeighbours()){
+                String vertexDisplayName = getQalifiedName(neighbourVertex);
+                parentMapForNeighbours
+                        .computeIfAbsent(vertexDisplayName, k -> new ArrayList<>())
+                        .add(getQalifiedName(currentVertex));
+                childrenMapForNeighbours
+                        .computeIfAbsent(getQalifiedName(currentVertex), k -> new ArrayList<>())
+                        .add(vertexDisplayName);
+            }
         }
     }
 

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -1025,6 +1025,10 @@ public final class GraphHelper {
         return ret;
     }
 
+    public static String getQalifiedName(AtlasVertex vertex) {
+        return vertex.<String>getProperty(Constants.QUALIFIED_NAME, String.class);
+    }
+
     public static String getHomeId(AtlasElement element) {
         return element.getProperty(Constants.HOME_ID_KEY, String.class);
     }

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -1029,12 +1029,12 @@ public final class GraphHelper {
         return vertex.<String>getProperty(Constants.QUALIFIED_NAME, String.class);
     }
 
-    public static List<String> getNodeDetails(AtlasVertex vertex) {
-        List<String> stringList = new ArrayList<>();
+    public static Map<String,String> getNodeDetails(AtlasVertex vertex) {
+        Map<String,String> stringList = new HashMap<>();
         // Add strings to the list
-        stringList.add(getGuid(vertex));
-        stringList.add(vertex.<String>getProperty(QUALIFIED_NAME, String.class));
-        stringList.add(vertex.<String>getProperty(NAME, String.class));
+        stringList.put(ATTRIBUTE_NAME_GUID, getGuid(vertex));
+        stringList.put(QUALIFIED_NAME, vertex.<String>getProperty(QUALIFIED_NAME, String.class));
+        stringList.put(NAME, vertex.<String>getProperty(NAME, String.class));
         // Return the ArrayList
         return stringList;
     }

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -1025,18 +1025,20 @@ public final class GraphHelper {
         return ret;
     }
 
-    public static String getQalifiedName(AtlasVertex vertex) {
-        return vertex.<String>getProperty(Constants.QUALIFIED_NAME, String.class);
-    }
+    public static Map<String,String> fetchAttributes(AtlasVertex vertex, List<String> attributes) {
+        Map<String,String> attributesList = new HashMap<>();
 
-    public static Map<String,String> getNodeDetails(AtlasVertex vertex) {
-        Map<String,String> stringList = new HashMap<>();
-        // Add strings to the list
-        stringList.put(ATTRIBUTE_NAME_GUID, getGuid(vertex));
-        stringList.put(QUALIFIED_NAME, vertex.<String>getProperty(QUALIFIED_NAME, String.class));
-        stringList.put(NAME, vertex.<String>getProperty(NAME, String.class));
+        for (String attr: attributes){
+            if (Objects.equals(attr, ATTRIBUTE_NAME_GUID)){
+                // always add guid to the list from cache
+                attributesList.put(ATTRIBUTE_NAME_GUID, getGuid(vertex));
+            }
+            else{
+                attributesList.put(attr, vertex.<String>getProperty(attr, String.class));
+            }
+        }
         // Return the ArrayList
-        return stringList;
+        return attributesList;
     }
 
     public static String getHomeId(AtlasElement element) {

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -1029,6 +1029,16 @@ public final class GraphHelper {
         return vertex.<String>getProperty(Constants.QUALIFIED_NAME, String.class);
     }
 
+    public static List<String> getNodeDetails(AtlasVertex vertex) {
+        List<String> stringList = new ArrayList<>();
+        // Add strings to the list
+        stringList.add(getGuid(vertex));
+        stringList.add(vertex.<String>getProperty(QUALIFIED_NAME, String.class));
+        stringList.add(vertex.<String>getProperty(NAME, String.class));
+        // Return the ArrayList
+        return stringList;
+    }
+
     public static String getHomeId(AtlasElement element) {
         return element.getProperty(Constants.HOME_ID_KEY, String.class);
     }


### PR DESCRIPTION
## Change description
https://atlanhq.atlassian.net/browse/LIN-1079
PR will add two columns in list API reponse
immediateUpstream assets
IimmediateDownstream assets
this is one of the requirement raised by zoom team

there is boolean flag immediateNeighbours which can be set true to get this two columns, if passed as false then no additional columns will be added in the response

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [x] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
