### PR TITLE
MLH-173 Skip NPE due to corrupted vertex

### DIFF
--- a/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
@@ -216,6 +216,7 @@ public enum AtlasErrorCode {
     RESOURCE_NOT_FOUND(404, "ATLAS-404-00-019", "{0} not found"),
     INDEX_NOT_FOUND(404, "ATLAS-404-00-020", "ES index {0} not found"),
     RELATIONSHIP_DOES_NOT_EXIST(404, "ATLAS-409-00-0021", "relationship {0} does not exist between entities {1} and {2}"),
+    INTERNAL_ENTITY_ID_NOT_FOUND(404, "ATLAS-404-00-022", "Internal: Entity not found on vertex"),
 
     METHOD_NOT_ALLOWED(405, "ATLAS-405-00-001", "Error 405 - The request method {0} is inappropriate for the URL: {1}"),
     DELETE_TAG_PROPAGATION_NOT_ALLOWED(406, "ATLAS-406-00-001", "Classification delete is not allowed; Add/Update classification propagation is in queue for classification: {0} and entity: {1}. Please try again"),

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -2005,7 +2005,7 @@ public class EntityGraphMapper {
 
             Object newEntry = null;
             try {
-                mapCollectionElementsToVertex(arrCtx, context);
+                newEntry = mapCollectionElementsToVertex(arrCtx, context);
             } catch (AtlasBaseException abe) {
                 if (abe.getAtlasErrorCode() == INTERNAL_ENTITY_ID_NOT_FOUND) {
                     corruptedCurrentElements.add(existingEdge);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -84,6 +84,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.atlas.AtlasConfiguration.LABEL_MAX_LENGTH;
 import static org.apache.atlas.AtlasConfiguration.STORE_DIFFERENTIAL_AUDITS;
+import static org.apache.atlas.AtlasErrorCode.INTERNAL_ENTITY_ID_NOT_FOUND;
 import static org.apache.atlas.model.TypeCategory.ARRAY;
 import static org.apache.atlas.model.TypeCategory.CLASSIFICATION;
 import static org.apache.atlas.model.instance.AtlasEntity.Status.ACTIVE;
@@ -1992,15 +1993,25 @@ public class EntityGraphMapper {
             newElements = (List) newElements.stream().distinct().collect(Collectors.toList());
         }
 
+        List<AtlasEdge> corruptedCurrentElements = new ArrayList<>(0);
         for (int index = 0; index < newElements.size(); index++) {
             AtlasEdge               existingEdge = (isSoftReference) ? null : getEdgeAt(currentElements, index, elementType);
             AttributeMutationContext arrCtx      = new AttributeMutationContext(ctx.getOp(), ctx.getReferringVertex(), ctx.getAttribute(), newElements.get(index),
                                                                                  ctx.getVertexProperty(), elementType, existingEdge);
+
             if (deleteExistingRelations) {
                 removeExistingRelationWithOtherVertex(arrCtx, ctx, context);
             }
 
-            Object newEntry = mapCollectionElementsToVertex(arrCtx, context);
+            Object newEntry = null;
+            try {
+                mapCollectionElementsToVertex(arrCtx, context);
+            } catch (AtlasBaseException abe) {
+                if (abe.getAtlasErrorCode() == INTERNAL_ENTITY_ID_NOT_FOUND) {
+                    corruptedCurrentElements.add(existingEdge);
+                }
+            }
+
             if (isReference && newEntry != null && newEntry instanceof AtlasEdge && inverseRefAttribute != null) {
                 // Update the inverse reference value.
                 AtlasEdge newEdge = (AtlasEdge) newEntry;
@@ -2013,6 +2024,8 @@ public class EntityGraphMapper {
                 newElementsCreated.add(newEntry);
             }
         }
+
+        currentElements.removeAll(corruptedCurrentElements);
 
         if (isReference && !isSoftReference ) {
             boolean isAppendOnPartialUpdate = !isStructType ? getAppendOptionForRelationship(ctx.getReferringVertex(), attribute.getName()) : false;
@@ -2986,6 +2999,10 @@ public class EntityGraphMapper {
             currentEntityId = getIdFromInVertex(currentEdge);
         } else {
             currentEntityId = getIdFromBothVertex(currentEdge, parentEntityVertex);
+        }
+        
+        if (StringUtils.isEmpty(currentEntityId)) {
+            throw new AtlasBaseException(AtlasErrorCode.INTERNAL_ENTITY_ID_NOT_FOUND);
         }
 
         String    newEntityId = getIdFromVertex(newEntityVertex);


### PR DESCRIPTION
## Change description
* On one of the prod tenants, we are getting NPE resulting in WF failures 
* NullPointerException at [this location](https://github.com/atlanhq/atlas-metastore/blob/c7ebc0948c6109aca511af8bfc25e1905d095df3/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java#L2994)
* The goal of the change is to have quick relief for failures by skipping corrupted vertices
* This PR helps to skip corrupted vertices & discards them from further logic
* Testing - [Ref](https://atlanhq.atlassian.net/browse/MLH-173?focusedCommentId=354584)

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> https://atlanhq.atlassian.net/browse/MLH-173
> https://atlanhq.atlassian.net/browse/BL-4707

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
