### PR TITLE
PES-3306 Added try catches for where illegalStateExceptions could and are occuring.

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -376,7 +376,7 @@ public abstract class DeleteHandlerV1 {
             try {
                 deleteTypeVertex(vertexForDelete, typeCategory, forceDelete);
             }
-            catch (IllegalStateException e){
+            catch (IllegalStateException | AtlasBaseException e){
                 e.printStackTrace();
             }
         } else {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -373,7 +373,12 @@ public abstract class DeleteHandlerV1 {
 
             //If deleting the edge and then the in vertex, reverse attribute shouldn't be updated
             deleteEdge(edge, false, forceDelete);
-            deleteTypeVertex(vertexForDelete, typeCategory, forceDelete);
+            try {
+                deleteTypeVertex(vertexForDelete, typeCategory, forceDelete);
+            }
+            catch (IllegalStateException e){
+                e.printStackTrace();
+            }
         } else {
             //If the vertex is of type class, and its not a composite attributes, the reference AtlasVertex' lifecycle is not controlled
             //through this delete. Hence just remove the reference edge. Leave the reference AtlasVertex as is

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -3066,9 +3066,14 @@ public class EntityGraphMapper {
                             List<AtlasClassification> deletedClassifications = new ArrayList<>();
                             List<AtlasEdge> classificationEdges = GraphHelper.getClassificationEdges(vertex, null, classificationName);
                             for (AtlasEdge edge : classificationEdges) {
-                                AtlasClassification classification = entityRetriever.toAtlasClassification(edge.getInVertex());
-                                deletedClassifications.add(classification);
-                                deleteDelegate.getHandler().deleteEdgeReference(edge, TypeCategory.CLASSIFICATION, false, true, null, vertex);
+                                try {
+                                    AtlasClassification classification = entityRetriever.toAtlasClassification(edge.getInVertex());
+                                    deletedClassifications.add(classification);
+                                    deleteDelegate.getHandler().deleteEdgeReference(edge, TypeCategory.CLASSIFICATION, false, true, null, vertex);
+                                }
+                                catch (IllegalStateException e){
+                                    e.printStackTrace();
+                                }
                             }
 
                             AtlasEntity entity = repairClassificationMappings(vertex);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -3071,7 +3071,7 @@ public class EntityGraphMapper {
                                     deletedClassifications.add(classification);
                                     deleteDelegate.getHandler().deleteEdgeReference(edge, TypeCategory.CLASSIFICATION, false, true, null, vertex);
                                 }
-                                catch (IllegalStateException e){
+                                catch (IllegalStateException | AtlasBaseException e){
                                     e.printStackTrace();
                                 }
                             }


### PR DESCRIPTION
## Change description

> While running cleanup, got IllegalstateExceptions due to a classification vertex having been deleted but being referenced by an asset vertex. Incase of illegal state exception, we are ignoring that particular classification vertex, as done previously in other similar cases in this flow.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
