### PR TITLE
MESH-438 | Allow READ on Stakeholder for all roles via bootstrap policy.

### DIFF
--- a/addons/policies/bootstrap_entity_policies.json
+++ b/addons/policies/bootstrap_entity_policies.json
@@ -3522,6 +3522,41 @@
             "typeName": "AuthPolicy",
             "attributes":
             {
+                "name": "READ_STAKEHOLDER_ENTITIES",
+                "qualifiedName": "READ_STAKEHOLDER_ENTITIES",
+                "policyCategory": "bootstrap",
+                "policySubCategory": "default",
+                "policyServiceName": "atlas",
+                "policyType": "allow",
+                "policyPriority": 0,
+                "policyUsers":
+                [],
+                "policyGroups":
+                [],
+                "policyRoles":
+                [
+                    "$admin",
+                    "$guest",
+                    "$member",
+                    "$api-token-default-access"
+                ],
+                "policyResourceCategory": "ENTITY",
+                "policyResources":
+                [
+                    "entity:*",
+                    "entity-type:Stakeholder",
+                    "entity-classification:*"
+                ],
+                "policyActions":
+                [
+                    "entity-read"
+                ]
+            }
+        },
+        {
+            "typeName": "AuthPolicy",
+            "attributes":
+            {
                 "name": "READ_FORMS",
                 "qualifiedName": "READ_FORM_ENTITIES",
                 "description": "Allows user to perform read operation on Form assets.",
@@ -3663,41 +3698,6 @@
                 [
                     "entity-update",
                     "entity-delete"
-                ]
-            }
-        },
-        {
-            "typeName": "AuthPolicy",
-            "attributes":
-            {
-                "name": "READ_STAKEHOLDER_ENTITIES",
-                "qualifiedName": "READ_STAKEHOLDER_ENTITIES",
-                "policyCategory": "bootstrap",
-                "policySubCategory": "default",
-                "policyServiceName": "atlas",
-                "policyType": "allow",
-                "policyPriority": 0,
-                "policyUsers":
-                [],
-                "policyGroups":
-                [],
-                "policyRoles":
-                [
-                    "$admin",
-                    "$guest",
-                    "$member",
-                    "$api-token-default-access"
-                ],
-                "policyResourceCategory": "ENTITY",
-                "policyResources":
-                [
-                    "entity:*",
-                    "entity-type:Stakeholder",
-                    "entity-classification:*"
-                ],
-                "policyActions":
-                [
-                    "entity-read"
                 ]
             }
         }

--- a/addons/policies/bootstrap_entity_policies.json
+++ b/addons/policies/bootstrap_entity_policies.json
@@ -3665,6 +3665,41 @@
                     "entity-delete"
                 ]
             }
+        },
+        {
+            "typeName": "AuthPolicy",
+            "attributes":
+            {
+                "name": "READ_STAKEHOLDER_ENTITIES",
+                "qualifiedName": "READ_STAKEHOLDER_ENTITIES",
+                "policyCategory": "bootstrap",
+                "policySubCategory": "default",
+                "policyServiceName": "atlas",
+                "policyType": "allow",
+                "policyPriority": 0,
+                "policyUsers":
+                [],
+                "policyGroups":
+                [],
+                "policyRoles":
+                [
+                    "$admin",
+                    "$guest",
+                    "$member",
+                    "$api-token-default-access"
+                ],
+                "policyResourceCategory": "ENTITY",
+                "policyResources":
+                [
+                    "entity:*",
+                    "entity-type:Stakeholder",
+                    "entity-classification:*"
+                ],
+                "policyActions":
+                [
+                    "entity-read"
+                ]
+            }
         }
     ]
 }


### PR DESCRIPTION
## Change description

> Users with the "Members/Guest" role are unable to view domain stakeholders unless they have the "Update Domains" entitlement, which also grants them edit access. We need a way for Members/Guest to view the stakeholders without providing them edit access. 

JIRA: [MESH-438](https://atlanhq.atlassian.net/browse/MESH-438)

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable


[MESH-438]: https://atlanhq.atlassian.net/browse/MESH-438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ