### PR TITLE
DG-1831 Add Metric log to calculate hasEdges impact

### DIFF
--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusVertex.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusVertex.java
@@ -22,12 +22,14 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.stream.StreamSupport;
 
+import org.apache.atlas.RequestContext;
 import org.apache.atlas.repository.graphdb.AtlasEdge;
 import org.apache.atlas.repository.graphdb.AtlasEdgeDirection;
 import org.apache.atlas.repository.graphdb.AtlasSchemaViolationException;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
 import org.apache.atlas.repository.graphdb.AtlasVertexQuery;
 import org.apache.atlas.repository.graphdb.utils.IteratorToIterableAdapter;
+import org.apache.atlas.utils.AtlasPerfMetrics;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
@@ -90,9 +92,14 @@ public class AtlasJanusVertex extends AtlasJanusElement<Vertex> implements Atlas
 
     @Override
     public boolean hasEdges(AtlasEdgeDirection dir, String edgeLabel) {
-        Direction      direction = AtlasJanusObjectFactory.createDirection(dir);
-        Iterator<Edge> edges     = getWrappedElement().edges(direction, edgeLabel);
-        return edges.hasNext();
+        AtlasPerfMetrics.MetricRecorder recorder = RequestContext.get().startMetricRecord("hasEdges");
+        try {
+            Direction      direction = AtlasJanusObjectFactory.createDirection(dir);
+            Iterator<Edge> edges     = getWrappedElement().edges(direction, edgeLabel);
+            return edges.hasNext();
+        } finally {
+            RequestContext.get().endMetricRecord(recorder);
+        }
     }
 
     private JanusGraphVertex getAsJanusVertex() {


### PR DESCRIPTION
## Change description
Add Metric loggings to calculate hasEdges & getEdgeBetweenVertices impact


## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> https://atlanhq.atlassian.net/browse/DG-1831

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
