### PR TITLE
MESH-316 | Support Unarchiving of Products

### DIFF
--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -162,6 +162,8 @@ public final class Constants {
     public static final String UD_RELATIONSHIP_END_NAME_FROM = "userDefRelationshipFrom";
     public static final String UD_RELATIONSHIP_END_NAME_TO = "userDefRelationshipTo";
 
+    public static final String MODIFICATION_TIMESTAMP = "__modificationTimestamp";
+
     /**
      * SQL property keys.
      */

--- a/repository/src/main/java/org/apache/atlas/repository/migration/SoftDeletionProductMigrationService.java
+++ b/repository/src/main/java/org/apache/atlas/repository/migration/SoftDeletionProductMigrationService.java
@@ -16,6 +16,7 @@ import java.util.Set;
 
 import static org.apache.atlas.model.instance.AtlasEntity.Status.ACTIVE;
 import static org.apache.atlas.model.instance.AtlasEntity.Status.DELETED;
+import static org.apache.atlas.repository.Constants.MODIFICATION_TIMESTAMP;
 import static org.apache.atlas.repository.graph.GraphHelper.getStatus;
 
 public class SoftDeletionProductMigrationService {
@@ -120,7 +121,7 @@ public class SoftDeletionProductMigrationService {
     private boolean deleteEdgeForArchivedProduct(AtlasVertex productVertex) {
         boolean isCommitRequired = false;
         try {
-            Long updatedTime = productVertex.getProperty("__modificationTimestamp", Long.class);
+            Long updatedTime = productVertex.getProperty(MODIFICATION_TIMESTAMP, Long.class);
             Iterator<AtlasEdge> existingEdges = productVertex.getEdges(AtlasEdgeDirection.BOTH).iterator();
 
             if (existingEdges == null || !existingEdges.hasNext()) {
@@ -130,7 +131,7 @@ public class SoftDeletionProductMigrationService {
 
             while (existingEdges.hasNext()) {
                 AtlasEdge edge = existingEdges.next();
-                Long modifiedEdgeTimestamp = edge.getProperty("__modificationTimestamp", Long.class);
+                Long modifiedEdgeTimestamp = edge.getProperty(MODIFICATION_TIMESTAMP, Long.class);
 
                 if (!updatedTime.equals(modifiedEdgeTimestamp)) {
                     LOG.info("Removing edge with different timestamp: {}", edge);

--- a/repository/src/main/java/org/apache/atlas/repository/migration/ValidateProductEdgesMigrationService.java
+++ b/repository/src/main/java/org/apache/atlas/repository/migration/ValidateProductEdgesMigrationService.java
@@ -15,6 +15,7 @@ import java.util.Set;
 
 import static org.apache.atlas.model.instance.AtlasEntity.Status.ACTIVE;
 import static org.apache.atlas.model.instance.AtlasEntity.Status.DELETED;
+import static org.apache.atlas.repository.Constants.MODIFICATION_TIMESTAMP;
 import static org.apache.atlas.repository.graph.GraphHelper.getStatus;
 
 public class ValidateProductEdgesMigrationService {
@@ -117,7 +118,7 @@ public class ValidateProductEdgesMigrationService {
     public boolean validateEdgeForArchivedProduct (AtlasVertex productVertex) {
         boolean edgeWithDifferentTimeStampFound = false;
         try {
-            Long updatedTime = productVertex.getProperty("__modificationTimestamp", Long.class);
+            Long updatedTime = productVertex.getProperty(MODIFICATION_TIMESTAMP, Long.class);
             Iterator<AtlasEdge> existingEdges = productVertex.getEdges(AtlasEdgeDirection.BOTH).iterator();
 
             if (existingEdges == null || !existingEdges.hasNext()) {
@@ -127,7 +128,7 @@ public class ValidateProductEdgesMigrationService {
 
             while (existingEdges.hasNext()) {
                 AtlasEdge edge = existingEdges.next();
-                Long modifiedEdgeTimestamp = edge.getProperty("__modificationTimestamp", Long.class);
+                Long modifiedEdgeTimestamp = edge.getProperty(MODIFICATION_TIMESTAMP, Long.class);
 
                 if (!updatedTime.equals(modifiedEdgeTimestamp)) {
                     LOG.info("Found edge with different timestamp: {}", edge);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -386,12 +386,7 @@ public abstract class DeleteHandlerV1 {
             // for relationship edges, inverse vertex's relationship attribute doesn't need to be updated.
             // only delete the reference relationship edge
             if (GraphHelper.isRelationshipEdge(edge)) {
-                if (edgeLabelsForHardDeletion.contains(edge.getLabel())) {
-                    //Hard delete for product relationships
-                    deleteEdge(edge, true, isHardDeletionEdge(edge));
-                } else {
-                    deleteEdge(edge, isInternalType || isCustomRelationship(edge));
-                }
+                deleteEdge(edge, isInternalType || isCustomRelationship(edge) || isHardDeletionRelationship(edge));
 
                 AtlasVertex referencedVertex = entityRetriever.getReferencedEntityVertex(edge, relationshipDirection, entityVertex);
 
@@ -409,13 +404,7 @@ public abstract class DeleteHandlerV1 {
                 //legacy case - not a relationship edge
                 //If deleting just the edge, reverse attribute should be updated for any references
                 //For example, for the department type system, if the person's manager edge is deleted, subordinates of manager should be updated
-                if(edgeLabelsForHardDeletion.contains(edge.getLabel())) {
-                    //Hard delete for product relationships
-                    deleteEdge(edge, true, isHardDeletionEdge(edge));
-                }
-                else {
-                    deleteEdge(edge, true, isInternalType || isCustomRelationship(edge));
-                }
+                deleteEdge(edge, true, isInternalType || isCustomRelationship(edge) || isHardDeletionRelationship(edge));
             }
         }
 
@@ -1091,7 +1080,7 @@ public abstract class DeleteHandlerV1 {
         return edge.getLabel().equals(UD_RELATIONSHIP_EDGE_LABEL);
     }
 
-    private boolean isHardDeletionEdge(final AtlasEdge edge) {
+    private boolean isHardDeletionRelationship(final AtlasEdge edge) {
         return edgeLabelsForHardDeletion.contains(edge.getLabel());
     }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -1976,8 +1976,14 @@ public class EntityGraphMapper {
        for (int index = 0; allArrayElements != null && index < allArrayElements.size(); index++) {
            Object element = allArrayElements.get(index);
 
-           if (element instanceof AtlasEdge) {
-               AtlasGraphUtilsV2.setEncodedProperty((AtlasEdge) element, ATTRIBUTE_INDEX_PROPERTY_KEY, index);
+           if ((element instanceof AtlasEdge)) {
+               AtlasEdge edge = (AtlasEdge) element;
+               if ((removedElements.contains(element) && (edgeLabelsForHardDeletion.contains(edge.getLabel())))) {
+                   continue;
+               }
+               else {
+                   AtlasGraphUtilsV2.setEncodedProperty((AtlasEdge) element, ATTRIBUTE_INDEX_PROPERTY_KEY, index);
+               }
             }
         }
 
@@ -3006,14 +3012,8 @@ public class EntityGraphMapper {
                             continue;
                         }
 
-                        boolean deleted = false;
-                        if (edgeLabelsForHardDeletion.contains(edge.getLabel())) {
-                            graph.removeEdge(edge);
-                        } else {
-                            deleted = deleteDelegate.getHandler().deleteEdgeReference(edge, entryType.getTypeCategory(), attribute.isOwnedRef(),
-                                    true, attribute.getRelationshipEdgeDirection(), entityVertex);
-                        }
-
+                        boolean deleted = deleteDelegate.getHandler().deleteEdgeReference(edge, entryType.getTypeCategory(), attribute.isOwnedRef(),
+                                true, attribute.getRelationshipEdgeDirection(), entityVertex);
 
                         if (!deleted) {
                             additionalElements.add(edge);
@@ -3047,14 +3047,8 @@ public class EntityGraphMapper {
                         recordEntityUpdateForNonRelationsipAttribute(edge.getInVertex());
                         recordEntityUpdateForNonRelationsipAttribute(edge.getOutVertex());
 
-                        boolean deleted = false;
-
-                        if (edgeLabelsForHardDeletion.contains(edge.getLabel())) {
-                            graph.removeEdge(edge);
-                        } else {
-                            deleted = deleteDelegate.getHandler().deleteEdgeReference(edge, entryType.getTypeCategory(), attribute.isOwnedRef(),
-                                    true, attribute.getRelationshipEdgeDirection(), entityVertex);
-                        }
+                        boolean deleted = deleteDelegate.getHandler().deleteEdgeReference(edge, entryType.getTypeCategory(), attribute.isOwnedRef(),
+                                true, attribute.getRelationshipEdgeDirection(), entityVertex);
 
                         if (!deleted) {
                             additionalElements.add(edge);


### PR DESCRIPTION
## Change description

> When certain assets are deleted/removed from a product , the edge between the asset and product is softDeleted i.e the edge is never completely removed only the relationshipAttribute of the edge with the product is marked as DELETED. This becomes a problem when the product is archived because while archiving a product all the existing edges are softDeleted. Now there is no way to differentiate between an asset which was intentionally deleted/removed by the end user and the assets which were removed during archiving. When the product is unarchived all the softDeleted edges become ACTIVE and we end up with redundant edges. In this PR I introduced a hard deletion logic while removing edges to resolve the problem and for existing products I have added the APIs for the migration.

 [JIRA](https://atlanhq.atlassian.net/browse/MESH-316).

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)


### Development

- [ ] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [x] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
