### PR TITLE
MM-3720 Skip corrupted vertex

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -1688,8 +1688,9 @@ public class EntityGraphRetriever {
             String typeName = getTypeName(referenceVertex);
 
             if (StringUtils.isEmpty(typeName)) {
-                LOG.error("typeName not found for vertex {}", getGuid(referenceVertex) );
-                throw new AtlasBaseException(AtlasErrorCode.TYPE_NAME_NOT_FOUND, typeName);
+                LOG.error("typeName not found for in-vertex {} on edge {} from vertex {} ",
+                        getGuid(referenceVertex), edge.getId(), getGuid(entityVertex));
+                return ret;
             }
 
             ret = new AtlasStruct(typeName);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -1688,6 +1688,7 @@ public class EntityGraphRetriever {
             String typeName = getTypeName(referenceVertex);
 
             if (StringUtils.isEmpty(typeName)) {
+                LOG.error("typeName not found for vertex {}", getGuid(referenceVertex) );
                 throw new AtlasBaseException(AtlasErrorCode.TYPE_NAME_NOT_FOUND, typeName);
             }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -1684,7 +1684,14 @@ public class EntityGraphRetriever {
 
         if (GraphHelper.elementExists(edge)) {
             final AtlasVertex referenceVertex = edge.getInVertex();
-            ret = new AtlasStruct(getTypeName(referenceVertex));
+
+            String typeName = getTypeName(referenceVertex);
+
+            if (StringUtils.isEmpty(typeName)) {
+                throw new AtlasBaseException(AtlasErrorCode.TYPE_NAME_NOT_FOUND, typeName);
+            }
+
+            ret = new AtlasStruct(typeName);
 
             mapAttributes(referenceVertex, ret, entityExtInfo, isMinExtInfo);
         }


### PR DESCRIPTION
## Change description

> Description here

JIRA : https://atlanhq.atlassian.net/browse/MM-3720
Miners are failing for chargebee due to NULL Pointer Exception

- added a log to capture vertexId for debug purpose
- skip the computation for corrupted vertex

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
