### PR TITLE
PLTS-51 | Add full log in body attr and fix resource attr in auth audit

### DIFF
--- a/auth-audits/src/main/java/org/apache/atlas/audit/destination/Log4JAuditDestination.java
+++ b/auth-audits/src/main/java/org/apache/atlas/audit/destination/Log4JAuditDestination.java
@@ -100,11 +100,13 @@ public class Log4JAuditDestination extends AuditDestination {
 			MDC.put(AUTH_AUDIT_USER, event.getUser());
 			MDC.put(AUTH_AUDIT_ACTION, event.getAction());
 			MDC.put(AUTH_AUDIT_ENTITY_GUID, event.getEntityGuid());
-			MDC.put(AUTH_AUDIT_POLICY_ID, event.getPolicyId());
+			MDC.put(AUTH_AUDIT_POLICY_ID, event.getPolicyId()+"---test---");
 			MDC.put(AUTH_AUDIT_RESOURCE, event.getResourcePath());
 			MDC.put(AUTH_AUDIT_RESULT, String.valueOf(event.getAccessResult()));
 			MDC.put(AUTH_AUDIT_CLIENT_IP, event.getClientIP());
 			MDC.put(AUTH_AUDIT_AGENT, event.getAgentId());
+			logger.info("AuthzAuditEvent: getResourcePath" + event.getResourcePath());
+			logger.info("AuthzAuditEvent: " + event);
 		}
 	}
 

--- a/auth-audits/src/main/java/org/apache/atlas/audit/destination/Log4JAuditDestination.java
+++ b/auth-audits/src/main/java/org/apache/atlas/audit/destination/Log4JAuditDestination.java
@@ -101,7 +101,7 @@ public class Log4JAuditDestination extends AuditDestination {
 			MDC.put(AUTH_AUDIT_ACTION, event.getAction());
 			MDC.put(AUTH_AUDIT_ENTITY_GUID, event.getEntityGuid());
 			MDC.put(AUTH_AUDIT_POLICY_ID, event.getPolicyId());
-			MDC.put(AUTH_AUDIT_RESOURCE, event.getResourceType());
+			MDC.put(AUTH_AUDIT_RESOURCE, event.getResourcePath());
 			MDC.put(AUTH_AUDIT_RESULT, String.valueOf(event.getAccessResult()));
 			MDC.put(AUTH_AUDIT_CLIENT_IP, event.getClientIP());
 			MDC.put(AUTH_AUDIT_AGENT, event.getAgentId());

--- a/auth-audits/src/main/java/org/apache/atlas/audit/destination/Log4JAuditDestination.java
+++ b/auth-audits/src/main/java/org/apache/atlas/audit/destination/Log4JAuditDestination.java
@@ -100,13 +100,11 @@ public class Log4JAuditDestination extends AuditDestination {
 			MDC.put(AUTH_AUDIT_USER, event.getUser());
 			MDC.put(AUTH_AUDIT_ACTION, event.getAction());
 			MDC.put(AUTH_AUDIT_ENTITY_GUID, event.getEntityGuid());
-			MDC.put(AUTH_AUDIT_POLICY_ID, event.getPolicyId()+"---test---");
+			MDC.put(AUTH_AUDIT_POLICY_ID, event.getPolicyId());
 			MDC.put(AUTH_AUDIT_RESOURCE, event.getResourcePath());
 			MDC.put(AUTH_AUDIT_RESULT, String.valueOf(event.getAccessResult()));
 			MDC.put(AUTH_AUDIT_CLIENT_IP, event.getClientIP());
 			MDC.put(AUTH_AUDIT_AGENT, event.getAgentId());
-			logger.info("AuthzAuditEvent: getResourcePath" + event.getResourcePath());
-			logger.info("AuthzAuditEvent: " + event);
 		}
 	}
 

--- a/webapp/src/main/java/org/apache/atlas/web/filters/AuditFilter.java
+++ b/webapp/src/main/java/org/apache/atlas/web/filters/AuditFilter.java
@@ -19,6 +19,7 @@
 package org.apache.atlas.web.filters;
 
 import org.apache.atlas.*;
+import org.apache.atlas.audit.provider.MiscUtil;
 import org.apache.atlas.authorize.AtlasAuthorizationUtils;
 import org.apache.atlas.service.metrics.MetricUtils;
 import org.apache.atlas.service.metrics.MetricsRegistry;
@@ -164,7 +165,9 @@ public class AuditFilter implements Filter {
             MDC.put("requestUrl", auditLog.requestUrl);
             MDC.put("httpStatus", String.valueOf(auditLog.httpStatus));
             MDC.put("timeTaken", String.valueOf(auditLog.timeTaken));
-            AUDIT_LOG.info("Capturing audit log");
+            String auditLogStr = MiscUtil.stringify(auditLog);
+//            AUDIT_LOG.info("ATLAS_AUDIT - {} {} {} {}", auditLog.requestMethod, auditLog.requestUrl, auditLog.httpStatus, auditLog.timeTaken);
+            AUDIT_LOG.info(auditLogStr);
         }
     }
 

--- a/webapp/src/main/java/org/apache/atlas/web/filters/AuditFilter.java
+++ b/webapp/src/main/java/org/apache/atlas/web/filters/AuditFilter.java
@@ -19,7 +19,6 @@
 package org.apache.atlas.web.filters;
 
 import org.apache.atlas.*;
-import org.apache.atlas.audit.provider.MiscUtil;
 import org.apache.atlas.authorize.AtlasAuthorizationUtils;
 import org.apache.atlas.service.metrics.MetricUtils;
 import org.apache.atlas.service.metrics.MetricsRegistry;
@@ -165,9 +164,7 @@ public class AuditFilter implements Filter {
             MDC.put("requestUrl", auditLog.requestUrl);
             MDC.put("httpStatus", String.valueOf(auditLog.httpStatus));
             MDC.put("timeTaken", String.valueOf(auditLog.timeTaken));
-            String auditLogStr = MiscUtil.stringify(auditLog);
-//            AUDIT_LOG.info("ATLAS_AUDIT - {} {} {} {}", auditLog.requestMethod, auditLog.requestUrl, auditLog.httpStatus, auditLog.timeTaken);
-            AUDIT_LOG.info(auditLogStr);
+            AUDIT_LOG.info("ATLAS_AUDIT - {} {} {} {}", auditLog.requestMethod, auditLog.requestUrl, auditLog.httpStatus, auditLog.timeTaken);
         }
     }
 


### PR DESCRIPTION
## Change description
- This changes body of atlas audit log to be more useful which is helpful exploring logs.


|Change |  Earlier | Now |
|--------|--------|--------|
| Atlas Audit log message | <img width="399" alt="Screenshot 2025-02-05 at 5 02 10 PM" src="https://github.com/user-attachments/assets/02cadbbb-d873-4ec7-8722-ffad27c5c994" /> | <img width="1031" alt="Screenshot 2025-02-05 at 5 02 44 PM" src="https://github.com/user-attachments/assets/165da03d-74be-4456-9840-08dddf28376b" /> |
| Auth Audit Resource Attribute | <img width="887" alt="image" src="https://github.com/user-attachments/assets/656681da-598e-492f-bb28-179ea7454365" /> |  <img width="942" alt="image" src="https://github.com/user-attachments/assets/43da9935-ab5f-4b85-a558-f39b52600cc0" /> |


## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
