### PR TITLE
DG-1791 | Cache computation logic for vertex label combination

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -1489,7 +1489,6 @@ public abstract class DeleteHandlerV1 {
 
             boolean isOutputEdge = PROCESS_OUTPUTS.equals(atlasEdge.getLabel());
 
-            AtlasVertex processVertex = atlasEdge.getOutVertex();
             AtlasVertex assetVertex = atlasEdge.getInVertex();
             String assetEdgeLabel = getLabel(getGuid(assetVertex), atlasEdge.getLabel());
 
@@ -1501,18 +1500,20 @@ public abstract class DeleteHandlerV1 {
                     updateAssetHasLineageStatus(assetVertex, atlasEdge, removedEdges);
                 }
             }
+
+            AtlasVertex processVertex = atlasEdge.getOutVertex();
+            String processId = getGuid(processVertex);
+            String edgeLabel = isOutputEdge ? PROCESS_OUTPUTS : PROCESS_INPUTS;
+            String processEdgeLabel = getLabel(processId, edgeLabel);
+            boolean processLabelPairAlreadyProcessed = RequestContext.get().isEdgeLabelAlreadyProcessed(processEdgeLabel);
+
+            if (processLabelPairAlreadyProcessed) {
+                continue;
+            }
+
+            RequestContext.get().addEdgeLabel(processEdgeLabel);
+
                 if (getStatus(processVertex) == ACTIVE && !processVertex.equals(deletedVertex)) {
-                String edgeLabel = isOutputEdge ? PROCESS_OUTPUTS : PROCESS_INPUTS;
-
-                    String processId = getGuid(processVertex);
-                    String processEdgeLabel = getLabel(processId,edgeLabel);
-                    boolean processLabelPairAlreadyProcessed = RequestContext.get().isEdgeLabelAlreadyProcessed(processEdgeLabel);
-
-                    if (processLabelPairAlreadyProcessed) {
-                        continue;
-                    }
-                    RequestContext.get().addEdgeLabel(processEdgeLabel);
-
                 Iterator<AtlasEdge> edgeIterator = GraphHelper.getActiveEdges(processVertex, edgeLabel, AtlasEdgeDirection.BOTH);
 
                 boolean activeEdgeFound = false;

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -1496,14 +1496,10 @@ public abstract class DeleteHandlerV1 {
             AtlasVertex assetVertex = atlasEdge.getInVertex();
             String assetEdgeLabel = getLabel(AtlasGraphUtilsV2.getIdFromVertex(assetVertex), atlasEdge.getLabel());
 
-            if (context.isAssetEdgeLabelAlreadyProcessed(assetEdgeLabel)) {
-                continue;
-            }else {
-                context.addAssetEdgeLabel(assetEdgeLabel);
-            }
-
-            if (getStatus(assetVertex) == ACTIVE && !assetVertex.equals(deletedVertex)) {
+            if (!context.isAssetEdgeLabelAlreadyProcessed(assetEdgeLabel) && getStatus(assetVertex) == ACTIVE && !assetVertex.equals(deletedVertex)) {
                 updateAssetHasLineageStatus(assetVertex, atlasEdge, removedEdges);
+            } else if (!context.isAssetEdgeLabelAlreadyProcessed(assetEdgeLabel)){
+                context.addAssetEdgeLabel(assetEdgeLabel);
             }
 
                 if (getStatus(processVertex) == ACTIVE && !processVertex.equals(deletedVertex)) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -1495,12 +1495,12 @@ public abstract class DeleteHandlerV1 {
 
             boolean assetLabelPairAlreadyProcessed = RequestContext.get().isEdgeLabelAlreadyProcessed(assetEdgeLabel);
 
-            if (!assetLabelPairAlreadyProcessed && getStatus(assetVertex) == ACTIVE && !assetVertex.equals(deletedVertex)) {
-                updateAssetHasLineageStatus(assetVertex, atlasEdge, removedEdges);
-            } else if (!assetLabelPairAlreadyProcessed){
+            if (!assetLabelPairAlreadyProcessed) {
                 RequestContext.get().addEdgeLabel(assetEdgeLabel);
+                if (getStatus(assetVertex) == ACTIVE && !assetVertex.equals(deletedVertex)) {
+                    updateAssetHasLineageStatus(assetVertex, atlasEdge, removedEdges);
+                }
             }
-
                 if (getStatus(processVertex) == ACTIVE && !processVertex.equals(deletedVertex)) {
                 String edgeLabel = isOutputEdge ? PROCESS_OUTPUTS : PROCESS_INPUTS;
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -1503,7 +1503,7 @@ public abstract class DeleteHandlerV1 {
             }
 
             if (getStatus(assetVertex) == ACTIVE && !assetVertex.equals(deletedVertex)) {
-                updateAssetHasLineageStatus(assetVertex, atlasEdge, removedEdges);;
+                updateAssetHasLineageStatus(assetVertex, atlasEdge, removedEdges);
             }
 
                 if (getStatus(processVertex) == ACTIVE && !processVertex.equals(deletedVertex)) {

--- a/server-api/src/main/java/org/apache/atlas/RequestContext.java
+++ b/server-api/src/main/java/org/apache/atlas/RequestContext.java
@@ -70,8 +70,7 @@ public class RequestContext {
     private final Map<String, List<Object>> removedElementsMap = new HashMap<>();
     private final Map<String, List<Object>> newElementsCreatedMap = new HashMap<>();
     private final Map<String, Set<AtlasRelationship>> relationshipMutationMap = new HashMap<>();
-    private final Set<String> processEdgeLabels = new HashSet<>();
-    private final Set<String> assetEdgeLabels = new HashSet<>();
+    private final Set<String> edgeLabels = new HashSet<>();
 
     private String user;
     private Set<String> userGroups;
@@ -800,19 +799,12 @@ public class RequestContext {
         return relationshipMutationMap;
     }
 
-    public void addProcessEdgeLabel(String processEdgeLabel) {
-        processEdgeLabels.add(processEdgeLabel);
+    public void addEdgeLabel(String processEdgeLabel) {
+        edgeLabels.add(processEdgeLabel);
     }
 
-    public void addAssetEdgeLabel(String assetEdgeLabel) {
-        assetEdgeLabels.add(assetEdgeLabel);
+    public boolean isEdgeLabelAlreadyProcessed(String processEdgeLabel) {
+        return edgeLabels.contains(processEdgeLabel);
     }
 
-    public boolean isProcessEdgeLabelAlreadyProcessed(String processEdgeLabel) {
-        return processEdgeLabels.contains(processEdgeLabel);
-    }
-
-    public boolean isAssetEdgeLabelAlreadyProcessed(String assetEdgeLabel) {
-        return assetEdgeLabels.add(assetEdgeLabel);
-    }
 }

--- a/server-api/src/main/java/org/apache/atlas/RequestContext.java
+++ b/server-api/src/main/java/org/apache/atlas/RequestContext.java
@@ -69,8 +69,9 @@ public class RequestContext {
     private static String USERNAME = "";
     private final Map<String, List<Object>> removedElementsMap = new HashMap<>();
     private final Map<String, List<Object>> newElementsCreatedMap = new HashMap<>();
-
     private final Map<String, Set<AtlasRelationship>> relationshipMutationMap = new HashMap<>();
+    private final Set<String> processEdgeLabels = new HashSet<>();
+    private final Set<String> assetEdgeLabels = new HashSet<>();
 
     private String user;
     private Set<String> userGroups;
@@ -797,5 +798,21 @@ public class RequestContext {
 
     public Map<String, Set<AtlasRelationship>> getRelationshipMutationMap() {
         return relationshipMutationMap;
+    }
+
+    public void addProcessEdgeLabel(String processEdgeLabel) {
+        processEdgeLabels.add(processEdgeLabel);
+    }
+
+    public void addAssetEdgeLabel(String assetEdgeLabel) {
+        assetEdgeLabels.add(assetEdgeLabel);
+    }
+
+    public boolean isProcessEdgeLabelAlreadyProcessed(String processEdgeLabel) {
+        return processEdgeLabels.contains(processEdgeLabel);
+    }
+
+    public boolean isAssetEdgeLabelAlreadyProcessed(String assetEdgeLabel) {
+        return assetEdgeLabels.add(assetEdgeLabel);
     }
 }


### PR DESCRIPTION
## Change description

> Description here

JIRA : https://atlanhq.atlassian.net/browse/DG-1791
Observed `getActiveEdges` method was called `n` times for `n` number of edges. The result of each computation generates same result. So added a logic to skip computation of this method

Test Cases



## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
