### PR TITLE
PLT-2622 : Upgrade zookepeer to 3.5.5 from 3.4.6 to fix zookeper-jute unavailable during build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -775,7 +775,7 @@
         <testng.version>6.9.4</testng.version>
         <tinkerpop.version>3.5.1</tinkerpop.version>
         <woodstox-core.version>5.0.3</woodstox-core.version>
-        <zookeeper.version>3.4.6</zookeeper.version>
+        <zookeeper.version>3.5.5</zookeeper.version>
         <redis.client.version>3.20.1</redis.client.version>
         <micrometer.version>1.11.1</micrometer.version>
         <netty4.version>4.1.61.Final</netty4.version>


### PR DESCRIPTION
## feat: Upgrade zookepeer to 3.5.5 from 3.4.6 to fix zookeper-jute unavailable during build

> Right now all the metastore build is failing with error Failed to execute goal on project atlas-graphdb-janus: Could not resolve dependencies for project org.apache.atlas:atlas-graphdb-janus:jar:3.0.0-SNAPSHOT: Could not find artifact org.apache.zookeeper:zookeeper-jute:jar:3.4.6 in central ([Central Repository:](https://repo1.maven.org/maven2) ) -> [Help 1] realised that right now zookeeper-jute:jar:3.4.6 doesn’t exist in central maven repo.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [Metastore build failing with Could not find artifact org.apache.zookeeper:zookeeper-jute:jar:3.4.6](https://atlanhq.atlassian.net/browse/PLT-2622) 

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
