### PR TITLE
MLH-187 Disable ES index logger for authorization events

### DIFF
--- a/atlas-hub/pre-conf/atlas-auth/atlas-atlas-audit.xml
+++ b/atlas-hub/pre-conf/atlas-auth/atlas-atlas-audit.xml
@@ -122,7 +122,7 @@
 	<!-- ElasticSearch audit provider configuration -->
 	<property>
 		<name>xasecure.audit.destination.elasticsearch</name>
-		<value>true</value>
+		<value>false</value>
 	</property>
 	<property>
 		<name>xasecure.audit.elasticsearch.is.enabled</name>


### PR DESCRIPTION
## Change description

- We observed high throughputs on Elasticsearch service on a few production tenants.
- Given that we have exposed Authorisation logs to OTEL, we do not need the ES index writing into ranger-audit representing the same information.
- This PR will disable Elasticsearch Authorisation logging, keeping log4j logger active for OTEL exporter


Tests - https://atlanhq.atlassian.net/browse/MLH-187?focusedCommentId=358781


## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix https://atlanhq.atlassian.net/browse/MLH-187

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
