### PR TITLE
PLT-2568 brotli compression for all endpoints

### DIFF
--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -585,6 +585,12 @@
             <scope>compile</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.aayushatharva.brotli4j</groupId>
+            <artifactId>brotli4j</artifactId>
+            <version>1.17.0</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/webapp/src/main/java/org/apache/atlas/web/filters/BrotliCompressionFilter.java
+++ b/webapp/src/main/java/org/apache/atlas/web/filters/BrotliCompressionFilter.java
@@ -1,0 +1,59 @@
+package org.apache.atlas.web.filters;
+
+import com.aayushatharva.brotli4j.Brotli4jLoader;
+import com.aayushatharva.brotli4j.encoder.Encoder;
+import com.aayushatharva.brotli4j.encoder.Encoder.Parameters;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class BrotliCompressionFilter implements Filter {
+
+    @Override
+    public void init(FilterConfig filterConfig) {
+        Brotli4jLoader.ensureAvailability();
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
+        // Ensure request and response are HttpServletRequest and HttpServletResponse
+        if (request instanceof HttpServletRequest && response instanceof HttpServletResponse) {
+            HttpServletRequest httpRequest = (HttpServletRequest) request;
+            HttpServletResponse httpResponse = (HttpServletResponse) response;
+
+            String acceptEncoding = httpRequest.getHeader("Accept-Encoding");
+
+            // Check if the client supports Brotli compression
+            if (acceptEncoding != null && acceptEncoding.contains("br")) {
+                // Wrap the response with a Brotli compression wrapper
+                BrotliResponseWrapper responseWrapper = new BrotliResponseWrapper(httpResponse);
+                chain.doFilter(request, responseWrapper);
+
+                // Compress the response content with Brotli
+                byte[] uncompressedData = responseWrapper.getOutputStreamData();
+                Parameters params = new Parameters().setQuality(6); // Set Brotli quality level
+                byte[] compressedOutput = Encoder.compress(uncompressedData, params);
+
+                // Write Brotli-compressed data to the actual response
+                httpResponse.setHeader("Content-Encoding", "br");
+                httpResponse.setContentLength(compressedOutput.length);
+                httpResponse.getOutputStream().write(compressedOutput);
+            } else {
+                // Proceed without compression
+                chain.doFilter(request, response);
+            }
+        } else {
+            // Proceed without compression if not HTTP
+            chain.doFilter(request, response);
+        }
+    }
+
+    @Override
+    public void destroy() {
+        // Optional: Add cleanup logic here if needed
+    }
+}

--- a/webapp/src/main/java/org/apache/atlas/web/filters/BrotliResponseWrapper.java
+++ b/webapp/src/main/java/org/apache/atlas/web/filters/BrotliResponseWrapper.java
@@ -1,0 +1,54 @@
+package org.apache.atlas.web.filters;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+public class BrotliResponseWrapper extends HttpServletResponseWrapper {
+
+    private final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    private ServletOutputStream servletOutputStream;
+    private PrintWriter writer;
+
+    public BrotliResponseWrapper(HttpServletResponse response) {
+        super(response);
+    }
+
+    @Override
+    public ServletOutputStream getOutputStream() throws IOException {
+        if (servletOutputStream == null) {
+            servletOutputStream = new ServletOutputStream() {
+                @Override
+                public void write(int b) {
+                    outputStream.write(b);
+                }
+
+                @Override
+                public boolean isReady() {
+                    return true;
+                }
+
+                @Override
+                public void setWriteListener(javax.servlet.WriteListener listener) {
+                    // No-op for this example
+                }
+            };
+        }
+        return servletOutputStream;
+    }
+
+    @Override
+    public PrintWriter getWriter() throws IOException {
+        if (writer == null) {
+            writer = new PrintWriter(outputStream);
+        }
+        return writer;
+    }
+
+    public byte[] getOutputStreamData() {
+        return outputStream.toByteArray();
+    }
+}

--- a/webapp/src/main/webapp/WEB-INF/web.xml
+++ b/webapp/src/main/webapp/WEB-INF/web.xml
@@ -114,6 +114,16 @@
         <url-pattern>/api/atlas/admin/status</url-pattern>
     </filter-mapping>
 
+    <filter>
+        <filter-name>brotliFilter</filter-name>
+        <filter-class>org.apache.atlas.web.filters.BrotliCompressionFilter</filter-class>
+    </filter>
+
+    <filter-mapping>
+        <filter-name>brotliFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
     <listener>
         <listener-class>org.springframework.web.context.request.RequestContextListener</listener-class>
     </listener>


### PR DESCRIPTION
## Change description

> Enable brotli compression on all endpoints. Tested locally and tested gzip before. Refer this PR https://github.com/atlanhq/atlas-metastore/pull/3574

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

https://atlanhq.atlassian.net/browse/PLT-2568

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
