### PR TITLE
MESH-299 | Changed the position of linkedentity attribute to root

### DIFF
--- a/intg/src/main/java/org/apache/atlas/model/audit/EntityAuditEventV2.java
+++ b/intg/src/main/java/org/apache/atlas/model/audit/EntityAuditEventV2.java
@@ -135,7 +135,6 @@ public class EntityAuditEventV2 implements Serializable, Clearable {
     private Map<String, Object> detail;
     private AtlasEntityHeader   entityDetail;
     private Map<String, String> headers;
-    private List<AtlasEntityHeader> linkedEntities;
 
     public EntityAuditEventV2() { }
 
@@ -251,19 +250,6 @@ public class EntityAuditEventV2 implements Serializable, Clearable {
         this.headers = headers;
     }
 
-    public List<AtlasEntityHeader> getLinkedEntities() {
-        return linkedEntities;
-    }
-
-    public void setLinkedEntities(List<AtlasEntityHeader> linkedEntities) {
-        this.linkedEntities = linkedEntities;
-    }
-
-    @JsonIgnore
-    public boolean hasLinkedEntities() {
-        return linkedEntities != null && !linkedEntities.isEmpty();
-    }
-
     @JsonIgnore
     public String getEntityDefinitionString() {
         if (entity != null) {
@@ -330,9 +316,6 @@ public class EntityAuditEventV2 implements Serializable, Clearable {
         sb.append(", created=").append(created);
         sb.append(", headers=").append(headers);
 
-        if (hasLinkedEntities()) {
-            sb.append(", linkedEntities=").append(linkedEntities);
-        }
 
         sb.append('}');
 

--- a/intg/src/main/java/org/apache/atlas/model/audit/EntityAuditSearchResult.java
+++ b/intg/src/main/java/org/apache/atlas/model/audit/EntityAuditSearchResult.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.apache.atlas.model.Clearable;
+import org.apache.atlas.model.instance.AtlasEntityHeader;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -30,6 +31,7 @@ public class EntityAuditSearchResult implements Serializable, Clearable  {
     private Map<String, Object> aggregations;
     private int count;
     private int totalCount;
+    private Map<String, AtlasEntityHeader> linkedEntities;
 
     public List<EntityAuditEventV2> getEntityAudits() {
         return entityAudits;
@@ -63,6 +65,10 @@ public class EntityAuditSearchResult implements Serializable, Clearable  {
         this.totalCount = totalCount;
     }
 
+    public Map<String, AtlasEntityHeader> getLinkedEntities() { return linkedEntities; }
+
+    public void setLinkedEntities(Map<String, AtlasEntityHeader> linkedEntities) { this.linkedEntities = linkedEntities; }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) { return true; }
@@ -85,6 +91,7 @@ public class EntityAuditSearchResult implements Serializable, Clearable  {
         final StringBuilder sb = new StringBuilder("EntityAuditSearchResult{");
         sb.append("entityAudits='").append(entityAudits).append('\'');
         sb.append(", aggregations='").append(aggregations).append('\'');
+        sb.append(", linkedEntities='").append(linkedEntities).append('\'');
         sb.append(", count=").append(count);
         sb.append(", totalCount=").append(totalCount);
         sb.append('}');


### PR DESCRIPTION
## Change description

> I have changed the location of the linkedEntities attribute to the root of the audit search log for [issue](https://atlanhq.atlassian.net/browse/MESH-299).

## Type of change
- [ ] Bug fix (fixes an issue)
- [ x] New feature (adds functionality)


### Development

- [ ] Lint rules pass locally
- [ x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
