### PR TITLE
DG-1895 Added a fix, incase corrupt or null classification vertices are found, we will skip them and detach them.

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -379,7 +379,8 @@ public final class GraphHelper {
                 AtlasEdge edge = iterator.next();
                 if(Objects.nonNull(edge))
                 {
-                    if(Objects.nonNull(edge.getInVertex())) {
+                    AtlasVertex classificationVertex = edge.getInVertex();
+                    if(Objects.nonNull(classificationVertex) && StringUtils.isNotEmpty(classificationVertex.getProperty(TYPE_NAME_PROPERTY_KEY, String.class))) {
                         return edge.getInVertex();
                     } else if(graphHelper != null) {
                         graphHelper.repairTagVertex(edge, edge.getInVertex());

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -3567,6 +3567,10 @@ public class EntityGraphMapper {
 
         AtlasVertex         classificationVertex = getClassificationVertex(graphHelper, entityVertex, classificationName);
 
+        if (Objects.isNull(classificationVertex)) {
+            LOG.error(AtlasErrorCode.CLASSIFICATION_NOT_FOUND.getFormattedErrorMessage(classificationName));
+            return;
+        }
         // Get in progress task to see if there already is a propagation for this particular vertex
         List<AtlasTask> inProgressTasks = taskManagement.getInProgressTasks();
         for (AtlasTask task : inProgressTasks) {
@@ -3578,7 +3582,8 @@ public class EntityGraphMapper {
         AtlasClassification classification       = entityRetriever.toAtlasClassification(classificationVertex);
 
         if (classification == null) {
-            throw new AtlasBaseException(AtlasErrorCode.CLASSIFICATION_NOT_FOUND, classificationName);
+            LOG.error(AtlasErrorCode.CLASSIFICATION_NOT_FOUND.getFormattedErrorMessage(classificationName));
+            return;
         }
 
         // remove classification from propagated entities if propagation is turned on
@@ -3781,7 +3786,8 @@ public class EntityGraphMapper {
             AtlasVertex classificationVertex = getClassificationVertex(graphHelper, entityVertex, classificationName);
 
             if (classificationVertex == null) {
-                throw new AtlasBaseException(AtlasErrorCode.CLASSIFICATION_NOT_ASSOCIATED_WITH_ENTITY, classificationName);
+                LOG.error(AtlasErrorCode.CLASSIFICATION_NOT_FOUND.getFormattedErrorMessage(classificationName));
+                continue;
             }
 
             if (LOG.isDebugEnabled()) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -3565,7 +3565,7 @@ public class EntityGraphMapper {
 
         validateClassificationExists(traitNames, classificationName);
 
-        AtlasVertex         classificationVertex = getClassificationVertex(entityVertex, classificationName);
+        AtlasVertex         classificationVertex = getClassificationVertex(graphHelper, entityVertex, classificationName);
 
         // Get in progress task to see if there already is a propagation for this particular vertex
         List<AtlasTask> inProgressTasks = taskManagement.getInProgressTasks();
@@ -3778,7 +3778,7 @@ public class EntityGraphMapper {
                 throw new AtlasBaseException(AtlasErrorCode.CLASSIFICATION_UPDATE_FROM_PROPAGATED_ENTITY, classificationName);
             }
 
-            AtlasVertex classificationVertex = getClassificationVertex(entityVertex, classificationName);
+            AtlasVertex classificationVertex = getClassificationVertex(graphHelper, entityVertex, classificationName);
 
             if (classificationVertex == null) {
                 throw new AtlasBaseException(AtlasErrorCode.CLASSIFICATION_NOT_ASSOCIATED_WITH_ENTITY, classificationName);

--- a/repository/src/main/java/org/apache/atlas/tasks/AtlasTaskService.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/AtlasTaskService.java
@@ -26,6 +26,7 @@ import javax.inject.Inject;
 import java.util.*;
 
 import static org.apache.atlas.repository.Constants.TASK_GUID;
+import static org.apache.atlas.repository.graph.GraphHelper.getClassificationVertex;
 import static org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2.setEncodedProperty;
 import static org.apache.atlas.repository.store.graph.v2.tasks.ClassificationTask.PARAM_CLASSIFICATION_VERTEX_ID;
 import static org.apache.atlas.tasks.TaskRegistry.toAtlasTask;
@@ -184,7 +185,7 @@ public class AtlasTaskService implements TaskService {
             throw new AtlasBaseException(AtlasErrorCode.INSTANCE_GUID_NOT_FOUND, entityGuid);
         }
 
-        AtlasVertex classificationVertex = GraphHelper.getClassificationVertex(entityVertex, classificationName);
+        AtlasVertex classificationVertex = getClassificationVertex(null, entityVertex, classificationName);
 
         if (classificationVertex != null) {
             ret = classificationVertex.getIdForDisplay();

--- a/repository/src/test/java/org/apache/atlas/repository/tagpropagation/ClassificationPropagationWithTasksTest.java
+++ b/repository/src/test/java/org/apache/atlas/repository/tagpropagation/ClassificationPropagationWithTasksTest.java
@@ -160,7 +160,7 @@ public class ClassificationPropagationWithTasksTest extends AtlasTestBase {
         entityStore.addClassification(Collections.singletonList(HDFS_PATH_EMPLOYEES), tagY);
 
         AtlasVertex entityVertex = AtlasGraphUtilsV2.findByGuid(hdfs_employees.getGuid());
-        AtlasVertex classificationVertex = GraphHelper.getClassificationVertex(entityVertex, TAG_NAME_X);
+        AtlasVertex classificationVertex = GraphHelper.getClassificationVertex(null, entityVertex, TAG_NAME_X);
 
         assertNotNull(entityVertex);
         assertNotNull(classificationVertex);
@@ -183,7 +183,7 @@ public class ClassificationPropagationWithTasksTest extends AtlasTestBase {
         entityStore.updateClassifications(hdfs_employees.getGuid(), Collections.singletonList(tagY));
 
         AtlasVertex entityVertex = AtlasGraphUtilsV2.findByGuid(hdfs_employees.getGuid());
-        AtlasVertex classificationVertex = GraphHelper.getClassificationVertex(entityVertex, TAG_NAME_Y);
+        AtlasVertex classificationVertex = GraphHelper.getClassificationVertex(null, entityVertex, TAG_NAME_Y);
 
         assertNotNull(RequestContext.get().getQueuedTasks());
         assertTrue(RequestContext.get().getQueuedTasks().size() > 0, "No tasks were queued!");
@@ -204,7 +204,7 @@ public class ClassificationPropagationWithTasksTest extends AtlasTestBase {
         tagX.setPropagate(false);
 
         AtlasVertex entityVertex = AtlasGraphUtilsV2.findByGuid(hdfs_employees.getGuid());
-        AtlasVertex classificationVertex = GraphHelper.getClassificationVertex(entityVertex, TAG_NAME);
+        AtlasVertex classificationVertex = GraphHelper.getClassificationVertex(null, entityVertex, TAG_NAME);
 
         try {
             entityStore.deleteClassification(HDFS_PATH_EMPLOYEES, tagX.getTypeName());


### PR DESCRIPTION
## Change description

> Added a fix, incase corrupt or null classification vertices are found, we will skip them and detach them.

## Type of change
- [ ] Bug fix (fixes an issue)

## Screenshots
# PreChange
![image](https://github.com/user-attachments/assets/f4e4d200-dabe-4ab4-b0d5-8fc2b3f4e4b8)
![image](https://github.com/user-attachments/assets/6d325ae2-27cc-4e00-ab64-b852177b9c4b)

# PostChange
![image](https://github.com/user-attachments/assets/128d57e2-e5a1-44c2-8ec5-13224a7a6734)
![image](https://github.com/user-attachments/assets/dbd309be-2aa2-4f34-ba07-26f30a1a3e44)
Out of 4 tag-vertices connected 3 were corrupted, 1 was fixed because a non-corrupted was found before that and therefore the last 2 were not repaired.

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
