### PR TITLE
DG-1875 setClassification.deleteClassification optimisation fix

### DIFF
--- a/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
@@ -84,6 +84,7 @@ public enum AtlasConfiguration {
     DEBUG_METRICS_ENABLED("atlas.debug.metrics.enabled", false),
     TASKS_USE_ENABLED("atlas.tasks.enabled", true),
     TASKS_REQUEUE_GRAPH_QUERY("atlas.tasks.requeue.graph.query", false),
+    TASKS_IN_PROGRESS_GRAPH_QUERY("atlas.tasks.inprogress.graph.query", false),
     TASKS_REQUEUE_POLL_INTERVAL("atlas.tasks.requeue.poll.interval.millis", 60000),
     TASKS_QUEUE_SIZE("atlas.tasks.queue.size", 1000),
     SESSION_TIMEOUT_SECS("atlas.session.timeout.secs", -1),

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -3570,7 +3570,7 @@ public class EntityGraphMapper {
         // Get in progress task to see if there already is a propagation for this particular vertex
         List<AtlasTask> inProgressTasks = taskManagement.getInProgressTasks();
         for (AtlasTask task : inProgressTasks) {
-            if (isTaskMatchingWithVertexIdAndEntityGuid(task, classificationVertex.getIdForDisplay(), entityGuid)) {
+            if (IN_PROGRESS.equals(task.getStatus()) && isTaskMatchingWithVertexIdAndEntityGuid(task, classificationVertex.getIdForDisplay(), entityGuid)) {
                 throw new AtlasBaseException(AtlasErrorCode.CLASSIFICATION_CURRENTLY_BEING_PROPAGATED, classificationName);
             }
         }
@@ -3670,7 +3670,7 @@ public class EntityGraphMapper {
 
     private boolean isTaskMatchingWithVertexIdAndEntityGuid(AtlasTask task, String classificationVertexId, String entityGuid) {
         try {
-            if (CLASSIFICATION_PROPAGATION_ADD.equals(task.getType()) && IN_PROGRESS.equals(task.getStatus())) {
+            if (CLASSIFICATION_PROPAGATION_ADD.equals(task.getType())) {
                 return task.getParameters().get(ClassificationTask.PARAM_CLASSIFICATION_VERTEX_ID).equals(classificationVertexId)
                         && task.getParameters().get(ClassificationTask.PARAM_ENTITY_GUID).equals(entityGuid);
             }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -3567,12 +3567,12 @@ public class EntityGraphMapper {
         AtlasVertex         classificationVertex = getClassificationVertex(entityVertex, classificationName);
 
         // Get in progress task to see if there already is a propagation for this particular vertex
-//        List<AtlasTask> inProgressTasks = taskManagement.getInProgressTasks();
-//        for (AtlasTask task : inProgressTasks) {
-//            if (isTaskMatchingWithVertexIdAndEntityGuid(task, classificationVertex.getIdForDisplay(), entityGuid)) {
-//                throw new AtlasBaseException(AtlasErrorCode.CLASSIFICATION_CURRENTLY_BEING_PROPAGATED, classificationName);
-//            }
-//        }
+        List<AtlasTask> inProgressTasks = taskManagement.getInProgressTasks();
+        for (AtlasTask task : inProgressTasks) {
+            if (isTaskMatchingWithVertexIdAndEntityGuid(task, classificationVertex.getIdForDisplay(), entityGuid)) {
+                throw new AtlasBaseException(AtlasErrorCode.CLASSIFICATION_CURRENTLY_BEING_PROPAGATED, classificationName);
+            }
+        }
 
         AtlasClassification classification       = entityRetriever.toAtlasClassification(classificationVertex);
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -3567,12 +3567,12 @@ public class EntityGraphMapper {
         AtlasVertex         classificationVertex = getClassificationVertex(entityVertex, classificationName);
 
         // Get in progress task to see if there already is a propagation for this particular vertex
-        List<AtlasTask> inProgressTasks = taskManagement.getInProgressTasks();
-        for (AtlasTask task : inProgressTasks) {
-            if (isTaskMatchingWithVertexIdAndEntityGuid(task, classificationVertex.getIdForDisplay(), entityGuid)) {
-                throw new AtlasBaseException(AtlasErrorCode.CLASSIFICATION_CURRENTLY_BEING_PROPAGATED, classificationName);
-            }
-        }
+//        List<AtlasTask> inProgressTasks = taskManagement.getInProgressTasks();
+//        for (AtlasTask task : inProgressTasks) {
+//            if (isTaskMatchingWithVertexIdAndEntityGuid(task, classificationVertex.getIdForDisplay(), entityGuid)) {
+//                throw new AtlasBaseException(AtlasErrorCode.CLASSIFICATION_CURRENTLY_BEING_PROPAGATED, classificationName);
+//            }
+//        }
 
         AtlasClassification classification       = entityRetriever.toAtlasClassification(classificationVertex);
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -94,6 +94,7 @@ import static org.apache.atlas.model.instance.EntityMutations.EntityOperation.CR
 import static org.apache.atlas.model.instance.EntityMutations.EntityOperation.DELETE;
 import static org.apache.atlas.model.instance.EntityMutations.EntityOperation.PARTIAL_UPDATE;
 import static org.apache.atlas.model.instance.EntityMutations.EntityOperation.UPDATE;
+import static org.apache.atlas.model.tasks.AtlasTask.Status.IN_PROGRESS;
 import static org.apache.atlas.model.typedef.AtlasStructDef.AtlasAttributeDef.Cardinality.SET;
 import static org.apache.atlas.repository.Constants.*;
 import static org.apache.atlas.repository.graph.GraphHelper.getClassificationEdge;
@@ -3669,7 +3670,7 @@ public class EntityGraphMapper {
 
     private boolean isTaskMatchingWithVertexIdAndEntityGuid(AtlasTask task, String classificationVertexId, String entityGuid) {
         try {
-            if (CLASSIFICATION_PROPAGATION_ADD.equals(task.getType())) {
+            if (CLASSIFICATION_PROPAGATION_ADD.equals(task.getType()) && IN_PROGRESS.equals(task.getStatus())) {
                 return task.getParameters().get(ClassificationTask.PARAM_CLASSIFICATION_VERTEX_ID).equals(classificationVertexId)
                         && task.getParameters().get(ClassificationTask.PARAM_ENTITY_GUID).equals(entityGuid);
             }

--- a/repository/src/main/java/org/apache/atlas/tasks/TaskManagement.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/TaskManagement.java
@@ -208,7 +208,11 @@ public class TaskManagement implements Service, ActiveStateChangeHandler {
     }
 
     public List<AtlasTask> getInProgressTasks() {
-        return registry.getInProgressTasks();
+        if(AtlasConfiguration.TASKS_REQUEUE_GRAPH_QUERY.getBoolean()) {
+            return registry.getInProgressTasks();
+        } else {
+            return registry.getInProgressTasksES();
+        }
     }
 
     public void deleteByGuid(String guid) throws AtlasBaseException {

--- a/repository/src/main/java/org/apache/atlas/tasks/TaskManagement.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/TaskManagement.java
@@ -208,7 +208,7 @@ public class TaskManagement implements Service, ActiveStateChangeHandler {
     }
 
     public List<AtlasTask> getInProgressTasks() {
-        if(AtlasConfiguration.TASKS_REQUEUE_GRAPH_QUERY.getBoolean()) {
+        if(AtlasConfiguration.TASKS_IN_PROGRESS_GRAPH_QUERY.getBoolean()) {
             return registry.getInProgressTasks();
         } else {
             return registry.getInProgressTasksES();

--- a/repository/src/main/java/org/apache/atlas/tasks/TaskRegistry.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/TaskRegistry.java
@@ -130,8 +130,7 @@ public class TaskRegistry {
     public List<AtlasTask> getInProgressTasksES() {
         List<AtlasTask> ret = new ArrayList<>();
         int size = 100;
-        try {
-            int from = 0;
+        int from = 0;
             while(true) {
                 List statusClauseList = new ArrayList();
                 statusClauseList.add(mapOf("match", mapOf(TASK_STATUS, AtlasTask.Status.IN_PROGRESS.toString())));
@@ -142,17 +141,20 @@ public class TaskRegistry {
                 dsl.put("from", from);
                 TaskSearchParams taskSearchParams = new TaskSearchParams();
                 taskSearchParams.setDsl(dsl);
-                List<AtlasTask> results = taskService.getTasks(taskSearchParams).getTasks();
-                if (results.isEmpty()){
-                    break;
+                try {
+                    List<AtlasTask> results = taskService.getTasks(taskSearchParams).getTasks();
+                    if (results.isEmpty()){
+                        break;
+                    }
+                    ret.addAll(results);
+                    from+=size;
+                } catch (AtlasBaseException exception) {
+                    LOG.error("Error fetching in progress tasks from ES, redirecting to GraphQuery", exception);
+                    exception.printStackTrace();
+                    ret = getInProgressTasks();
+                    return ret;
                 }
-                ret.addAll(results);
-                from+=size;
             }
-        } catch (Exception exception) {
-            LOG.error("Error fetching in progress tasks!", exception);
-            exception.printStackTrace();
-        }
 
         return ret;
     }

--- a/repository/src/main/java/org/apache/atlas/tasks/TaskRegistry.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/TaskRegistry.java
@@ -60,6 +60,7 @@ import static org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2.setEn
 public class TaskRegistry {
     private static final Logger LOG = LoggerFactory.getLogger(TaskRegistry.class);
     public static final int TASK_FETCH_BATCH_SIZE = 100;
+    public static final List<Map<String, Object>> SORT_ARRAY = Collections.singletonList(mapOf(Constants.TASK_CREATED_TIME, mapOf("order", "asc")));
 
     private AtlasGraph graph;
     private TaskService taskService;
@@ -137,11 +138,11 @@ public class TaskRegistry {
     public List<AtlasTask> getInProgressTasksES() {
         AtlasPerfMetrics.MetricRecorder metric = RequestContext.get().startMetricRecord("getInProgressTasksES");
         List<AtlasTask> ret = new ArrayList<>();
+        Map<String, Object> dsl = mapOf("query", QUERY_MAP);
+        dsl.put("sort", SORT_ARRAY);
+        dsl.put("size", TASK_FETCH_BATCH_SIZE);
         int from = 0;
             while(true) {
-                Map<String, Object> dsl = mapOf("query", QUERY_MAP);
-                dsl.put("sort", Collections.singletonList(mapOf(Constants.TASK_CREATED_TIME, mapOf("order", "asc"))));
-                dsl.put("size", TASK_FETCH_BATCH_SIZE);
                 dsl.put("from", from);
                 TaskSearchParams taskSearchParams = new TaskSearchParams();
                 taskSearchParams.setDsl(dsl);

--- a/repository/src/main/java/org/apache/atlas/tasks/TaskRegistry.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/TaskRegistry.java
@@ -32,6 +32,7 @@ import org.apache.atlas.repository.graphdb.AtlasIndexQuery;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
 import org.apache.atlas.repository.graphdb.DirectIndexQueryResult;
 import org.apache.atlas.type.AtlasType;
+import org.apache.atlas.utils.AtlasPerfMetrics;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.slf4j.Logger;
@@ -46,21 +47,27 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import static org.apache.atlas.repository.Constants.*;
+import static org.apache.atlas.repository.Constants.TASK_GUID;
+import static org.apache.atlas.repository.Constants.TASK_STATUS;
 import static org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2.setEncodedProperty;
 
 @Component
 public class TaskRegistry {
     private static final Logger LOG = LoggerFactory.getLogger(TaskRegistry.class);
+    public static final int TASK_FETCH_BATCH_SIZE = 100;
 
     private AtlasGraph graph;
     private TaskService taskService;
     private int queueSize;
     private boolean useGraphQuery;
+
+    private static final List<Map<String, Object>> STATUS_CLAUSE_LIST = Arrays.asList(mapOf("match", mapOf(TASK_STATUS, AtlasTask.Status.IN_PROGRESS.toString())));
+    private static final Map<String, Object> QUERY_MAP = mapOf("bool", mapOf("must", STATUS_CLAUSE_LIST));
 
     @Inject
     public TaskRegistry(AtlasGraph graph, TaskService taskService) {
@@ -128,16 +135,13 @@ public class TaskRegistry {
     }
 
     public List<AtlasTask> getInProgressTasksES() {
+        AtlasPerfMetrics.MetricRecorder metric = RequestContext.get().startMetricRecord("getInProgressTasksES");
         List<AtlasTask> ret = new ArrayList<>();
-        int size = 100;
         int from = 0;
             while(true) {
-                List statusClauseList = new ArrayList();
-                statusClauseList.add(mapOf("match", mapOf(TASK_STATUS, AtlasTask.Status.IN_PROGRESS.toString())));
-
-                Map<String, Object> dsl = mapOf("query", mapOf("bool", mapOf("must", statusClauseList)));
+                Map<String, Object> dsl = mapOf("query", QUERY_MAP);
                 dsl.put("sort", Collections.singletonList(mapOf(Constants.TASK_CREATED_TIME, mapOf("order", "asc"))));
-                dsl.put("size", size);
+                dsl.put("size", TASK_FETCH_BATCH_SIZE);
                 dsl.put("from", from);
                 TaskSearchParams taskSearchParams = new TaskSearchParams();
                 taskSearchParams.setDsl(dsl);
@@ -147,7 +151,7 @@ public class TaskRegistry {
                         break;
                     }
                     ret.addAll(results);
-                    from+=size;
+                    from += TASK_FETCH_BATCH_SIZE;
                 } catch (AtlasBaseException exception) {
                     LOG.error("Error fetching in progress tasks from ES, redirecting to GraphQuery", exception);
                     exception.printStackTrace();
@@ -155,7 +159,7 @@ public class TaskRegistry {
                     return ret;
                 }
             }
-
+        RequestContext.get().endMetricRecord(metric);
         return ret;
     }
 
@@ -561,7 +565,7 @@ public class TaskRegistry {
         return taskService.createTaskVertex(task);
     }
 
-    private Map<String, Object> mapOf(String key, Object value) {
+    private static Map<String, Object> mapOf(String key, Object value) {
         Map<String, Object> map = new HashMap<>();
         map.put(key, value);
 


### PR DESCRIPTION
## Change description

> in setClassification.deleteClassification flow, taskManagement.getInProgressTasks() is fetching tasks from gremlin query, which is inherently slow on large-dataset tenants. Instead of doing a gremlin query to fetch in-progress tasks, added an ES-fetching mechanism.

## Alternative to current implementations which failed
> Alternative was that, we simply remove the getInProgressTasks() check so that deleteClassification can detach and create deleteTasks while ADD-PROPAGATION was running. It provided an IllegalStateException issue [see below]
![image](https://github.com/user-attachments/assets/fca58dcb-5db7-44e2-a2c9-f14b1fa36d2e)
Along with causing inconsistencies [see below]
![image](https://github.com/user-attachments/assets/e852fc34-5b51-46e1-871e-41054f232979)
This is while the delete-propagation task found nothing to remove.^

## Current implementation proof
![image](https://github.com/user-attachments/assets/84a78bbb-3054-4b2e-866d-744f22f0e7e8)
![image](https://github.com/user-attachments/assets/f1566417-b49f-4cbd-8a26-0202702dfeaa)
![image](https://github.com/user-attachments/assets/ce799816-b61c-4e93-baf0-c81fd82857d8)


## Type of change
- [ ] Bug fix (fixes an issue)

## Related issues

> Fix [#1](https://atlanhq.atlassian.net/browse/DG-1875) 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
