### PR TITLE
DG-1986 | Use policy update time as last refresh time

### DIFF
--- a/auth-agents-common/src/main/java/org/apache/atlas/plugin/service/RangerBasePlugin.java
+++ b/auth-agents-common/src/main/java/org/apache/atlas/plugin/service/RangerBasePlugin.java
@@ -324,6 +324,7 @@ public class RangerBasePlugin {
 						if (defaultSvcPolicies == null) {
 							LOG.error("Could not get default Service Policies. Keeping old policy-engine! This is a FATAL error as the old policy-engine is null!");
 							isNewEngineNeeded = false;
+							throw new RuntimeException("PolicyRefresher("+policies.getServiceName()+").setPolicies: fetched service policies contains no policies or delta and current policy engine is null");
 						} else {
 							defaultSvcPolicies.setPolicyVersion(policies.getPolicyVersion());
 							policies = defaultSvcPolicies;

--- a/auth-agents-common/src/main/java/org/apache/atlas/plugin/service/RangerBasePlugin.java
+++ b/auth-agents-common/src/main/java/org/apache/atlas/plugin/service/RangerBasePlugin.java
@@ -420,6 +420,7 @@ public class RangerBasePlugin {
 					if (this.refresher != null) {
 						this.refresher.saveToCache(usePolicyDeltas ? servicePolicies : policies);
 					}
+					LOG.info("New RangerPolicyEngine created with policy count:"+ (usePolicyDeltas? servicePolicies.getPolicies().size() : policies.getPolicies().size()));
 				}
 
 			} else {

--- a/auth-agents-common/src/main/java/org/apache/atlas/plugin/util/PolicyRefresher.java
+++ b/auth-agents-common/src/main/java/org/apache/atlas/plugin/util/PolicyRefresher.java
@@ -295,7 +295,7 @@ public class PolicyRefresher extends Thread {
 				lastUpdatedTimeInMillis = -1;
 			}
 		} catch (Exception excp) {
-			LOG.error("Encountered unexpected exception!!!!!!!!!!!", excp);
+			LOG.error("Encountered unexpected exception!!!!!!!!!!! Message:" + excp.getMessage() + "Stacktrace: " + excp.getStackTrace().toString(), excp);
 		}
 
 		RangerPerfTracer.log(perf);

--- a/auth-agents-common/src/main/java/org/apache/atlas/policytransformer/CachePolicyTransformerImpl.java
+++ b/auth-agents-common/src/main/java/org/apache/atlas/policytransformer/CachePolicyTransformerImpl.java
@@ -174,6 +174,8 @@ public class CachePolicyTransformerImpl {
 
                 ArrayList<String> policyGuids = new ArrayList<>(policyChanges.keySet());
                 List<AtlasEntityHeader> allAtlasPolicies = getAtlasPolicies(serviceName, POLICY_BATCH_SIZE, policyGuids);
+                Date latestUpdateTime = allAtlasPolicies.stream().map(AtlasEntityHeader::getUpdateTime).max(Date::compareTo).orElse(null);
+                servicePolicies.setPolicyUpdateTime(latestUpdateTime);
 
                 List<AtlasEntityHeader> atlasServicePolicies = allAtlasPolicies.stream().filter(x -> serviceName.equals(x.getAttribute(ATTR_POLICY_SERVICE_NAME))).collect(Collectors.toList());
                 List<RangerPolicyDelta> policiesDelta = getRangerPolicyDelta(service, policyChanges, atlasServicePolicies);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -1974,6 +1974,8 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
 
             MetricRecorder metric = RequestContext.get().startMetricRecord("filterCategoryVertices");
             for (AtlasVertex vertex : deletionCandidates) {
+                updateModificationMetadata(vertex);
+
                 String typeName = getTypeName(vertex);
 
                 List<PreProcessor> preProcessors = getPreProcessor(typeName);

--- a/webapp/src/main/java/org/apache/atlas/web/rest/AuthREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/AuthREST.java
@@ -158,13 +158,12 @@ public class AuthREST {
             ServicePolicies ret;
             if (usePolicyDelta) {
                 List<EntityAuditEventV2> auditEvents = getPolicyAuditLogs(serviceName, lastUpdatedTime);
-                long lastEventTime = auditEvents.isEmpty() ? 0 : auditEvents.get(auditEvents.size() - 1).getCreated();
-                LOG.info("PolicyDelta: serviceName={}, lastUpdatedTime={}, audit events found={}", serviceName, lastEventTime, auditEvents.size());
+                LOG.info("PolicyDelta: serviceName={}, lastUpdatedTime={}, audit events found={}", serviceName, lastUpdatedTime, auditEvents.size());
                 if (auditEvents.isEmpty()) {
                     return null;
                 }
                 Map<String, EntityAuditEventV2.EntityAuditActionV2> policyChanges = policyTransformer.createPolicyChangeMap(serviceName, auditEvents);
-                ret = policyTransformer.getPoliciesDelta(serviceName, policyChanges, lastEventTime);
+                ret = policyTransformer.getPoliciesDelta(serviceName, policyChanges, lastUpdatedTime);
             } else {
                 if (!isPolicyUpdated(serviceName, lastUpdatedTime)) {
                     return null;
@@ -196,12 +195,12 @@ public class AuthREST {
         mustClauseList.add(getMap("terms", getMap("typeName", entityUpdateToWatch)));
 
         lastUpdatedTime = lastUpdatedTime == -1 ? 0 : lastUpdatedTime;
-        mustClauseList.add(getMap("range", getMap("created", getMap("gt", lastUpdatedTime))));
+        mustClauseList.add(getMap("range", getMap("timestamp", getMap("gt", lastUpdatedTime))));
 
         dsl.put("query", getMap("bool", getMap("must", mustClauseList)));
 
         List<Map<String, Object>> sortClause = new ArrayList<>();
-        sortClause.add(getMap("created", getMap("order", "asc")));
+        sortClause.add(getMap("timestamp", getMap("order", "asc")));
         dsl.put("sort", sortClause);
 
         int from = 0;


### PR DESCRIPTION
## Change description
This PR contains following 3 small / one liner changes:

1. Use highest updated time from fetched policies as last refresh time instead of audit event time. This will keep the last updated time always equal to a actual policy update time, allowing any missed policies to be fetched in next cycle even if policies are not synced with ES but audit event is generated.

Since this timestamp is used to while fetching next set of policies, earlier method where audit event time was getting used had an edge case where if ES is not synced with policies that are created, policy refresher will not find that policy but since the last updated timestamp is updated with event time, it will be missed in subsequent fetches as well.

2. Currently, deleting an entity doesn't update `updateTime` of the entity, so if a policy is updated and then deleted, there would two audit events but both will have same value for `timestamp` which is the time when it was updated. This means then the delete event will not be catched by policy refresher since it has the already tracked timestamp which was generated later on.
 
3. Adds an exception if policy refresher does not find any policies to create the policy engine. Earlier it was silently getting handled causing problem when delta is applied since there was no policy engine to apply delta to. Throwing exception allows it to keep trying to create engine if no policies are available in the system e.g. in case of atlas reset.


__Test Cases__
1. Run atlas reset workflow to ensure typdefs are able to seed, ensuring the policy engine is getting created - ✅ 
2. Execute a workflow after resetting to ensure policies are getting refreshed - ✅ 
3. Create / update / delete a metadata policy in a Persona to ensure existing flow is untouched - ✅ 
4. Create / update / delete a metadata policy in a Purpose to ensure existing flow for tag is also untouched - ✅ 
5. Delete an entity and ensure `timestamp` is getting updated - ✅ 


## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
