### PR TITLE
DG-1908 TLS Cookie Without Secure Flag Set Fix

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/web.xml
+++ b/webapp/src/main/webapp/WEB-INF/web.xml
@@ -139,6 +139,7 @@
         <cookie-config>
             <name>ATLASSESSIONID</name>
             <http-only>true</http-only>
+            <secure>true</secure>
         </cookie-config>
     </session-config>
 


### PR DESCRIPTION
## Change description

> Added secure tag to the cookie ATLASSESSIONID. The secure flag is set on a cookie, then browsers will not submit the cookie in any requests that use an unencrypted HTTP connection, thereby preventing the cookie from being trivially intercepted by an attacker monitoring network traffic.

## Type of change
- [ ] Bug fix (fixes an issue)

## Related issues

> Fix [Ticket](https://atlanhq.atlassian.net/browse/DG-1908) 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
