### PR TITLE
MLH-169 Improve edge label fetching to improve prefetch marker logic

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,7 +28,7 @@ on:
       - master
       - taskdg1924
       - taskdg1924deleteprop
-      - MLH-73-ImproveEdgeLabelsFetching
+      - improve_edgelabel_fetch
 
 jobs:
   build:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,6 +28,7 @@ on:
       - master
       - taskdg1924
       - taskdg1924deleteprop
+      - MLH-73-ImproveEdgeLabelsFetching
 
 jobs:
   build:

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -2144,4 +2144,16 @@ public final class GraphHelper {
                 .toStream()
                 .collect(Collectors.toSet());
     }
+
+    public Set<String> getActiveEdgeTypeNames(AtlasVertex vertex) {
+        return ((AtlasJanusGraph) graph).getGraph().traversal()
+                .V(vertex.getId())
+                .bothE()
+                .has(STATE_PROPERTY_KEY, ACTIVE_STATE_VALUE) // Filter only active edges
+                .values(TYPE_NAME_PROPERTY_KEY) // Extract only the __typeName property
+                .dedup() // Ensure unique values
+                .toStream()
+                .map(Object::toString)
+                .collect(Collectors.toSet());
+    }
 }

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -45,6 +45,7 @@ import org.apache.atlas.repository.graphdb.AtlasGraphQuery;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
 import org.apache.atlas.repository.graphdb.AtlasVertexQuery;
 import org.apache.atlas.repository.graphdb.janus.AtlasJanusEdge;
+import org.apache.atlas.repository.graphdb.janus.AtlasJanusGraph;
 import org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2;
 import org.apache.atlas.type.AtlasArrayType;
 import org.apache.atlas.type.AtlasEntityType;
@@ -2130,5 +2131,17 @@ public final class GraphHelper {
         finally {
             RequestContext.get().endMetricRecord(metricRecorder);
         }
+    }
+
+    public Set<String> getActiveEdgeLabels(AtlasVertex vertex) {
+
+        return ((AtlasJanusGraph)graph).getGraph().traversal()
+                .V(vertex.getId())
+                .bothE()
+                .has(STATE_PROPERTY_KEY, ACTIVE_STATE_VALUE) // Filter only active edges
+                .label() // Get only edge labels
+                .dedup()
+                .toStream()
+                .collect(Collectors.toSet());
     }
 }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -1067,22 +1067,23 @@ public class EntityGraphRetriever {
         try {
             // Fetch only edge Labels that are active
             Set<String> allEdgeLabels = graphHelper.getActiveEdgeLabels(entityVertex);
-
+            LOG.info("All Edge Labels: {}", allEdgeLabels);
             Set<String> requestedEdgeLabels = new HashSet<>();
 
-            attributes.forEach(a -> {
-                if (allEdgeLabels.contains(a)) {
-                    requestedEdgeLabels.add(a);
-                }
-            });
+            allEdgeLabels.stream().filter(Objects::nonNull).forEach(edgeLabel -> attributes.forEach(attribute->{
 
-            relationshipsLookup.forEach((k,v) -> {
-                if (allEdgeLabels.contains(k)) {
-                    requestedEdgeLabels.addAll(v);
+                if (edgeLabel.contains(attribute)){
+                    requestedEdgeLabels.add(attribute);
+                    return;
                 }
-            });
+
+                if (MapUtils.isNotEmpty(relationshipsLookup) && relationshipsLookup.containsKey(edgeLabel) && relationshipsLookup.get(edgeLabel).contains(attribute)) {
+                    requestedEdgeLabels.add(attribute);
+                }
+            }));
 
             requestedEdgeLabels.forEach(e -> propertiesMap.put(e, StringUtils.SPACE));
+            LOG.info("Requested Edge Labels: {}", requestedEdgeLabels);
         } finally {
             RequestContext.get().endMetricRecord(metricRecorder);
         }


### PR DESCRIPTION
## Change description

> 
- Improve Marker logic to handle Complex/relationship attributes better. Previously it was fetching the edges itself which was slower.
- Fetch edge type names to cover relationship labels
- Also fallback to use without prefetch when there are errors in prefetch path (This is interim till https://atlanhq.atlassian.net/browse/MLH-170 will put a better solution)

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues
- https://atlanhq.atlassian.net/browse/MLH-169

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
