### PR TITLE
MESH-292 : Update unique qualifiedName attribute in move flow

### DIFF
--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -39,6 +39,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static org.apache.atlas.type.AtlasStructType.AtlasAttribute.encodePropertyKey;
+import static org.apache.atlas.type.AtlasStructType.UNIQUE_ATTRIBUTE_SHADE_PROPERTY_PREFIX;
 
 /**
  * Repository Constants.
@@ -269,6 +270,7 @@ public final class Constants {
 
     public static final String NAME                                    = "name";
     public static final String QUALIFIED_NAME                          = "qualifiedName";
+    public static final String UNIQUE_QUALIFIED_NAME                   = UNIQUE_ATTRIBUTE_SHADE_PROPERTY_PREFIX + QUALIFIED_NAME;
     public static final String TYPE_NAME_PROPERTY_KEY                  = INTERNAL_PROPERTY_KEY_PREFIX + "typeName";
     public static final String INDEX_SEARCH_MAX_RESULT_SET_SIZE        = "atlas.graph.index.search.max-result-set-size";
     public static final String INDEX_SEARCH_TYPES_MAX_QUERY_STR_LENGTH = "atlas.graph.index.search.types.max-query-str-length";

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataDomainPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataDomainPreProcessor.java
@@ -53,6 +53,7 @@ public class DataDomainPreProcessor extends AbstractDomainPreProcessor {
     private Map<String, String> updatedPolicyResources;
     private EntityGraphRetriever retrieverNoRelation = null;
     private Map<String, String> updatedDomainQualifiedNames;
+    public static final String UNIQUE_ATTRIBUTE_SHADE_PROPERTY_PREFIX = "__u_";
 
     public DataDomainPreProcessor(AtlasTypeRegistry typeRegistry, EntityGraphRetriever entityRetriever,
                                   AtlasGraph graph) {
@@ -290,9 +291,14 @@ public class DataDomainPreProcessor extends AbstractDomainPreProcessor {
             String currentDomainQualifiedName = childDomainVertex.getProperty(QUALIFIED_NAME, String.class);
             String updatedDomainQualifiedName = parentDomainQualifiedName + getOwnQualifiedNameForChild(currentDomainQualifiedName);
 
+            String uniqueQualifiedNameAttribute = UNIQUE_ATTRIBUTE_SHADE_PROPERTY_PREFIX + QUALIFIED_NAME;
+
             // Change domain qualifiedName
             childDomainVertex.setProperty(QUALIFIED_NAME, updatedDomainQualifiedName);
             updatedAttributes.put(QUALIFIED_NAME, updatedDomainQualifiedName);
+
+            // Change unique qualifiedName attribute
+            childDomainVertex.setProperty(uniqueQualifiedNameAttribute, updatedDomainQualifiedName);
 
             //change superDomainQN, parentDomainQN
             childDomainVertex.setProperty(SUPER_DOMAIN_QN_ATTR, superDomainQualifiedName);
@@ -347,7 +353,10 @@ public class DataDomainPreProcessor extends AbstractDomainPreProcessor {
             String currentQualifiedName = productVertex.getProperty(QUALIFIED_NAME, String.class);
             String updatedQualifiedName = parentDomainQualifiedName + getOwnQualifiedNameForChild(currentQualifiedName);
 
+            String uniqueQualifiedNameAttribute = UNIQUE_ATTRIBUTE_SHADE_PROPERTY_PREFIX + QUALIFIED_NAME;
+
             productVertex.setProperty(QUALIFIED_NAME, updatedQualifiedName);
+            productVertex.setProperty(uniqueQualifiedNameAttribute, updatedQualifiedName);
             updatedAttributes.put(QUALIFIED_NAME, updatedQualifiedName);
 
             productVertex.setProperty(PARENT_DOMAIN_QN_ATTR, parentDomainQualifiedName);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataDomainPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataDomainPreProcessor.java
@@ -53,7 +53,6 @@ public class DataDomainPreProcessor extends AbstractDomainPreProcessor {
     private Map<String, String> updatedPolicyResources;
     private EntityGraphRetriever retrieverNoRelation = null;
     private Map<String, String> updatedDomainQualifiedNames;
-    public static final String UNIQUE_ATTRIBUTE_SHADE_PROPERTY_PREFIX = "__u_";
 
     public DataDomainPreProcessor(AtlasTypeRegistry typeRegistry, EntityGraphRetriever entityRetriever,
                                   AtlasGraph graph) {
@@ -291,14 +290,12 @@ public class DataDomainPreProcessor extends AbstractDomainPreProcessor {
             String currentDomainQualifiedName = childDomainVertex.getProperty(QUALIFIED_NAME, String.class);
             String updatedDomainQualifiedName = parentDomainQualifiedName + getOwnQualifiedNameForChild(currentDomainQualifiedName);
 
-            String uniqueQualifiedNameAttribute = UNIQUE_ATTRIBUTE_SHADE_PROPERTY_PREFIX + QUALIFIED_NAME;
-
             // Change domain qualifiedName
             childDomainVertex.setProperty(QUALIFIED_NAME, updatedDomainQualifiedName);
             updatedAttributes.put(QUALIFIED_NAME, updatedDomainQualifiedName);
 
             // Change unique qualifiedName attribute
-            childDomainVertex.setProperty(uniqueQualifiedNameAttribute, updatedDomainQualifiedName);
+            childDomainVertex.setProperty(UNIQUE_QUALIFIED_NAME, updatedDomainQualifiedName);
 
             //change superDomainQN, parentDomainQN
             childDomainVertex.setProperty(SUPER_DOMAIN_QN_ATTR, superDomainQualifiedName);
@@ -353,10 +350,8 @@ public class DataDomainPreProcessor extends AbstractDomainPreProcessor {
             String currentQualifiedName = productVertex.getProperty(QUALIFIED_NAME, String.class);
             String updatedQualifiedName = parentDomainQualifiedName + getOwnQualifiedNameForChild(currentQualifiedName);
 
-            String uniqueQualifiedNameAttribute = UNIQUE_ATTRIBUTE_SHADE_PROPERTY_PREFIX + QUALIFIED_NAME;
-
             productVertex.setProperty(QUALIFIED_NAME, updatedQualifiedName);
-            productVertex.setProperty(uniqueQualifiedNameAttribute, updatedQualifiedName);
+            productVertex.setProperty(UNIQUE_QUALIFIED_NAME, updatedQualifiedName);
             updatedAttributes.put(QUALIFIED_NAME, updatedQualifiedName);
 
             productVertex.setProperty(PARENT_DOMAIN_QN_ATTR, parentDomainQualifiedName);


### PR DESCRIPTION
## Change description

> In move flow, the unique qn attribute was not getting updated with right value. It hold the old value before move. Added a fix to explicitly set value for this attribute .

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## JIRA

- [https://atlanhq.atlassian.net/browse/MESH-292](url)

## Test-case doc

- [https://www.notion.so/atlanhq/Test-case-doc-MESH-292-1540e027187b80c7895fe4e020048d0f?pvs=4](url)

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
