### PR TITLE
DG-2027 : Added metrics for number of mismatches found in a single taskFetch call

### DIFF
--- a/common/src/main/java/org/apache/atlas/utils/AtlasPerfMetrics.java
+++ b/common/src/main/java/org/apache/atlas/utils/AtlasPerfMetrics.java
@@ -166,5 +166,8 @@ public class AtlasPerfMetrics {
             invocations++;
         }
 
+        public void setInvocations(long invocations) {
+            this.invocations = invocations;
+        }
     }
 }

--- a/common/src/main/java/org/apache/atlas/utils/AtlasPerfMetrics.java
+++ b/common/src/main/java/org/apache/atlas/utils/AtlasPerfMetrics.java
@@ -53,7 +53,7 @@ public class AtlasPerfMetrics {
     public void recordMetric(MetricRecorder recorder, long invocations) {
         if (recorder != null) {
             final String name = recorder.name;
-
+            final long timeTaken = recorder.getElapsedTime();
             Metric metric = metrics.get(name);
 
             if (metric == null) {
@@ -62,8 +62,8 @@ public class AtlasPerfMetrics {
                 metrics.put(name, metric);
             }
 
-            metric.invocations = invocations;
-            metric.totalTimeMSecs = 0;
+            metric.invocations += invocations;
+            metric.totalTimeMSecs += timeTaken;
         }
     }
 

--- a/common/src/main/java/org/apache/atlas/utils/AtlasPerfMetrics.java
+++ b/common/src/main/java/org/apache/atlas/utils/AtlasPerfMetrics.java
@@ -50,6 +50,23 @@ public class AtlasPerfMetrics {
         }
     }
 
+    public void recordMetric(MetricRecorder recorder, long invocations) {
+        if (recorder != null) {
+            final String name = recorder.name;
+
+            Metric metric = metrics.get(name);
+
+            if (metric == null) {
+                metric = new Metric(name);
+
+                metrics.put(name, metric);
+            }
+
+            metric.invocations = invocations;
+            metric.totalTimeMSecs = 0;
+        }
+    }
+
     public void clear() {
         metrics.clear();
     }

--- a/repository/src/main/java/org/apache/atlas/tasks/TaskRegistry.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/TaskRegistry.java
@@ -35,6 +35,7 @@ import org.apache.atlas.repository.graphdb.AtlasVertex;
 import org.apache.atlas.repository.graphdb.DirectIndexQueryResult;
 import org.apache.atlas.repository.graphdb.janus.AtlasElasticsearchQuery;
 import org.apache.atlas.type.AtlasType;
+import org.apache.atlas.utils.AtlasMetricType;
 import org.apache.atlas.utils.AtlasPerfMetrics;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
@@ -466,11 +467,12 @@ public class TaskRegistry {
             }
         }
         if(mismatches > 0) {
-            AtlasPerfMetrics.Metric indexsearchMetric = new AtlasPerfMetrics.Metric(TASK_MISMATCH_TAG);
-            indexsearchMetric.addTag("name", TASK_MISMATCH_TAG);
-            indexsearchMetric.setInvocations(mismatches);
-            indexsearchMetric.setTotalTimeMSecs(0);
-            RequestContext.get().addApplicationMetrics(indexsearchMetric);
+            AtlasPerfMetrics.Metric mismatchMetrics = new AtlasPerfMetrics.Metric(TASK_MISMATCH_TAG);
+            mismatchMetrics.setMetricType(AtlasMetricType.COUNTER);
+            mismatchMetrics.addTag("name", TASK_MISMATCH_TAG);
+            mismatchMetrics.setInvocations(mismatches);
+            mismatchMetrics.setTotalTimeMSecs(0);
+            RequestContext.get().addApplicationMetrics(mismatchMetrics);
         }
         return ret;
     }

--- a/repository/src/main/java/org/apache/atlas/tasks/TaskRegistry.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/TaskRegistry.java
@@ -68,6 +68,7 @@ public class TaskRegistry {
     public static final int TASK_FETCH_BATCH_SIZE = 100;
     public static final List<Map<String, Object>> SORT_ARRAY = Collections.singletonList(mapOf(Constants.TASK_CREATED_TIME, mapOf("order", "asc")));
     public static final String JANUSGRAPH_VERTEX_INDEX = "janusgraph_vertex_index";
+    public static final String TASK_MISMATCH_TAG = "mismatchTask";
 
     private AtlasGraph graph;
     private TaskService taskService;
@@ -464,8 +465,13 @@ public class TaskRegistry {
                 break;
             }
         }
-        RequestContext.get().endMetricRecord(RequestContext.get().startMetricRecord("elasticSearchTaskMismatch"), mismatches);
-
+        if(mismatches > 0) {
+            AtlasPerfMetrics.Metric indexsearchMetric = new AtlasPerfMetrics.Metric(TASK_MISMATCH_TAG);
+            indexsearchMetric.addTag("name", TASK_MISMATCH_TAG);
+            indexsearchMetric.setInvocations(mismatches);
+            indexsearchMetric.setTotalTimeMSecs(0);
+            RequestContext.get().addApplicationMetrics(indexsearchMetric);
+        }
         return ret;
     }
 

--- a/repository/src/main/java/org/apache/atlas/tasks/TaskRegistry.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/TaskRegistry.java
@@ -53,6 +53,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Objects;
 import java.util.LinkedHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -398,6 +399,7 @@ public class TaskRegistry {
         Map<String, Object> dsl = mapOf("query", mapOf("bool", mapOf("should", statusClauseList)));
         dsl.put("sort", Collections.singletonList(mapOf(Constants.TASK_CREATED_TIME, mapOf("order", "asc"))));
         dsl.put("size", size);
+        long mismatches = 0;
         int totalFetched = 0;
         while (true) {
             int fetched = 0;
@@ -434,9 +436,9 @@ public class TaskRegistry {
                                 LOG.info(String.format("Fetched task from index search: %s", atlasTask.toString()));
                                 ret.add(atlasTask);
                             } else {
-                                RequestContext.get().endMetricRecord(RequestContext.get().startMetricRecord("elasticSearchTaskMismatch"));
                                 LOG.warn("Status mismatch for task with guid: {}. Expected PENDING/IN_PROGRESS but found: {}",
                                         atlasTask.getGuid(), atlasTask.getStatus());
+                                mismatches++;
                                 try {
                                     String docId = LongEncoding.encode(Long.parseLong(vertex.getIdForDisplay()));
                                     repairMismatchedTask(atlasTask, docId);
@@ -462,6 +464,7 @@ public class TaskRegistry {
                 break;
             }
         }
+        RequestContext.get().endMetricRecord(RequestContext.get().startMetricRecord("elasticSearchTaskMismatch"), mismatches);
 
         return ret;
     }
@@ -472,9 +475,12 @@ public class TaskRegistry {
         try {
             // Create a map for the fields to be updated
             Map<String, Object> fieldsToUpdate = new HashMap<>();
-
-            fieldsToUpdate.put("__task_endTime", atlasTask.getEndTime().getTime());// add try for this, what if FAILED
-            fieldsToUpdate.put("__task_timeTakenInSeconds", atlasTask.getTimeTakenInSeconds());// add try for this, what if FAILED
+            if(Objects.nonNull(atlasTask.getEndTime())) {
+                fieldsToUpdate.put("__task_endTime", atlasTask.getEndTime().getTime());
+            }
+            if(Objects.nonNull(atlasTask.getTimeTakenInSeconds())) {
+                fieldsToUpdate.put("__task_timeTakenInSeconds", atlasTask.getTimeTakenInSeconds());
+            }
             fieldsToUpdate.put("__task_status", atlasTask.getStatus().toString());
             fieldsToUpdate.put("__task_modificationTimestamp", atlasTask.getUpdatedTime().getTime());
 

--- a/server-api/src/main/java/org/apache/atlas/RequestContext.java
+++ b/server-api/src/main/java/org/apache/atlas/RequestContext.java
@@ -669,6 +669,12 @@ public class RequestContext {
         }
     }
 
+    public void endMetricRecord(MetricRecorder recorder,long invocations){
+        if (metrics != null && recorder != null) {
+            metrics.recordMetric(recorder, invocations);
+        }
+    }
+
     public void recordEntityGuidUpdate(AtlasEntity entity, String guidInRequest) {
         recordEntityGuidUpdate(new EntityGuidPair(entity, guidInRequest));
     }


### PR DESCRIPTION
## Change description

> Need to setup regular alerts for a particular scenario where repetitive iterations of task-mismatch keep on happening on a tenant. This is a case where the propagation tasks stop proceeding and get blocked.

## Proof :

<img width="1333" alt="image" src="https://github.com/user-attachments/assets/fe10e967-7365-4bf7-aff6-1b92ea499d32" />
<img width="1322" alt="image" src="https://github.com/user-attachments/assets/51d6b82e-d693-4ea9-94b6-ce0329f9d277" />


## Type of change
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
