### PR TITLE
MLH-62: (fix) just fetch ACTIVE edges from the entity during deletion

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -1673,10 +1673,27 @@ public final class GraphHelper {
         return getCollectionElementsUsingRelationship(vertex, attribute, edgeLabel);
     }
 
+    public static List<AtlasEdge> getActiveCollectionElementsUsingRelationship(AtlasVertex vertex, AtlasAttribute attribute) throws AtlasBaseException {
+        String edgeLabel = attribute.getRelationshipEdgeLabel();
+        return getActiveCollectionElementsUsingRelationship(vertex, attribute, edgeLabel);
+    }
+
     public static List<AtlasEdge> getCollectionElementsUsingRelationship(AtlasVertex vertex, AtlasAttribute attribute,
                                                                          boolean isStructType) {
         String edgeLabel = isStructType ? AtlasGraphUtilsV2.getEdgeLabel(attribute.getName()) :  attribute.getRelationshipEdgeLabel();
         return getCollectionElementsUsingRelationship(vertex, attribute, edgeLabel);
+    }
+
+    public static List<AtlasEdge> getActiveCollectionElementsUsingRelationship(AtlasVertex vertex, AtlasAttribute attribute, String edgeLabel) throws AtlasBaseException {
+        List<AtlasEdge>                ret;
+        AtlasRelationshipEdgeDirection edgeDirection = attribute.getRelationshipEdgeDirection();
+        Iterator<AtlasEdge>            edgesForLabel = getActiveEdges(vertex, edgeLabel, AtlasEdgeDirection.valueOf(edgeDirection.name()));
+
+        ret = IteratorUtils.toList(edgesForLabel);
+
+        sortCollectionElements(attribute, ret);
+
+        return ret;
     }
 
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -828,7 +828,7 @@ public abstract class DeleteHandlerV1 {
                             AtlasType      elemType = arrType.getElementType();
 
                             if (isReference(elemType.getTypeCategory())) {
-                                List<AtlasEdge> edges = getCollectionElementsUsingRelationship(instanceVertex, attributeInfo);
+                                List<AtlasEdge> edges = getActiveCollectionElementsUsingRelationship(instanceVertex, attributeInfo);
 
                                 if (CollectionUtils.isNotEmpty(edges)) {
                                     for (AtlasEdge edge : edges) {


### PR DESCRIPTION
## Change description

> So for asset deletion we are fetching all edges, so even if there were no ACTIVE edges were present we will be processing those during deletion. Which is very sub-optimal, changed the approach to just ACTIVE edges.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
