### PR TITLE
MESH-422 | Empower admins to have access to ALL data products functionality without needing any policies

### DIFF
--- a/addons/policies/bootstrap_entity_policies.json
+++ b/addons/policies/bootstrap_entity_policies.json
@@ -2116,7 +2116,6 @@
                 "policySubCategory": "default",
                 "policyServiceName": "atlas",
                 "policyType": "allow",
-                "policyPriority": 1,
                 "policyUsers":
                 [
                     "admin",
@@ -2989,7 +2988,7 @@
                 "policySubCategory": "default",
                 "policyServiceName": "atlas",
                 "policyType": "allow",
-                "policyPriority": 1,
+                "policyPriority": 0,
                 "policyUsers":
                 [],
                 "policyGroups":
@@ -3516,6 +3515,41 @@
                 "policyActions":
                 [
                     "entity-update-business-metadata"
+                ]
+            }
+        },
+        {
+            "typeName": "AuthPolicy",
+            "attributes":
+            {
+                "name": "READ_STAKEHOLDER_ENTITIES",
+                "qualifiedName": "READ_STAKEHOLDER_ENTITIES",
+                "policyCategory": "bootstrap",
+                "policySubCategory": "default",
+                "policyServiceName": "atlas",
+                "policyType": "allow",
+                "policyPriority": 0,
+                "policyUsers":
+                [],
+                "policyGroups":
+                [],
+                "policyRoles":
+                [
+                    "$admin",
+                    "$guest",
+                    "$member",
+                    "$api-token-default-access"
+                ],
+                "policyResourceCategory": "ENTITY",
+                "policyResources":
+                [
+                    "entity:*",
+                    "entity-type:Stakeholder",
+                    "entity-classification:*"
+                ],
+                "policyActions":
+                [
+                    "entity-read"
                 ]
             }
         },

--- a/addons/policies/bootstrap_entity_policies.json
+++ b/addons/policies/bootstrap_entity_policies.json
@@ -2116,6 +2116,7 @@
                 "policySubCategory": "default",
                 "policyServiceName": "atlas",
                 "policyType": "allow",
+                "policyPriority": 1,
                 "policyUsers":
                 [
                     "admin",
@@ -2988,7 +2989,7 @@
                 "policySubCategory": "default",
                 "policyServiceName": "atlas",
                 "policyType": "allow",
-                "policyPriority": 0,
+                "policyPriority": 1,
                 "policyUsers":
                 [],
                 "policyGroups":
@@ -2999,7 +3000,7 @@
                     "$api-token-default-access"
                 ],
                 "policyResourceCategory": "ENTITY",
-                "isPolicyEnabled": false,
+                "isPolicyEnabled": true,
                 "policyResources":
                 [
                     "entity-type:DataProduct",
@@ -3515,6 +3516,108 @@
                 "policyActions":
                 [
                     "entity-update-business-metadata"
+                ]
+            }
+        },
+        {
+            "typeName": "AuthPolicy",
+            "attributes":
+            {
+                "name": "DATA_DOMAIN_BUSINESS_UPDATE_METADATA",
+                "qualifiedName": "DATA_DOMAIN_BUSINESS_UPDATE_METADATA",
+                "policyCategory": "bootstrap",
+                "policySubCategory": "default",
+                "policyServiceName": "atlas",
+                "policyType": "allow",
+                "policyPriority": 1,
+                "policyUsers":
+                [],
+                "policyGroups":
+                [],
+                "policyRoles":
+                [
+                    "$admin",
+                    "$api-token-default-access"
+                ],
+                "policyResourceCategory": "ENTITY",
+                "policyResources":
+                [
+                    "entity:*",
+                    "entity-type:DataDomain",
+                    "entity-classification:*",
+                    "entity-business-metadata:*"
+                ],
+                "policyActions":
+                [
+                    "entity-update-business-metadata"
+                ]
+            }
+        },
+        {
+            "typeName": "AuthPolicy",
+            "attributes":
+            {
+                "name": "DATA_PRODUCT_BUSINESS_UPDATE_METADATA",
+                "qualifiedName": "DATA_PRODUCT_BUSINESS_UPDATE_METADATA",
+                "policyCategory": "bootstrap",
+                "policySubCategory": "default",
+                "policyServiceName": "atlas",
+                "policyType": "allow",
+                "policyPriority": 1,
+                "policyUsers":
+                [],
+                "policyGroups":
+                [],
+                "policyRoles":
+                [
+                    "$admin",
+                    "$api-token-default-access"
+                ],
+                "policyResourceCategory": "ENTITY",
+                "policyResources":
+                [
+                    "entity:*/product/*",
+                    "entity-type:DataProduct",
+                    "entity-classification:*",
+                    "entity-business-metadata:*"
+                ],
+                "policyActions":
+                [
+                    "entity-update-business-metadata"
+                ]
+            }
+        },
+        {
+            "typeName": "AuthPolicy",
+            "attributes":
+            {
+                "name": "READ_DATA_PRODUCT_ENTITY",
+                "qualifiedName": "READ_DATA_PRODUCT_ENTITY",
+                "description": "Allows user to perform read operation on data products asset",
+                "policyCategory": "bootstrap",
+                "policySubCategory": "default",
+                "policyServiceName": "atlas",
+                "policyType": "allow",
+                "policyPriority": 1,
+                "policyUsers":
+                [],
+                "policyGroups":
+                [],
+                "policyRoles":
+                [
+                    "$admin",
+                    "$api-token-default-access"
+                ],
+                "policyResourceCategory": "ENTITY",
+                "policyResources":
+                [
+                    "entity-type:DataProduct",
+                    "entity-classification:*",
+                    "entity:*"
+                ],
+                "policyActions":
+                [
+                    "entity-read"
                 ]
             }
         },

--- a/addons/policies/bootstrap_entity_policies.json
+++ b/addons/policies/bootstrap_entity_policies.json
@@ -3557,108 +3557,6 @@
             "typeName": "AuthPolicy",
             "attributes":
             {
-                "name": "DATA_DOMAIN_BUSINESS_UPDATE_METADATA",
-                "qualifiedName": "DATA_DOMAIN_BUSINESS_UPDATE_METADATA",
-                "policyCategory": "bootstrap",
-                "policySubCategory": "default",
-                "policyServiceName": "atlas",
-                "policyType": "allow",
-                "policyPriority": 1,
-                "policyUsers":
-                [],
-                "policyGroups":
-                [],
-                "policyRoles":
-                [
-                    "$admin",
-                    "$api-token-default-access"
-                ],
-                "policyResourceCategory": "ENTITY",
-                "policyResources":
-                [
-                    "entity:*",
-                    "entity-type:DataDomain",
-                    "entity-classification:*",
-                    "entity-business-metadata:*"
-                ],
-                "policyActions":
-                [
-                    "entity-update-business-metadata"
-                ]
-            }
-        },
-        {
-            "typeName": "AuthPolicy",
-            "attributes":
-            {
-                "name": "DATA_PRODUCT_BUSINESS_UPDATE_METADATA",
-                "qualifiedName": "DATA_PRODUCT_BUSINESS_UPDATE_METADATA",
-                "policyCategory": "bootstrap",
-                "policySubCategory": "default",
-                "policyServiceName": "atlas",
-                "policyType": "allow",
-                "policyPriority": 1,
-                "policyUsers":
-                [],
-                "policyGroups":
-                [],
-                "policyRoles":
-                [
-                    "$admin",
-                    "$api-token-default-access"
-                ],
-                "policyResourceCategory": "ENTITY",
-                "policyResources":
-                [
-                    "entity:*/product/*",
-                    "entity-type:DataProduct",
-                    "entity-classification:*",
-                    "entity-business-metadata:*"
-                ],
-                "policyActions":
-                [
-                    "entity-update-business-metadata"
-                ]
-            }
-        },
-        {
-            "typeName": "AuthPolicy",
-            "attributes":
-            {
-                "name": "READ_DATA_PRODUCT_ENTITY",
-                "qualifiedName": "READ_DATA_PRODUCT_ENTITY",
-                "description": "Allows user to perform read operation on data products asset",
-                "policyCategory": "bootstrap",
-                "policySubCategory": "default",
-                "policyServiceName": "atlas",
-                "policyType": "allow",
-                "policyPriority": 1,
-                "policyUsers":
-                [],
-                "policyGroups":
-                [],
-                "policyRoles":
-                [
-                    "$admin",
-                    "$api-token-default-access"
-                ],
-                "policyResourceCategory": "ENTITY",
-                "policyResources":
-                [
-                    "entity-type:DataProduct",
-                    "entity-classification:*",
-                    "entity:*"
-                ],
-                "policyActions":
-                [
-                    "entity-read"
-                ]
-            }
-        },
-        {
-            "typeName": "AuthPolicy",
-            "attributes":
-            {
                 "name": "READ_FORMS",
                 "qualifiedName": "READ_FORM_ENTITIES",
                 "description": "Allows user to perform read operation on Form assets.",
@@ -3800,6 +3698,108 @@
                 [
                     "entity-update",
                     "entity-delete"
+                ]
+            }
+        },
+        {
+            "typeName": "AuthPolicy",
+            "attributes":
+            {
+                "name": "DATA_DOMAIN_BUSINESS_UPDATE_METADATA",
+                "qualifiedName": "DATA_DOMAIN_BUSINESS_UPDATE_METADATA",
+                "policyCategory": "bootstrap",
+                "policySubCategory": "default",
+                "policyServiceName": "atlas",
+                "policyType": "allow",
+                "policyPriority": 1,
+                "policyUsers":
+                [],
+                "policyGroups":
+                [],
+                "policyRoles":
+                [
+                    "$admin",
+                    "$api-token-default-access"
+                ],
+                "policyResourceCategory": "ENTITY",
+                "policyResources":
+                [
+                    "entity:*",
+                    "entity-type:DataDomain",
+                    "entity-classification:*",
+                    "entity-business-metadata:*"
+                ],
+                "policyActions":
+                [
+                    "entity-update-business-metadata"
+                ]
+            }
+        },
+        {
+            "typeName": "AuthPolicy",
+            "attributes":
+            {
+                "name": "DATA_PRODUCT_BUSINESS_UPDATE_METADATA",
+                "qualifiedName": "DATA_PRODUCT_BUSINESS_UPDATE_METADATA",
+                "policyCategory": "bootstrap",
+                "policySubCategory": "default",
+                "policyServiceName": "atlas",
+                "policyType": "allow",
+                "policyPriority": 1,
+                "policyUsers":
+                [],
+                "policyGroups":
+                [],
+                "policyRoles":
+                [
+                    "$admin",
+                    "$api-token-default-access"
+                ],
+                "policyResourceCategory": "ENTITY",
+                "policyResources":
+                [
+                    "entity:*/product/*",
+                    "entity-type:DataProduct",
+                    "entity-classification:*",
+                    "entity-business-metadata:*"
+                ],
+                "policyActions":
+                [
+                    "entity-update-business-metadata"
+                ]
+            }
+        },
+        {
+            "typeName": "AuthPolicy",
+            "attributes":
+            {
+                "name": "READ_DATA_PRODUCT_ENTITY",
+                "qualifiedName": "READ_DATA_PRODUCT_ENTITY",
+                "description": "Allows user to perform read operation on data products asset",
+                "policyCategory": "bootstrap",
+                "policySubCategory": "default",
+                "policyServiceName": "atlas",
+                "policyType": "allow",
+                "policyPriority": 1,
+                "policyUsers":
+                [],
+                "policyGroups":
+                [],
+                "policyRoles":
+                [
+                    "$admin",
+                    "$api-token-default-access"
+                ],
+                "policyResourceCategory": "ENTITY",
+                "policyResources":
+                [
+                    "entity-type:DataProduct",
+                    "entity-classification:*",
+                    "entity:*"
+                ],
+                "policyActions":
+                [
+                    "entity-read"
                 ]
             }
         }

--- a/addons/policies/bootstrap_relationship_policies.json
+++ b/addons/policies/bootstrap_relationship_policies.json
@@ -957,6 +957,162 @@
             "typeName": "AuthPolicy",
             "attributes":
             {
+                "name": "LINK_MESH_DATA_DOMAIN_TO_STAKE_HOLDER",
+                "qualifiedName": "LINK_MESH_DATA_DOMAIN_TO_STAKE_HOLDER",
+                "policyCategory": "bootstrap",
+                "policySubCategory": "default",
+                "policyServiceName": "atlas",
+                "policyType": "allow",
+                "policyPriority": 1,
+                "policyUsers":
+                [],
+                "policyGroups":
+                [],
+                "policyRoles":
+                [
+                    "$admin",
+                    "$api-token-default-access"
+                ],
+                "policyResourceCategory": "RELATIONSHIP",
+                "policyResources":
+                [
+                    "relationship-type:*",
+                    "end-one-entity-type:DataDomain",
+                    "end-one-entity-classification:*",
+                    "end-one-entity:*",
+                    "end-two-entity-type:Stakeholder",
+                    "end-two-entity-classification:*",
+                    "end-two-entity:*"
+                ],
+                "policyActions":
+                [
+                    "add-relationship",
+                    "update-relationship",
+                    "remove-relationship"
+                ]
+            }
+        },
+        {
+            "typeName": "AuthPolicy",
+            "attributes":
+            {
+                "name": "LINK_STAKEHOLDER_TITLE_TO_DATA_DOMAIN_STAKEHOLDER",
+                "qualifiedName": "LINK_STAKEHOLDER_TITLE_TO_DATA_DOMAIN_STAKEHOLDER",
+                "policyCategory": "bootstrap",
+                "policySubCategory": "default",
+                "policyServiceName": "atlas",
+                "policyType": "allow",
+                "policyPriority": 1,
+                "policyUsers":
+                [],
+                "policyGroups":
+                [],
+                "policyRoles":
+                [
+                    "$admin",
+                    "$api-token-default-access"
+                ],
+                "policyResourceCategory": "RELATIONSHIP",
+                "policyResources":
+                [
+                    "relationship-type:*",
+                    "end-one-entity-type:StakeholderTitle",
+                    "end-one-entity-classification:*",
+                    "end-one-entity:*",
+                    "end-two-entity-type:Stakeholder",
+                    "end-two-entity-classification:*",
+                    "end-two-entity:*"
+                ],
+                "policyActions":
+                [
+                    "add-relationship",
+                    "update-relationship",
+                    "remove-relationship"
+                ]
+            }
+        },
+        {
+            "typeName": "AuthPolicy",
+            "attributes":
+            {
+                "name": "LINK_ASSET_TO_MESH_DATA_PRODUCT",
+                "qualifiedName": "LINK_ASSET_TO_MESH_DATA_PRODUCT",
+                "policyCategory": "bootstrap",
+                "policySubCategory": "default",
+                "policyServiceName": "atlas",
+                "policyType": "allow",
+                "policyPriority": 1,
+                "policyUsers":
+                [],
+                "policyGroups":
+                [],
+                "policyRoles":
+                [
+                    "$admin",
+                    "$api-token-default-access"
+                ],
+                "policyResourceCategory": "RELATIONSHIP",
+                "policyResources":
+                [
+                    "relationship-type:*",
+                    "end-one-entity-type:Asset",
+                    "end-one-entity-classification:*",
+                    "end-one-entity:*",
+                    "end-two-entity-type:DataProduct",
+                    "end-two-entity-classification:*",
+                    "end-two-entity:*"
+                ],
+                "policyActions":
+                [
+                    "add-relationship",
+                    "update-relationship",
+                    "remove-relationship"
+                ]
+            }
+        },
+        {
+            "typeName": "AuthPolicy",
+            "attributes":
+            {
+                "name": "LINK_MESH_DATA_PRODUCT_TO_ASSET",
+                "qualifiedName": "LINK_MESH_DATA_PRODUCT_TO_ASSET",
+                "policyCategory": "bootstrap",
+                "policySubCategory": "default",
+                "policyServiceName": "atlas",
+                "policyType": "allow",
+                "policyPriority": 1,
+                "policyUsers":
+                [],
+                "policyGroups":
+                [],
+                "policyRoles":
+                [
+                    "$admin",
+                    "$api-token-default-access"
+                ],
+                "policyResourceCategory": "RELATIONSHIP",
+                "policyResources":
+                [
+                    "relationship-type:*",
+                    "end-one-entity-type:DataProduct",
+                    "end-one-entity-classification:*",
+                    "end-one-entity:*",
+                    "end-two-entity-type:Asset",
+                    "end-two-entity-classification:*",
+                    "end-two-entity:*"
+                ],
+                "policyActions":
+                [
+                    "add-relationship",
+                    "update-relationship",
+                    "remove-relationship"
+                ]
+            }
+        },
+        {
+            "typeName": "AuthPolicy",
+            "attributes":
+            {
                 "name": "LINK_RESOURCES_TO_AI_APP_MODELS",
                 "qualifiedName": "LINK_RESOURCES_TO_AI_APP_MODELS",
                 "policyCategory": "bootstrap",


### PR DESCRIPTION
## Change description

> Admins can create domains, create products, and edit other domain metadata using bootstrap policies, but they can’t edit product metadata and update stakeholders using the bootstrap policies. Admins need domain policies to update product metadata and stakeholders. 

JIRA: [MESH-422](https://atlanhq.atlassian.net/browse/MESH-422), [MESH_413](https://atlanhq.atlassian.net/browse/MESH-413)

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable


[MESH-422]: https://atlanhq.atlassian.net/browse/MESH-422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ