### PR TITLE
DG-1986 | Use policy update time as last refresh time

### DIFF
--- a/auth-agents-common/src/main/java/org/apache/atlas/policytransformer/CachePolicyTransformerImpl.java
+++ b/auth-agents-common/src/main/java/org/apache/atlas/policytransformer/CachePolicyTransformerImpl.java
@@ -174,6 +174,8 @@ public class CachePolicyTransformerImpl {
 
                 ArrayList<String> policyGuids = new ArrayList<>(policyChanges.keySet());
                 List<AtlasEntityHeader> allAtlasPolicies = getAtlasPolicies(serviceName, POLICY_BATCH_SIZE, policyGuids);
+                Date latestUpdateTime = allAtlasPolicies.stream().map(AtlasEntityHeader::getUpdateTime).max(Date::compareTo).orElse(null);
+                servicePolicies.setPolicyUpdateTime(latestUpdateTime);
 
                 List<AtlasEntityHeader> atlasServicePolicies = allAtlasPolicies.stream().filter(x -> serviceName.equals(x.getAttribute(ATTR_POLICY_SERVICE_NAME))).collect(Collectors.toList());
                 List<RangerPolicyDelta> policiesDelta = getRangerPolicyDelta(service, policyChanges, atlasServicePolicies);

--- a/webapp/src/main/java/org/apache/atlas/web/rest/AuthREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/AuthREST.java
@@ -158,13 +158,12 @@ public class AuthREST {
             ServicePolicies ret;
             if (usePolicyDelta) {
                 List<EntityAuditEventV2> auditEvents = getPolicyAuditLogs(serviceName, lastUpdatedTime);
-                long lastEventTime = auditEvents.isEmpty() ? 0 : auditEvents.get(auditEvents.size() - 1).getCreated();
-                LOG.info("PolicyDelta: serviceName={}, lastUpdatedTime={}, audit events found={}", serviceName, lastEventTime, auditEvents.size());
+                LOG.info("PolicyDelta: serviceName={}, lastUpdatedTime={}, audit events found={}", serviceName, lastUpdatedTime, auditEvents.size());
                 if (auditEvents.isEmpty()) {
                     return null;
                 }
                 Map<String, EntityAuditEventV2.EntityAuditActionV2> policyChanges = policyTransformer.createPolicyChangeMap(serviceName, auditEvents);
-                ret = policyTransformer.getPoliciesDelta(serviceName, policyChanges, lastEventTime);
+                ret = policyTransformer.getPoliciesDelta(serviceName, policyChanges, lastUpdatedTime);
             } else {
                 if (!isPolicyUpdated(serviceName, lastUpdatedTime)) {
                     return null;
@@ -196,12 +195,12 @@ public class AuthREST {
         mustClauseList.add(getMap("terms", getMap("typeName", entityUpdateToWatch)));
 
         lastUpdatedTime = lastUpdatedTime == -1 ? 0 : lastUpdatedTime;
-        mustClauseList.add(getMap("range", getMap("created", getMap("gt", lastUpdatedTime))));
+        mustClauseList.add(getMap("range", getMap("timestamp", getMap("gt", lastUpdatedTime))));
 
         dsl.put("query", getMap("bool", getMap("must", mustClauseList)));
 
         List<Map<String, Object>> sortClause = new ArrayList<>();
-        sortClause.add(getMap("created", getMap("order", "asc")));
+        sortClause.add(getMap("timestamp", getMap("order", "asc")));
         dsl.put("sort", sortClause);
 
         int from = 0;


### PR DESCRIPTION
## Change description

Use highest updated time from fetched policies as last refresh time instead of audit event time. This will allow missed policies to be fetched in next cycle even if policies are not synced with ES but audit event is generated.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
