### PR TITLE
PLT-2568 use all hosts available for es for connection pooling, node visibility and retries

### DIFF
--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -358,7 +358,25 @@ public final class Constants {
     public static final String TASK_ENTITY_GUID             = encodePropertyKey(TASK_PREFIX + "entityGuid");
     public static final String TASK_CLASSIFICATION_TYPENAME = encodePropertyKey(TASK_PREFIX + "classificationTypeName");
     public static final String ACTIVE_STATE_VALUE           = "ACTIVE";
-
+    public static final String TASK_HEADER_ATLAN_AGENT      = "x-atlan-agent";
+    public static final String TASK_HEADER_ATLAN_AGENT_ID   = "x-atlan-agent-id";
+    public static final String TASK_HEADER_ATLAN_PKG_NAME   = "x-atlan-package-name";
+    public static final String TASK_HEADER_ATLAN_AGENT_WORKFLOW_ID = "x-atlan-agent-workflow-id";
+    public static final String TASK_HEADER_ATLAN_VIA_UI            = "x-atlan-via-ui";
+    public static final String TASK_HEADER_ATLAN_REQUEST_ID        = "x-atlan-request-id";
+    public static final String TASK_HEADER_ATLAN_GOOGLE_SHEETS_ID  = "x-atlan-google-sheets-id";
+    public static final String TASK_HEADER_ATLAN_MS_EXCEL_ID       = "x-atlan-microsoft-excel-id";
+    public static final Set<String> TASK_HEADER_SET = new HashSet<String>() {{
+        add(TASK_HEADER_ATLAN_AGENT);
+        add(TASK_HEADER_ATLAN_AGENT_ID);
+        add(TASK_HEADER_ATLAN_VIA_UI);
+        add(TASK_HEADER_ATLAN_PKG_NAME);
+        add(TASK_HEADER_ATLAN_AGENT_WORKFLOW_ID);
+        add(TASK_HEADER_ATLAN_REQUEST_ID);
+        add(TASK_HEADER_ATLAN_GOOGLE_SHEETS_ID);
+        add(TASK_HEADER_ATLAN_MS_EXCEL_ID);
+    }};
+    
     /**
      * Index Recovery vertex property keys.
      */

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchDatabase.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchDatabase.java
@@ -86,7 +86,7 @@ public class AtlasElasticsearchDatabase {
                     try {
                         List<HttpHost> httpHosts = getHttpHosts();
 
-                        RestClientBuilder builder = RestClient.builder(httpHosts.get(0));
+                        RestClientBuilder builder = RestClient.builder(httpHosts.toArray(new HttpHost[0]));
                         builder.setHttpClientConfigCallback(httpAsyncClientBuilder -> httpAsyncClientBuilder.setKeepAliveStrategy(((httpResponse, httpContext) -> 3600000)));
                         builder.setRequestConfigCallback(requestConfigBuilder -> requestConfigBuilder
                                 .setConnectTimeout(AtlasConfiguration.INDEX_CLIENT_CONNECTION_TIMEOUT.getInt())

--- a/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
@@ -268,7 +268,7 @@ public enum AtlasErrorCode {
     REPAIR_INDEX_FAILED(500, "ATLAS-500-00-018", "Error occurred while repairing indices: {0}"),
     INDEX_SEARCH_FAILED(400, "ATLAS-400-00-102", "Error occurred while running direct index query on ES: {0}"),
 
-    INDEX_SEARCH_FAILED_DUE_TO_TIMEOUT(429, "ATLAS-400-00-502", "Error : Exceeded timeout while running direct index query on ES: {0}"),
+    INDEX_SEARCH_FAILED_DUE_TO_TIMEOUT(429, "ATLAS-400-00-502", "ES query exceeded timeout: {0}"),
     DEPRECATED_API(400, "ATLAS-400-00-103", "Deprecated API. Use {0} instead"),
     DISABLED_API(400, "ATLAS-400-00-104", "API temporarily disabled. Reason: {0}"),
     HAS_LINEAGE_GET_EDGE_FAILED(500, "ATLAS-500-00-019", "Error occurred while getting edge between vertices for hasLineage migration: {0}"),

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphBackedSearchIndexer.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphBackedSearchIndexer.java
@@ -330,6 +330,11 @@ public class GraphBackedSearchIndexer implements SearchIndexer, ActiveStateChang
             HashMap<String, HashMap<String, Object>> KEYWORD_MULTIFIELD = new HashMap<>();
             KEYWORD_MULTIFIELD.put("keyword", ES_KEYWORD_FIELD);
 
+            HashMap<String, Object> ES_KEYWORD_WO_NORMALIZER = new HashMap<>();
+            ES_KEYWORD_WO_NORMALIZER.put("type", "keyword");
+            HashMap<String, HashMap<String, Object>> KEYWORD_FIELD = new HashMap<>();
+            KEYWORD_FIELD.put("keyword", ES_KEYWORD_WO_NORMALIZER);
+
             HashMap<String, Object> ES_GLOSSARY_ANALYZER_TEXT_FIELD = new HashMap<>();
             ES_GLOSSARY_ANALYZER_TEXT_FIELD.put("type", "text");
             ES_GLOSSARY_ANALYZER_TEXT_FIELD.put("analyzer", "atlan_glossary_analyzer");
@@ -393,7 +398,7 @@ public class GraphBackedSearchIndexer implements SearchIndexer, ActiveStateChang
             createCommonVertexIndex(management, TASK_GUID, UniqueKind.GLOBAL_UNIQUE, String.class, SINGLE, true, false);
             createCommonVertexIndex(management, TASK_TYPE_PROPERTY_KEY, UniqueKind.NONE, String.class, SINGLE, true, false);
             createCommonVertexIndex(management, TASK_CREATED_TIME, UniqueKind.NONE, Long.class, SINGLE, true, false);
-            createCommonVertexIndex(management, TASK_STATUS, UniqueKind.NONE, String.class, SINGLE, true, false);
+            createCommonVertexIndex(management, TASK_STATUS, UniqueKind.NONE, String.class, SINGLE, true, false, false, new HashMap<>(), KEYWORD_FIELD);
 
             createCommonVertexIndex(management, TASK_TYPE, UniqueKind.NONE, String.class, SINGLE, true, false, true);
             createCommonVertexIndex(management, TASK_CREATED_BY, UniqueKind.NONE, String.class, SINGLE, false, false, true);
@@ -407,7 +412,15 @@ public class GraphBackedSearchIndexer implements SearchIndexer, ActiveStateChang
             createCommonVertexIndex(management, TASK_TIME_TAKEN_IN_SECONDS, UniqueKind.NONE, Long.class, SINGLE, false, false);
             createCommonVertexIndex(management, TASK_START_TIME, UniqueKind.NONE, Long.class, SINGLE, false, false);
             createCommonVertexIndex(management, TASK_END_TIME, UniqueKind.NONE, Long.class, SINGLE, false, false);
-
+            createCommonVertexIndex(management, TASK_HEADER_ATLAN_AGENT, UniqueKind.NONE, String.class, SINGLE, false, false, true);
+            createCommonVertexIndex(management, TASK_HEADER_ATLAN_AGENT_ID, UniqueKind.NONE, String.class, SINGLE, false, false, true);
+            createCommonVertexIndex(management, TASK_HEADER_ATLAN_PKG_NAME, UniqueKind.NONE, String.class, SINGLE, false, false, true);
+            createCommonVertexIndex(management, TASK_HEADER_ATLAN_AGENT_WORKFLOW_ID, UniqueKind.NONE, String.class, SINGLE, false, false, true);
+            createCommonVertexIndex(management, TASK_HEADER_ATLAN_VIA_UI, UniqueKind.NONE, String.class, SINGLE, false, false, true);
+            createCommonVertexIndex(management, TASK_HEADER_ATLAN_REQUEST_ID, UniqueKind.NONE, String.class, SINGLE, false, false, true);
+            createCommonVertexIndex(management, TASK_HEADER_ATLAN_GOOGLE_SHEETS_ID, UniqueKind.NONE, String.class, SINGLE, false, false, true);
+            createCommonVertexIndex(management, TASK_HEADER_ATLAN_MS_EXCEL_ID, UniqueKind.NONE, String.class, SINGLE, false, false, true);
+            
             // index recovery
             createCommonVertexIndex(management, PROPERTY_KEY_INDEX_RECOVERY_NAME, UniqueKind.GLOBAL_UNIQUE, String.class, SINGLE, true, false);
 

--- a/repository/src/main/java/org/apache/atlas/tasks/AtlasTaskService.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/AtlasTaskService.java
@@ -18,6 +18,7 @@ import org.apache.atlas.utils.AtlasJson;
 import org.apache.atlas.utils.AtlasPerfMetrics;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.collections.MapUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -225,6 +226,7 @@ public class AtlasTaskService implements TaskService {
     @Override
     public AtlasVertex createTaskVertex(AtlasTask task) {
         AtlasVertex ret = graph.addVertex();
+        Map<String, String> requestContextHeaders = RequestContext.get().getRequestContextHeaders();
 
         setEncodedProperty(ret, Constants.TASK_GUID, task.getGuid());
         setEncodedProperty(ret, Constants.TASK_TYPE_PROPERTY_KEY, Constants.TASK_TYPE_NAME);
@@ -252,6 +254,16 @@ public class AtlasTaskService implements TaskService {
 
         if (task.getEndTime() != null) {
             setEncodedProperty(ret, Constants.TASK_END_TIME, task.getEndTime().getTime());
+        }
+
+        if (MapUtils.isNotEmpty(requestContextHeaders)) {
+            for (Map.Entry<String, String> entry : requestContextHeaders.entrySet()) {
+                String key = entry.getKey().toLowerCase().trim();
+                if (Constants.TASK_HEADER_SET.contains(key)) {
+                    String val = entry.getValue();
+                    setEncodedProperty(ret, key, val);
+                }
+            }
         }
 
         setEncodedProperty(ret, Constants.TASK_PARAMETERS, AtlasJson.toJson(task.getParameters()));


### PR DESCRIPTION
use all hosts available for es for connection pooling, node visibility and retries

## Change description

> use all hosts available for es for connection pooling, node visibility and retries

Kubernetes Load Balancing vs. Elasticsearch Client Load Balancing

	•	Kubernetes Service Load Balancing: When you configure a Kubernetes Service (such as a ClusterIP or LoadBalancer) to front multiple Elasticsearch pods, Kubernetes will handle the load balancing automatically. Requests sent to the Service IP or DNS name will be distributed across the available pods, and you only need to specify the Service’s endpoint in your code.
	•	Elasticsearch RestClient Load Balancing: By providing multiple HttpHost instances to the Elasticsearch RestClient, the client will directly handle round-robin load balancing across those nodes, independent of Kubernetes. This approach is beneficial if you’re running outside Kubernetes or if you want more control over load balancing directly within the client.

2. Failure Detection and Retry Mechanisms

	•	Kubernetes Service: Kubernetes automatically detects when a pod goes down and removes it from the Service endpoint list until it is healthy again, thereby routing traffic only to healthy pods. However, depending on the configuration, Kubernetes may not handle transient connection errors as well as Elasticsearch’s client, which has built-in retry mechanisms.
	•	Elasticsearch Client: The Elasticsearch RestClient can detect and reroute failed requests if a node goes down, thanks to its retry logic and round-robin mechanism. It allows you to control how retries, failovers, and timeouts are handled specifically within the context of Elasticsearch.

3. Direct Node Awareness

	•	Kubernetes Service: The Service abstracts the nodes, and your application does not directly know about individual Elasticsearch nodes or their health status. This setup keeps your application configuration simpler but limits finer-grained control over node selection.
	•	Elasticsearch Client with Multiple Nodes: When specifying multiple nodes directly, the RestClient is aware of each node’s status. This visibility can provide better resiliency and failover since the client will avoid routing traffic to known failed nodes immediately.

4. Connection Pooling and Efficiency

	•	Kubernetes Service: Using a single Service endpoint results in connection pooling across that one endpoint. While Kubernetes will distribute requests among pods, it may not balance connections perfectly due to the intermediate layer of load balancing.
	•	Elasticsearch Client: By configuring the client with multiple HttpHost nodes, the RestClient manages the connection pool for each node directly, leading to more efficient use of connections and potentially reducing latencies due to the client’s more optimized, internal load-balancing mechanisms.

Choosing Between Kubernetes Service and Multiple Hosts in Code:

	•	If you prefer simplicity and are running in Kubernetes, using a single Service endpoint may be sufficient, as Kubernetes will handle load balancing and failover.
	•	If you need more control over failover behavior, retries, or want fine-grained visibility into node status and client-managed load balancing, configuring multiple nodes directly in the Elasticsearch client might be more beneficial

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
