### PR TITLE
DG-1869 Evaluates API cache optimisation.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,7 +25,7 @@ on:
       - beta
       - development
       - master
-      - lineageondemand
+      - dg1869dev
 
 jobs:
   build:
@@ -64,7 +64,7 @@ jobs:
       - name: Build with Maven
         run: |
           branch_name=${{ steps.get_branch.outputs.branch }} 
-          if [[ $branch_name == 'main' || $branch_name == 'master' || $branch_name == 'lineageondemand' ]]
+          if [[ $branch_name == 'main' || $branch_name == 'master' || $branch_name == 'dg1869dev' ]]
           then
               echo "build without dashboard"
               chmod +x ./build.sh && ./build.sh build_without_dashboard

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,7 +25,7 @@ on:
       - beta
       - development
       - master
-      - dg1869dev
+      - lineageondemand
 
 jobs:
   build:
@@ -64,7 +64,7 @@ jobs:
       - name: Build with Maven
         run: |
           branch_name=${{ steps.get_branch.outputs.branch }} 
-          if [[ $branch_name == 'main' || $branch_name == 'master' || $branch_name == 'dg1869dev' ]]
+          if [[ $branch_name == 'main' || $branch_name == 'master' || $branch_name == 'lineageondemand' ]]
           then
               echo "build without dashboard"
               chmod +x ./build.sh && ./build.sh build_without_dashboard

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasEntityStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasEntityStore.java
@@ -374,4 +374,13 @@ public interface AtlasEntityStore {
     void unlinkBusinessPolicy(String policyId, Set<String> unlinkGuids) throws AtlasBaseException;
 
     void moveBusinessPolicies(Set<String> policyId, String assetId, String type) throws AtlasBaseException;
+
+    /**
+     *
+     * @param entities
+     * @throws AtlasBaseException
+     *
+     *  For evaluations of policies
+     */
+    List<AtlasEvaluatePolicyResponse> evaluatePolicies(List<AtlasEvaluatePolicyRequest> entities) throws AtlasBaseException;
 }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -806,24 +806,24 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
                         atlasEntityHeaderCache.put(entity.getEntityGuid(), entityHeader);
                     }
 
-                    AtlasEntityAccessRequest.AtlasEntityAccessRequestBuilder requestBuilder = new AtlasEntityAccessRequest.AtlasEntityAccessRequestBuilder(typeRegistry, AtlasPrivilege.valueOf(entities.get(i).getAction()), entityHeader);
-                    if (entities.get(i).getBusinessMetadata() != null) {
-                        requestBuilder.setBusinessMetadata(entities.get(i).getBusinessMetadata());
+                    AtlasEntityAccessRequest.AtlasEntityAccessRequestBuilder requestBuilder = new AtlasEntityAccessRequest.AtlasEntityAccessRequestBuilder(typeRegistry, AtlasPrivilege.valueOf(entity.getAction()), entityHeader);
+                    if (entity.getBusinessMetadata() != null) {
+                        requestBuilder.setBusinessMetadata(entity.getBusinessMetadata());
                     }
 
                     AtlasEntityAccessRequest entityAccessRequest = requestBuilder.build();
 
-                    AtlasAuthorizationUtils.verifyAccess(entityAccessRequest, entities.get(i).getAction() + "guid=" + entities.get(i).getEntityGuid());
-                    response.add(new AtlasEvaluatePolicyResponse(entities.get(i).getTypeName(), entities.get(i).getEntityGuid(), entities.get(i).getAction(), entities.get(i).getEntityId(), true, null , entities.get(i).getBusinessMetadata()));
+                    AtlasAuthorizationUtils.verifyAccess(entityAccessRequest, entity.getAction() + "guid=" + entity.getEntityGuid());
+                    response.add(new AtlasEvaluatePolicyResponse(entity.getTypeName(), entity.getEntityGuid(), entity.getAction(), entity.getEntityId(), true, null , entity.getBusinessMetadata()));
                 } catch (AtlasBaseException e) {
                     AtlasErrorCode code = e.getAtlasErrorCode();
                     String errorCode = code.getErrorCode();
-                    response.add(new AtlasEvaluatePolicyResponse(entities.get(i).getTypeName(), entities.get(i).getEntityGuid(), entities.get(i).getAction(), entities.get(i).getEntityId(), false, errorCode, entities.get(i).getBusinessMetadata()));
+                    response.add(new AtlasEvaluatePolicyResponse(entity.getTypeName(), entity.getEntityGuid(), entity.getAction(), entity.getEntityId(), false, errorCode, entity.getBusinessMetadata()));
                 }
 
             } else if (ENTITY_REMOVE_CLASSIFICATION.name().equals(action) || ENTITY_ADD_CLASSIFICATION.name().equals(action) || ENTITY_UPDATE_CLASSIFICATION.name().equals(action)) {
 
-                if (entities.get(i).getClassification() == null) {
+                if (entity.getClassification() == null) {
                     throw new AtlasBaseException(BAD_REQUEST, "classification needed for " + action + " authorization");
                 }
                 try {
@@ -834,18 +834,18 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
                         atlasEntityHeaderCache.put(entity.getEntityGuid(), entityHeader);
                     }
 
-                    AtlasAuthorizationUtils.verifyAccess(new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.valueOf(entities.get(i).getAction()), entityHeader, new AtlasClassification(entities.get(i).getClassification())));
-                    response.add(new AtlasEvaluatePolicyResponse(entities.get(i).getTypeName(), entities.get(i).getEntityGuid(), entities.get(i).getAction(), entities.get(i).getEntityId(), entities.get(i).getClassification(), true, null));
+                    AtlasAuthorizationUtils.verifyAccess(new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.valueOf(entity.getAction()), entityHeader, new AtlasClassification(entity.getClassification())));
+                    response.add(new AtlasEvaluatePolicyResponse(entity.getTypeName(), entity.getEntityGuid(), entity.getAction(), entity.getEntityId(), entity.getClassification(), true, null));
 
                 } catch (AtlasBaseException e) {
                     AtlasErrorCode code = e.getAtlasErrorCode();
                     String errorCode = code.getErrorCode();
-                    response.add(new AtlasEvaluatePolicyResponse(entities.get(i).getTypeName(), entities.get(i).getEntityGuid(), entities.get(i).getAction(), entities.get(i).getEntityId(), entities.get(i).getClassification(), false, errorCode));
+                    response.add(new AtlasEvaluatePolicyResponse(entity.getTypeName(), entity.getEntityGuid(), entity.getAction(), entity.getEntityId(), entity.getClassification(), false, errorCode));
                 }
 
             }    else if (RELATIONSHIP_ADD.name().equals(action) || RELATIONSHIP_REMOVE.name().equals(action) || RELATIONSHIP_UPDATE.name().equals(action)) {
 
-                if (entities.get(i).getRelationShipTypeName() == null) {
+                if (entity.getRelationShipTypeName() == null) {
                     throw new AtlasBaseException(BAD_REQUEST, "RelationShip TypeName needed for " + action + " authorization");
                 }
 
@@ -855,21 +855,25 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
                         end1Entity = atlasEntityHeaderCache.get(entity.getEntityGuidEnd1());
                     } else {
                         end1Entity = getAtlasEntityHeader(entity.getEntityGuidEnd1(), entity.getEntityIdEnd1(), entity.getEntityTypeEnd1());
-                        atlasEntityHeaderCache.put(entity.getEntityGuidEnd1(), end1Entity);
+                        if (entity.getEntityGuidEnd1() != null) {
+                            atlasEntityHeaderCache.put(entity.getEntityGuidEnd1(), end1Entity);
+                        }
                     }
                     AtlasEntityHeader end2Entity;
                     if (atlasEntityHeaderCache.containsKey(entity.getEntityGuidEnd2())) {
                         end2Entity = atlasEntityHeaderCache.get(entity.getEntityGuidEnd2());
                     } else {
                         end2Entity = getAtlasEntityHeader(entity.getEntityGuidEnd2(), entity.getEntityIdEnd2(), entity.getEntityTypeEnd2());
-                        atlasEntityHeaderCache.put(entity.getEntityGuidEnd2(), end2Entity);
+                        if (entity.getEntityGuidEnd2() != null) {
+                            atlasEntityHeaderCache.put(entity.getEntityGuidEnd2(), end2Entity);
+                        }
                     }
-                    AtlasAuthorizationUtils.verifyAccess(new AtlasRelationshipAccessRequest(typeRegistry, AtlasPrivilege.valueOf(action), entities.get(i).getRelationShipTypeName(), end1Entity, end2Entity));
-                    response.add(new AtlasEvaluatePolicyResponse(action, entities.get(i).getRelationShipTypeName(), entities.get(i).getEntityTypeEnd1(), entities.get(i).getEntityGuidEnd1(), entities.get(i).getEntityIdEnd1(), entities.get(i).getEntityTypeEnd2(), entities.get(i).getEntityGuidEnd2(), entities.get(i).getEntityIdEnd2(), true, null));
+                    AtlasAuthorizationUtils.verifyAccess(new AtlasRelationshipAccessRequest(typeRegistry, AtlasPrivilege.valueOf(action), entity.getRelationShipTypeName(), end1Entity, end2Entity));
+                    response.add(new AtlasEvaluatePolicyResponse(action, entity.getRelationShipTypeName(), entity.getEntityTypeEnd1(), entity.getEntityGuidEnd1(), entity.getEntityIdEnd1(), entity.getEntityTypeEnd2(), entity.getEntityGuidEnd2(), entity.getEntityIdEnd2(), true, null));
                 } catch (AtlasBaseException e) {
                     AtlasErrorCode code = e.getAtlasErrorCode();
                     String errorCode = code.getErrorCode();
-                    response.add(new AtlasEvaluatePolicyResponse(action, entities.get(i).getRelationShipTypeName(), entities.get(i).getEntityTypeEnd1(), entities.get(i).getEntityGuidEnd1(), entities.get(i).getEntityIdEnd1(), entities.get(i).getEntityTypeEnd2(), entities.get(i).getEntityGuidEnd2(), entities.get(i).getEntityIdEnd2(), false, errorCode));
+                    response.add(new AtlasEvaluatePolicyResponse(action, entity.getRelationShipTypeName(), entity.getEntityTypeEnd1(), entity.getEntityGuidEnd1(), entity.getEntityIdEnd1(), entity.getEntityTypeEnd2(), entity.getEntityGuidEnd2(), entity.getEntityIdEnd2(), false, errorCode));
                 }
             }
         }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -788,7 +788,7 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
 
     @Override
     public List<AtlasEvaluatePolicyResponse> evaluatePolicies(List<AtlasEvaluatePolicyRequest> entities) throws AtlasBaseException {
-        List<AtlasEvaluatePolicyResponse> response = new ArrayList();
+        List<AtlasEvaluatePolicyResponse> response = new ArrayList<>();
         HashMap<String, AtlasEntityHeader> atlasEntityHeaderCache = new HashMap<>();
         for (AtlasEvaluatePolicyRequest entity : entities) {
             String action = entity.getAction();
@@ -802,8 +802,8 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
                     || ENTITY_DELETE.name().equals(action) || ENTITY_UPDATE_BUSINESS_METADATA.name().equals(action)) {
 
                 try {
-                    if (StringUtils.isNotEmpty(entity.getEntityGuid())) {
-                        String cacheKey = generateCacheKey(entity.getEntityGuid(), entity.getEntityId(), entity.getTypeName());
+                    String cacheKey = generateCacheKey(entity.getEntityGuid(), entity.getEntityId(), entity.getTypeName());
+                    if (StringUtils.isNotEmpty(entity.getEntityGuid()) || StringUtils.isNotEmpty(entity.getEntityId())) {
                         if (atlasEntityHeaderCache.containsKey(cacheKey)) {
                             entityHeader = atlasEntityHeaderCache.get(cacheKey);
                         } else {
@@ -835,9 +835,8 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
                     throw new AtlasBaseException(BAD_REQUEST, "classification needed for " + action + " authorization");
                 }
                 try {
-
-                    if (StringUtils.isNotEmpty(entity.getEntityGuid())) {
-                        String cacheKey = generateCacheKey(entity.getEntityGuid(), entity.getEntityId(), entity.getTypeName());
+                    String cacheKey = generateCacheKey(entity.getEntityGuid(), entity.getEntityId(), entity.getTypeName());
+                    if (StringUtils.isNotEmpty(entity.getEntityGuid()) || StringUtils.isNotEmpty(entity.getEntityId())) {
                         if (atlasEntityHeaderCache.containsKey(cacheKey)) {
                             entityHeader = atlasEntityHeaderCache.get(cacheKey);
                         } else {
@@ -864,31 +863,31 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
                 }
 
                 try {
-                AtlasEntityHeader end1Entity;
-                if (StringUtils.isNotEmpty(entity.getEntityGuidEnd1())) {
+                    AtlasEntityHeader end1Entity;
                     String cacheKeyEnd1 = generateCacheKey(entity.getEntityGuidEnd1(), entity.getEntityIdEnd1(), entity.getEntityTypeEnd1());
-                    if (atlasEntityHeaderCache.containsKey(cacheKeyEnd1)) {
-                        end1Entity = atlasEntityHeaderCache.get(cacheKeyEnd1);
+                    if (StringUtils.isNotEmpty(entity.getEntityGuidEnd1()) || StringUtils.isNotEmpty(entity.getEntityIdEnd1())) {
+                        if (atlasEntityHeaderCache.containsKey(cacheKeyEnd1)) {
+                            end1Entity = atlasEntityHeaderCache.get(cacheKeyEnd1);
+                        } else {
+                            end1Entity = getAtlasEntityHeader(entity.getEntityGuidEnd1(), entity.getEntityIdEnd1(), entity.getEntityTypeEnd1());
+                            atlasEntityHeaderCache.put(cacheKeyEnd1, end1Entity);
+                        }
                     } else {
                         end1Entity = getAtlasEntityHeader(entity.getEntityGuidEnd1(), entity.getEntityIdEnd1(), entity.getEntityTypeEnd1());
-                        atlasEntityHeaderCache.put(cacheKeyEnd1, end1Entity);
                     }
-                } else {
-                    end1Entity = getAtlasEntityHeader(entity.getEntityGuidEnd1(), entity.getEntityIdEnd1(), entity.getEntityTypeEnd1());
-                }
 
-                AtlasEntityHeader end2Entity;
-                if (StringUtils.isNotEmpty(entity.getEntityGuidEnd2())) {
+                    AtlasEntityHeader end2Entity;
                     String cacheKeyEnd2 = generateCacheKey(entity.getEntityGuidEnd2(), entity.getEntityIdEnd2(), entity.getEntityTypeEnd2());
-                    if (atlasEntityHeaderCache.containsKey(cacheKeyEnd2)) {
-                        end2Entity = atlasEntityHeaderCache.get(cacheKeyEnd2);
+                    if (StringUtils.isNotEmpty(entity.getEntityGuidEnd2()) || StringUtils.isNotEmpty(entity.getEntityIdEnd2())) {
+                        if (atlasEntityHeaderCache.containsKey(cacheKeyEnd2)) {
+                            end2Entity = atlasEntityHeaderCache.get(cacheKeyEnd2);
+                        } else {
+                            end2Entity = getAtlasEntityHeader(entity.getEntityGuidEnd2(), entity.getEntityIdEnd2(), entity.getEntityTypeEnd2());
+                            atlasEntityHeaderCache.put(cacheKeyEnd2, end2Entity);
+                        }
                     } else {
                         end2Entity = getAtlasEntityHeader(entity.getEntityGuidEnd2(), entity.getEntityIdEnd2(), entity.getEntityTypeEnd2());
-                        atlasEntityHeaderCache.put(cacheKeyEnd2, end2Entity);
                     }
-                } else {
-                    end2Entity = getAtlasEntityHeader(entity.getEntityGuidEnd2(), entity.getEntityIdEnd2(), entity.getEntityTypeEnd2());
-                }
 
                     AtlasAuthorizationUtils.verifyAccess(new AtlasRelationshipAccessRequest(typeRegistry, AtlasPrivilege.valueOf(action), entity.getRelationShipTypeName(), end1Entity, end2Entity));
                     response.add(new AtlasEvaluatePolicyResponse(action, entity.getRelationShipTypeName(), entity.getEntityTypeEnd1(), entity.getEntityGuidEnd1(), entity.getEntityIdEnd1(), entity.getEntityTypeEnd2(), entity.getEntityGuidEnd2(), entity.getEntityIdEnd2(), true, null));

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -92,6 +92,7 @@ import org.springframework.stereotype.Component;
 import javax.inject.Inject;
 import java.io.InputStream;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static java.lang.Boolean.FALSE;
@@ -761,6 +762,8 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
     }
 
     private AtlasEntityHeader getAtlasEntityHeader(String entityGuid, String entityId, String entityType) throws AtlasBaseException {
+        // Metric logs
+        AtlasPerfMetrics.MetricRecorder metric = RequestContext.get().startMetricRecord("getAtlasEntityHeader");
         AtlasEntityHeader entityHeader = null;
 
         if (StringUtils.isNotEmpty(entityGuid)) {
@@ -779,6 +782,7 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
         } else {
             throw new AtlasBaseException(BAD_REQUEST, "requires entityGuid or typeName and qualifiedName for entity authorization");
         }
+        RequestContext.get().endMetricRecord(metric);
         return entityHeader;
     }
 
@@ -786,8 +790,7 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
     public List<AtlasEvaluatePolicyResponse> evaluatePolicies(List<AtlasEvaluatePolicyRequest> entities) throws AtlasBaseException {
         List<AtlasEvaluatePolicyResponse> response = new ArrayList();
         HashMap<String, AtlasEntityHeader> atlasEntityHeaderCache = new HashMap<>();
-        for (int i = 0; i < entities.size(); i++) {
-            AtlasEvaluatePolicyRequest entity = entities.get(i);
+        for (AtlasEvaluatePolicyRequest entity : entities) {
             String action = entity.getAction();
 
             if (action == null) {
@@ -799,11 +802,16 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
                     || ENTITY_DELETE.name().equals(action) || ENTITY_UPDATE_BUSINESS_METADATA.name().equals(action)) {
 
                 try {
-                    if (atlasEntityHeaderCache.containsKey(entity.getEntityGuid())) {
-                        entityHeader = atlasEntityHeaderCache.get(entity.getEntityGuid());
+                    if (StringUtils.isNotEmpty(entity.getEntityGuid())) {
+                        String cacheKey = generateCacheKey(entity.getEntityGuid(), entity.getEntityId(), entity.getTypeName());
+                        if (atlasEntityHeaderCache.containsKey(cacheKey)) {
+                            entityHeader = atlasEntityHeaderCache.get(cacheKey);
+                        } else {
+                            entityHeader = getAtlasEntityHeader(entity.getEntityGuid(), entity.getEntityId(), entity.getTypeName());
+                            atlasEntityHeaderCache.put(cacheKey, entityHeader);
+                        }
                     } else {
                         entityHeader = getAtlasEntityHeader(entity.getEntityGuid(), entity.getEntityId(), entity.getTypeName());
-                        atlasEntityHeaderCache.put(entity.getEntityGuid(), entityHeader);
                     }
 
                     AtlasEntityAccessRequest.AtlasEntityAccessRequestBuilder requestBuilder = new AtlasEntityAccessRequest.AtlasEntityAccessRequestBuilder(typeRegistry, AtlasPrivilege.valueOf(entity.getAction()), entityHeader);
@@ -827,11 +835,17 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
                     throw new AtlasBaseException(BAD_REQUEST, "classification needed for " + action + " authorization");
                 }
                 try {
-                    if (atlasEntityHeaderCache.containsKey(entity.getEntityGuid())) {
-                        entityHeader = atlasEntityHeaderCache.get(entity.getEntityGuid());
+
+                    if (StringUtils.isNotEmpty(entity.getEntityGuid())) {
+                        String cacheKey = generateCacheKey(entity.getEntityGuid(), entity.getEntityId(), entity.getTypeName());
+                        if (atlasEntityHeaderCache.containsKey(cacheKey)) {
+                            entityHeader = atlasEntityHeaderCache.get(cacheKey);
+                        } else {
+                            entityHeader = getAtlasEntityHeader(entity.getEntityGuid(), entity.getEntityId(), entity.getTypeName());
+                            atlasEntityHeaderCache.put(cacheKey, entityHeader);
+                        }
                     } else {
                         entityHeader = getAtlasEntityHeader(entity.getEntityGuid(), entity.getEntityId(), entity.getTypeName());
-                        atlasEntityHeaderCache.put(entity.getEntityGuid(), entityHeader);
                     }
 
                     AtlasAuthorizationUtils.verifyAccess(new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.valueOf(entity.getAction()), entityHeader, new AtlasClassification(entity.getClassification())));
@@ -850,24 +864,32 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
                 }
 
                 try {
-                    AtlasEntityHeader end1Entity;
-                    if (atlasEntityHeaderCache.containsKey(entity.getEntityGuidEnd1())) {
-                        end1Entity = atlasEntityHeaderCache.get(entity.getEntityGuidEnd1());
+                AtlasEntityHeader end1Entity;
+                if (StringUtils.isNotEmpty(entity.getEntityGuidEnd1())) {
+                    String cacheKeyEnd1 = generateCacheKey(entity.getEntityGuidEnd1(), entity.getEntityIdEnd1(), entity.getEntityTypeEnd1());
+                    if (atlasEntityHeaderCache.containsKey(cacheKeyEnd1)) {
+                        end1Entity = atlasEntityHeaderCache.get(cacheKeyEnd1);
                     } else {
                         end1Entity = getAtlasEntityHeader(entity.getEntityGuidEnd1(), entity.getEntityIdEnd1(), entity.getEntityTypeEnd1());
-                        if (entity.getEntityGuidEnd1() != null) {
-                            atlasEntityHeaderCache.put(entity.getEntityGuidEnd1(), end1Entity);
-                        }
+                        atlasEntityHeaderCache.put(cacheKeyEnd1, end1Entity);
                     }
-                    AtlasEntityHeader end2Entity;
-                    if (atlasEntityHeaderCache.containsKey(entity.getEntityGuidEnd2())) {
-                        end2Entity = atlasEntityHeaderCache.get(entity.getEntityGuidEnd2());
+                } else {
+                    end1Entity = getAtlasEntityHeader(entity.getEntityGuidEnd1(), entity.getEntityIdEnd1(), entity.getEntityTypeEnd1());
+                }
+
+                AtlasEntityHeader end2Entity;
+                if (StringUtils.isNotEmpty(entity.getEntityGuidEnd2())) {
+                    String cacheKeyEnd2 = generateCacheKey(entity.getEntityGuidEnd2(), entity.getEntityIdEnd2(), entity.getEntityTypeEnd2());
+                    if (atlasEntityHeaderCache.containsKey(cacheKeyEnd2)) {
+                        end2Entity = atlasEntityHeaderCache.get(cacheKeyEnd2);
                     } else {
                         end2Entity = getAtlasEntityHeader(entity.getEntityGuidEnd2(), entity.getEntityIdEnd2(), entity.getEntityTypeEnd2());
-                        if (entity.getEntityGuidEnd2() != null) {
-                            atlasEntityHeaderCache.put(entity.getEntityGuidEnd2(), end2Entity);
-                        }
+                        atlasEntityHeaderCache.put(cacheKeyEnd2, end2Entity);
                     }
+                } else {
+                    end2Entity = getAtlasEntityHeader(entity.getEntityGuidEnd2(), entity.getEntityIdEnd2(), entity.getEntityTypeEnd2());
+                }
+
                     AtlasAuthorizationUtils.verifyAccess(new AtlasRelationshipAccessRequest(typeRegistry, AtlasPrivilege.valueOf(action), entity.getRelationShipTypeName(), end1Entity, end2Entity));
                     response.add(new AtlasEvaluatePolicyResponse(action, entity.getRelationShipTypeName(), entity.getEntityTypeEnd1(), entity.getEntityGuidEnd1(), entity.getEntityIdEnd1(), entity.getEntityTypeEnd2(), entity.getEntityGuidEnd2(), entity.getEntityIdEnd2(), true, null));
                 } catch (AtlasBaseException e) {
@@ -879,6 +901,11 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
         }
         return response;
     }
+
+    private String generateCacheKey(String guid, String id, String typeName) {
+        return (guid != null ? guid : "") + "|" + (id != null ? id : "") + "|" + (typeName != null ? typeName : "");
+    }
+
 
 
     @Override

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -851,18 +851,18 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
 
                 try {
                     AtlasEntityHeader end1Entity;
-                    if (atlasEntityHeaderCache.containsKey(entity.getEntityGuid())) {
-                        end1Entity = atlasEntityHeaderCache.get(entity.getEntityGuid());
+                    if (atlasEntityHeaderCache.containsKey(entity.getEntityGuidEnd1())) {
+                        end1Entity = atlasEntityHeaderCache.get(entity.getEntityGuidEnd1());
                     } else {
                         end1Entity = getAtlasEntityHeader(entity.getEntityGuidEnd1(), entity.getEntityIdEnd1(), entity.getEntityTypeEnd1());
-                        atlasEntityHeaderCache.put(entity.getEntityGuid(), entityHeader);
+                        atlasEntityHeaderCache.put(entity.getEntityGuidEnd1(), end1Entity);
                     }
                     AtlasEntityHeader end2Entity;
-                    if (atlasEntityHeaderCache.containsKey(entity.getEntityGuid())) {
-                        end2Entity = atlasEntityHeaderCache.get(entity.getEntityGuid());
+                    if (atlasEntityHeaderCache.containsKey(entity.getEntityGuidEnd2())) {
+                        end2Entity = atlasEntityHeaderCache.get(entity.getEntityGuidEnd2());
                     } else {
                         end2Entity = getAtlasEntityHeader(entity.getEntityGuidEnd2(), entity.getEntityIdEnd2(), entity.getEntityTypeEnd2());
-                        atlasEntityHeaderCache.put(entity.getEntityGuid(), entityHeader);
+                        atlasEntityHeaderCache.put(entity.getEntityGuidEnd2(), end2Entity);
                     }
                     AtlasAuthorizationUtils.verifyAccess(new AtlasRelationshipAccessRequest(typeRegistry, AtlasPrivilege.valueOf(action), entities.get(i).getRelationShipTypeName(), end1Entity, end2Entity));
                     response.add(new AtlasEvaluatePolicyResponse(action, entities.get(i).getRelationShipTypeName(), entities.get(i).getEntityTypeEnd1(), entities.get(i).getEntityGuidEnd1(), entities.get(i).getEntityIdEnd1(), entities.get(i).getEntityTypeEnd2(), entities.get(i).getEntityGuidEnd2(), entities.get(i).getEntityIdEnd2(), true, null));

--- a/server-api/src/main/java/org/apache/atlas/RequestContext.java
+++ b/server-api/src/main/java/org/apache/atlas/RequestContext.java
@@ -60,6 +60,7 @@ public class RequestContext {
     private final Set<String>                            deletedEdgesIds      = new HashSet<>();
     private final Set<String>                            processGuidIds      = new HashSet<>();
 
+    private       Map<String, String>                    evaluateEntityHeaderCache        = null;
     private final AtlasPerfMetrics metrics = isMetricsEnabled ? new AtlasPerfMetrics() : null;
     private final List<AtlasPerfMetrics.Metric> applicationMetrics = new ArrayList<>();
     private List<EntityGuidPair> entityGuidInRequest = null;
@@ -567,17 +568,17 @@ public class RequestContext {
         }
     }
 
-    public void setEntityHeaderCache(AtlasEntityHeader headerCache){
-        if(headerCache != null && headerCache.getGuid() != null){
-            entityHeaderCache.put(headerCache.getGuid(), headerCache);
+    public void setEntityHeaderCache(String cacheKey, AtlasEntityHeader headerCache){
+        if(headerCache != null && StringUtils.isNotEmpty(cacheKey)){
+            entityHeaderCache.put(cacheKey, headerCache);
         }
     }
 
-    public AtlasEntityHeader getCachedEntityHeader(String guid){
-        if(guid == null){
+    public AtlasEntityHeader getCachedEntityHeader(String cacheKey){
+        if(cacheKey == null){
             return null;
         }
-        return entityHeaderCache.get(guid);
+        return entityHeaderCache.getOrDefault(cacheKey,null);
     }
 
     public AtlasEntity getDifferentialEntity(String guid) {
@@ -751,6 +752,14 @@ public class RequestContext {
 
     public void setClientOrigin(String clientOrigin) {
         this.clientOrigin = StringUtils.isEmpty(this.clientOrigin) ? "other" :clientOrigin;
+    }
+
+    public Map<String, String> getEvaluateEntityHeaderCache() {
+        return evaluateEntityHeaderCache;
+    }
+
+    public void setEvaluateEntityHeaderCache(Map<String, String> evaluateEntityHeaderCache) {
+        this.evaluateEntityHeaderCache = evaluateEntityHeaderCache;
     }
 
     public class EntityGuidPair {


### PR DESCRIPTION
## Change description

> In simple usecase of evaluates API from UI, multiple entities with same entityGuid or entityId were being fetched. for each entityGuid or entityId, we were fetching AtlasEntityHeader from DB, which was unnecessary as calls for same entityGuid or Id were redundant, thus added caching to optimise the flow.

## Type of change
- [ ] Bug fix (fixes an issue)

## Related issues

> Fix [Ticket](https://atlanhq.atlassian.net/browse/DG-1869) 
> [Testcases](https://www.notion.so/atlanhq/Eval-API-Optimisation-TestCase-Curls-1520e027187b80f08123f29ee733fe92?pvs=4)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
