### PR TITLE
MESH-438 | Allow READ on Stakeholder for all roles via bootstrap policy.

### DIFF
--- a/addons/policies/bootstrap_entity_policies.json
+++ b/addons/policies/bootstrap_entity_policies.json
@@ -3102,6 +3102,7 @@
                 [
                     "$admin",
                     "$member",
+                    "$guest",
                     "$api-token-default-access"
                 ],
                 "policyResourceCategory": "ENTITY",


### PR DESCRIPTION
## Change description

> This PR is the continuation of the previous PR raised on master for stakeholder read access. Earlier, I had missed adding guest users to have `stakeholderTitle` read access, here I have added `stakeholderTitle` read access for guest users.

JIRA: [MESH-438](https://atlanhq.atlassian.net/browse/MESH-438)
Test Doc - [Test doc](https://atlanhq.atlassian.net/wiki/spaces/dg/pages/721158172/Test+cases+for+MESH-438+Allow+READ+on+Stakeholder+for+all+roles+via+bootstrap+policy.)

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable


[MESH-438]: https://atlanhq.atlassian.net/browse/MESH-438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ