### PR TITLE
MLH-44 Fix fetching relationship attributes NPE for corrupt vertex

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -1887,15 +1887,23 @@ public class EntityGraphRetriever {
                 } else {
                     ret = toAtlasObjectId(referenceVertex);
                 }
+
+                if (ret == null) {
+                    LOG.warn("Found corrupted vertex with Id: {}", referenceVertex.getIdForDisplay());
+                }
             }
 
-            if (RequestContext.get().isIncludeRelationshipAttributes()) {
+            if (ret != null && RequestContext.get().isIncludeRelationshipAttributes()) {
                 String relationshipTypeName = GraphHelper.getTypeName(edge);
                 boolean isRelationshipAttribute = typeRegistry.getRelationshipDefByName(relationshipTypeName) != null;
                 if (isRelationshipAttribute) {
                     AtlasRelationship relationship = mapEdgeToAtlasRelationship(edge);
                     Map<String, Object> relationshipAttributes = mapOf("typeName", relationshipTypeName);
                     relationshipAttributes.put("attributes", relationship.getAttributes());
+
+                    if (ret.getAttributes() == null) {
+                        ret.setAttributes(new HashMap<>());
+                    }
                     ret.getAttributes().put("relationshipAttributes", relationshipAttributes);
                 }
             }


### PR DESCRIPTION
## Change description
* Handle case when extracting relationshipAttributes for UDF relationship from other vertex object is null due to corrupted vertex
* Print want with ID of such vertex

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> https://atlanhq.atlassian.net/browse/MLH-44

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
