### PR TITLE
Audit listener npe fix for SSB

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/audit/EntityAuditListenerV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/EntityAuditListenerV2.java
@@ -871,6 +871,13 @@ public class EntityAuditListenerV2 implements EntityChangeListenerV2 {
         }
 
         for (AtlasClassification classification : classifications) {
+            if(Objects.isNull(entity) ||
+                    Objects.isNull(classification) ||
+                    Objects.isNull(entity.getGuid()) ||
+                    Objects.isNull(classification.getEntityGuid())) {
+                LOG.info("Probable NPE prevented : Entity {}, classification : {}, entity : {}, entity.Guid : {}, classification.getEntityGuid : {}");
+                continue;
+            }
             if (entity.getGuid().equals(classification.getEntityGuid())) {
                 entityClassifications.computeIfAbsent(entity, key -> new ArrayList<>()).add(getDeleteClassificationMap(classification.getTypeName()));
             } else {

--- a/repository/src/main/java/org/apache/atlas/repository/converters/AtlasInstanceConverter.java
+++ b/repository/src/main/java/org/apache/atlas/repository/converters/AtlasInstanceConverter.java
@@ -52,12 +52,7 @@ import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @Singleton
 @Component
@@ -332,7 +327,7 @@ public class AtlasInstanceConverter {
         } else {
             entity = entityGraphRetriever.toAtlasEntity(guid);
         }
-        return entity;
+        return Objects.isNull(entity)?new AtlasEntity() : entity;
     }
 
 


### PR DESCRIPTION
## Change description

> AuditListner is facing a NPE when cleaning up SSB's tag. Added a fix for that, which skips audit for a null entity or null classification vertex

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
