### PR TITLE
DG-1989 NPE while creating a new edge when updating a relationship for attributeVertex

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -1247,13 +1247,14 @@ public class EntityGraphMapper {
                     deleteDelegate.getHandler().deleteEdgeReference(currentEdge, ctx.getAttrType().getTypeCategory(), ctx.getAttribute().isOwnedRef(),
                             true, ctx.getAttribute().getRelationshipEdgeDirection(), ctx.getReferringVertex());
                 }
+                if(StringUtils.isNotEmpty(edgeLabel)) {
+                    if (edgeLabel.equals(GLOSSARY_TERMS_EDGE_LABEL) || edgeLabel.equals(GLOSSARY_CATEGORY_EDGE_LABEL)) {
+                        addGlossaryAttr(ctx, newEdge);
+                    }
 
-                if (edgeLabel.equals(GLOSSARY_TERMS_EDGE_LABEL) || edgeLabel.equals(GLOSSARY_CATEGORY_EDGE_LABEL)) {
-                    addGlossaryAttr(ctx, newEdge);
-                }
-
-                if (CATEGORY_PARENT_EDGE_LABEL.equals(edgeLabel)) {
-                    addCatParentAttr(ctx, newEdge);
+                    if (CATEGORY_PARENT_EDGE_LABEL.equals(edgeLabel)) {
+                        addCatParentAttr(ctx, newEdge);
+                    }
                 }
 
                 return newEdge;
@@ -1307,6 +1308,9 @@ public class EntityGraphMapper {
     }
 
     private void addInverseReference(EntityMutationContext context, AtlasAttribute inverseAttribute, AtlasEdge edge, Map<String, Object> relationshipAttributes) throws AtlasBaseException {
+        if(Objects.isNull(edge)){
+            return;
+        }
         AtlasStructType inverseType      = inverseAttribute.getDefinedInType();
         AtlasVertex     inverseVertex    = edge.getInVertex();
         String          inverseEdgeLabel = inverseAttribute.getRelationshipEdgeLabel();
@@ -2927,7 +2931,7 @@ public class EntityGraphMapper {
 
         String    newEntityId = getIdFromVertex(newEntityVertex);
         AtlasEdge ret         = currentEdge;
-
+        // TODO : discuss this currentEdge to throw null or not, or to simply delete this as currentVertex does not exists.
         if (!currentEntityId.equals(newEntityId)) {
             // create a new relationship edge to the new attribute vertex from the instance
             String relationshipName = AtlasGraphUtilsV2.getTypeName(currentEdge);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -1247,12 +1247,12 @@ public class EntityGraphMapper {
                     deleteDelegate.getHandler().deleteEdgeReference(currentEdge, ctx.getAttrType().getTypeCategory(), ctx.getAttribute().isOwnedRef(),
                             true, ctx.getAttribute().getRelationshipEdgeDirection(), ctx.getReferringVertex());
                 }
-                if(StringUtils.isNotEmpty(edgeLabel)) {
+                if(StringUtils.isNotEmpty(edgeLabel) && Objects.nonNull(newEdge)) {
                     if (edgeLabel.equals(GLOSSARY_TERMS_EDGE_LABEL) || edgeLabel.equals(GLOSSARY_CATEGORY_EDGE_LABEL)) {
                         addGlossaryAttr(ctx, newEdge);
                     }
 
-                    if (CATEGORY_PARENT_EDGE_LABEL.equals(edgeLabel)) {
+                    if (CATEGORY_PARENT_EDGE_LABEL.equals(edgeLabel) && Objects.nonNull(newEdge)) {
                         addCatParentAttr(ctx, newEdge);
                     }
                 }
@@ -2931,7 +2931,11 @@ public class EntityGraphMapper {
 
         String    newEntityId = getIdFromVertex(newEntityVertex);
         AtlasEdge ret         = currentEdge;
-        // TODO : discuss this currentEdge to throw null or not, or to simply delete this as currentVertex does not exists.
+
+        if(StringUtils.isEmpty(currentEntityId)){
+            return null;
+        }
+
         if (!currentEntityId.equals(newEntityId)) {
             // create a new relationship edge to the new attribute vertex from the instance
             String relationshipName = AtlasGraphUtilsV2.getTypeName(currentEdge);


### PR DESCRIPTION
## Change description

> NPE while creating a new edge when updating a relationship for attributeVertex.The flow is failing when trying to read a guid from a vertex but guid-value is coming to be null which is causing the NPE. Added a null check for it while maintaining the existing flow.

## Type of change
- [ ] Bug fix (fixes an issue)

## Related issues

> Fix [#1](https://atlanhq.atlassian.net/browse/DG-1989)
> [Testcases](https://atlanhq.atlassian.net/wiki/x/JACjIg) 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
