### PR TITLE
FT-800 Added better message logging for unhandled exceptions

### DIFF
--- a/webapp/src/main/java/org/apache/atlas/web/errors/ExceptionMapperUtil.java
+++ b/webapp/src/main/java/org/apache/atlas/web/errors/ExceptionMapperUtil.java
@@ -27,6 +27,15 @@ public class ExceptionMapperUtil {
 
     @SuppressWarnings("UnusedParameters")
     protected static String formatErrorMessage(long id, Exception exception) {
+        if (exception == null) {
+            // If the exception is null, return a minimal error message
+            return "{\n"
+                    + String.format("  \"errorId\": \"%016x\",\n", id)
+                    + "  \"message\": \"No exception provided\",\n"
+                    + "  \"causes\": []\n"
+                    + "}";
+        }
+
         StringBuilder response = new StringBuilder();
 
         // Add error ID and general error message

--- a/webapp/src/main/java/org/apache/atlas/web/errors/ExceptionMapperUtil.java
+++ b/webapp/src/main/java/org/apache/atlas/web/errors/ExceptionMapperUtil.java
@@ -35,12 +35,18 @@ public class ExceptionMapperUtil {
                 .append("  \"message\": \"There was an error processing your request.\",\n")
                 .append("  \"causes\": [\n");
 
-        // Traverse through the chain of causes
+        // Traverse through the chain of causes, avoiding cycles
         List<String> causes = new ArrayList<>();
+        List<Throwable> visited = new ArrayList<>();
         Throwable currentException = exception;
         while (currentException != null) {
+            if (visited.contains(currentException)) {
+                causes.add("    {\n      \"errorType\": \"CircularReferenceDetected\",\n      \"errorMessage\": \"A circular reference was detected in the exception chain.\",\n      \"location\": \"Unavailable\"\n    }");
+                break;
+            }
+            visited.add(currentException);
             causes.add(formatCause(currentException));
-            currentException =currentException .getCause();
+            currentException = currentException.getCause();
         }
 
         // Add all formatted causes to the response


### PR DESCRIPTION
## Description

- This update improves exception handling by enhancing the error response to provide more meaningful information for developers.
- Instead of a generic error message, the response now includes a detailed stack trace analysis, offering insights into the specific cause of the error.


## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> Fix [FT-800](https://atlanhq.atlassian.net/browse/FT-800) , [PLT-2791](https://atlanhq.atlassian.net/browse/PLT-2791)

### Test Cases

1. **Test Case 1: Single exception**
   - **Input:** `IllegalArgumentException("Invalid argument provided")`
   - **Expected Output:** JSON with exception type, message, and location.

2. **Test Case 2: Exception with a cause**
   - **Input:** `IllegalStateException("Illegal state occurred")` with `NullPointerException` as cause
   - **Expected Output:** JSON with both exceptions and their details.

3. **Test Case 3: Exception with no message**
   - **Input:** `RuntimeException()`
   - **Expected Output:** JSON with default message "No additional information provided."

4. **Test Case 4: Exception with empty stack trace**
   - **Input:** `RuntimeException("Runtime exception occurred")` with empty stack trace
   - **Expected Output:** JSON with "Unavailable" as location.

5. **Test Case 5: Circular cause**
   - **Input:** `IllegalArgumentException("Self-causation not permitted")` causing itself
   - **Expected Output:** JSON indicating circular reference detected.

6. **Test Case 6: Null exception**
   - **Input:** `null`
   - **Expected Output:** JSON with "No exception provided" message and empty causes list.

## Checklists

### Development

- [ ] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable


[FT-800]: https://atlanhq.atlassian.net/browse/FT-800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PLT-2791]: https://atlanhq.atlassian.net/browse/PLT-2791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ