### PR TITLE
DISC-392 : add persona field in request metadata and in searchlog

### DIFF
--- a/intg/src/main/java/org/apache/atlas/model/discovery/SearchParams.java
+++ b/intg/src/main/java/org/apache/atlas/model/discovery/SearchParams.java
@@ -124,6 +124,10 @@ public class SearchParams {
         return requestMetadata;
     }
 
+    public String getRequestMetadataPersona() {
+        return requestMetadata.getPersona();
+    }
+
     public void setRequestMetadata(RequestMetadata requestMetadata) {
         this.requestMetadata = requestMetadata;
     }
@@ -170,6 +174,8 @@ public class SearchParams {
         private Set<String> utmTags;
         private boolean saveSearchLog;
 
+        private String persona;
+
         public String getSearchInput() {
             return searchInput;
         }
@@ -192,6 +198,14 @@ public class SearchParams {
 
         public void setSaveSearchLog(boolean saveSearchLog) {
             this.saveSearchLog = saveSearchLog;
+        }
+
+        public String getPersona() {
+            return persona;
+        }
+
+        public void setPersona(String persona) {
+            this.persona = persona;
         }
     }
 

--- a/webapp/src/main/java/org/apache/atlas/web/rest/DiscoveryREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/DiscoveryREST.java
@@ -972,8 +972,9 @@ public class DiscoveryREST {
     private void logSearchLog(IndexSearchParams parameters, HttpServletRequest servletRequest,
                               SearchRequestLogDataBuilder builder, long requestTime) {
 
-        if (StringUtils.isNotEmpty(parameters.getPersona())) {
-            builder.setPersona(parameters.getPersona());
+        String persona = StringUtils.isNotEmpty(parameters.getPersona()) ? parameters.getPersona() : parameters.getRequestMetadataPersona();
+        if (StringUtils.isNotEmpty(persona)) {
+            builder.setPersona(persona);
         } else {
             builder.setPurpose(parameters.getPurpose());
         }


### PR DESCRIPTION
## DISC-392 : add persona field in request metadata and in searchlog

> When a user searches for a persona from the discovery page, we log that information in the search log. However, when the user searches for a persona from other places, such as the assets info sidebar, we cannot log the persona in the search log as we are not directly querying on persona alias. This causes us to miss out on overall persona-level search log analysis.
We can make a minimal change to the search log storage logic. If the user does not perform an index search on the persona alias but passes the persona name in the request metadata, we can store the persona information in the search log as is.

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> Fix [https://atlanhq.atlassian.net/browse/DISC-392](Add persona field in request metadata to track in searchlog) 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
