### PR TITLE
PLT-2568 optimise vertex fetch from janusgraph

### DIFF
--- a/repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java
@@ -41,10 +41,8 @@ import org.apache.atlas.query.executors.DSLQueryExecutor;
 import org.apache.atlas.query.executors.ScriptEngineBasedExecutor;
 import org.apache.atlas.query.executors.TraversalBasedExecutor;
 import org.apache.atlas.repository.Constants;
-import org.apache.atlas.repository.audit.ESBasedAuditRepository;
 import org.apache.atlas.repository.graph.GraphBackedSearchIndexer;
 import org.apache.atlas.repository.graph.GraphHelper;
-import org.apache.atlas.repository.audit.ESBasedAuditRepository;
 import org.apache.atlas.repository.graphdb.*;
 import org.apache.atlas.repository.graphdb.AtlasIndexQuery.Result;
 import org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2;
@@ -76,6 +74,9 @@ import javax.inject.Inject;
 import javax.script.ScriptEngine;
 import javax.script.ScriptException;
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ForkJoinPool;
 import java.util.stream.Collectors;
 
 import static org.apache.atlas.AtlasErrorCode.*;
@@ -83,8 +84,6 @@ import static org.apache.atlas.SortOrder.ASCENDING;
 import static org.apache.atlas.model.instance.AtlasEntity.Status.ACTIVE;
 import static org.apache.atlas.model.instance.AtlasEntity.Status.DELETED;
 import static org.apache.atlas.repository.Constants.*;
-import static org.apache.atlas.repository.util.AccessControlUtils.ACCESS_READ_DOMAIN;
-import static org.apache.atlas.repository.util.AtlasEntityUtils.mapOf;
 import static org.apache.atlas.util.AtlasGremlinQueryProvider.AtlasGremlinQuery.BASIC_SEARCH_STATE_FILTER;
 import static org.apache.atlas.util.AtlasGremlinQueryProvider.AtlasGremlinQuery.TO_RANGE_LIST;
 
@@ -92,6 +91,8 @@ import static org.apache.atlas.util.AtlasGremlinQueryProvider.AtlasGremlinQuery.
 public class EntityDiscoveryService implements AtlasDiscoveryService {
     private static final Logger LOG = LoggerFactory.getLogger(EntityDiscoveryService.class);
     private static final String DEFAULT_SORT_ATTRIBUTE_NAME = "name";
+    private static final int AVAILABLEPROCESSORS = Runtime.getRuntime().availableProcessors();
+    private static final ForkJoinPool CUSTOMTHREADPOOL = new ForkJoinPool(AVAILABLEPROCESSORS/2); // Use half of available cores
 
     private final AtlasGraph                      graph;
     private final EntityGraphRetriever            entityRetriever;
@@ -1083,81 +1084,111 @@ public class EntityDiscoveryService implements AtlasDiscoveryService {
         }
     }
 
+    @SuppressWarnings("rawtypes")
     private void prepareSearchResult(AtlasSearchResult ret, DirectIndexQueryResult indexQueryResult, Set<String> resultAttributes, boolean fetchCollapsedResults) throws AtlasBaseException {
         SearchParams searchParams = ret.getSearchParameters();
-        try {
-            if(LOG.isDebugEnabled()){
-                LOG.debug("Preparing search results for ({})", ret.getSearchParameters());
-            }
-            Iterator<Result> iterator = indexQueryResult.getIterator();
-            boolean showSearchScore = searchParams.getShowSearchScore();
-            if (iterator == null) {
-                return;
-            }
+        boolean showSearchScore = searchParams.getShowSearchScore();
+        List<Result> results = new ArrayList<>();
 
-            while (iterator.hasNext()) {
-                Result result = iterator.next();
-                AtlasVertex vertex = result.getVertex();
-
-                if (vertex == null) {
-                    LOG.warn("vertex in null");
-                    continue;
-                }
-
-                AtlasEntityHeader header = entityRetriever.toAtlasEntityHeader(vertex, resultAttributes);
-                if(RequestContext.get().includeClassifications()){
-                    header.setClassifications(entityRetriever.getAllClassifications(vertex));
-                }
-                if (showSearchScore) {
-                    ret.addEntityScore(header.getGuid(), result.getScore());
-                }
-                if (fetchCollapsedResults) {
-                    Map<String, AtlasSearchResult> collapse = new HashMap<>();
-
-                    Set<String> collapseKeys = result.getCollapseKeys();
-                    for (String collapseKey : collapseKeys) {
-                        AtlasSearchResult collapseRet = new AtlasSearchResult();
-                        collapseRet.setSearchParameters(ret.getSearchParameters());
-
-                        Set<String> collapseResultAttributes = new HashSet<>();
-                        if (searchParams.getCollapseAttributes() != null) {
-                            collapseResultAttributes.addAll(searchParams.getCollapseAttributes());
-                        } else {
-                            collapseResultAttributes = resultAttributes;
-                        }
-
-                        if (searchParams.getCollapseRelationAttributes() != null) {
-                            RequestContext.get().getRelationAttrsForSearch().clear();
-                            RequestContext.get().setRelationAttrsForSearch(searchParams.getCollapseRelationAttributes());
-                        }
-
-                        DirectIndexQueryResult indexQueryCollapsedResult = result.getCollapseVertices(collapseKey);
-                        collapseRet.setApproximateCount(indexQueryCollapsedResult.getApproximateCount());
-                        prepareSearchResult(collapseRet, indexQueryCollapsedResult, collapseResultAttributes, false);
-
-                        collapseRet.setSearchParameters(null);
-                        collapse.put(collapseKey, collapseRet);
-                    }
-                    if (!collapse.isEmpty()) {
-                        header.setCollapse(collapse);
-                    }
-                }
-                if (searchParams.getShowSearchMetadata()) {
-                    ret.addHighlights(header.getGuid(), result.getHighLights());
-                    ret.addSort(header.getGuid(), result.getSort());
-                } else if (searchParams.getShowHighlights()) {
-                    ret.addHighlights(header.getGuid(), result.getHighLights());
-                }
-
-                ret.addEntity(header);
-            }
-        } catch (Exception e) {
-                throw e;
+        // Collect results for batch processing
+        Iterator<Result> iterator = indexQueryResult.getIterator();
+        while (iterator != null && iterator.hasNext()) {
+            results.add(iterator.next());
         }
+
+        // Batch fetch vertices
+        List<AtlasVertex> vertices = results.stream()
+                .map(Result::getVertex)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        // Use ConcurrentHashMap for thread-safe access
+        ConcurrentHashMap<String, AtlasEntityHeader> headers = new ConcurrentHashMap<>();
+
+        // Run vertex processing in limited parallel threads
+        CompletableFuture.runAsync(() -> CUSTOMTHREADPOOL.submit(() ->
+                vertices.parallelStream().forEach(vertex -> {
+                    String guid = vertex.getProperty("guid", String.class);
+                    headers.computeIfAbsent(guid, k -> {
+                        try {
+                            AtlasEntityHeader header = entityRetriever.toAtlasEntityHeader(vertex, resultAttributes);
+                            if (RequestContext.get().includeClassifications()) {
+                                header.setClassifications(entityRetriever.getAllClassifications(vertex));
+                            }
+                            return header;
+                        } catch (AtlasBaseException e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+                })
+        ).join(), CUSTOMTHREADPOOL);
+
+        // Process results and handle collapse in parallel
+        results.parallelStream().forEach(result -> {
+            AtlasVertex vertex = result.getVertex();
+            if (vertex == null) return;
+
+            String guid = vertex.getProperty("guid", String.class);
+            AtlasEntityHeader header = headers.get(guid);
+
+            if (showSearchScore) {
+                ret.addEntityScore(header.getGuid(), result.getScore());
+            }
+
+            if (fetchCollapsedResults) {
+                Map<String, AtlasSearchResult> collapse;
+                try {
+                    collapse = processCollapseResults(result, searchParams, resultAttributes);
+                } catch (AtlasBaseException e) {
+                    throw new RuntimeException(e);
+                }
+                if (!collapse.isEmpty()) {
+                    header.setCollapse(collapse);
+                }
+            }
+
+            if (searchParams.getShowSearchMetadata()) {
+                ret.addHighlights(header.getGuid(), result.getHighLights());
+                ret.addSort(header.getGuid(), result.getSort());
+            } else if (searchParams.getShowHighlights()) {
+                ret.addHighlights(header.getGuid(), result.getHighLights());
+            }
+
+            ret.addEntity(header);
+        });
 
         if (!searchParams.getEnableFullRestriction()) {
             scrubSearchResults(ret, searchParams.getSuppressLogs());
         }
+    }
+
+    // Non-recursive collapse processing
+    private Map<String, AtlasSearchResult> processCollapseResults(Result result, SearchParams searchParams, Set<String> resultAttributes) throws AtlasBaseException {
+        Map<String, AtlasSearchResult> collapse = new HashMap<>();
+        Set<String> collapseKeys = result.getCollapseKeys();
+
+        for (String collapseKey : collapseKeys) {
+            AtlasSearchResult collapseRet = new AtlasSearchResult();
+            collapseRet.setSearchParameters(searchParams);
+            Set<String> collapseResultAttributes = new HashSet<>(Optional.ofNullable(searchParams.getCollapseAttributes()).orElse(resultAttributes));
+            DirectIndexQueryResult indexQueryCollapsedResult = result.getCollapseVertices(collapseKey);
+            collapseRet.setApproximateCount(indexQueryCollapsedResult.getApproximateCount());
+
+            // Directly iterate over collapse vertices
+            Iterator<Result> iterator = indexQueryCollapsedResult.getIterator();
+            while (iterator != null && iterator.hasNext()) {
+                Result collapseResult = iterator.next();
+                AtlasVertex collapseVertex = collapseResult.getVertex();
+                if (collapseVertex == null) continue;
+
+                AtlasEntityHeader collapseHeader = entityRetriever.toAtlasEntityHeader(collapseVertex, collapseResultAttributes);
+                collapseRet.addEntity(collapseHeader);
+            }
+
+            collapse.put(collapseKey, collapseRet);
+        }
+
+        return collapse;
     }
 
     private Map<String, Object> getMap(String key, Object value) {


### PR DESCRIPTION
## Change description

> Post elastic fetch optimisation to reduce `mapVertexToAtlasEntityHeader` number
Janus graph lookup optimisation with batching and memoization
removing recursive code

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues
https://atlanhq.atlassian.net/browse/PLT-2568

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
