### PR TITLE
APP-5713 Added new Error code for service unavailable

### DIFF
--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchQuery.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchQuery.java
@@ -66,12 +66,7 @@ import static org.apache.atlas.AtlasErrorCode.INDEX_NOT_FOUND;
 
 public class AtlasElasticsearchQuery implements AtlasIndexQuery<AtlasJanusVertex, AtlasJanusEdge> {
     private static final Logger LOG = LoggerFactory.getLogger(AtlasElasticsearchQuery.class);
-    private static final Set<String> NETWORK_ERROR_MESSAGES =
-            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
-                    "Connection reset by peer",
-                    "Network error",
-                    "Connection refused"
-            )));
+
     private AtlasJanusGraph graph;
     private RestHighLevelClient esClient;
     private RestClient lowLevelRestClient;
@@ -275,7 +270,10 @@ public class AtlasElasticsearchQuery implements AtlasIndexQuery<AtlasJanusVertex
      */
     private void handleNetworkErrors(Exception e) throws AtlasBaseException {
         if (e instanceof SocketTimeoutException || e instanceof UnknownHostException ||
-                (e.getMessage() != null && NETWORK_ERROR_MESSAGES.stream().anyMatch(e.getMessage()::contains))) {
+                (e.getMessage() != null &&
+                        (e.getMessage().contains("Connection reset by peer") ||
+                                e.getMessage().contains("Network error") ||
+                                e.getMessage().contains("Connection refused")))) {
             throw new AtlasBaseException(AtlasErrorCode.SERVICE_UNAVAILABLE,
                     "Service is unavailable or a network error occurred: Elasticsearch - " + e.getMessage());
         }

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchQuery.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchQuery.java
@@ -265,15 +265,15 @@ public class AtlasElasticsearchQuery implements AtlasIndexQuery<AtlasJanusVertex
         return result;
     }
 
-    /*
-     * Checks if the exception is a network-related issue and throws a SERVICE_UNAVAILABLE error.
-     */
-    private void handleNetworkErrors(Exception e) throws AtlasBaseException {
-        List<String> NETWORK_ERROR_MESSAGES = Arrays.asList(
+    private static final List<String> NETWORK_ERROR_MESSAGES = Arrays.asList(
                 "Connection reset by peer",
                 "Network error",
                 "Connection refused"
         );
+    /*
+     * Checks if the exception is a network-related issue and throws a SERVICE_UNAVAILABLE error.
+     */
+    private void handleNetworkErrors(Exception e) throws AtlasBaseException {
         if (e instanceof SocketTimeoutException || e instanceof UnknownHostException ||
                 (e.getMessage() != null && NETWORK_ERROR_MESSAGES.stream().anyMatch(e.getMessage()::contains))) {
             throw new AtlasBaseException(AtlasErrorCode.SERVICE_UNAVAILABLE,

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchQuery.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchQuery.java
@@ -143,6 +143,12 @@ public class AtlasElasticsearchQuery implements AtlasIndexQuery<AtlasJanusVertex
             }
         } catch (IOException e) {
             LOG.error("Failed to execute direct query on ES {}", e.getMessage());
+
+            if (e.getMessage() != null &&
+                    (e.getMessage().contains("Connection reset by peer") || e.getMessage().contains("Network error"))) {
+                throw new AtlasBaseException(AtlasErrorCode.SERVICE_UNAVAILABLE, e.getMessage());
+            }
+
             throw new AtlasBaseException(AtlasErrorCode.INDEX_SEARCH_FAILED, e.getMessage());
         }
     }
@@ -170,6 +176,12 @@ public class AtlasElasticsearchQuery implements AtlasIndexQuery<AtlasJanusVertex
 
         } catch (IOException e) {
             LOG.error("Failed to execute direct query on ES {}", e.getMessage());
+
+            if (e.getMessage() != null &&
+                    (e.getMessage().contains("Connection reset by peer") || e.getMessage().contains("Network error"))) {
+                throw new AtlasBaseException(AtlasErrorCode.SERVICE_UNAVAILABLE, e.getMessage());
+            }
+
             throw new AtlasBaseException(AtlasErrorCode.INDEX_SEARCH_FAILED, e.getMessage());
         }
     }
@@ -183,6 +195,12 @@ public class AtlasElasticsearchQuery implements AtlasIndexQuery<AtlasJanusVertex
 
         } catch (IOException e) {
             LOG.error("Failed to execute direct query on ES {}", e.getMessage());
+
+            if (e.getMessage() != null &&
+                    (e.getMessage().contains("Connection reset by peer") || e.getMessage().contains("Network error"))) {
+                throw new AtlasBaseException(AtlasErrorCode.SERVICE_UNAVAILABLE, e.getMessage());
+            }
+
             throw new AtlasBaseException(AtlasErrorCode.INDEX_SEARCH_FAILED, e.getMessage());
         }
     }
@@ -234,6 +252,12 @@ public class AtlasElasticsearchQuery implements AtlasIndexQuery<AtlasJanusVertex
             }
         }catch (Exception e) {
             LOG.error("Failed to execute direct query on ES {}", e.getMessage());
+
+            if (e.getMessage() != null &&
+                    (e.getMessage().contains("Connection reset by peer") || e.getMessage().contains("Network error"))) {
+                throw new AtlasBaseException(AtlasErrorCode.SERVICE_UNAVAILABLE, e.getMessage());
+            }
+
             throw new AtlasBaseException(AtlasErrorCode.INDEX_SEARCH_FAILED, e.getMessage());
         } finally {
             if (contextIdExists) {

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchQuery.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchQuery.java
@@ -146,13 +146,7 @@ public class AtlasElasticsearchQuery implements AtlasIndexQuery<AtlasJanusVertex
         } catch (IOException e) {
             LOG.error("Failed to execute direct query on ES {}", e.getMessage());
 
-            if (e instanceof SocketTimeoutException ||
-                    e instanceof UnknownHostException ||
-                    (e.getMessage() != null &&
-                            (e.getMessage().contains("Connection reset by peer") ||
-                                    e.getMessage().contains("Network error")))) {
-                throw new AtlasBaseException(AtlasErrorCode.SERVICE_UNAVAILABLE, e.getMessage());
-            }
+            handleNetworkErrors(e);
 
             throw new AtlasBaseException(AtlasErrorCode.INDEX_SEARCH_FAILED, e.getMessage());
         }
@@ -182,13 +176,7 @@ public class AtlasElasticsearchQuery implements AtlasIndexQuery<AtlasJanusVertex
         } catch (IOException e) {
             LOG.error("Failed to execute direct query on ES {}", e.getMessage());
 
-            if (e instanceof SocketTimeoutException ||
-                    e instanceof UnknownHostException ||
-                    (e.getMessage() != null &&
-                            (e.getMessage().contains("Connection reset by peer") ||
-                                    e.getMessage().contains("Network error")))) {
-                throw new AtlasBaseException(AtlasErrorCode.SERVICE_UNAVAILABLE, e.getMessage());
-            }
+            handleNetworkErrors(e);
 
             throw new AtlasBaseException(AtlasErrorCode.INDEX_SEARCH_FAILED, e.getMessage());
         }
@@ -204,13 +192,7 @@ public class AtlasElasticsearchQuery implements AtlasIndexQuery<AtlasJanusVertex
         } catch (IOException e) {
             LOG.error("Failed to execute direct query on ES {}", e.getMessage());
 
-            if (e instanceof SocketTimeoutException ||
-                    e instanceof UnknownHostException ||
-                    (e.getMessage() != null &&
-                            (e.getMessage().contains("Connection reset by peer") ||
-                                    e.getMessage().contains("Network error")))) {
-                throw new AtlasBaseException(AtlasErrorCode.SERVICE_UNAVAILABLE, e.getMessage());
-            }
+            handleNetworkErrors(e);
 
             throw new AtlasBaseException(AtlasErrorCode.INDEX_SEARCH_FAILED, e.getMessage());
         }
@@ -264,12 +246,8 @@ public class AtlasElasticsearchQuery implements AtlasIndexQuery<AtlasJanusVertex
         }catch (Exception e) {
             LOG.error("Failed to execute direct query on ES {}", e.getMessage());
 
-            if (e instanceof SocketTimeoutException ||
-                    e instanceof UnknownHostException ||
-                    (e.getMessage() != null &&
-                            (e.getMessage().contains("Connection reset by peer") ||
-                                    e.getMessage().contains("Network error")))) {
-                throw new AtlasBaseException(AtlasErrorCode.SERVICE_UNAVAILABLE, e.getMessage());
+            if (e instanceof IOException) {
+                handleNetworkErrors((IOException) e);
             }
 
             throw new AtlasBaseException(AtlasErrorCode.INDEX_SEARCH_FAILED, e.getMessage());
@@ -285,6 +263,20 @@ public class AtlasElasticsearchQuery implements AtlasIndexQuery<AtlasJanusVertex
             RequestContext.get().endMetricRecord(metric);
         }
         return result;
+    }
+
+    /*
+     * Checks if the exception is a network-related issue and throws a SERVICE_UNAVAILABLE error.
+     */
+    private void handleNetworkErrors(IOException e) throws AtlasBaseException {
+        if (e instanceof SocketTimeoutException ||
+                e instanceof UnknownHostException ||
+                (e.getMessage() != null &&
+                        (e.getMessage().contains("Connection reset by peer") ||
+                                e.getMessage().contains("Network error")))) {
+            throw new AtlasBaseException(AtlasErrorCode.SERVICE_UNAVAILABLE,
+                    "Service is unavailable or a network error occurred: Elasticsearch - " + e.getMessage());
+        }
     }
 
     /*

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchQuery.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchQuery.java
@@ -54,6 +54,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
@@ -144,8 +146,11 @@ public class AtlasElasticsearchQuery implements AtlasIndexQuery<AtlasJanusVertex
         } catch (IOException e) {
             LOG.error("Failed to execute direct query on ES {}", e.getMessage());
 
-            if (e.getMessage() != null &&
-                    (e.getMessage().contains("Connection reset by peer") || e.getMessage().contains("Network error"))) {
+            if (e instanceof SocketTimeoutException ||
+                    e instanceof UnknownHostException ||
+                    (e.getMessage() != null &&
+                            (e.getMessage().contains("Connection reset by peer") ||
+                                    e.getMessage().contains("Network error")))) {
                 throw new AtlasBaseException(AtlasErrorCode.SERVICE_UNAVAILABLE, e.getMessage());
             }
 
@@ -177,8 +182,11 @@ public class AtlasElasticsearchQuery implements AtlasIndexQuery<AtlasJanusVertex
         } catch (IOException e) {
             LOG.error("Failed to execute direct query on ES {}", e.getMessage());
 
-            if (e.getMessage() != null &&
-                    (e.getMessage().contains("Connection reset by peer") || e.getMessage().contains("Network error"))) {
+            if (e instanceof SocketTimeoutException ||
+                    e instanceof UnknownHostException ||
+                    (e.getMessage() != null &&
+                            (e.getMessage().contains("Connection reset by peer") ||
+                                    e.getMessage().contains("Network error")))) {
                 throw new AtlasBaseException(AtlasErrorCode.SERVICE_UNAVAILABLE, e.getMessage());
             }
 
@@ -196,8 +204,11 @@ public class AtlasElasticsearchQuery implements AtlasIndexQuery<AtlasJanusVertex
         } catch (IOException e) {
             LOG.error("Failed to execute direct query on ES {}", e.getMessage());
 
-            if (e.getMessage() != null &&
-                    (e.getMessage().contains("Connection reset by peer") || e.getMessage().contains("Network error"))) {
+            if (e instanceof SocketTimeoutException ||
+                    e instanceof UnknownHostException ||
+                    (e.getMessage() != null &&
+                            (e.getMessage().contains("Connection reset by peer") ||
+                                    e.getMessage().contains("Network error")))) {
                 throw new AtlasBaseException(AtlasErrorCode.SERVICE_UNAVAILABLE, e.getMessage());
             }
 
@@ -253,8 +264,11 @@ public class AtlasElasticsearchQuery implements AtlasIndexQuery<AtlasJanusVertex
         }catch (Exception e) {
             LOG.error("Failed to execute direct query on ES {}", e.getMessage());
 
-            if (e.getMessage() != null &&
-                    (e.getMessage().contains("Connection reset by peer") || e.getMessage().contains("Network error"))) {
+            if (e instanceof SocketTimeoutException ||
+                    e instanceof UnknownHostException ||
+                    (e.getMessage() != null &&
+                            (e.getMessage().contains("Connection reset by peer") ||
+                                    e.getMessage().contains("Network error")))) {
                 throw new AtlasBaseException(AtlasErrorCode.SERVICE_UNAVAILABLE, e.getMessage());
             }
 

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchQuery.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchQuery.java
@@ -268,13 +268,14 @@ public class AtlasElasticsearchQuery implements AtlasIndexQuery<AtlasJanusVertex
     /*
      * Checks if the exception is a network-related issue and throws a SERVICE_UNAVAILABLE error.
      */
-    private void handleNetworkErrors(IOException e) throws AtlasBaseException {
-        if (e instanceof SocketTimeoutException ||
-                e instanceof UnknownHostException ||
-                (e.getMessage() != null &&
-                        (e.getMessage().contains("Connection reset by peer") ||
-                                e.getMessage().contains("Network error") ||
-                                e.getMessage().contains("Connection refused")))) {
+    private void handleNetworkErrors(Exception e) throws AtlasBaseException {
+        List<String> NETWORK_ERROR_MESSAGES = Arrays.asList(
+                "Connection reset by peer",
+                "Network error",
+                "Connection refused"
+        );
+        if (e instanceof SocketTimeoutException || e instanceof UnknownHostException ||
+                (e.getMessage() != null && NETWORK_ERROR_MESSAGES.stream().anyMatch(e.getMessage()::contains))) {
             throw new AtlasBaseException(AtlasErrorCode.SERVICE_UNAVAILABLE,
                     "Service is unavailable or a network error occurred: Elasticsearch - " + e.getMessage());
         }

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchQuery.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchQuery.java
@@ -273,7 +273,8 @@ public class AtlasElasticsearchQuery implements AtlasIndexQuery<AtlasJanusVertex
                 e instanceof UnknownHostException ||
                 (e.getMessage() != null &&
                         (e.getMessage().contains("Connection reset by peer") ||
-                                e.getMessage().contains("Network error")))) {
+                                e.getMessage().contains("Network error") ||
+                                e.getMessage().contains("Connection refused")))) {
             throw new AtlasBaseException(AtlasErrorCode.SERVICE_UNAVAILABLE,
                     "Service is unavailable or a network error occurred: Elasticsearch - " + e.getMessage());
         }

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchQuery.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchQuery.java
@@ -66,7 +66,12 @@ import static org.apache.atlas.AtlasErrorCode.INDEX_NOT_FOUND;
 
 public class AtlasElasticsearchQuery implements AtlasIndexQuery<AtlasJanusVertex, AtlasJanusEdge> {
     private static final Logger LOG = LoggerFactory.getLogger(AtlasElasticsearchQuery.class);
-
+    private static final Set<String> NETWORK_ERROR_MESSAGES =
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+                    "Connection reset by peer",
+                    "Network error",
+                    "Connection refused"
+            )));
     private AtlasJanusGraph graph;
     private RestHighLevelClient esClient;
     private RestClient lowLevelRestClient;
@@ -265,11 +270,6 @@ public class AtlasElasticsearchQuery implements AtlasIndexQuery<AtlasJanusVertex
         return result;
     }
 
-    private static final List<String> NETWORK_ERROR_MESSAGES = Arrays.asList(
-                "Connection reset by peer",
-                "Network error",
-                "Connection refused"
-        );
     /*
      * Checks if the exception is a network-related issue and throws a SERVICE_UNAVAILABLE error.
      */

--- a/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
@@ -279,6 +279,7 @@ public enum AtlasErrorCode {
     KEYCLOAK_INIT_FAILED(500, "ATLAS-500-00-022", "Failed to initialize keycloak client: {0}"),
 
     MAINTENANCE_MODE_ENABLED(503, "ATLAS-503-00-001", "Atlas is in maintenance mode for this specific operation. Please try again later."),
+    SERVICE_UNAVAILABLE(503, "ATLAS-503-00-002", "Service is unavailable or a network error occurred: {0}"),
 
     BATCH_SIZE_TOO_LARGE(406, "ATLAS-406-00-001", "Batch size is too large, please use a smaller batch size"),
 


### PR DESCRIPTION
## Description

- Updated error handling to return `503 (Service Unavailable)` instead of `400 (Bad Request)` for network-related failures like `"Connection reset by peer"`, ensuring proper retries.

## Testing Locally

- When ElasticSearch is down response should be 503

<img width="1512" alt="Screenshot 2025-03-11 at 10 57 05 AM" src="https://github.com/user-attachments/assets/b87540a4-4fcb-4970-9c7f-30976969ef8d" />
<img width="1512" alt="Screenshot 2025-03-11 at 10 56 58 AM" src="https://github.com/user-attachments/assets/9ebc5f06-40a0-4acb-a487-a908c0f0acea" /> 

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [APP-5713](https://atlanhq.atlassian.net/browse/APP-5713) 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable


[APP-5713]: https://atlanhq.atlassian.net/browse/APP-5713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ