### PR TITLE
MLH-41 | Added my feature-branch(mlh41tests) to chart-release-dispatcher

### DIFF
--- a/.github/workflows/chart-release-dispatcher.yaml
+++ b/.github/workflows/chart-release-dispatcher.yaml
@@ -9,6 +9,7 @@ on:
       - staging
       - beta
       - mlh41-integration-tests
+      - mlh41tests
     types:
       - completed
 


### PR DESCRIPTION
## Added my feature-branch(mlh41tests) to chart-release-dispatcher

> I was working on MT Cross Repo Branch Mapping InstanceMap Atlan -> [Link](https://www.notion.so/atlanhq/MT-Cross-Repo-Branch-Mapping-InstanceMap-Atlan-728265612525477dbd28106eb9449eab) for my task-> [Jira ticket](https://atlanhq.atlassian.net/browse/MLH-41).
I was following the doc and I needed to add my custom branch to the chart-release-dispatcher. (Refer the docs for more info). This would help my custom branch (MLH-41-integration-tests) use the build in the charts for the cluster to get deployed.

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
