### PR TITLE
DG-1851 Fix : classificationEdge count causing statement overflow in CQL in Cassandra while running tag-cleanup-task

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -171,7 +171,7 @@ public class EntityGraphMapper {
 
     private static final boolean RESTRICT_PROPAGATION_THROUGH_HIERARCHY_DEFAULT        = false;
     public static final int CLEANUP_BATCH_SIZE = 200000;
-    public static final int CLASSIFICATION_EDGE_BATCH_LIMIT = 10000;
+    public static final int CLASSIFICATION_EDGE_BATCH_LIMIT = 100;
     private              boolean DEFERRED_ACTION_ENABLED                             = AtlasConfiguration.TASKS_USE_ENABLED.getBoolean();
     private              boolean DIFFERENTIAL_AUDITS                                 = STORE_DIFFERENTIAL_AUDITS.getBoolean();
 
@@ -3073,14 +3073,14 @@ public class EntityGraphMapper {
                                         e.printStackTrace();
                                     }
                                 }
+                                transactionInterceptHelper.intercept();
 
-                                try {
-                                    AtlasEntity entity = repairClassificationMappings(vertex);
-                                    entityChangeNotifier.onClassificationDeletedFromEntity(entity, deletedClassifications);
-                                } catch (IllegalStateException | AtlasBaseException e) {
-                                    e.printStackTrace();
-                                }
-
+                            }
+                            try {
+                                AtlasEntity entity = repairClassificationMappings(vertex);
+                                entityChangeNotifier.onClassificationDeletedFromEntity(entity, deletedClassifications);
+                            } catch (IllegalStateException | AtlasBaseException e) {
+                                e.printStackTrace();
                             }
 
                             transactionInterceptHelper.intercept();

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -3052,10 +3052,9 @@ public class EntityGraphMapper {
                     try {
                         int toIndex = Math.min((offset + CHUNK_SIZE), currentAssetsBatchSize);
                         List<AtlasVertex> entityVertices = currentAssetVerticesBatch.subList(offset, toIndex);
-                        List<String> impactedGuids = entityVertices.stream().map(GraphHelper::getGuid).collect(Collectors.toList());
-                        GraphTransactionInterceptor.lockObjectAndReleasePostCommit(impactedGuids);
                         for (AtlasVertex vertex : entityVertices) {
                             List<AtlasClassification> deletedClassifications = new ArrayList<>();
+                            GraphTransactionInterceptor.lockObjectAndReleasePostCommit(graphHelper.getGuid(vertex));
                             List<AtlasEdge> classificationEdges = GraphHelper.getClassificationEdges(vertex, null, classificationName);
                             classificationEdgeCount += classificationEdges.size();
                             int batchSize = CHUNK_SIZE;
@@ -3074,7 +3073,6 @@ public class EntityGraphMapper {
                                 }
                                 if(classificationEdgeInMemoryCount >= CHUNK_SIZE){
                                     transactionInterceptHelper.intercept();
-                                    GraphTransactionInterceptor.lockObjectAndReleasePostCommit(impactedGuids);
                                     classificationEdgeInMemoryCount = 0;
                                 }
                             }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -3074,6 +3074,7 @@ public class EntityGraphMapper {
                                 }
                                 if(classificationEdgeInMemoryCount >= CHUNK_SIZE){
                                     transactionInterceptHelper.intercept();
+                                    GraphTransactionInterceptor.lockObjectAndReleasePostCommit(impactedGuids);
                                     classificationEdgeInMemoryCount = 0;
                                 }
                             }


### PR DESCRIPTION
## Change description

> No pagination on number classificationEdges being get from asset vertex was causing 65535+ CQL statements to be commited at once into cassandra, which was failing the tag-cleanup-task. Added pagination for this.

# Screenshots
Before : 
![image](https://github.com/user-attachments/assets/fe56577d-8808-49af-8c2a-b5a6718edbe0)
After : 
Ran cleanup with 78999 classificationedges
![image](https://github.com/user-attachments/assets/1868ac65-6166-4d48-8a76-0b6ffc49966a)
![image](https://github.com/user-attachments/assets/3702b3c1-2bf6-4b93-a81e-f4b7dfb24ae5)
![image](https://github.com/user-attachments/assets/0419a656-be93-4c63-b3b7-2ca49fd51da0)
![image](https://github.com/user-attachments/assets/515f0e81-2fc8-4bd9-a531-b221ad624b5c)
Finally : 
![image](https://github.com/user-attachments/assets/2554d4ea-3f32-4922-a649-0814d53e3f44)
![image](https://github.com/user-attachments/assets/56fea781-05df-4596-b693-6e277f6826ad)

# TestCase : 150 edges 1 asset
<img width="624" alt="image" src="https://github.com/user-attachments/assets/5ed22126-8820-4f2e-9617-f2ba6bfb83a4">
<img width="417" alt="image" src="https://github.com/user-attachments/assets/bef6c672-a0a3-4184-9e42-3f55fab68206">

# TestCase : 75edges per asset. 2 asset thus 150 edges total
<img width="584" alt="image" src="https://github.com/user-attachments/assets/1acfdf81-6538-4953-9928-887ded06b4cc">
<img width="407" alt="image" src="https://github.com/user-attachments/assets/e977b3b3-f105-4e63-9771-c89eaac00fc6">

# Testcase : 150 edges 150 assets

<img width="393" alt="image" src="https://github.com/user-attachments/assets/4e25e11b-7e87-4b27-bf4a-24bb8224e2dc">
<img width="428" alt="image" src="https://github.com/user-attachments/assets/31b6cc67-3b07-49c9-b25b-05b97fba6f62">
<img width="440" alt="image" src="https://github.com/user-attachments/assets/ebbe3418-3728-4972-891f-c52ad2048ef6">
<img width="422" alt="image" src="https://github.com/user-attachments/assets/5925c63e-a5ad-485f-9e6e-869bbab7e8ff">


## Type of change
- [x] Bug fix (fixes an issue)

## Related issues

> Fix [#1](https://atlanhq.atlassian.net/browse/DG-1851) 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
