### PR TITLE
DG-1854 : Optimize tag fetching using denormalized attributes during authz check

### DIFF
--- a/authorization/src/main/java/org/apache/atlas/authorize/AtlasAccessRequest.java
+++ b/authorization/src/main/java/org/apache/atlas/authorize/AtlasAccessRequest.java
@@ -23,6 +23,7 @@ import org.apache.atlas.type.AtlasClassificationType;
 import org.apache.atlas.type.AtlasEntityType;
 import org.apache.atlas.type.AtlasStructType.AtlasAttribute;
 import org.apache.atlas.type.AtlasTypeRegistry;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,6 +34,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 
 public class AtlasAccessRequest {
     private static Logger LOG = LoggerFactory.getLogger(AtlasAccessRequest.class);
@@ -176,7 +179,7 @@ public class AtlasAccessRequest {
         return ret == null ? "" : ret.toString();
     }
 
-    public Set<AtlasClassification> getClassificationNames(AtlasEntityHeader entity) {
+    public Set<AtlasClassification> getClassifications(AtlasEntityHeader entity) {
         final Set<AtlasClassification> ret;
 
         if (entity == null || entity.getClassifications() == null) {
@@ -188,7 +191,19 @@ public class AtlasAccessRequest {
                 ret.add(classification);
             }
         }
+        return ret;
+    }
 
+    public Set<AtlasClassification> getClassificationNames(AtlasEntityHeader entity) {
+        final Set<AtlasClassification> ret = new HashSet<>();
+        List<String> classificationNames = entity.getClassificationNames();
+        if(CollectionUtils.isEmpty(classificationNames))
+            return ret;
+
+        classificationNames = new ArrayList<>(new LinkedHashSet<>(classificationNames));
+        for (String classificationName : classificationNames) {
+            ret.add(new AtlasClassification(classificationName));
+        }
         return ret;
     }
 

--- a/authorization/src/main/java/org/apache/atlas/authorize/AtlasAccessRequest.java
+++ b/authorization/src/main/java/org/apache/atlas/authorize/AtlasAccessRequest.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
+import java.util.stream.Collectors;
 
 public class AtlasAccessRequest {
     private static Logger LOG = LoggerFactory.getLogger(AtlasAccessRequest.class);
@@ -180,31 +181,19 @@ public class AtlasAccessRequest {
     }
 
     public Set<AtlasClassification> getClassifications(AtlasEntityHeader entity) {
-        final Set<AtlasClassification> ret;
-
-        if (entity == null || entity.getClassifications() == null) {
-            ret = Collections.emptySet();
-        } else {
-            ret = new HashSet<>();
-
-            for (AtlasClassification classification : entity.getClassifications()) {
-                ret.add(classification);
-            }
+        if (CollectionUtils.isNotEmpty(entity.getClassifications())) {
+            return new HashSet<>(entity.getClassifications());
         }
-        return ret;
-    }
 
-    public Set<AtlasClassification> getClassificationsFromNames(AtlasEntityHeader entity) {
-        final Set<AtlasClassification> ret = new HashSet<>();
         List<String> classificationNames = entity.getClassificationNames();
-        if(CollectionUtils.isEmpty(classificationNames))
-            return ret;
-
-        classificationNames = new ArrayList<>(new LinkedHashSet<>(classificationNames));
-        for (String classificationName : classificationNames) {
-            ret.add(new AtlasClassification(classificationName));
+        if (CollectionUtils.isEmpty(classificationNames)) {
+            return new HashSet<>();
         }
-        return ret;
+        // Create new classification objects with name using stream filter
+        return classificationNames.stream()
+                .distinct()
+                .map(AtlasClassification::new)
+                .collect(Collectors.toSet());
     }
 
     @Override

--- a/authorization/src/main/java/org/apache/atlas/authorize/AtlasAccessRequest.java
+++ b/authorization/src/main/java/org/apache/atlas/authorize/AtlasAccessRequest.java
@@ -194,7 +194,7 @@ public class AtlasAccessRequest {
         return ret;
     }
 
-    public Set<AtlasClassification> getClassificationNames(AtlasEntityHeader entity) {
+    public Set<AtlasClassification> getClassificationsFromNames(AtlasEntityHeader entity) {
         final Set<AtlasClassification> ret = new HashSet<>();
         List<String> classificationNames = entity.getClassificationNames();
         if(CollectionUtils.isEmpty(classificationNames))

--- a/authorization/src/main/java/org/apache/atlas/authorize/AtlasEntityAccessRequest.java
+++ b/authorization/src/main/java/org/apache/atlas/authorize/AtlasEntityAccessRequest.java
@@ -82,7 +82,7 @@ public class AtlasEntityAccessRequest extends AtlasAccessRequest {
         this.businessMetadata      = businessMetadata;
         this.attributeName         = attributeName;
         this.typeRegistry          = typeRegistry;
-        this.entityClassifications = super.getClassificationNames(entity);
+        this.entityClassifications = super.getClassifications(entity);
         this.auditEnabled = auditEnabled;
     }
 

--- a/authorization/src/main/java/org/apache/atlas/authorize/AtlasRelationshipAccessRequest.java
+++ b/authorization/src/main/java/org/apache/atlas/authorize/AtlasRelationshipAccessRequest.java
@@ -62,7 +62,7 @@ public class AtlasRelationshipAccessRequest extends AtlasAccessRequest {
     }
 
     public Set<AtlasClassification> getEnd1EntityClassifications() {
-        return super.getClassificationNames(end1Entity);
+        return super.getClassificationsFromNames(end1Entity);
     }
 
     public String getEnd1EntityId() {
@@ -74,7 +74,7 @@ public class AtlasRelationshipAccessRequest extends AtlasAccessRequest {
     }
 
     public Set<AtlasClassification> getEnd2EntityClassifications() {
-        return super.getClassificationNames(end2Entity);
+        return super.getClassificationsFromNames(end2Entity);
     }
 
     public String getEnd2EntityId() {

--- a/authorization/src/main/java/org/apache/atlas/authorize/AtlasRelationshipAccessRequest.java
+++ b/authorization/src/main/java/org/apache/atlas/authorize/AtlasRelationshipAccessRequest.java
@@ -62,7 +62,7 @@ public class AtlasRelationshipAccessRequest extends AtlasAccessRequest {
     }
 
     public Set<AtlasClassification> getEnd1EntityClassifications() {
-        return super.getClassificationsFromNames(end1Entity);
+        return super.getClassifications(end1Entity);
     }
 
     public String getEnd1EntityId() {
@@ -74,7 +74,7 @@ public class AtlasRelationshipAccessRequest extends AtlasAccessRequest {
     }
 
     public Set<AtlasClassification> getEnd2EntityClassifications() {
-        return super.getClassificationsFromNames(end2Entity);
+        return super.getClassifications(end2Entity);
     }
 
     public String getEnd2EntityId() {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -520,9 +520,10 @@ public abstract class DeleteHandlerV1 {
         if (relationshipDef == null) {
             return;
         }
+        RequestContext.get().setIncludeClassificationNames(true);
 
-        end1Entity = entityRetriever.toAtlasEntityHeaderWithClassifications(edge.getOutVertex());
-        end2Entity = entityRetriever.toAtlasEntityHeaderWithClassifications(edge.getInVertex());
+        end1Entity = entityRetriever.toAtlasEntityHeader(edge.getOutVertex());
+        end2Entity = entityRetriever.toAtlasEntityHeader(edge.getInVertex());
 
         AtlasAuthorizationUtils.verifyAccess(new AtlasRelationshipAccessRequest(typeRegistry, AtlasPrivilege.RELATIONSHIP_REMOVE, relationShipType, end1Entity, end2Entity ));
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -520,7 +520,6 @@ public abstract class DeleteHandlerV1 {
         if (relationshipDef == null) {
             return;
         }
-        RequestContext.get().setIncludeClassificationNames(true);
 
         end1Entity = entityRetriever.toAtlasEntityHeader(edge.getOutVertex());
         end2Entity = entityRetriever.toAtlasEntityHeader(edge.getInVertex());

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -375,7 +375,7 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
     @Override
     @GraphTransaction
     public AtlasEntityHeader getAtlasEntityHeaderWithoutAuthorization(String guid, String qualifiedName, String typeName) throws AtlasBaseException {
-        return extractEntityHeader( guid,  qualifiedName,  typeName);
+        return extractEntityHeader( guid,  qualifiedName,  typeName, false);
     }
 
     @Override
@@ -2253,8 +2253,8 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
                     case RELATIONSHIP_ADD:
                     case RELATIONSHIP_UPDATE:
                     case RELATIONSHIP_REMOVE:
-                        AtlasEntityHeader end1EntityHeader = extractEntityHeader(accessorRequest.getEntityGuidEnd1(), accessorRequest.getEntityQualifiedNameEnd1(), accessorRequest.getEntityTypeEnd1());
-                        AtlasEntityHeader end2EntityHeader = extractEntityHeader(accessorRequest.getEntityGuidEnd2(), accessorRequest.getEntityQualifiedNameEnd2(), accessorRequest.getEntityTypeEnd2());
+                        AtlasEntityHeader end1EntityHeader = extractEntityHeader(accessorRequest.getEntityGuidEnd1(), accessorRequest.getEntityQualifiedNameEnd1(), accessorRequest.getEntityTypeEnd1(), true);
+                        AtlasEntityHeader end2EntityHeader = extractEntityHeader(accessorRequest.getEntityGuidEnd2(), accessorRequest.getEntityQualifiedNameEnd2(), accessorRequest.getEntityTypeEnd2(), true);
 
                         AtlasRelationshipAccessRequest relAccessRequest = new AtlasRelationshipAccessRequest(typeRegistry,
                                 action, accessorRequest.getRelationshipTypeName(), end1EntityHeader, end2EntityHeader);
@@ -2294,16 +2294,19 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
     }
 
     private AtlasEntityAccessRequestBuilder getEntityAccessRequest(AtlasAccessorRequest element, AtlasPrivilege action) throws AtlasBaseException {
-        AtlasEntityHeader entityHeader = extractEntityHeader(element.getGuid(), element.getQualifiedName(), element.getTypeName());
+        AtlasEntityHeader entityHeader = extractEntityHeader(element.getGuid(), element.getQualifiedName(), element.getTypeName(), false);
 
         return new AtlasEntityAccessRequestBuilder(typeRegistry, action, entityHeader);
     }
 
-    private AtlasEntityHeader extractEntityHeader(String guid, String qualifiedName, String typeName) throws AtlasBaseException {
+    private AtlasEntityHeader extractEntityHeader(String guid, String qualifiedName, String typeName, boolean useClassificationsNames) throws AtlasBaseException {
         AtlasEntityHeader entityHeader = null;
+        RequestContext.get().setIncludeClassificationNames(useClassificationsNames);
 
         if (StringUtils.isNotEmpty(guid)) {
-            entityHeader = entityRetriever.toAtlasEntityHeaderWithClassifications(guid);
+            entityHeader = useClassificationsNames ?
+                    entityRetriever.toAtlasEntityHeader(guid) :
+                    entityRetriever.toAtlasEntityHeaderWithClassifications(guid);
 
         } else {
             AtlasEntityType entityType = typeRegistry.getEntityTypeByName(typeName);
@@ -2313,7 +2316,9 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
                     uniqueAttrs.put(QUALIFIED_NAME, qualifiedName);
 
                     AtlasVertex vertex = AtlasGraphUtilsV2.getVertexByUniqueAttributes(this.graph, entityType, uniqueAttrs);
-                    entityHeader = entityRetriever.toAtlasEntityHeaderWithClassifications(vertex);
+                    entityHeader = useClassificationsNames ?
+                            entityRetriever.toAtlasEntityHeader(vertex) :
+                            entityRetriever.toAtlasEntityHeaderWithClassifications(vertex);
 
                 } catch (AtlasBaseException abe) {
                     if (abe.getAtlasErrorCode() != AtlasErrorCode.INSTANCE_BY_UNIQUE_ATTRIBUTE_NOT_FOUND) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -2301,7 +2301,6 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
 
     private AtlasEntityHeader extractEntityHeader(String guid, String qualifiedName, String typeName, boolean useClassificationsNames) throws AtlasBaseException {
         AtlasEntityHeader entityHeader = null;
-        RequestContext.get().setIncludeClassificationNames(useClassificationsNames);
 
         if (StringUtils.isNotEmpty(guid)) {
             entityHeader = useClassificationsNames ?

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasRelationshipStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasRelationshipStoreV2.java
@@ -476,8 +476,8 @@ public class AtlasRelationshipStoreV2 implements AtlasRelationshipStore {
             AtlasRelationshipType relationType = typeRegistry.getRelationshipTypeByName(relationship.getTypeName());
 
 
-            AtlasEntityHeader end1Entity = entityRetriever.toAtlasEntityHeaderWithClassifications(end1Vertex);
-            AtlasEntityHeader end2Entity = entityRetriever.toAtlasEntityHeaderWithClassifications(end2Vertex);
+            AtlasEntityHeader end1Entity = entityRetriever.toAtlasEntityHeader(end1Vertex);
+            AtlasEntityHeader end2Entity = entityRetriever.toAtlasEntityHeader(end2Vertex);
 
             AtlasAuthorizationUtils.verifyAccess(new AtlasRelationshipAccessRequest(typeRegistry, AtlasPrivilege.RELATIONSHIP_ADD,
                                                                                         relationship.getTypeName(), end1Entity, end2Entity));
@@ -532,8 +532,8 @@ public class AtlasRelationshipStoreV2 implements AtlasRelationshipStore {
         AtlasRelationshipType relationType = typeRegistry.getRelationshipTypeByName(relationship.getTypeName());
         AtlasVertex           end1Vertex   = relationshipEdge.getOutVertex();
         AtlasVertex           end2Vertex   = relationshipEdge.getInVertex();
-        AtlasEntityHeader     end1Entity   = entityRetriever.toAtlasEntityHeaderWithClassifications(end1Vertex);
-        AtlasEntityHeader     end2Entity   = entityRetriever.toAtlasEntityHeaderWithClassifications(end2Vertex);
+        AtlasEntityHeader     end1Entity   = entityRetriever.toAtlasEntityHeader(end1Vertex);
+        AtlasEntityHeader     end2Entity   = entityRetriever.toAtlasEntityHeader(end2Vertex);
 
         AtlasAuthorizationUtils.verifyAccess(new AtlasRelationshipAccessRequest(typeRegistry, AtlasPrivilege.RELATIONSHIP_UPDATE, relationship.getTypeName(), end1Entity, end2Entity));
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/AuthPolicyPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/AuthPolicyPreProcessor.java
@@ -1,4 +1,4 @@
-/**
+    /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/AuthPolicyPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/AuthPolicyPreProcessor.java
@@ -1,4 +1,4 @@
-    /**
+/**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information


### PR DESCRIPTION
## Optimize tag fetching using denormalized attributes during authz check

> Customer Workiva is facing an issue during remove relations authorisations check where it is spending most of its time fetching tags so updated the logic to use the denormalized attrs `__traitNames` and `__propagatedTraitNames` to form the classifications as for authz nly typename is needed

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Enhancement

## Related issues

> Fix [workiva | Quicksight wf failing with deadline exceeded in bulk-delete step](https://atlanhq.atlassian.net/browse/MM-3667) 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
