### PR TITLE
DG-1726 Paginated the logic for Clean Up Task

### DIFF
--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -349,7 +349,7 @@ public final class Constants {
     public static final String TASK_TIME_TAKEN_IN_SECONDS   = encodePropertyKey(TASK_PREFIX + "timeTakenInSeconds");
     public static final String TASK_CLASSIFICATION_ID       = encodePropertyKey(TASK_PREFIX + "classificationId");
     public static final String TASK_ENTITY_GUID             = encodePropertyKey(TASK_PREFIX + "entityGuid");
-    public static final String TASK_CLASSIFICATION_NAME    = encodePropertyKey(TASK_PREFIX + "classificationName");
+    public static final String TASK_CLASSIFICATION_TYPENAME = encodePropertyKey(TASK_PREFIX + "classificationTypeName");
     public static final String ACTIVE_STATE_VALUE           = "ACTIVE";
 
     /**

--- a/intg/src/main/java/org/apache/atlas/model/tasks/AtlasTask.java
+++ b/intg/src/main/java/org/apache/atlas/model/tasks/AtlasTask.java
@@ -38,12 +38,12 @@ public class AtlasTask {
     @JsonIgnore
     public static final int MAX_ATTEMPT_COUNT = 3;
 
-    public String getClassificationName() {
-        return classificationName;
+    public String getClassificationTypeName() {
+        return classificationTypeName;
     }
 
-    public void setClassificationName(String classificationName) {
-        this.classificationName = classificationName;
+    public void setClassificationTypeName(String classificationTypeName) {
+        this.classificationTypeName = classificationTypeName;
     }
 
     public enum Status {
@@ -94,7 +94,7 @@ public class AtlasTask {
     private Status              status;
     private String              classificationId;
     private String              entityGuid;
-    private String              classificationName;
+    private String              classificationTypeName;
 
     public AtlasTask() {
     }

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphBackedSearchIndexer.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphBackedSearchIndexer.java
@@ -397,6 +397,7 @@ public class GraphBackedSearchIndexer implements SearchIndexer, ActiveStateChang
             createCommonVertexIndex(management, TASK_TYPE, UniqueKind.NONE, String.class, SINGLE, true, false, true);
             createCommonVertexIndex(management, TASK_CREATED_BY, UniqueKind.NONE, String.class, SINGLE, false, false, true);
             createCommonVertexIndex(management, TASK_CLASSIFICATION_ID, UniqueKind.NONE, String.class, SINGLE, false, false, true);
+            createCommonVertexIndex(management, TASK_CLASSIFICATION_NAME, UniqueKind.NONE, String.class, SINGLE, false, false, true);
             createCommonVertexIndex(management, TASK_ENTITY_GUID, UniqueKind.NONE, String.class, SINGLE, false, false, true);
             createCommonVertexIndex(management, TASK_ERROR_MESSAGE, UniqueKind.NONE, String.class, SINGLE, false, false);
             createCommonVertexIndex(management, TASK_ATTEMPT_COUNT, UniqueKind.NONE, Integer.class, SINGLE, false, false);

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphBackedSearchIndexer.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphBackedSearchIndexer.java
@@ -397,7 +397,7 @@ public class GraphBackedSearchIndexer implements SearchIndexer, ActiveStateChang
             createCommonVertexIndex(management, TASK_TYPE, UniqueKind.NONE, String.class, SINGLE, true, false, true);
             createCommonVertexIndex(management, TASK_CREATED_BY, UniqueKind.NONE, String.class, SINGLE, false, false, true);
             createCommonVertexIndex(management, TASK_CLASSIFICATION_ID, UniqueKind.NONE, String.class, SINGLE, false, false, true);
-            createCommonVertexIndex(management, TASK_CLASSIFICATION_NAME, UniqueKind.NONE, String.class, SINGLE, false, false, true);
+            createCommonVertexIndex(management, TASK_CLASSIFICATION_TYPENAME, UniqueKind.NONE, String.class, SINGLE, false, false, true);
             createCommonVertexIndex(management, TASK_ENTITY_GUID, UniqueKind.NONE, String.class, SINGLE, false, false, true);
             createCommonVertexIndex(management, TASK_ERROR_MESSAGE, UniqueKind.NONE, String.class, SINGLE, false, false);
             createCommonVertexIndex(management, TASK_ATTEMPT_COUNT, UniqueKind.NONE, Integer.class, SINGLE, false, false);

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -397,15 +397,20 @@ public final class GraphHelper {
 
     public static List<AtlasVertex> getAllAssetsWithClassificationVertex(AtlasVertex classificationVertice, int availableSlots) {
         HashSet<AtlasVertex> entityVerticesSet = new HashSet<>();
-        Iterable attachedVertices =  classificationVertice.query()
-                .direction(AtlasEdgeDirection.IN)
-                .label(CLASSIFICATION_LABEL).vertices(availableSlots);
-        if (attachedVertices != null) {
-            Iterator<AtlasVertex> attachedVerticesIterator = attachedVertices.iterator();
-            while (attachedVerticesIterator.hasNext()) {
-                entityVerticesSet.add(attachedVerticesIterator.next());
+        try {
+            Iterable attachedVertices = classificationVertice.query()
+                    .direction(AtlasEdgeDirection.IN)
+                    .label(CLASSIFICATION_LABEL).vertices(availableSlots);
+            if (attachedVertices != null) {
+                Iterator<AtlasVertex> attachedVerticesIterator = attachedVertices.iterator();
+                while (attachedVerticesIterator.hasNext()) {
+                    entityVerticesSet.add(attachedVerticesIterator.next());
+                }
+                LOG.info("entityVerticesSet size: {}", entityVerticesSet.size());
             }
-            LOG.info("entityVerticesSet size: {}", entityVerticesSet.size());
+        }
+        catch (IllegalStateException e){
+            e.printStackTrace();
         }
         return entityVerticesSet.stream().collect(Collectors.toList());
     }

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -392,6 +392,7 @@ public final class GraphHelper {
         }
         List<AtlasVertex> classificationVerticesList = IteratorUtils.toList(classificationVertices.iterator());
         LOG.info("classificationVerticesList size: {}", classificationVerticesList.size());
+        return classificationVerticesList;
     }
 
     public static List<AtlasVertex> getAllAssetsWithClassificationVertex(AtlasGraph graph, AtlasVertex classificationVertice) {
@@ -406,8 +407,6 @@ public final class GraphHelper {
             }
             LOG.info("entityVerticesSet size: {}", entityVerticesSet.size());
         }
-
-
         return entityVerticesSet.stream().collect(Collectors.toList());
     }
     public static AtlasEdge getClassificationEdge(AtlasVertex entityVertex, AtlasVertex classificationVertex) {

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -376,15 +376,12 @@ public final class GraphHelper {
 
         return ret;
     }
-
-    public static List<AtlasVertex> getClassificationVertexes(AtlasGraph graph, String classificationName, int size) {
+    public static Iterator<AtlasVertex> getClassificationVertices(AtlasGraph graph, String classificationName, int size) {
         Iterable classificationVertices = graph.query().has(TYPE_NAME_PROPERTY_KEY, classificationName).vertices(size);
         if (classificationVertices == null) {
-            return Collections.emptyList();
+            return null;
         }
-        List<AtlasVertex> classificationVerticesList = IteratorUtils.toList(classificationVertices.iterator());
-        LOG.info("classificationVerticesList size: {}", classificationVerticesList.size());
-        return classificationVerticesList;
+        return classificationVertices.iterator();
     }
 
     public static List<AtlasVertex> getAllAssetsWithClassificationVertex(AtlasVertex classificationVertice, int availableSlots) {

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -379,6 +379,7 @@ public final class GraphHelper {
     public static Iterator<AtlasVertex> getClassificationVertices(AtlasGraph graph, String classificationName, int size) {
         Iterable classificationVertices = graph.query().has(TYPE_NAME_PROPERTY_KEY, classificationName).vertices(size);
         if (classificationVertices == null) {
+            LOG.info("classificationVertices are null");
             return null;
         }
         return classificationVertices.iterator();

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -395,11 +395,11 @@ public final class GraphHelper {
         return classificationVerticesList;
     }
 
-    public static List<AtlasVertex> getAllAssetsWithClassificationVertex(AtlasGraph graph, AtlasVertex classificationVertice) {
+    public static List<AtlasVertex> getAllAssetsWithClassificationVertex(AtlasVertex classificationVertice, int availableSlots) {
         HashSet<AtlasVertex> entityVerticesSet = new HashSet<>();
         Iterable attachedVertices =  classificationVertice.query()
                 .direction(AtlasEdgeDirection.IN)
-                .label(CLASSIFICATION_LABEL).vertices();
+                .label(CLASSIFICATION_LABEL).vertices(availableSlots);
         if (attachedVertices != null) {
             Iterator<AtlasVertex> attachedVerticesIterator = attachedVertices.iterator();
             while (attachedVerticesIterator.hasNext()) {
@@ -408,6 +408,13 @@ public final class GraphHelper {
             LOG.info("entityVerticesSet size: {}", entityVerticesSet.size());
         }
         return entityVerticesSet.stream().collect(Collectors.toList());
+    }
+
+    public static long getAssetsCountOfClassificationVertex(AtlasVertex classificationVertice) {
+        long count =  classificationVertice.query()
+                .direction(AtlasEdgeDirection.IN)
+                .label(CLASSIFICATION_LABEL).count();
+        return count;
     }
     public static AtlasEdge getClassificationEdge(AtlasVertex entityVertex, AtlasVertex classificationVertex) {
         AtlasEdge ret   = null;

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -377,8 +377,8 @@ public final class GraphHelper {
         return ret;
     }
 
-    public static List<AtlasVertex> getClassificationVertexes(AtlasGraph graph, String classificationName) {
-        Iterable classificationVertices = graph.query().has(TYPE_NAME_PROPERTY_KEY, classificationName).vertices();
+    public static List<AtlasVertex> getClassificationVertexes(AtlasGraph graph, String classificationName, int size) {
+        Iterable classificationVertices = graph.query().has(TYPE_NAME_PROPERTY_KEY, classificationName).vertices(size);
         if (classificationVertices == null) {
             return Collections.emptyList();
         }

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -411,9 +411,15 @@ public final class GraphHelper {
     }
 
     public static long getAssetsCountOfClassificationVertex(AtlasVertex classificationVertice) {
-        long count =  classificationVertice.query()
-                .direction(AtlasEdgeDirection.IN)
-                .label(CLASSIFICATION_LABEL).count();
+        long count = 0;
+        try {
+            count = classificationVertice.query()
+                    .direction(AtlasEdgeDirection.IN)
+                    .label(CLASSIFICATION_LABEL).count();
+        }
+        catch (IllegalStateException e){
+            e.printStackTrace();
+        }
         return count;
     }
     public static AtlasEdge getClassificationEdge(AtlasVertex entityVertex, AtlasVertex classificationVertex) {

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -377,34 +377,36 @@ public final class GraphHelper {
         return ret;
     }
 
-    public static List<AtlasVertex> getAllClassificationVerticesByClassificationName(AtlasGraph graph, String classificationName) {
-        Iterable vertices = graph.query().has(TYPE_NAME_PROPERTY_KEY, classificationName).vertices();
-        if (vertices == null) {
-            return Collections.emptyList();
-        }
-        return IteratorUtils.toList(vertices.iterator());
-    }
+//    public static List<AtlasVertex> getAllClassificationVerticesByClassificationName(AtlasGraph graph, String classificationName) {
+//        Iterable vertices = graph.query().has(TYPE_NAME_PROPERTY_KEY, classificationName).vertices();
+//        if (vertices == null) {
+//            return Collections.emptyList();
+//        }
+//        return IteratorUtils.toList(vertices.iterator());
+//    }
 
-    public static List<AtlasVertex> getAllAssetsWithClassificationAttached(AtlasGraph graph, String classificationName) {
+    public static List<AtlasVertex> getClassificationVertexes(AtlasGraph graph, String classificationName) {
         Iterable classificationVertices = graph.query().has(TYPE_NAME_PROPERTY_KEY, classificationName).vertices();
         if (classificationVertices == null) {
             return Collections.emptyList();
         }
         List<AtlasVertex> classificationVerticesList = IteratorUtils.toList(classificationVertices.iterator());
-            LOG.info("classificationVerticesList size: {}", classificationVerticesList.size());
+        LOG.info("classificationVerticesList size: {}", classificationVerticesList.size());
+    }
+
+    public static List<AtlasVertex> getAllAssetsWithClassificationVertex(AtlasGraph graph, AtlasVertex classificationVertice) {
         HashSet<AtlasVertex> entityVerticesSet = new HashSet<>();
-        for (AtlasVertex classificationVertex : classificationVerticesList) {
-            Iterable attachedVertices =  classificationVertex.query()
-                    .direction(AtlasEdgeDirection.IN)
-                    .label(CLASSIFICATION_LABEL).vertices();
-            if (attachedVertices != null) {
-                Iterator<AtlasVertex> attachedVerticesIterator = attachedVertices.iterator();
-                while (attachedVerticesIterator.hasNext()) {
-                    entityVerticesSet.add(attachedVerticesIterator.next());
-                }
-                LOG.info("entityVerticesSet size: {}", entityVerticesSet.size());
+        Iterable attachedVertices =  classificationVertice.query()
+                .direction(AtlasEdgeDirection.IN)
+                .label(CLASSIFICATION_LABEL).vertices();
+        if (attachedVertices != null) {
+            Iterator<AtlasVertex> attachedVerticesIterator = attachedVertices.iterator();
+            while (attachedVerticesIterator.hasNext()) {
+                entityVerticesSet.add(attachedVerticesIterator.next());
             }
+            LOG.info("entityVerticesSet size: {}", entityVerticesSet.size());
         }
+
 
         return entityVerticesSet.stream().collect(Collectors.toList());
     }

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -377,14 +377,6 @@ public final class GraphHelper {
         return ret;
     }
 
-//    public static List<AtlasVertex> getAllClassificationVerticesByClassificationName(AtlasGraph graph, String classificationName) {
-//        Iterable vertices = graph.query().has(TYPE_NAME_PROPERTY_KEY, classificationName).vertices();
-//        if (vertices == null) {
-//            return Collections.emptyList();
-//        }
-//        return IteratorUtils.toList(vertices.iterator());
-//    }
-
     public static List<AtlasVertex> getClassificationVertexes(AtlasGraph graph, String classificationName) {
         Iterable classificationVertices = graph.query().has(TYPE_NAME_PROPERTY_KEY, classificationName).vertices();
         if (classificationVertices == null) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -428,7 +428,7 @@ public abstract class DeleteHandlerV1 {
 
         if (taskManagement != null && DEFERRED_ACTION_ENABLED) {
             for (AtlasVertex classificationVertex : classificationVertices) {
-                createAndQueueTask(CLASSIFICATION_PROPAGATION_ADD, toVertex, classificationVertex.getIdForDisplay(), relationshipGuid);
+                createAndQueueTask(CLASSIFICATION_PROPAGATION_ADD, toVertex, classificationVertex.getIdForDisplay(), getTypeName(classificationVertex), relationshipGuid);
             }
         } else {
             final List<AtlasVertex> propagatedEntityVertices = CollectionUtils.isNotEmpty(classificationVertices) ? entityRetriever.getIncludedImpactedVerticesV2(toVertex, relationshipGuid) : null;
@@ -1119,7 +1119,7 @@ public abstract class DeleteHandlerV1 {
 
             if (isClassificationEdge && removePropagations) {
                 if (taskManagement != null && DEFERRED_ACTION_ENABLED) {
-                    createAndQueueTask(CLASSIFICATION_PROPAGATION_DELETE, instanceVertex, classificationVertex.getIdForDisplay(), null);
+                    createAndQueueTask(CLASSIFICATION_PROPAGATION_DELETE, instanceVertex, classificationVertex.getIdForDisplay(),getTypeName(classificationVertex) , null);
                 } else {
                     removeTagPropagation(classificationVertex);
                 }
@@ -1292,31 +1292,31 @@ public abstract class DeleteHandlerV1 {
             }
         }
     }
-    public void createAndQueueTaskWithoutCheck(String taskType, AtlasVertex entityVertex, String classificationVertexId, String relationshipGuid) throws AtlasBaseException {
+    public void createAndQueueTaskWithoutCheck(String taskType, AtlasVertex entityVertex, String classificationVertexId, String classificationName, String relationshipGuid) throws AtlasBaseException {
         String              currentUser = RequestContext.getCurrentUser();
         String              entityGuid  = GraphHelper.getGuid(entityVertex);
         Map<String, Object> taskParams  = ClassificationTask.toParameters(entityGuid, classificationVertexId, relationshipGuid);
-        AtlasTask           task        = taskManagement.createTask(taskType, currentUser, taskParams, classificationVertexId, entityGuid);
+        AtlasTask           task        = taskManagement.createTask(taskType, currentUser, taskParams, classificationVertexId, classificationName, entityGuid);
 
         AtlasGraphUtilsV2.addEncodedProperty(entityVertex, PENDING_TASKS_PROPERTY_KEY, task.getGuid());
 
         RequestContext.get().queueTask(task);
     }
 
-    public void createAndQueueTask(String taskType, AtlasVertex entityVertex, String classificationVertexId, String relationshipGuid) throws AtlasBaseException {
+    public void createAndQueueTask(String taskType, AtlasVertex entityVertex, String classificationVertexId, String classificationName, String relationshipGuid) throws AtlasBaseException {
         if (!CLASSIFICATION_PROPAGATION_DELETE.equals(taskType) && skipClassificationTaskCreation(classificationVertexId)) {
             LOG.info("Task is already scheduled for classification id {}, no need to schedule task for vertex {}", classificationVertexId, entityVertex.getIdForDisplay());
             return;
         }
 
-        createAndQueueTaskWithoutCheck(taskType, entityVertex, classificationVertexId, relationshipGuid);
+        createAndQueueTaskWithoutCheck(taskType, entityVertex, classificationVertexId, classificationName, relationshipGuid);
     }
 
-    public void createAndQueueTaskWithoutCheck(String taskType, AtlasVertex entityVertex, String classificationVertexId, String relationshipGuid, Boolean currentRestrictPropagationThroughLineage,Boolean currentRestrictPropogationThroughHierarchy) throws AtlasBaseException {
+    public void createAndQueueTaskWithoutCheck(String taskType, AtlasVertex entityVertex, String classificationVertexId,String classificationName, String relationshipGuid, Boolean currentRestrictPropagationThroughLineage,Boolean currentRestrictPropogationThroughHierarchy) throws AtlasBaseException {
         String              currentUser = RequestContext.getCurrentUser();
         String              entityGuid  = GraphHelper.getGuid(entityVertex);
         Map<String, Object> taskParams  = ClassificationTask.toParameters(entityGuid, classificationVertexId, relationshipGuid, currentRestrictPropagationThroughLineage,currentRestrictPropogationThroughHierarchy);
-        AtlasTask           task        = taskManagement.createTask(taskType, currentUser, taskParams, classificationVertexId, entityGuid);
+        AtlasTask           task        = taskManagement.createTask(taskType, currentUser, taskParams, classificationVertexId, classificationName, entityGuid);
 
         AtlasGraphUtilsV2.addEncodedProperty(entityVertex, PENDING_TASKS_PROPERTY_KEY, task.getGuid());
 
@@ -1360,6 +1360,7 @@ public abstract class DeleteHandlerV1 {
         List<AtlasVertex> currentClassificationVertices = GraphHelper.getPropagatableClassifications(edge);
         for (AtlasVertex currentClassificationVertex : currentClassificationVertices) {
             String currentClassificationId = currentClassificationVertex.getIdForDisplay();
+            String classificationName      = getTypeName(currentClassificationVertex);
             boolean removePropagationOnEntityDelete = GraphHelper.getRemovePropagations(currentClassificationVertex);
 
             if (!(isTermEntityEdge || removePropagationOnEntityDelete)) {
@@ -1373,7 +1374,7 @@ public abstract class DeleteHandlerV1 {
             }
 
             Map<String, Object> taskParams = ClassificationTask.toParameters(currentClassificationVertex.getIdForDisplay());
-            AtlasTask task  =  taskManagement.createTask(CLASSIFICATION_REFRESH_PROPAGATION, currentUser, taskParams, currentClassificationId, GraphHelper.getGuid(referenceVertex));
+            AtlasTask task  =  taskManagement.createTask(CLASSIFICATION_REFRESH_PROPAGATION, currentUser, taskParams, currentClassificationId, classificationName,GraphHelper.getGuid(referenceVertex));
 
             RequestContext.get().queueTask(task);
         }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -1292,31 +1292,31 @@ public abstract class DeleteHandlerV1 {
             }
         }
     }
-    public void createAndQueueTaskWithoutCheck(String taskType, AtlasVertex entityVertex, String classificationVertexId, String classificationName, String relationshipGuid) throws AtlasBaseException {
+    public void createAndQueueTaskWithoutCheck(String taskType, AtlasVertex entityVertex, String classificationVertexId, String classificationTypeName, String relationshipGuid) throws AtlasBaseException {
         String              currentUser = RequestContext.getCurrentUser();
         String              entityGuid  = GraphHelper.getGuid(entityVertex);
         Map<String, Object> taskParams  = ClassificationTask.toParameters(entityGuid, classificationVertexId, relationshipGuid);
-        AtlasTask           task        = taskManagement.createTask(taskType, currentUser, taskParams, classificationVertexId, classificationName, entityGuid);
+        AtlasTask           task        = taskManagement.createTask(taskType, currentUser, taskParams, classificationVertexId, classificationTypeName, entityGuid);
 
         AtlasGraphUtilsV2.addEncodedProperty(entityVertex, PENDING_TASKS_PROPERTY_KEY, task.getGuid());
 
         RequestContext.get().queueTask(task);
     }
 
-    public void createAndQueueTask(String taskType, AtlasVertex entityVertex, String classificationVertexId, String classificationName, String relationshipGuid) throws AtlasBaseException {
+    public void createAndQueueTask(String taskType, AtlasVertex entityVertex, String classificationVertexId, String classificationTypeName, String relationshipGuid) throws AtlasBaseException {
         if (!CLASSIFICATION_PROPAGATION_DELETE.equals(taskType) && skipClassificationTaskCreation(classificationVertexId)) {
             LOG.info("Task is already scheduled for classification id {}, no need to schedule task for vertex {}", classificationVertexId, entityVertex.getIdForDisplay());
             return;
         }
 
-        createAndQueueTaskWithoutCheck(taskType, entityVertex, classificationVertexId, classificationName, relationshipGuid);
+        createAndQueueTaskWithoutCheck(taskType, entityVertex, classificationVertexId, classificationTypeName, relationshipGuid);
     }
 
-    public void createAndQueueTaskWithoutCheck(String taskType, AtlasVertex entityVertex, String classificationVertexId,String classificationName, String relationshipGuid, Boolean currentRestrictPropagationThroughLineage,Boolean currentRestrictPropogationThroughHierarchy) throws AtlasBaseException {
+    public void createAndQueueTaskWithoutCheck(String taskType, AtlasVertex entityVertex, String classificationVertexId,String classificationTypeName, String relationshipGuid, Boolean currentRestrictPropagationThroughLineage,Boolean currentRestrictPropogationThroughHierarchy) throws AtlasBaseException {
         String              currentUser = RequestContext.getCurrentUser();
         String              entityGuid  = GraphHelper.getGuid(entityVertex);
         Map<String, Object> taskParams  = ClassificationTask.toParameters(entityGuid, classificationVertexId, relationshipGuid, currentRestrictPropagationThroughLineage,currentRestrictPropogationThroughHierarchy);
-        AtlasTask           task        = taskManagement.createTask(taskType, currentUser, taskParams, classificationVertexId, classificationName, entityGuid);
+        AtlasTask           task        = taskManagement.createTask(taskType, currentUser, taskParams, classificationVertexId, classificationTypeName, entityGuid);
 
         AtlasGraphUtilsV2.addEncodedProperty(entityVertex, PENDING_TASKS_PROPERTY_KEY, task.getGuid());
 
@@ -1360,7 +1360,7 @@ public abstract class DeleteHandlerV1 {
         List<AtlasVertex> currentClassificationVertices = GraphHelper.getPropagatableClassifications(edge);
         for (AtlasVertex currentClassificationVertex : currentClassificationVertices) {
             String currentClassificationId = currentClassificationVertex.getIdForDisplay();
-            String classificationName      = getTypeName(currentClassificationVertex);
+            String classificationTypeName      = getTypeName(currentClassificationVertex);
             boolean removePropagationOnEntityDelete = GraphHelper.getRemovePropagations(currentClassificationVertex);
 
             if (!(isTermEntityEdge || removePropagationOnEntityDelete)) {
@@ -1374,7 +1374,7 @@ public abstract class DeleteHandlerV1 {
             }
 
             Map<String, Object> taskParams = ClassificationTask.toParameters(currentClassificationVertex.getIdForDisplay());
-            AtlasTask task  =  taskManagement.createTask(CLASSIFICATION_REFRESH_PROPAGATION, currentUser, taskParams, currentClassificationId, classificationName,GraphHelper.getGuid(referenceVertex));
+            AtlasTask task  =  taskManagement.createTask(CLASSIFICATION_REFRESH_PROPAGATION, currentUser, taskParams, currentClassificationId, classificationTypeName,GraphHelper.getGuid(referenceVertex));
 
             RequestContext.get().queueTask(task);
         }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -189,7 +189,7 @@ public class EntityGraphMapper {
     private static final boolean RESTRICT_PROPAGATION_THROUGH_LINEAGE_DEFAULT        = false;
 
     private static final boolean RESTRICT_PROPAGATION_THROUGH_HIERARCHY_DEFAULT        = false;
-    public static final int CLEANUP_BATCH_SIZE = 2000;
+    public static final int CLEANUP_BATCH_SIZE = 200000;
     private              boolean DEFERRED_ACTION_ENABLED                             = AtlasConfiguration.TASKS_USE_ENABLED.getBoolean();
     private              boolean DIFFERENTIAL_AUDITS                                 = STORE_DIFFERENTIAL_AUDITS.getBoolean();
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -189,7 +189,7 @@ public class EntityGraphMapper {
     private static final boolean RESTRICT_PROPAGATION_THROUGH_LINEAGE_DEFAULT        = false;
 
     private static final boolean RESTRICT_PROPAGATION_THROUGH_HIERARCHY_DEFAULT        = false;
-    public static final int CLEANUP_BATCH_SIZE = 200000;
+    public static final int CLEANUP_BATCH_SIZE = 2000;
     private              boolean DEFERRED_ACTION_ENABLED                             = AtlasConfiguration.TASKS_USE_ENABLED.getBoolean();
     private              boolean DIFFERENTIAL_AUDITS                                 = STORE_DIFFERENTIAL_AUDITS.getBoolean();
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -3105,6 +3105,9 @@ public class EntityGraphMapper {
                 }
             }
             transactionInterceptHelper.intercept();
+            if(batchLimit > 0 && batchesExecuted >= batchLimit){
+                break;
+            }
             classificationVertices = GraphHelper.getClassificationVertexes(graph, classificationName, CLEANUP_BATCH_SIZE);
         }
         LOG.info("Completed cleaning up classification {}", classificationName);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -3042,7 +3042,7 @@ public class EntityGraphMapper {
             List<AtlasVertex> assetVertices = new ArrayList<>();
             int i;
             for (i = 0; i < classificationVertices.size(); i++) {
-                if(batchesExecuted >= batchLimit){
+                if(batchLimit > 0 && batchesExecuted >= batchLimit){
                     break;
                 }
                 long assetCount = GraphHelper.getAssetsCountOfClassificationVertex(classificationVertices.get(i));

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -3092,7 +3092,13 @@ public class EntityGraphMapper {
 
                 } while (offset < currentAssetsBatchSize);
 
-                tagVerticesProcessed.forEach(x -> deleteDelegate.getHandler().deleteClassificationVertex(x, true));
+                for (AtlasVertex classificationVertex : tagVerticesProcessed) {
+                    try {
+                        deleteDelegate.getHandler().deleteClassificationVertex(classificationVertex, true);
+                    } catch (IllegalStateException e) {
+                        e.printStackTrace();
+                    }
+                }
                 transactionInterceptHelper.intercept();
 
                 cleanedUpCount += currentAssetsBatchSize;

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -3220,7 +3220,7 @@ public class EntityGraphMapper {
                 if (propagateTags && taskManagement != null && DEFERRED_ACTION_ENABLED) {
                     propagateTags = false;
 
-                    createAndQueueTask(CLASSIFICATION_PROPAGATION_ADD, entityVertex, classificationVertex.getIdForDisplay());
+                    createAndQueueTask(CLASSIFICATION_PROPAGATION_ADD, entityVertex, classificationVertex.getIdForDisplay(), getTypeName(classificationVertex));
                 }
 
                 // add the attributes for the trait instance
@@ -3493,7 +3493,7 @@ public class EntityGraphMapper {
                 }
 
                 if (propagateDelete) {
-                    createAndQueueTask(CLASSIFICATION_PROPAGATION_DELETE, entityVertex, classificationVertex.getIdForDisplay());
+                    createAndQueueTask(CLASSIFICATION_PROPAGATION_DELETE, entityVertex, classificationVertex.getIdForDisplay(), classificationName);
                 }
 
                 entityVertices = new ArrayList<>();
@@ -3769,7 +3769,7 @@ public class EntityGraphMapper {
                 if (removePropagation || !updatedTagPropagation) {
                     propagationType = CLASSIFICATION_PROPAGATION_DELETE;
                 }
-                createAndQueueTask(propagationType, entityVertex, classificationVertex.getIdForDisplay(), currentRestrictPropagationThroughLineage,currentRestrictPropagationThroughHierarchy);
+                createAndQueueTask(propagationType, entityVertex, classificationVertex.getIdForDisplay(), classificationName, currentRestrictPropagationThroughLineage,currentRestrictPropagationThroughHierarchy);
                 updatedTagPropagation = null;
             }
 
@@ -4528,13 +4528,13 @@ public class EntityGraphMapper {
         attributes.put(bmAttribute.getName(), attrValue);
     }
 
-    private void createAndQueueTask(String taskType, AtlasVertex entityVertex, String classificationVertexId, Boolean currentPropagateThroughLineage, Boolean currentRestrictPropagationThroughHierarchy) throws AtlasBaseException{
+    private void createAndQueueTask(String taskType, AtlasVertex entityVertex, String classificationVertexId, String classificationName, Boolean currentPropagateThroughLineage, Boolean currentRestrictPropagationThroughHierarchy) throws AtlasBaseException{
 
-        deleteDelegate.getHandler().createAndQueueTaskWithoutCheck(taskType, entityVertex, classificationVertexId, null, currentPropagateThroughLineage,currentRestrictPropagationThroughHierarchy);
+        deleteDelegate.getHandler().createAndQueueTaskWithoutCheck(taskType, entityVertex, classificationVertexId,classificationName, null, currentPropagateThroughLineage,currentRestrictPropagationThroughHierarchy);
     }
 
-    private void createAndQueueTask(String taskType, AtlasVertex entityVertex, String classificationVertexId) throws AtlasBaseException {
-        deleteDelegate.getHandler().createAndQueueTaskWithoutCheck(taskType, entityVertex, classificationVertexId, null);
+    private void createAndQueueTask(String taskType, AtlasVertex entityVertex, String classificationVertexId, String classificationName) throws AtlasBaseException {
+        deleteDelegate.getHandler().createAndQueueTaskWithoutCheck(taskType, entityVertex, classificationVertexId, classificationName, null);
     }
 
     public void removePendingTaskFromEntity(String entityGuid, String taskGuid) throws EntityNotFoundException {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -190,7 +190,7 @@ public class EntityGraphMapper {
     private static final boolean RESTRICT_PROPAGATION_THROUGH_LINEAGE_DEFAULT        = false;
 
     private static final boolean RESTRICT_PROPAGATION_THROUGH_HIERARCHY_DEFAULT        = false;
-    public static final int CLEANUP_BATCH_SIZE = 3000;
+    public static final int CLEANUP_BATCH_SIZE = 200000;
     private              boolean DEFERRED_ACTION_ENABLED                             = AtlasConfiguration.TASKS_USE_ENABLED.getBoolean();
     private              boolean DIFFERENTIAL_AUDITS                                 = STORE_DIFFERENTIAL_AUDITS.getBoolean();
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -190,7 +190,7 @@ public class EntityGraphMapper {
     private static final boolean RESTRICT_PROPAGATION_THROUGH_LINEAGE_DEFAULT        = false;
 
     private static final boolean RESTRICT_PROPAGATION_THROUGH_HIERARCHY_DEFAULT        = false;
-    public static final int CLEANUP_BATCH_SIZE = 250;
+    public static final int CLEANUP_BATCH_SIZE = 200000;
     private              boolean DEFERRED_ACTION_ENABLED                             = AtlasConfiguration.TASKS_USE_ENABLED.getBoolean();
     private              boolean DIFFERENTIAL_AUDITS                                 = STORE_DIFFERENTIAL_AUDITS.getBoolean();
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -190,7 +190,7 @@ public class EntityGraphMapper {
     private static final boolean RESTRICT_PROPAGATION_THROUGH_LINEAGE_DEFAULT        = false;
 
     private static final boolean RESTRICT_PROPAGATION_THROUGH_HIERARCHY_DEFAULT        = false;
-    public static final int CLEANUP_BATCH_SIZE = 200000;
+    public static final int CLEANUP_BATCH_SIZE = 2000;
     private              boolean DEFERRED_ACTION_ENABLED                             = AtlasConfiguration.TASKS_USE_ENABLED.getBoolean();
     private              boolean DIFFERENTIAL_AUDITS                                 = STORE_DIFFERENTIAL_AUDITS.getBoolean();
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -190,7 +190,7 @@ public class EntityGraphMapper {
     private static final boolean RESTRICT_PROPAGATION_THROUGH_LINEAGE_DEFAULT        = false;
 
     private static final boolean RESTRICT_PROPAGATION_THROUGH_HIERARCHY_DEFAULT        = false;
-    public static final int CLEANUP_BATCH_SIZE = 200000;
+    public static final int CLEANUP_BATCH_SIZE = 250;
     private              boolean DEFERRED_ACTION_ENABLED                             = AtlasConfiguration.TASKS_USE_ENABLED.getBoolean();
     private              boolean DIFFERENTIAL_AUDITS                                 = STORE_DIFFERENTIAL_AUDITS.getBoolean();
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -3103,6 +3103,7 @@ public class EntityGraphMapper {
 
                 cleanedUpCount += currentAssetsBatchSize;
                 currentAssetVerticesBatch.clear();
+                tagVerticesProcessed.clear();
             }
             tagVertices = GraphHelper.getClassificationVertices(graph, classificationName, CLEANUP_BATCH_SIZE);
         }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -3091,7 +3091,12 @@ public class EntityGraphMapper {
         }
         // Fetch all classificationVertex by classificationName and delete them if remaining
         for (AtlasVertex classificationVertex : classificationVertices) {
-            deleteDelegate.getHandler().deleteClassificationVertex(classificationVertex, true);
+            try {
+                deleteDelegate.getHandler().deleteClassificationVertex(classificationVertex, true);
+            }
+            catch (IllegalStateException e){
+                e.printStackTrace();
+            }
         }
         transactionInterceptHelper.intercept();
         LOG.info("Completed cleaning up classification {}", classificationName);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -3046,7 +3046,7 @@ public class EntityGraphMapper {
                 return;
             }
 
-            while (tagVertices.hasNext() && currentAssetVerticesBatch.size() <= CLEANUP_BATCH_SIZE) {
+            while (tagVertices.hasNext() && currentAssetVerticesBatch.size() < CLEANUP_BATCH_SIZE) {
                 AtlasVertex tagVertex = tagVertices.next();
 
                 int availableSlots = CLEANUP_BATCH_SIZE - currentAssetVerticesBatch.size();

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -190,7 +190,7 @@ public class EntityGraphMapper {
     private static final boolean RESTRICT_PROPAGATION_THROUGH_LINEAGE_DEFAULT        = false;
 
     private static final boolean RESTRICT_PROPAGATION_THROUGH_HIERARCHY_DEFAULT        = false;
-    public static final int CLEANUP_BATCH_SIZE = 50000;
+    public static final int CLEANUP_BATCH_SIZE = 3000;
     private              boolean DEFERRED_ACTION_ENABLED                             = AtlasConfiguration.TASKS_USE_ENABLED.getBoolean();
     private              boolean DIFFERENTIAL_AUDITS                                 = STORE_DIFFERENTIAL_AUDITS.getBoolean();
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -190,7 +190,7 @@ public class EntityGraphMapper {
     private static final boolean RESTRICT_PROPAGATION_THROUGH_LINEAGE_DEFAULT        = false;
 
     private static final boolean RESTRICT_PROPAGATION_THROUGH_HIERARCHY_DEFAULT        = false;
-    public static final int CLEANUP_BATCH_SIZE = 2000;
+    public static final int CLEANUP_BATCH_SIZE = 50000;
     private              boolean DEFERRED_ACTION_ENABLED                             = AtlasConfiguration.TASKS_USE_ENABLED.getBoolean();
     private              boolean DIFFERENTIAL_AUDITS                                 = STORE_DIFFERENTIAL_AUDITS.getBoolean();
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tasks/ClassificationPropagationTasks.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tasks/ClassificationPropagationTasks.java
@@ -130,8 +130,10 @@ public class ClassificationPropagationTasks {
         @Override
         protected void run(Map<String, Object> parameters) throws AtlasBaseException {
             String            classificationName      = (String) parameters.get(PARAM_CLASSIFICATION_NAME);
-            int            batchLimit              = (int) parameters.get(PARAM_BATCH_LIMIT);
-
+            int batchLimit = -1;
+            if(parameters.containsKey(PARAM_BATCH_LIMIT)) {
+                batchLimit = (int) parameters.get(PARAM_BATCH_LIMIT);
+            }
             entityGraphMapper.cleanUpClassificationPropagation(classificationName, batchLimit);
         }
     }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tasks/ClassificationPropagationTasks.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tasks/ClassificationPropagationTasks.java
@@ -130,8 +130,9 @@ public class ClassificationPropagationTasks {
         @Override
         protected void run(Map<String, Object> parameters) throws AtlasBaseException {
             String            classificationName      = (String) parameters.get(PARAM_CLASSIFICATION_NAME);
+            int            batchLimit              = (int) parameters.get(PARAM_BATCH_LIMIT);
 
-            entityGraphMapper.cleanUpClassificationPropagation(classificationName);
+            entityGraphMapper.cleanUpClassificationPropagation(classificationName, batchLimit);
         }
     }
 }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tasks/ClassificationTask.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tasks/ClassificationTask.java
@@ -52,6 +52,7 @@ public abstract class ClassificationTask extends AbstractTask {
     public static final String PARAM_RELATIONSHIP_EDGE_ID     = "relationshipEdgeId";
 
     public static final String PARAM_CLASSIFICATION_NAME      = "classificationName";
+    public static final String PARAM_BATCH_LIMIT      = "batchLimit";
     public static final String PARAM_REFERENCED_VERTEX_ID     = "referencedVertexId";
     public static final String PARAM_IS_TERM_ENTITY_EDGE       = "isTermEntityEdge";
     public static final String PARAM_PREVIOUS_CLASSIFICATION_RESTRICT_PROPAGATE_THROUGH_LINEAGE = "previousRestrictPropagationThroughLineage";

--- a/repository/src/main/java/org/apache/atlas/tasks/AtlasTaskService.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/AtlasTaskService.java
@@ -233,6 +233,11 @@ public class AtlasTaskService implements TaskService {
         setEncodedProperty(ret, Constants.TASK_CREATED_BY, task.getCreatedBy());
         setEncodedProperty(ret, Constants.TASK_CREATED_TIME, task.getCreatedTime());
         setEncodedProperty(ret, Constants.TASK_UPDATED_TIME, task.getUpdatedTime());
+
+        if (task.getClassificationName() != null) {
+            setEncodedProperty(ret, Constants.TASK_CLASSIFICATION_NAME, task.getClassificationName());
+        }
+
         if (task.getClassificationId() != null) {
             setEncodedProperty(ret, Constants.TASK_CLASSIFICATION_ID, task.getClassificationId());
         }

--- a/repository/src/main/java/org/apache/atlas/tasks/AtlasTaskService.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/AtlasTaskService.java
@@ -148,7 +148,7 @@ public class AtlasTaskService implements TaskService {
                     throw new AtlasBaseException(AtlasErrorCode.TASK_TYPE_NOT_SUPPORTED, task.getType());
                 }
                 if (isClassificationTaskType(taskType) && !taskType.equals(ClassificationPropagateTaskFactory.CLEANUP_CLASSIFICATION_PROPAGATION)) {
-                    String classificationName = task.getClassificationName();
+                    String classificationName = task.getClassificationTypeName();
                     String entityGuid = task.getEntityGuid();
                     String classificationId = StringUtils.isEmpty(task.getClassificationId()) ? resolveAndReturnClassificationId(classificationName, entityGuid) : task.getClassificationId();
                     if (StringUtils.isEmpty(classificationId)) {
@@ -233,8 +233,8 @@ public class AtlasTaskService implements TaskService {
         setEncodedProperty(ret, Constants.TASK_CREATED_TIME, task.getCreatedTime());
         setEncodedProperty(ret, Constants.TASK_UPDATED_TIME, task.getUpdatedTime());
 
-        if (task.getClassificationName() != null) {
-            setEncodedProperty(ret, Constants.TASK_CLASSIFICATION_TYPENAME, task.getClassificationName());
+        if (task.getClassificationTypeName() != null) {
+            setEncodedProperty(ret, Constants.TASK_CLASSIFICATION_TYPENAME, task.getClassificationTypeName());
         }
 
         if (task.getClassificationId() != null) {

--- a/repository/src/main/java/org/apache/atlas/tasks/AtlasTaskService.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/AtlasTaskService.java
@@ -23,7 +23,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
-import java.lang.reflect.Field;
 import java.util.*;
 
 import static org.apache.atlas.repository.Constants.TASK_GUID;
@@ -235,7 +234,7 @@ public class AtlasTaskService implements TaskService {
         setEncodedProperty(ret, Constants.TASK_UPDATED_TIME, task.getUpdatedTime());
 
         if (task.getClassificationName() != null) {
-            setEncodedProperty(ret, Constants.TASK_CLASSIFICATION_NAME, task.getClassificationName());
+            setEncodedProperty(ret, Constants.TASK_CLASSIFICATION_TYPENAME, task.getClassificationName());
         }
 
         if (task.getClassificationId() != null) {

--- a/repository/src/main/java/org/apache/atlas/tasks/TaskExecutor.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/TaskExecutor.java
@@ -110,6 +110,7 @@ public class TaskExecutor {
             int         attemptCount;
 
             try {
+                RequestContext.get().setTraceId("task-"+task.getGuid());
                 if (task == null) {
                     TASK_LOG.info("Task not scheduled as it was not found");
                     return;

--- a/repository/src/main/java/org/apache/atlas/tasks/TaskManagement.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/TaskManagement.java
@@ -141,6 +141,10 @@ public class TaskManagement implements Service, ActiveStateChangeHandler {
         return this.registry.createVertex(taskType, createdBy, parameters, classificationId, entityGuid);
     }
 
+    public AtlasTask createTask(String taskType, String createdBy, Map<String, Object> parameters, String classificationId, String classificationName, String entityGuid) {
+        return this.registry.createVertex(taskType, createdBy, parameters, classificationId, classificationName, entityGuid);
+    }
+
     public List<AtlasTask> getAll() {
         return this.registry.getAll();
     }

--- a/repository/src/main/java/org/apache/atlas/tasks/TaskRegistry.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/TaskRegistry.java
@@ -428,9 +428,9 @@ public class TaskRegistry {
         return ret;
     }
 
-    public AtlasTask createVertex(String taskType, String createdBy, Map<String, Object> parameters, String classificationId,String classificationName, String entityGuid) {
+    public AtlasTask createVertex(String taskType, String createdBy, Map<String, Object> parameters, String classificationId,String classificationTypeName, String entityGuid) {
         AtlasTask ret = new AtlasTask(taskType, createdBy, parameters, classificationId, entityGuid);
-        ret.setClassificationName(classificationName);
+        ret.setClassificationTypeName(classificationTypeName);
         createVertex(ret);
 
         return ret;
@@ -504,7 +504,7 @@ public class TaskRegistry {
 
         String classificationName = v.getProperty(Constants.TASK_CLASSIFICATION_TYPENAME, String.class);
         if (classificationName != null) {
-            ret.setClassificationName(classificationName);
+            ret.setClassificationTypeName(classificationName);
         }
 
         String entityGuid = v.getProperty(Constants.TASK_ENTITY_GUID, String.class);

--- a/repository/src/main/java/org/apache/atlas/tasks/TaskRegistry.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/TaskRegistry.java
@@ -428,6 +428,14 @@ public class TaskRegistry {
         return ret;
     }
 
+    public AtlasTask createVertex(String taskType, String createdBy, Map<String, Object> parameters, String classificationId,String classificationName, String entityGuid) {
+        AtlasTask ret = new AtlasTask(taskType, createdBy, parameters, classificationId, entityGuid);
+        ret.setClassificationName(classificationName);
+        createVertex(ret);
+
+        return ret;
+    }
+
     private void deleteVertex(AtlasVertex taskVertex) {
         if (taskVertex == null) {
             return;

--- a/repository/src/main/java/org/apache/atlas/tasks/TaskRegistry.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/TaskRegistry.java
@@ -502,6 +502,11 @@ public class TaskRegistry {
             ret.setClassificationId(classificationId);
         }
 
+        String classificationName = v.getProperty(Constants.TASK_CLASSIFICATION_TYPENAME, String.class);
+        if (classificationName != null) {
+            ret.setClassificationName(classificationName);
+        }
+
         String entityGuid = v.getProperty(Constants.TASK_ENTITY_GUID, String.class);
         if(entityGuid != null) {
             ret.setEntityGuid(entityGuid);


### PR DESCRIPTION
## Change description

> Added pagination in Cleanup Task Logic. When fetching vertices, the list would previously grow to be so much that it caused memory overflow. Currently have set a Batch size limit to prevent this from happening.

Batch limit logic working, in screenshot batch size set is 3000 and batch limit is 2
![image](https://github.com/user-attachments/assets/741954a8-6331-4e83-bfcb-319d8d672fdc)
Basic Flow SS:
Before : 
![image](https://github.com/user-attachments/assets/8a085a50-fe1c-4d19-a29c-cab39b1c6e46)
After:
![image](https://github.com/user-attachments/assets/56ace6eb-605a-4080-8e7f-af1613f4d189)
Along with that added classificationTypeName attribute in ES for better searching and aggregation (improving debug efforts)
## Type of change
- [ ] Bug fix (fixes an issue)

## Related issues

> Fix [#1](https://atlanhq.atlassian.net/browse/DG-1726) 
> [Basic Flow](https://www.notion.so/atlanhq/Testing-for-adding-classification-TypeName-to-task-schema-2132188494094e80a155580a47f9d83a?pvs=4#ac3ae105bd064693a3d42e79dd3ae8e3)
> [TestCase for new ES attribute of classificationTypeName](https://www.notion.so/atlanhq/Testing-for-adding-classification-TypeName-to-task-schema-2132188494094e80a155580a47f9d83a?pvs=4#3d794038c0fc401eaae6e16ed32dca6e)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
