### PR TITLE
DG-1875 setClassification.deleteClassification optimisation fix

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -3567,12 +3567,12 @@ public class EntityGraphMapper {
         AtlasVertex         classificationVertex = getClassificationVertex(entityVertex, classificationName);
 
         // Get in progress task to see if there already is a propagation for this particular vertex
-//        List<AtlasTask> inProgressTasks = taskManagement.getInProgressTasks();
-//        for (AtlasTask task : inProgressTasks) {
-//            if (isTaskMatchingWithVertexIdAndEntityGuid(task, classificationVertex.getIdForDisplay(), entityGuid)) {
-//                throw new AtlasBaseException(AtlasErrorCode.CLASSIFICATION_CURRENTLY_BEING_PROPAGATED, classificationName);
-//            }
-//        }
+        List<AtlasTask> inProgressTasks = taskManagement.getInProgressTasks();
+        for (AtlasTask task : inProgressTasks) {
+            if (isTaskMatchingWithVertexIdAndEntityGuid(task, classificationVertex.getIdForDisplay(), entityGuid)) {
+                throw new AtlasBaseException(AtlasErrorCode.CLASSIFICATION_CURRENTLY_BEING_PROPAGATED, classificationName);
+            }
+        }
 
         AtlasClassification classification       = entityRetriever.toAtlasClassification(classificationVertex);
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -3567,12 +3567,12 @@ public class EntityGraphMapper {
         AtlasVertex         classificationVertex = getClassificationVertex(entityVertex, classificationName);
 
         // Get in progress task to see if there already is a propagation for this particular vertex
-        List<AtlasTask> inProgressTasks = taskManagement.getInProgressTasks();
-        for (AtlasTask task : inProgressTasks) {
-            if (isTaskMatchingWithVertexIdAndEntityGuid(task, classificationVertex.getIdForDisplay(), entityGuid)) {
-                throw new AtlasBaseException(AtlasErrorCode.CLASSIFICATION_CURRENTLY_BEING_PROPAGATED, classificationName);
-            }
-        }
+//        List<AtlasTask> inProgressTasks = taskManagement.getInProgressTasks();
+//        for (AtlasTask task : inProgressTasks) {
+//            if (isTaskMatchingWithVertexIdAndEntityGuid(task, classificationVertex.getIdForDisplay(), entityGuid)) {
+//                throw new AtlasBaseException(AtlasErrorCode.CLASSIFICATION_CURRENTLY_BEING_PROPAGATED, classificationName);
+//            }
+//        }
 
         AtlasClassification classification       = entityRetriever.toAtlasClassification(classificationVertex);
 

--- a/repository/src/main/java/org/apache/atlas/tasks/TaskManagement.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/TaskManagement.java
@@ -208,7 +208,11 @@ public class TaskManagement implements Service, ActiveStateChangeHandler {
     }
 
     public List<AtlasTask> getInProgressTasks() {
-        return registry.getInProgressTasks();
+        if(AtlasConfiguration.TASKS_REQUEUE_GRAPH_QUERY.getBoolean()) {
+            return registry.getInProgressTasks();
+        } else {
+            return registry.getInProgressTasksES();
+        }
     }
 
     public void deleteByGuid(String guid) throws AtlasBaseException {


### PR DESCRIPTION
## Change description

> in setClassification.deleteClassification flow, taskManagement.getInProgressTasks() is fetching tasks from gremlin query, which is inherently slow on large-dataset tenants. Instead of doing a gremlin query to fetch in-progress tasks, added an ES-fetching mechanism.

## Alternative to current implementations which failed
> Alternative was that, we simply remove the getInProgressTasks() check so that deleteClassification can detach and create deleteTasks while ADD-PROPAGATION was running. It provided an IllegalStateException issue [see below]
![image](https://github.com/user-attachments/assets/fca58dcb-5db7-44e2-a2c9-f14b1fa36d2e)
Along with causing inconsistencies [see below]
![image](https://github.com/user-attachments/assets/e852fc34-5b51-46e1-871e-41054f232979)
This is while the delete-propagation task found nothing to remove.^

## Current implementation proof
![image](https://github.com/user-attachments/assets/84a78bbb-3054-4b2e-866d-744f22f0e7e8)
![image](https://github.com/user-attachments/assets/f1566417-b49f-4cbd-8a26-0202702dfeaa)
![image](https://github.com/user-attachments/assets/ce799816-b61c-4e93-baf0-c81fd82857d8)


## Type of change
- [ ] Bug fix (fixes an issue)

## Related issues

> Fix [#1](https://atlanhq.atlassian.net/browse/DG-1875) 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
