### PR TITLE
DG-1847 Added try catch to repairClassificationMappings for java.lang.Illegal…

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -3018,7 +3018,7 @@ public class EntityGraphMapper {
     }
 
 
-    public void cleanUpClassificationPropagation(String classificationName, int batchLimit) throws AtlasBaseException {
+    public void cleanUpClassificationPropagation(String classificationName, int batchLimit) {
         int CLEANUP_MAX = batchLimit <= 0 ? CLEANUP_BATCH_SIZE : batchLimit * CLEANUP_BATCH_SIZE;
         int cleanedUpCount = 0;
         final int CHUNK_SIZE_TEMP = 50;
@@ -3070,9 +3070,13 @@ public class EntityGraphMapper {
                                 }
                             }
 
-                            AtlasEntity entity = repairClassificationMappings(vertex);
+                            try {
+                                AtlasEntity entity = repairClassificationMappings(vertex);
+                                entityChangeNotifier.onClassificationDeletedFromEntity(entity, deletedClassifications);
+                            } catch (IllegalStateException | AtlasBaseException e) {
+                                e.printStackTrace();
+                            }
 
-                            entityChangeNotifier.onClassificationDeletedFromEntity(entity, deletedClassifications);
                         }
 
                         transactionInterceptHelper.intercept();


### PR DESCRIPTION
…StateException: Vertex with id [] was removed.

## Change description

> While running cleanup , repairClassificationMappings is throwing `java.lang.IllegalStateException: Vertex with id 4839538712 was removed.` Fixed that with surrounding with try/catch for this.

## Type of change
- [ ] Bug fix (fixes an issue)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
