### PR TITLE
MLH-73 use a single method to fetch both label and typeName

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,6 +29,7 @@ on:
       - taskdg1924
       - taskdg1924deleteprop
       - improve_edgelabel_fetch
+      - merge_edge_label_typename_fetch
 
 jobs:
   build:

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -65,17 +65,7 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.apache.atlas.AtlasErrorCode.RELATIONSHIP_CREATE_INVALID_PARAMS;
@@ -2133,27 +2123,19 @@ public final class GraphHelper {
         }
     }
 
-    public Set<String> getActiveEdgeLabels(AtlasVertex vertex) {
-
-        return ((AtlasJanusGraph)graph).getGraph().traversal()
-                .V(vertex.getId())
-                .bothE()
-                .has(STATE_PROPERTY_KEY, ACTIVE_STATE_VALUE) // Filter only active edges
-                .label() // Get only edge labels
-                .dedup()
-                .toStream()
-                .collect(Collectors.toSet());
-    }
-
-    public Set<String> getActiveEdgeTypeNames(AtlasVertex vertex) {
+    public Set<Map.Entry<String, String>> getActiveEdgeLabels(AtlasVertex vertex) {
         return ((AtlasJanusGraph) graph).getGraph().traversal()
                 .V(vertex.getId())
                 .bothE()
-                .has(STATE_PROPERTY_KEY, ACTIVE_STATE_VALUE) // Filter only active edges
-                .values(TYPE_NAME_PROPERTY_KEY) // Extract only the __typeName property
-                .dedup() // Ensure unique values
+                .has(STATE_PROPERTY_KEY, ACTIVE_STATE_VALUE)
+                .project("label", "__typeName")
+                .by("label")        // Get label property
+                .by("__typeName")   // Get typeName property
                 .toStream()
-                .map(Object::toString)
-                .collect(Collectors.toSet());
+                .map(m -> Map.entry(
+                        m.get("label").toString(),
+                        m.get("__typeName").toString()
+                ))
+                .collect(Collectors.toSet()); // Ensure uniqueness
     }
 }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -1061,13 +1061,11 @@ public class EntityGraphRetriever {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("markAvailableAttributes");
         try {
             // Fetch only edge Labels that are active (useful for complex attribute marking
-            Set<String> allEdgeLabels = graphHelper.getActiveEdgeLabels(entityVertex);
-            // Fetch only edge typeName that are active (useful for relationship attribute marking)
-            Set<String> allEdgeLabelTypes = graphHelper.getActiveEdgeTypeNames(entityVertex);
+            Set<Map.Entry<String, String>> allEdgeLabels = graphHelper.getActiveEdgeLabels(entityVertex);
             Set<String> availableAttributes = new HashSet<>();
 
             // Get the available edge labels based on edge labels for this vertex
-            allEdgeLabels.stream().filter(Objects::nonNull).forEach(edgeLabel -> attributes.forEach(attribute->{
+            allEdgeLabels.stream().filter(Objects::nonNull).map(Map.Entry::getKey).forEach(edgeLabel -> attributes.forEach(attribute->{
 
                 if (edgeLabel.contains(attribute)){
                     availableAttributes.add(attribute);
@@ -1077,7 +1075,7 @@ public class EntityGraphRetriever {
             // Get the available edge labels based on edge type Names and relationship attributes for entityType of this vertex
             // e.g. If `atlanSchema` is requested and one of the edgeTypeNames are `schema_tables`
             // and relationship attribute has `atlanSchema` as an attribute for this vertex's entityType, then this edgeLabel is present
-            allEdgeLabelTypes.stream().filter(Objects::nonNull).forEach(edgeTypeName -> attributes.forEach(attribute->{
+            allEdgeLabels.stream().filter(Objects::nonNull).map(Map.Entry::getValue).forEach(edgeTypeName -> attributes.forEach(attribute->{
 
                 if (MapUtils.isNotEmpty(relationshipsLookup) && relationshipsLookup.containsKey(edgeTypeName) && relationshipsLookup.get(edgeTypeName).contains(attribute)) {
                     availableAttributes.add(attribute);


### PR DESCRIPTION
## Change description

> Fetch both edge label and edge typeNames together to reduce further calls to Cassandra.
edgeLabels are required for complex attribute marking
edgeTypeNames are required for relationship attributes marking.

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues
- https://atlanhq.atlassian.net/browse/MLH-169
> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
