### PR TITLE
added code to create kafka topic 'TAG_PROP_EVENTS' and push events to…

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,6 +28,7 @@ on:
       - lineageondemand
       - taskdg1924
       - taskdg1924deleteprop
+      - tagpropv1.5
 
 jobs:
   build:
@@ -66,7 +67,7 @@ jobs:
       - name: Build with Maven
         run: |
           branch_name=${{ steps.get_branch.outputs.branch }} 
-          if [[ $branch_name == 'main' || $branch_name == 'master' || $branch_name == 'taskdg1924deleteprop' ]]
+          if [[ $branch_name == 'main' || $branch_name == 'master' || $branch_name == 'tagpropv1.5' ]]
           then
               echo "build without dashboard"
               chmod +x ./build.sh && ./build.sh build_without_dashboard

--- a/common/src/main/java/org/apache/atlas/AtlasConstants.java
+++ b/common/src/main/java/org/apache/atlas/AtlasConstants.java
@@ -39,4 +39,6 @@ public final class AtlasConstants {
     public static final String DEFAULT_TYPE_VERSION          = "1.0";
     public static final int    ATLAS_SHUTDOWN_HOOK_PRIORITY  = 30;
     public static final int TASK_WAIT_TIME_MS = 180_000;
+    public static final String ATLAS_KAFKA_TAG_TOPIC = "TAG_PROP_EVENTS";
+
 }

--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -478,6 +478,9 @@ public final class Constants {
     public static final String REQUEST_HEADER_USER_AGENT = "User-Agent";
     public static final String REQUEST_HEADER_HOST       = "Host";
 
+    //kafka partition value for TAG_PROP_EVENTS
+    public static final String TAG_PROP_EVENTS_PARTITION_COUNT = "5";
+
     public static final Set<String> SKIP_UPDATE_AUTH_CHECK_TYPES = new HashSet<String>() {{
         add(README_ENTITY_TYPE);
         add(LINK_ENTITY_TYPE);

--- a/distro/src/bin/atlas_config.py
+++ b/distro/src/bin/atlas_config.py
@@ -500,7 +500,7 @@ def get_topics_to_create(confdir):
     if topic_list is not None:
         topics = topic_list.split(",")
     else:
-        topics = [getConfigWithDefault("atlas.notification.hook.topic.name", "ATLAS_HOOK"), getConfigWithDefault("atlas.notification.entities.topic.name", "ATLAS_ENTITIES"), getConfigWithDefault("atlas.notification.relationships.topic.name", "ATLAS_RELATIONSHIPS")]
+        topics = [getConfigWithDefault("atlas.notification.hook.topic.name", "ATLAS_HOOK"), getConfigWithDefault("atlas.notification.entities.topic.name", "ATLAS_ENTITIES"), getConfigWithDefault("atlas.notification.relationships.topic.name", "ATLAS_RELATIONSHIPS"), getConfigWithDefault("atlas.notification.propagation.topic.name", "TAG_PROP_EVENTS")]
     return topics
 
 def get_atlas_url_port(confdir):

--- a/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
@@ -40,6 +40,7 @@ public enum AtlasConfiguration {
     NOTIFICATION_HOOK_TOPIC_NAME("atlas.notification.hook.topic.name", "ATLAS_HOOK"),
     NOTIFICATION_ENTITIES_TOPIC_NAME("atlas.notification.entities.topic.name", "ATLAS_ENTITIES"),
     NOTIFICATION_RELATIONSHIPS_TOPIC_NAME("atlas.notification.relationships.topic.name", "ATLAS_RELATIONSHIPS"),
+    NOTIFICATION_PROPAGATION_TOPIC_NAME("atlas.notification.propagation.topic.name", "TAG_PROP_EVENTS"),
 
     NOTIFICATION_HOOK_CONSUMER_TOPIC_NAMES("atlas.notification.hook.consumer.topic.names", "ATLAS_HOOK"), //  a comma separated list of topic names
     NOTIFICATION_ENTITIES_CONSUMER_TOPIC_NAMES("atlas.notification.entities.consumer.topic.names", "ATLAS_ENTITIES"), //  a comma separated list of topic names

--- a/notification/src/main/java/org/apache/atlas/notification/AbstractNotification.java
+++ b/notification/src/main/java/org/apache/atlas/notification/AbstractNotification.java
@@ -120,7 +120,7 @@ public abstract class AbstractNotification implements NotificationInterface {
      */
     public abstract void sendInternal(NotificationType type, List<String> messages) throws NotificationException;
 
-
+    public abstract void sendInternal(NotificationType notificationType, List<String> messages, Integer partition) throws NotificationException;
     // ----- utility methods -------------------------------------------------
 
     public static String getMessageJson(Object message) {

--- a/notification/src/main/java/org/apache/atlas/notification/NotificationInterface.java
+++ b/notification/src/main/java/org/apache/atlas/notification/NotificationInterface.java
@@ -46,10 +46,13 @@ public interface NotificationInterface {
         // Notifications from the Atlas integration hooks.
         HOOK(new HookMessageDeserializer()),
 
+        EMIT_PLANNED_RELATIONSHIPS(new EntityMessageDeserializer()),
+
         // Notifications to entity change consumers.
         ENTITIES(new EntityMessageDeserializer()),
 
         RELATIONSHIPS(new EntityMessageDeserializer());
+
 
         private final AtlasNotificationMessageDeserializer deserializer;
 

--- a/pom.xml
+++ b/pom.xml
@@ -1718,6 +1718,13 @@
             <version>2.2.2</version>
         </dependency>
 
+        <!-- Google guava library for hashing -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>33.3.1-jre</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -27,6 +27,7 @@ import org.apache.atlas.authorize.AtlasEntityAccessRequest;
 import org.apache.atlas.authorize.AtlasPrivilege;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.exception.EntityNotFoundException;
+import org.apache.atlas.kafka.KafkaNotification;
 import org.apache.atlas.model.TimeBoundary;
 import org.apache.atlas.model.TypeCategory;
 import org.apache.atlas.model.instance.*;
@@ -37,6 +38,7 @@ import org.apache.atlas.model.typedef.AtlasEntityDef.AtlasRelationshipAttributeD
 import org.apache.atlas.model.typedef.AtlasRelationshipDef;
 import org.apache.atlas.model.typedef.AtlasStructDef.AtlasAttributeDef;
 import org.apache.atlas.model.typedef.AtlasStructDef.AtlasAttributeDef.Cardinality;
+import org.apache.atlas.notification.NotificationInterface;
 import org.apache.atlas.repository.Constants;
 import org.apache.atlas.repository.RepositoryException;
 import org.apache.atlas.repository.converters.AtlasInstanceConverter;
@@ -72,6 +74,7 @@ import org.apache.atlas.utils.AtlasPerfTracer;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
+import org.apache.commons.configuration.Configuration;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -83,6 +86,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
+import org.apache.atlas.kafka.KafkaNotification;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static org.apache.atlas.AtlasConfiguration.LABEL_MAX_LENGTH;
 import static org.apache.atlas.AtlasConfiguration.STORE_DIFFERENTIAL_AUDITS;
@@ -136,6 +143,8 @@ import static org.apache.atlas.type.Constants.MEANINGS_PROPERTY_KEY;
 import static org.apache.atlas.type.Constants.MEANINGS_TEXT_PROPERTY_KEY;
 import static org.apache.atlas.type.Constants.MEANING_NAMES_PROPERTY_KEY;
 
+import com.google.common.hash.Hashing;
+import java.nio.charset.StandardCharsets;
 
 @Component
 public class EntityGraphMapper {
@@ -199,6 +208,10 @@ public class EntityGraphMapper {
 
     private static final Set<String> excludedTypes = new HashSet<>(Arrays.asList(TYPE_GLOSSARY, TYPE_CATEGORY, TYPE_TERM, TYPE_PRODUCT, TYPE_DOMAIN));
 
+    Configuration configuration;
+    KafkaNotification kfknotif;
+    int numPartitions = Integer.parseInt(TAG_PROP_EVENTS_PARTITION_COUNT); // Total number of partitions in the Kafka topic
+
     @Inject
     public EntityGraphMapper(DeleteHandlerDelegate deleteDelegate, RestoreHandlerV1 restoreHandlerV1, AtlasTypeRegistry typeRegistry, AtlasGraph graph,
                              AtlasRelationshipStore relationshipStore, IAtlasEntityChangeNotifier entityChangeNotifier,
@@ -216,7 +229,16 @@ public class EntityGraphMapper {
         this.retrieverNoRelation  = new EntityGraphRetriever(graph, typeRegistry, true);
         this.fullTextMapperV2     = fullTextMapperV2;
         this.taskManagement       = taskManagement;
-        this.transactionInterceptHelper = transactionInterceptHelper;}
+        this.transactionInterceptHelper = transactionInterceptHelper;
+        try {
+            this.configuration = ApplicationProperties.get();
+            this.kfknotif = new KafkaNotification(configuration);
+
+        } catch (AtlasException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
 
     @VisibleForTesting
     public void setTasksUseFlag(boolean value) {
@@ -3480,7 +3502,38 @@ public class EntityGraphMapper {
             List<String> edgeLabelsToCheck = CLASSIFICATION_PROPAGATION_MODE_LABELS_MAP.get(propagationMode);
             Boolean toExclude = propagationMode == CLASSIFICATION_PROPAGATION_MODE_RESTRICT_LINEAGE ? true:false;
             List<AtlasVertex> impactedVertices = entityRetriever.getIncludedImpactedVerticesV2(entityVertex, relationshipGuid, classificationVertexId, edgeLabelsToCheck,toExclude);
-            
+
+            // update the 'assetsCountToPropagate' on in memory java object.
+            AtlasTask currentTask = RequestContext.get().getCurrentTask();
+            currentTask.setAssetsCountToPropagate((long) impactedVertices.size());
+
+            //update the 'assetsCountToPropagate' in the current task vertex.
+            AtlasVertex currentTaskVertex = (AtlasVertex) graph.query().has(TASK_GUID, currentTask.getGuid()).vertices().iterator().next();
+            currentTaskVertex.setProperty(TASK_ASSET_COUNT_TO_PROPAGATE, impactedVertices.size());
+
+            //iterate over each impacted vertex to create a message and send it to kafka
+            for (AtlasVertex vertex : impactedVertices) {
+                // Create a Map to store vertex properties
+                Map<String, Object> vertexMap = new HashMap<>();
+
+                vertexMap.put("parentTaskVertexId", currentTaskVertex.getIdForDisplay());
+                vertexMap.put("action", CLASSIFICATION_PROPAGATION_ADD);
+                vertexMap.put("assetVertexId", vertex.getIdForDisplay());
+                vertexMap.put("tagVertexId", classificationVertexId);
+                vertexMap.put("parentTaskGuid", currentTask.getGuid());
+                vertexMap.put("tagTypeName", currentTask.getClassificationTypeName());
+
+                String vertexJson = AtlasType.toJson(vertexMap);
+
+
+                // Using Guava to calculate the partition
+                int partition = Math.abs((Integer) vertexMap.get("parentTaskGuid")) % numPartitions;
+                LOG.debug("sending message with  guid={} to partition={}",currentTaskVertex.getIdForDisplay(), partition);
+
+                //send vertexJson to kafka topic 'TAG_PROP_EVENTS'
+                kfknotif.sendInternal(NotificationInterface.NotificationType.EMIT_PLANNED_RELATIONSHIPS, Collections.singletonList(vertexJson), partition);
+                LOG.debug("Message with guid={} sent to partition={} sent successfully.",currentTaskVertex.getIdForDisplay(), partition );
+            }
             if (CollectionUtils.isEmpty(impactedVertices)) {
                 LOG.debug("propagateClassification(entityGuid={}, classificationVertexId={}): found no entities to propagate the classification", entityGuid, classificationVertexId);
 

--- a/webapp/src/main/java/org/apache/atlas/Atlas.java
+++ b/webapp/src/main/java/org/apache/atlas/Atlas.java
@@ -53,6 +53,8 @@ import java.util.*;
 import static org.apache.atlas.repository.Constants.INDEX_PREFIX;
 import static org.apache.atlas.repository.Constants.VERTEX_INDEX;
 
+import org.apache.atlas.hook.AtlasTopicCreator;
+
 /**
  * Driver for running Metadata as a standalone server with embedded jetty server.
  */
@@ -65,8 +67,6 @@ public final class Atlas {
     private static final String ATLAS_LOG_DIR = "atlas.log.dir";
     public static final String ATLAS_SERVER_HTTPS_PORT = "atlas.server.https.port";
     public static final String ATLAS_SERVER_HTTP_PORT = "atlas.server.http.port";
-
-
     private static EmbeddedServer server;
 
     static {
@@ -150,7 +150,6 @@ public final class Atlas {
 
         server = EmbeddedServer.newServer(appHost, appPort, appPath, enableTLS);
         installLogBridge();
-
         server.start();
     }
 


### PR DESCRIPTION
added better config to make sure messages are emitted to the right topic

removed 'assetGuid' from kafka message to remove duplication

Refactor: Wrap `ApplicationProperties.get()` and `KafkaNotification` initialization in try-catch blocks

- Added exception handling for `ApplicationProperties.get()` and `KafkaNotification` initialization.
- Ensures `AtlasException` is caught and rethrown as `RuntimeException` for better runtime error propagation.

Refactor: Initialize  and  in  constructor with exception handling

- Moved initialization of  and  () into the constructor.
- Added  block to handle  during initialization.
- Ensures any exceptions are wrapped and propagated as  for consistency.

Refactor: Initialize 'configuration' and 'kfknotif' in 'EntityGraphMapper' constructor with exception handling

- Moved initialization of 'configuration' and 'KafkaNotification' ('kfknotif') into the constructor.
- Added 'try-catch' block to handle 'AtlasException' during initialization.
- Ensures any exceptions are wrapped and propagated as 'RuntimeException' for consistency.

Implement Enhanced Kafka Topic Management and Partitioned Messaging in Apache Atlas

This commit introduces comprehensive enhancements to Apache Atlas's Kafka integration, focusing on dynamic topic management, partition-specific messaging, and configuration improvements to support scalability and efficient data distribution across Kafka topics.

Detailed Changes:

1. **Dynamic Topic Creation**:
   - Introduced a new method `createTopics` in the `KafkaUtils` class. This method facilitates the creation of Kafka topics with configurable numbers of partitions and replication factors, derived from a list of topic details. This allows for more granular control over topic configurations directly from the application layer.
   - Added debug logging to provide detailed traceability for topic creation operations, enhancing monitoring and troubleshooting capabilities.

2. **Configuration Management Enhancements**:
   - Modified `atlas_config.py` to automatically include the new `TAG_PROP_EVENTS` topic in the list of topics initialized at startup, ensuring that this topic is available for event propagation without manual configuration.
   - Introduced a new configuration key `NOTIFICATION_PROPAGATION_TOPIC_NAME` in `AtlasConfiguration.java`, standardizing the topic name across the codebase and reducing the risk of hard-coded string errors.

3. **Partition-Specific Messaging Capabilities**:
   - Extended the `KafkaNotification` and `AbstractNotification` classes to include methods that support sending messages to specific partitions. This feature is critical for directing messages to particular segments of a topic, thereby optimizing the workload distribution and message consumption based on topic partitioning.
   - Implemented partition calculation in `EntityGraphMapper` using Guava's consistent hashing algorithm. This calculation uses the SHA-256 hash of a parent task's GUID to determine the partition, ensuring that related messages are co-located in the same partition for improved processing efficiency.

4. **Dependency Updates**:
   - Added the Google Guava library to the project dependencies to utilize its robust hashing functions, which are essential for implementing consistent hashing for partition determination.

5. **Error Handling and Logging Improvements**:
   - Enhanced error handling in the topic creation process to re-throw exceptions, allowing calling methods to handle these exceptions according to the application's error management policies.
   - Improved logging statements to include detailed error messages and contextual information, aiding in faster diagnosis and resolution of issues related to Kafka messaging.

This push has changes related to Kafka topic partitioning and configuration enhancements. Details are below:
	1.	Introduced a constant TAG_PROP_EVENTS_PARTITION_COUNT for Kafka partition value management.
	2.	Updated AtlasTopicCreator to use configurable partition counts for topics dynamically.
	3.	Refactored EntityGraphMapper to use the new constant for partition count initialization.

added code to send kafka message to topic 'TAG_PROP_EVENTS'

## Change description

> Description here

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
