### PR TITLE
PLT-2568 Enable gzip filter for api response compression

### DIFF
--- a/webapp/src/main/java/org/apache/atlas/web/filters/GzipCompressionFilter.java
+++ b/webapp/src/main/java/org/apache/atlas/web/filters/GzipCompressionFilter.java
@@ -1,0 +1,35 @@
+package org.apache.atlas.web.filters;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.zip.GZIPOutputStream;
+
+public class GzipCompressionFilter implements Filter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GzipCompressionFilter.class);
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        LOG.info("GzipCompressionFilter initialized");
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+
+        if (httpResponse.getHeader("Content-Encoding") == null) {
+            GzipResponseWrapper gzipResponseWrapper = new GzipResponseWrapper(httpResponse);
+            chain.doFilter(request, gzipResponseWrapper);
+            gzipResponseWrapper.close();
+        } else {
+            chain.doFilter(request, response);
+        }
+    }
+
+    @Override
+    public void destroy() {
+        
+    }
+}

--- a/webapp/src/main/java/org/apache/atlas/web/filters/GzipResponseWrapper.java
+++ b/webapp/src/main/java/org/apache/atlas/web/filters/GzipResponseWrapper.java
@@ -1,0 +1,76 @@
+package org.apache.atlas.web.filters;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.WriteListener;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.zip.GZIPOutputStream;
+
+public class GzipResponseWrapper extends HttpServletResponseWrapper {
+
+    private GZIPServletOutputStream gzipOutputStream;
+    private ServletOutputStream outputStream;
+
+    public GzipResponseWrapper(HttpServletResponse response) throws IOException {
+        super(response);
+    }
+
+    @Override
+    public ServletOutputStream getOutputStream() throws IOException {
+        if (gzipOutputStream == null) {
+            outputStream = super.getOutputStream();
+            gzipOutputStream = new GZIPServletOutputStream(outputStream);
+        }
+        return gzipOutputStream;
+    }
+
+    @Override
+    public void setContentLength(int len) {
+        // Ignore, since content length may change after compression
+    }
+
+    public void close() throws IOException {
+        if (gzipOutputStream != null) {
+            gzipOutputStream.finish();
+        }
+    }
+
+    private class GZIPServletOutputStream extends ServletOutputStream {
+        private final GZIPOutputStream gzipStream;
+
+        public GZIPServletOutputStream(OutputStream output) throws IOException {
+            this.gzipStream = new GZIPOutputStream(output);
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            gzipStream.write(b);
+        }
+
+        @Override
+        public void flush() throws IOException {
+            gzipStream.flush();
+        }
+
+        @Override
+        public void close() throws IOException {
+            gzipStream.close();
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void setWriteListener(WriteListener listener) {
+            // Not needed for older Spring versions
+        }
+
+        public void finish() throws IOException {
+            gzipStream.finish();
+        }
+    }
+}

--- a/webapp/src/main/webapp/WEB-INF/web.xml
+++ b/webapp/src/main/webapp/WEB-INF/web.xml
@@ -114,6 +114,17 @@
         <url-pattern>/api/atlas/admin/status</url-pattern>
     </filter-mapping>
 
+
+    <filter>
+        <filter-name>gzipFilter</filter-name>
+        <filter-class>org.apache.atlas.web.filters.GzipCompressionFilter</filter-class>
+    </filter>
+
+    <filter-mapping>
+        <filter-name>gzipFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
     <listener>
         <listener-class>org.springframework.web.context.request.RequestContextListener</listener-class>
     </listener>


### PR DESCRIPTION
[PLT-2568
](https://atlanhq.atlassian.net/browse/PLT-2568)## Enable GZIP for all API (Intended for Lineage API but all endpoints would get affected but should not break)

Add a GZIP filter that should compress the API response for all endpoints. 
Should have NO functional impact

## Performance
- [x] Improve API performance(compression)

## Related issues
NA

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
