### PR TITLE
MLH-180 - read/write ES mappings with index prefix to allow read mappings as split index

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -72,4 +72,4 @@ jobs:
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
       with:
-        category: "/language:${{matrix.language}}"
+        category: "/language:${{ matrix.language }}"

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,8 +27,6 @@ on:
       - development
       - master
       - lineageondemand
-      - makerlogic
-      - initesrepo_with_split_index
 
 jobs:
   build:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,6 +28,7 @@ on:
       - master
       - lineageondemand
       - makerlogic
+      - initesrepo_with_split_index
 
 jobs:
   build:

--- a/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
@@ -448,7 +448,7 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
     }
 
     private boolean areConfigurationsSame(JsonNode activeIndexInformation, JsonNode indexInformationFromConfigurationFile) {
-        return indexInformationFromConfigurationFile.get("mappings").equals(activeIndexInformation.get("mappings"));
+        return indexInformationFromConfigurationFile.get("mappings").equals(activeIndexInformation);
     }
 
     private Response updateMappings(JsonNode indexInformationFromConfigurationFile) throws IOException {

--- a/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
@@ -448,7 +448,7 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
     }
 
     private boolean areConfigurationsSame(JsonNode activeIndexInformation, JsonNode indexInformationFromConfigurationFile) {
-        return indexInformationFromConfigurationFile.get("mappings").equals(activeIndexInformation.get("entity_audits").get("mappings"));
+        return indexInformationFromConfigurationFile.get("mappings").equals(activeIndexInformation.get("mappings"));
     }
 
     private Response updateMappings(JsonNode indexInformationFromConfigurationFile) throws IOException {

--- a/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
@@ -90,7 +90,7 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
     private static final String ENTITY = "entity";
     private static final String bulkMetadata = String.format("{ \"index\" : { \"_index\" : \"%s\" } }%n", INDEX_NAME);
     private static final Set<String> ALLOWED_LINKED_ATTRIBUTES = new HashSet<>(Arrays.asList(DOMAIN_GUIDS));
-    public static final String ENTITY_AUDITS_INDEX = "entity_audits";
+    private static final String ENTITY_AUDITS_INDEX = "entity_audits";
 
     /*
     *    created   → event creation time

--- a/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
@@ -90,6 +90,7 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
     private static final String ENTITY = "entity";
     private static final String bulkMetadata = String.format("{ \"index\" : { \"_index\" : \"%s\" } }%n", INDEX_NAME);
     private static final Set<String> ALLOWED_LINKED_ATTRIBUTES = new HashSet<>(Arrays.asList(DOMAIN_GUIDS));
+    public static final String ENTITY_AUDITS_INDEX = "entity_audits";
 
     /*
     *    created   → event creation time
@@ -416,35 +417,36 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
     private void updateMappingsIfChanged() throws IOException, AtlasException {
         LOG.info("ESBasedAuditRepo - updateMappings!");
         ObjectMapper mapper = new ObjectMapper();
-        JsonNode activeIndexInformation = getActiveIndexInfoAsJson(mapper);
+        Map<String, JsonNode> activeIndexMappings = getActiveIndexMappings(mapper);
         JsonNode indexInformationFromConfigurationFile = mapper.readTree(getAuditIndexMappings());
-        if (!areConfigurationsSame(activeIndexInformation, indexInformationFromConfigurationFile)) {
-            Response response = updateMappings(indexInformationFromConfigurationFile);
-            if (isSuccess(response)) {
-                LOG.info("ESBasedAuditRepo - Elasticsearch mappings have been updated!");
-            } else {
-                LOG.error("Error while updating the Elasticsearch indexes!");
-                throw new AtlasException(copyToString(response.getEntity().getContent(), Charset.defaultCharset()));
+        for (String activeAuditIndex : activeIndexMappings.keySet()) {
+            if (!areConfigurationsSame(activeIndexMappings.get(activeAuditIndex), indexInformationFromConfigurationFile)) {
+                Response response = updateMappings(indexInformationFromConfigurationFile);
+                if (isSuccess(response)) {
+                    LOG.info("ESBasedAuditRepo - Elasticsearch mappings have been updated!");
+                } else {
+                    LOG.error("Error while updating the Elasticsearch indexes!");
+                    throw new AtlasException(copyToString(response.getEntity().getContent(), Charset.defaultCharset()));
+                }
             }
         }
     }
 
-    private JsonNode getActiveIndexInfoAsJson(ObjectMapper mapper) throws IOException {
+    private Map<String, JsonNode> getActiveIndexMappings(ObjectMapper mapper) throws IOException {
         Request request = new Request("GET", INDEX_NAME);
         Response response = lowLevelClient.performRequest(request);
         String responseString = copyToString(response.getEntity().getContent(), Charset.defaultCharset());
-
+        Map<String, JsonNode> indexMappings = new TreeMap<>();
         JsonNode rootNode = mapper.readTree(responseString);
 
-        // Iterate over the index names and find one that starts with "entity_audits-"
+        // Iterate over the index names and get the mappings
         for (Iterator<String> it = rootNode.fieldNames(); it.hasNext(); ) {
             String indexName = it.next();
-            if (indexName.startsWith("entity_audits-")) {
-                return rootNode.get(indexName).get("mappings");
+            if (indexName.startsWith(ENTITY_AUDITS_INDEX)) {
+                indexMappings.put(indexName, rootNode.get(indexName).get("mappings"));
             }
         }
-
-        return null; // Return null if no matching index is found
+        return indexMappings;
     }
 
     private boolean areConfigurationsSame(JsonNode activeIndexInformation, JsonNode indexInformationFromConfigurationFile) {

--- a/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
@@ -423,9 +423,9 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
             if (!areConfigurationsSame(activeIndexMappings.get(activeAuditIndex), indexInformationFromConfigurationFile)) {
                 Response response = updateMappings(indexInformationFromConfigurationFile);
                 if (isSuccess(response)) {
-                    LOG.info("ESBasedAuditRepo - Elasticsearch mappings have been updated!");
+                    LOG.info("ESBasedAuditRepo - Elasticsearch mappings have been updated for index: {}", activeAuditIndex);
                 } else {
-                    LOG.error("Error while updating the Elasticsearch indexes!");
+                    LOG.error("Error while updating the Elasticsearch indexes for index: {}", activeAuditIndex);
                     throw new AtlasException(copyToString(response.getEntity().getContent(), Charset.defaultCharset()));
                 }
             }

--- a/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
@@ -433,7 +433,18 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
         Request request = new Request("GET", INDEX_NAME);
         Response response = lowLevelClient.performRequest(request);
         String responseString = copyToString(response.getEntity().getContent(), Charset.defaultCharset());
-        return mapper.readTree(responseString);
+
+        JsonNode rootNode = mapper.readTree(responseString);
+
+        // Iterate over the index names and find one that starts with "entity_audits-"
+        for (Iterator<String> it = rootNode.fieldNames(); it.hasNext(); ) {
+            String indexName = it.next();
+            if (indexName.startsWith("entity_audits-")) {
+                return rootNode.get(indexName).get("mappings");
+            }
+        }
+
+        return null; // Return null if no matching index is found
     }
 
     private boolean areConfigurationsSame(JsonNode activeIndexInformation, JsonNode indexInformationFromConfigurationFile) {


### PR DESCRIPTION
## Change description

> 
- Read entity audit ES repo mappings with index prefix rather than index name.
- index names are entity_audits-00000* 
- This will fix the startup failure mentioned here https://atlanhq.slack.com/archives/C0885B1U3GE/p1740530144255969?thread_ts=1740528154.097659&cid=C0885B1U3GE

Testing in atlan.atlan.com with split indices
![image](https://github.com/user-attachments/assets/4c19c0d2-d37a-497e-9466-9fc5e3293b2d)



## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues
- https://atlanhq.atlassian.net/browse/MLH-180

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
