### PR TITLE
fix: add policy to update ai assets business metadata

### DIFF
--- a/addons/policies/bootstrap_entity_policies.json
+++ b/addons/policies/bootstrap_entity_policies.json
@@ -3480,6 +3480,43 @@
                     "entity-read"
                 ]
             }
+        },
+        {
+            "typeName": "AuthPolicy",
+            "attributes":
+            {
+                "name": "BM_UPDATE_AI_ASSETS",
+                "qualifiedName": "BM_UPDATE_AI_ASSETS",
+                "description": "Allows user to update AI assets business metadata.",
+                "policyCategory": "bootstrap",
+                "policySubCategory": "default",
+                "policyServiceName": "atlas",
+                "policyType": "allow",
+                "policyPriority": 0,
+                "policyUsers":
+                [],
+                "policyGroups":
+                [],
+                "policyRoles":
+                [
+                    "$admin",
+                    "$api-token-default-access"
+                ],
+                "policyResourceCategory": "ENTITY",
+                "isPolicyEnabled": true,
+                "policyResources":
+                [
+                    "entity-type:AIApplication",
+                    "entity-type:AIModel",
+                    "entity-classification:*",
+                    "entity:*",
+                    "entity-business-metadata:*"
+                ],
+                "policyActions":
+                [
+                    "entity-update-business-metadata"
+                ]
+            }
         }
     ]
 }


### PR DESCRIPTION
## Change description

This pull request adds a new policy to the `addons/policies/bootstrap_entity_policies.json` file. The new policy allows users to update AI assets business metadata.

New policy addition:

* Added a new policy `BM_UPDATE_AI_ASSETS` to allow users to update AI assets business metadata. This policy includes attributes such as `policyCategory`, `policyType`, and `policyRoles`.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
