### PR TITLE
DG-1942 Fix task fetching inconsistency causing excessive lock churn and memory heap buildup in pods

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,7 +25,7 @@ on:
       - beta
       - development
       - master
-      - plt529
+      - plt529test
 
 jobs:
   build:
@@ -64,7 +64,7 @@ jobs:
       - name: Build with Maven
         run: |
           branch_name=${{ steps.get_branch.outputs.branch }} 
-          if [[ $branch_name == 'main' || $branch_name == 'master' || $branch_name == 'plt529' ]]
+          if [[ $branch_name == 'main' || $branch_name == 'master' || $branch_name == 'plt529test' ]]
           then
               echo "build without dashboard"
               chmod +x ./build.sh && ./build.sh build_without_dashboard

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,7 +25,7 @@ on:
       - beta
       - development
       - master
-      - lineageondemand
+      - plt529
 
 jobs:
   build:
@@ -64,7 +64,7 @@ jobs:
       - name: Build with Maven
         run: |
           branch_name=${{ steps.get_branch.outputs.branch }} 
-          if [[ $branch_name == 'main' || $branch_name == 'master' || $branch_name == 'lineageondemand' ]]
+          if [[ $branch_name == 'main' || $branch_name == 'master' || $branch_name == 'plt529' ]]
           then
               echo "build without dashboard"
               chmod +x ./build.sh && ./build.sh build_without_dashboard

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,7 +25,7 @@ on:
       - beta
       - development
       - master
-      - plt529test
+      - lineageondemand
 
 jobs:
   build:
@@ -64,7 +64,7 @@ jobs:
       - name: Build with Maven
         run: |
           branch_name=${{ steps.get_branch.outputs.branch }} 
-          if [[ $branch_name == 'main' || $branch_name == 'master' || $branch_name == 'plt529test' ]]
+          if [[ $branch_name == 'main' || $branch_name == 'master' || $branch_name == 'lineageondemand' ]]
           then
               echo "build without dashboard"
               chmod +x ./build.sh && ./build.sh build_without_dashboard

--- a/repository/src/main/java/org/apache/atlas/tasks/TaskQueueWatcher.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/TaskQueueWatcher.java
@@ -108,6 +108,7 @@ public class TaskQueueWatcher implements Runnable {
                 } else {
                     redisService.releaseDistributedLock(ATLAS_TASK_LOCK);
                 }
+                fetcher.clearTasks();
                 Thread.sleep(pollInterval);
             } catch (InterruptedException interruptedException) {
                 LOG.error("TaskQueueWatcher: Interrupted: thread is terminated, new tasks will not be loaded into the queue until next restart");
@@ -164,6 +165,10 @@ public class TaskQueueWatcher implements Runnable {
 
         public List<AtlasTask> getTasks() {
             return tasks;
+        }
+
+        public void clearTasks() {
+            this.tasks.clear();
         }
     }
 

--- a/repository/src/main/java/org/apache/atlas/tasks/TaskQueueWatcher.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/TaskQueueWatcher.java
@@ -90,7 +90,7 @@ public class TaskQueueWatcher implements Runnable {
             LOG.info("TaskQueueWatcher: Starting a new iteration of task fetching and processing.");
             TasksFetcher fetcher = new TasksFetcher(registry);
             try {
-                LOG.debug("TaskQueueWatcher: Attempting to acquire distributed lock: {}", ATLAS_TASK_LOCK);
+                LOG.info("TaskQueueWatcher: Attempting to acquire distributed lock: {}", ATLAS_TASK_LOCK);
                 if (!redisService.acquireDistributedLock(ATLAS_TASK_LOCK)) {
                     LOG.warn("TaskQueueWatcher: Could not acquire lock: {}. Retrying after {} ms.", ATLAS_TASK_LOCK, AtlasConstants.TASK_WAIT_TIME_MS);
                     Thread.sleep(AtlasConstants.TASK_WAIT_TIME_MS);
@@ -117,15 +117,15 @@ public class TaskQueueWatcher implements Runnable {
                 LOG.info("TaskQueueWatcher: Sleeping for {} ms before the next poll.", pollInterval);
                 Thread.sleep(pollInterval);
             } catch (InterruptedException interruptedException) {
-                LOG.error("TaskQueueWatcher: Interrupted. Thread is terminating. New tasks will not be loaded into the queue until next restart.", interruptedException);
+                LOG.info("TaskQueueWatcher: Interrupted. Thread is terminating. New tasks will not be loaded into the queue until next restart.", interruptedException);
                 break;
             } catch (Exception e) {
-                LOG.error("TaskQueueWatcher: Exception occurred during task processing: {}", e.getMessage(), e);
+                LOG.info("TaskQueueWatcher: Exception occurred during task processing: {}", e.getMessage(), e);
             } finally {
                 LOG.info("TaskQueueWatcher: Releasing distributed lock: {}", ATLAS_TASK_LOCK);
                 redisService.releaseDistributedLock(ATLAS_TASK_LOCK);
                 fetcher.clearTasks();
-                LOG.debug("TaskQueueWatcher: Cleared tasks from the fetcher.");
+                LOG.info("TaskQueueWatcher: Cleared tasks from the fetcher.");
             }
         }
 

--- a/repository/src/main/java/org/apache/atlas/tasks/TaskQueueWatcher.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/TaskQueueWatcher.java
@@ -78,60 +78,44 @@ public class TaskQueueWatcher implements Runnable {
     public void run() {
         boolean isMaintenanceMode = AtlasConfiguration.ATLAS_MAINTENANCE_MODE.getBoolean();
         if (isMaintenanceMode) {
-            LOG.info("TaskQueueWatcher: Maintenance mode is enabled. New tasks will not be loaded into the queue until next restart.");
+            LOG.info("TaskQueueWatcher: Maintenance mode is enabled, new tasks will not be loaded into the queue until next restart");
             return;
         }
         shouldRun.set(true);
 
         if (LOG.isDebugEnabled()) {
-            LOG.debug("TaskQueueWatcher: Starting thread {}:{}", Thread.currentThread().getName(), Thread.currentThread().getId());
+            LOG.debug("TaskQueueWatcher: running {}:{}", Thread.currentThread().getName(), Thread.currentThread().getId());
         }
         while (shouldRun.get()) {
-            LOG.info("TaskQueueWatcher: Starting a new iteration of task fetching and processing.");
             TasksFetcher fetcher = new TasksFetcher(registry);
             try {
-                LOG.info("TaskQueueWatcher: Attempting to acquire distributed lock: {}", ATLAS_TASK_LOCK);
                 if (!redisService.acquireDistributedLock(ATLAS_TASK_LOCK)) {
-                    LOG.warn("TaskQueueWatcher: Could not acquire lock: {}. Retrying after {} ms.", ATLAS_TASK_LOCK, AtlasConstants.TASK_WAIT_TIME_MS);
                     Thread.sleep(AtlasConstants.TASK_WAIT_TIME_MS);
                     continue;
                 }
                 LOG.info("TaskQueueWatcher: Acquired distributed lock: {}", ATLAS_TASK_LOCK);
 
                 List<AtlasTask> tasks = fetcher.getTasks();
-                LOG.info("TaskQueueWatcher: Fetched {} tasks for processing.", CollectionUtils.isNotEmpty(tasks) ? tasks.size() : 0);
-
                 if (CollectionUtils.isNotEmpty(tasks)) {
                     final CountDownLatch latch = new CountDownLatch(tasks.size());
-                    LOG.info("TaskQueueWatcher: Submitting {} tasks to the queue.", tasks.size());
                     submitAll(tasks, latch);
-
-                    LOG.info("TaskQueueWatcher: Waiting for submitted tasks to complete.");
+                    LOG.info("Submitted {} tasks to the queue", tasks.size());
                     waitForTasksToComplete(latch);
-                    LOG.info("TaskQueueWatcher: All tasks have been processed.");
                 } else {
-                    LOG.info("TaskQueueWatcher: No tasks fetched. Releasing distributed lock: {}", ATLAS_TASK_LOCK);
                     redisService.releaseDistributedLock(ATLAS_TASK_LOCK);
                 }
-
-                LOG.info("TaskQueueWatcher: Sleeping for {} ms before the next poll.", pollInterval);
                 Thread.sleep(pollInterval);
             } catch (InterruptedException interruptedException) {
-                LOG.info("TaskQueueWatcher: Interrupted. Thread is terminating. New tasks will not be loaded into the queue until next restart.", interruptedException);
+                LOG.error("TaskQueueWatcher: Interrupted: thread is terminated, new tasks will not be loaded into the queue until next restart");
                 break;
             } catch (Exception e) {
-                LOG.info("TaskQueueWatcher: Exception occurred during task processing: {}", e.getMessage(), e);
+                LOG.error("TaskQueueWatcher: Exception occurred " + e.getMessage(), e);
             } finally {
-                LOG.info("TaskQueueWatcher: Releasing distributed lock: {}", ATLAS_TASK_LOCK);
                 redisService.releaseDistributedLock(ATLAS_TASK_LOCK);
                 fetcher.clearTasks();
-                LOG.info("TaskQueueWatcher: Cleared tasks from the fetcher.");
             }
         }
-
-        LOG.info("TaskQueueWatcher: Thread has stopped. shouldRun is now set to false.");
     }
-
 
     private void waitForTasksToComplete(final CountDownLatch latch) throws InterruptedException {
         if (latch.getCount() != 0) {

--- a/repository/src/main/java/org/apache/atlas/tasks/TaskRegistry.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/TaskRegistry.java
@@ -385,38 +385,47 @@ public class TaskRegistry {
         DirectIndexQueryResult indexQueryResult = null;
         List<AtlasTask> ret = new ArrayList<>();
 
-        int size = 1000;
-        int from = 0;
+        int size = 1000; // Batch size for fetching tasks
+        int from = 0; // Pagination offset
+        int totalFetched = 0; // Tracks the total number of tasks fetched
+
+        LOG.info("Starting fetch of PENDING and IN_PROGRESS tasks. Queue size limit: {}", queueSize);
 
         IndexSearchParams indexSearchParams = new IndexSearchParams();
 
-        List statusClauseList = new ArrayList();
+        // Build query for PENDING and IN_PROGRESS tasks
+        List<Map<String, Object>> statusClauseList = new ArrayList<>();
         statusClauseList.add(mapOf("match", mapOf(TASK_STATUS, AtlasTask.Status.IN_PROGRESS.toString())));
         statusClauseList.add(mapOf("match", mapOf(TASK_STATUS, AtlasTask.Status.PENDING.toString())));
 
-        Map<String, Object> dsl = mapOf("query", mapOf("bool", mapOf("should", statusClauseList)));
+        Map<String, Object> dsl = mapOf(
+                "query", mapOf("bool", mapOf("should", statusClauseList))
+        );
         dsl.put("sort", Collections.singletonList(mapOf(Constants.TASK_CREATED_TIME, mapOf("order", "asc"))));
         dsl.put("size", size);
-        int totalFetched = 0;
+
         while (true) {
             int fetched = 0;
             try {
                 if (totalFetched + size > queueSize) {
-                    size = queueSize - totalFetched;
+                    size = queueSize - totalFetched; // Adjust size to not exceed queue size
+                    LOG.info("Adjusting fetch size to {} based on queue size constraint.", size);
                 }
 
                 dsl.put("from", from);
                 dsl.put("size", size);
 
+                LOG.debug("DSL Query for iteration: {}", dsl);
                 indexSearchParams.setDsl(dsl);
 
+                LOG.info("Executing Elasticsearch query with from: {} and size: {}", from, size);
                 AtlasIndexQuery indexQuery = graph.elasticsearchQuery(Constants.VERTEX_INDEX, indexSearchParams);
 
                 try {
                     indexQueryResult = indexQuery.vertices(indexSearchParams);
+                    LOG.info("Query executed successfully for from: {} with size: {}", from, size);
                 } catch (AtlasBaseException e) {
-                    LOG.error("Failed to fetch pending/in-progress task vertices to re-que");
-                    e.printStackTrace();
+                    LOG.error("Failed to fetch PENDING/IN_PROGRESS task vertices. Exiting loop.", e);
                     break;
                 }
 
@@ -428,34 +437,47 @@ public class TaskRegistry {
 
                         if (vertex != null) {
                             AtlasTask atlasTask = toAtlasTask(vertex);
+
+                            LOG.debug("Processing fetched task: {}", atlasTask);
                             if (atlasTask.getStatus().equals(AtlasTask.Status.PENDING) ||
-                                    atlasTask.getStatus().equals(AtlasTask.Status.IN_PROGRESS) ){
-                                LOG.info(String.format("Fetched task from index search: %s", atlasTask.toString()));
+                                    atlasTask.getStatus().equals(AtlasTask.Status.IN_PROGRESS)) {
+                                LOG.info("Adding task to the result list: {}", atlasTask);
                                 ret.add(atlasTask);
-                            }
-                            else {
-                                LOG.warn(String.format("There is a mismatch on tasks status between ES and Cassandra for guid: %s", atlasTask.getGuid()));
+                            } else {
+                                LOG.warn("Status mismatch for task with guid: {}. Expected PENDING/IN_PROGRESS but found: {}",
+                                        atlasTask.getGuid(), atlasTask.getStatus());
+
+                                // Repair mismatched task
                                 String docId = LongEncoding.encode(Long.parseLong(vertex.getIdForDisplay()));
+                                LOG.info("Repairing mismatched task with docId: {}", docId);
                                 repairMismatchedTask(atlasTask, docId);
                             }
                         } else {
-                            LOG.warn("Null vertex while re-queuing tasks at index {}", fetched);
+                            LOG.warn("Null vertex encountered while re-queuing tasks at index {}", fetched);
                         }
 
                         fetched++;
                     }
+                    LOG.info("Fetched {} tasks in this iteration.", fetched);
+                } else {
+                    LOG.warn("Index query result is null for from: {} and size: {}", from, size);
                 }
 
                 totalFetched += fetched;
+                LOG.info("Total tasks fetched so far: {}. Incrementing offset by {}.", totalFetched, size);
+
                 from += size;
                 if (fetched < size || totalFetched >= queueSize) {
+                    LOG.info("Breaking loop. Fetched fewer tasks ({}) than requested size ({}) or reached queue size limit ({}).", fetched, size, queueSize);
                     break;
                 }
-            } catch (Exception e){
+            } catch (Exception e) {
+                LOG.error("Exception occurred during task fetching process. Exiting loop.", e);
                 break;
             }
         }
 
+        LOG.info("Fetch process completed. Total tasks fetched: {}.", totalFetched);
         return ret;
     }
 

--- a/repository/src/main/java/org/apache/atlas/tasks/TaskRegistry.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/TaskRegistry.java
@@ -17,6 +17,7 @@
  */
 package org.apache.atlas.tasks;
 
+import com.datastax.oss.driver.shaded.fasterxml.jackson.core.JsonProcessingException;
 import com.datastax.oss.driver.shaded.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.atlas.AtlasConfiguration;
 import org.apache.atlas.RequestContext;
@@ -498,9 +499,12 @@ public class TaskRegistry {
             } else {
                 LOG.info("No documents updated in Elasticsearch for guid: " + atlasTask.getGuid());
             }
-        } catch (Exception e) {
-            e.printStackTrace();
+        } catch (JsonProcessingException e) {
+            LOG.error("Error converting fieldsToUpdate to JSON for task with guid: {} and docId: {}. Error: {}", atlasTask.getGuid(), docId, e.getMessage(), e);
         }
+         catch (AtlasBaseException e) {
+             LOG.error("Error executing Elasticsearch query for task with guid: {} and docId: {}. Error: {}", atlasTask.getGuid(), docId, e.getMessage(), e);
+         }
     }
 
     public void commit() {

--- a/repository/src/main/java/org/apache/atlas/tasks/TaskRegistry.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/TaskRegistry.java
@@ -430,6 +430,7 @@ public class TaskRegistry {
                             }
                             else {
                                 LOG.warn(String.format("There is a mismatch on tasks status between ES and Cassandra for guid: %s", atlasTask.getGuid()));
+                                vertex.setProperty(Constants.TASK_STATUS, atlasTask.getStatus().toString());
                             }
                         } else {
                             LOG.warn("Null vertex while re-queuing tasks at index {}", fetched);
@@ -446,6 +447,8 @@ public class TaskRegistry {
                 }
             } catch (Exception e){
                 break;
+            } finally {
+                graph.commit();
             }
         }
 

--- a/repository/src/main/java/org/apache/atlas/tasks/TaskRegistry.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/TaskRegistry.java
@@ -37,6 +37,7 @@ import org.apache.atlas.type.AtlasType;
 import org.apache.atlas.utils.AtlasPerfMetrics;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
+import org.janusgraph.util.encoding.LongEncoding;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -434,7 +435,8 @@ public class TaskRegistry {
                             }
                             else {
                                 LOG.warn(String.format("There is a mismatch on tasks status between ES and Cassandra for guid: %s", atlasTask.getGuid()));
-                                repairMismatchedTask(atlasTask);
+                                String docId = LongEncoding.encode(Long.parseLong(vertex.getIdForDisplay()));
+                                repairMismatchedTask(atlasTask, docId);
                             }
                         } else {
                             LOG.warn("Null vertex while re-queuing tasks at index {}", fetched);
@@ -457,7 +459,7 @@ public class TaskRegistry {
         return ret;
     }
 
-    private void repairMismatchedTask(AtlasTask atlasTask) {
+    private void repairMismatchedTask(AtlasTask atlasTask, String docId) {
         AtlasElasticsearchQuery indexQuery = null;
 
         try {
@@ -481,8 +483,8 @@ public class TaskRegistry {
                     + "    }"
                     + "},"
                     + "\"query\": {"
-                    + "    \"match\": {"
-                    + "        \"__task_guid\": \"" + atlasTask.getGuid() + "\""
+                    + "    \"term\": {"
+                    + "        \"_id\": \"" + docId + "\""
                     + "    }"
                     + "}"
                     + "}";


### PR DESCRIPTION
## Change description

> Due to ES<>Cassandra mismatch in Task Statuses, no valid tasks are being picked up. As 0 valid tasks are fetched, the lock is shifted to another pod for fetching. Same cycle repeats itself, thus increasing memory heap of all pods simultaneously. 
## Before fix memory graph
<img width="706" alt="image" src="https://github.com/user-attachments/assets/02f8d596-3ff7-47f6-a1ea-853c72f0065b">
<img width="713" alt="image" src="https://github.com/user-attachments/assets/d57f1d53-7019-4958-ae4b-751274512c08">

## After the fix
<img width="719" alt="image" src="https://github.com/user-attachments/assets/67730578-c8f7-4dc1-9e21-a8adfb429789">

## Picking only targeted 1 task at a time.
![image](https://github.com/user-attachments/assets/9a81d67f-8a65-4b78-8e69-aa80d4e81691)

## Type of change
- [ ] Bug fix (fixes an issue)

## Related issues

> Fix [Ticket](https://atlanhq.atlassian.net/browse/DG-1942)
> Ticket 2 (https://atlanhq.atlassian.net/browse/PLT-529)
> [Testcase](https://atlanhq.atlassian.net/wiki/x/JQDPHw)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
