### PR TITLE
MESH-422 | Empower admins to have access to ALL data products functionality without needing any policies

### DIFF
--- a/addons/policies/bootstrap_entity_policies.json
+++ b/addons/policies/bootstrap_entity_policies.json
@@ -2893,6 +2893,7 @@
                 "policyResources":
                 [
                     "entity-type:DataDomain",
+                    "entity-type:DataProduct",
                     "entity-classification:*",
                     "entity:*"
                 ],
@@ -3706,13 +3707,13 @@
             "typeName": "AuthPolicy",
             "attributes":
             {
-                "name": "DATA_DOMAIN_AND_PRODUCT_BUSINESS_UPDATE_METADATA",
-                "qualifiedName": "DATA_DOMAIN_AND_PRODUCT_BUSINESS_UPDATE_METADATA",
+                "name": "ENTITY_BUSINESS_UPDATE_METADATA_BOOT",
+                "qualifiedName": "ENTITY_BUSINESS_UPDATE_METADATA_BOOT",
                 "policyCategory": "bootstrap",
                 "policySubCategory": "default",
                 "policyServiceName": "atlas",
                 "policyType": "allow",
-                "policyPriority": 1,
+                "policyPriority": 0,
                 "policyUsers":
                 [],
                 "policyGroups":
@@ -3734,43 +3735,6 @@
                 "policyActions":
                 [
                     "entity-update-business-metadata"
-                ]
-            }
-        },
-        {
-            "typeName": "AuthPolicy",
-            "attributes":
-            {
-                "name": "CRUD_DATA_PRODUCT_ENTITY",
-                "qualifiedName": "CRUD_DATA_PRODUCT_ENTITY",
-                "description": "Allows user to perform CRUD operation on data products asset",
-                "policyCategory": "bootstrap",
-                "policySubCategory": "default",
-                "policyServiceName": "atlas",
-                "policyType": "allow",
-                "policyPriority": 1,
-                "policyUsers":
-                [],
-                "policyGroups":
-                [],
-                "policyRoles":
-                [
-                    "$admin",
-                    "$api-token-default-access"
-                ],
-                "policyResourceCategory": "ENTITY",
-                "policyResources":
-                [
-                    "entity-type:DataProduct",
-                    "entity-classification:*",
-                    "entity:*"
-                ],
-                "policyActions":
-                [
-                    "entity-read",
-                    "entity-create",
-                    "entity-update",
-                    "entity-delete"
                 ]
             }
         }

--- a/addons/policies/bootstrap_entity_policies.json
+++ b/addons/policies/bootstrap_entity_policies.json
@@ -2999,7 +2999,7 @@
                     "$api-token-default-access"
                 ],
                 "policyResourceCategory": "ENTITY",
-                "isPolicyEnabled": false,
+                "isPolicyEnabled": true,
                 "policyResources":
                 [
                     "entity-type:DataProduct",
@@ -3699,6 +3699,108 @@
                 [
                     "entity-update",
                     "entity-delete"
+                ]
+            }
+        },
+        {
+            "typeName": "AuthPolicy",
+            "attributes":
+            {
+                "name": "DATA_DOMAIN_BUSINESS_UPDATE_METADATA",
+                "qualifiedName": "DATA_DOMAIN_BUSINESS_UPDATE_METADATA",
+                "policyCategory": "bootstrap",
+                "policySubCategory": "default",
+                "policyServiceName": "atlas",
+                "policyType": "allow",
+                "policyPriority": 1,
+                "policyUsers":
+                [],
+                "policyGroups":
+                [],
+                "policyRoles":
+                [
+                    "$admin",
+                    "$api-token-default-access"
+                ],
+                "policyResourceCategory": "ENTITY",
+                "policyResources":
+                [
+                    "entity:*",
+                    "entity-type:DataDomain",
+                    "entity-classification:*",
+                    "entity-business-metadata:*"
+                ],
+                "policyActions":
+                [
+                    "entity-update-business-metadata"
+                ]
+            }
+        },
+        {
+            "typeName": "AuthPolicy",
+            "attributes":
+            {
+                "name": "DATA_PRODUCT_BUSINESS_UPDATE_METADATA",
+                "qualifiedName": "DATA_PRODUCT_BUSINESS_UPDATE_METADATA",
+                "policyCategory": "bootstrap",
+                "policySubCategory": "default",
+                "policyServiceName": "atlas",
+                "policyType": "allow",
+                "policyPriority": 1,
+                "policyUsers":
+                [],
+                "policyGroups":
+                [],
+                "policyRoles":
+                [
+                    "$admin",
+                    "$api-token-default-access"
+                ],
+                "policyResourceCategory": "ENTITY",
+                "policyResources":
+                [
+                    "entity:*/product/*",
+                    "entity-type:DataProduct",
+                    "entity-classification:*",
+                    "entity-business-metadata:*"
+                ],
+                "policyActions":
+                [
+                    "entity-update-business-metadata"
+                ]
+            }
+        },
+        {
+            "typeName": "AuthPolicy",
+            "attributes":
+            {
+                "name": "READ_DATA_PRODUCT_ENTITY",
+                "qualifiedName": "READ_DATA_PRODUCT_ENTITY",
+                "description": "Allows user to perform read operation on data products asset",
+                "policyCategory": "bootstrap",
+                "policySubCategory": "default",
+                "policyServiceName": "atlas",
+                "policyType": "allow",
+                "policyPriority": 1,
+                "policyUsers":
+                [],
+                "policyGroups":
+                [],
+                "policyRoles":
+                [
+                    "$admin",
+                    "$api-token-default-access"
+                ],
+                "policyResourceCategory": "ENTITY",
+                "policyResources":
+                [
+                    "entity-type:DataProduct",
+                    "entity-classification:*",
+                    "entity:*"
+                ],
+                "policyActions":
+                [
+                    "entity-read"
                 ]
             }
         }

--- a/addons/policies/bootstrap_entity_policies.json
+++ b/addons/policies/bootstrap_entity_policies.json
@@ -2999,7 +2999,7 @@
                     "$api-token-default-access"
                 ],
                 "policyResourceCategory": "ENTITY",
-                "isPolicyEnabled": true,
+                "isPolicyEnabled": false,
                 "policyResources":
                 [
                     "entity-type:DataProduct",
@@ -3706,8 +3706,8 @@
             "typeName": "AuthPolicy",
             "attributes":
             {
-                "name": "DATA_DOMAIN_BUSINESS_UPDATE_METADATA",
-                "qualifiedName": "DATA_DOMAIN_BUSINESS_UPDATE_METADATA",
+                "name": "DATA_DOMAIN_AND_PRODUCT_BUSINESS_UPDATE_METADATA",
+                "qualifiedName": "DATA_DOMAIN_AND_PRODUCT_BUSINESS_UPDATE_METADATA",
                 "policyCategory": "bootstrap",
                 "policySubCategory": "default",
                 "policyServiceName": "atlas",
@@ -3727,39 +3727,6 @@
                 [
                     "entity:*",
                     "entity-type:DataDomain",
-                    "entity-classification:*",
-                    "entity-business-metadata:*"
-                ],
-                "policyActions":
-                [
-                    "entity-update-business-metadata"
-                ]
-            }
-        },
-        {
-            "typeName": "AuthPolicy",
-            "attributes":
-            {
-                "name": "DATA_PRODUCT_BUSINESS_UPDATE_METADATA",
-                "qualifiedName": "DATA_PRODUCT_BUSINESS_UPDATE_METADATA",
-                "policyCategory": "bootstrap",
-                "policySubCategory": "default",
-                "policyServiceName": "atlas",
-                "policyType": "allow",
-                "policyPriority": 1,
-                "policyUsers":
-                [],
-                "policyGroups":
-                [],
-                "policyRoles":
-                [
-                    "$admin",
-                    "$api-token-default-access"
-                ],
-                "policyResourceCategory": "ENTITY",
-                "policyResources":
-                [
-                    "entity:*/product/*",
                     "entity-type:DataProduct",
                     "entity-classification:*",
                     "entity-business-metadata:*"
@@ -3774,9 +3741,9 @@
             "typeName": "AuthPolicy",
             "attributes":
             {
-                "name": "READ_DATA_PRODUCT_ENTITY",
-                "qualifiedName": "READ_DATA_PRODUCT_ENTITY",
-                "description": "Allows user to perform read operation on data products asset",
+                "name": "CRUD_DATA_PRODUCT_ENTITY",
+                "qualifiedName": "CRUD_DATA_PRODUCT_ENTITY",
+                "description": "Allows user to perform CRUD operation on data products asset",
                 "policyCategory": "bootstrap",
                 "policySubCategory": "default",
                 "policyServiceName": "atlas",
@@ -3800,7 +3767,10 @@
                 ],
                 "policyActions":
                 [
-                    "entity-read"
+                    "entity-read",
+                    "entity-create",
+                    "entity-update",
+                    "entity-delete"
                 ]
             }
         }

--- a/addons/policies/bootstrap_relationship_policies.json
+++ b/addons/policies/bootstrap_relationship_policies.json
@@ -957,47 +957,8 @@
             "typeName": "AuthPolicy",
             "attributes":
             {
-                "name": "LINK_MESH_DATA_DOMAIN_TO_STAKE_HOLDER",
-                "qualifiedName": "LINK_MESH_DATA_DOMAIN_TO_STAKE_HOLDER",
-                "policyCategory": "bootstrap",
-                "policySubCategory": "default",
-                "policyServiceName": "atlas",
-                "policyType": "allow",
-                "policyPriority": 1,
-                "policyUsers":
-                [],
-                "policyGroups":
-                [],
-                "policyRoles":
-                [
-                    "$admin",
-                    "$api-token-default-access"
-                ],
-                "policyResourceCategory": "RELATIONSHIP",
-                "policyResources":
-                [
-                    "relationship-type:*",
-                    "end-one-entity-type:DataDomain",
-                    "end-one-entity-classification:*",
-                    "end-one-entity:*",
-                    "end-two-entity-type:Stakeholder",
-                    "end-two-entity-classification:*",
-                    "end-two-entity:*"
-                ],
-                "policyActions":
-                [
-                    "add-relationship",
-                    "update-relationship",
-                    "remove-relationship"
-                ]
-            }
-        },
-        {
-            "typeName": "AuthPolicy",
-            "attributes":
-            {
-                "name": "LINK_STAKEHOLDER_TITLE_TO_DATA_DOMAIN_STAKEHOLDER",
-                "qualifiedName": "LINK_STAKEHOLDER_TITLE_TO_DATA_DOMAIN_STAKEHOLDER",
+                "name": "LINK_MESH_DATA_DOMAIN_AND_STAKEHOLDER_TITLE_TO_STAKE_HOLDER",
+                "qualifiedName": "LINK_MESH_DATA_DOMAIN_AND_STAKEHOLDER_TITLE_TO_STAKE_HOLDER",
                 "policyCategory": "bootstrap",
                 "policySubCategory": "default",
                 "policyServiceName": "atlas",
@@ -1017,6 +978,7 @@
                 [
                     "relationship-type:*",
                     "end-one-entity-type:StakeholderTitle",
+                    "end-one-entity-type:DataDomain",
                     "end-one-entity-classification:*",
                     "end-one-entity:*",
                     "end-two-entity-type:Stakeholder",
@@ -1059,45 +1021,6 @@
                     "end-one-entity-classification:*",
                     "end-one-entity:*",
                     "end-two-entity-type:DataProduct",
-                    "end-two-entity-classification:*",
-                    "end-two-entity:*"
-                ],
-                "policyActions":
-                [
-                    "add-relationship",
-                    "update-relationship",
-                    "remove-relationship"
-                ]
-            }
-        },
-        {
-            "typeName": "AuthPolicy",
-            "attributes":
-            {
-                "name": "LINK_MESH_DATA_PRODUCT_TO_ASSET",
-                "qualifiedName": "LINK_MESH_DATA_PRODUCT_TO_ASSET",
-                "policyCategory": "bootstrap",
-                "policySubCategory": "default",
-                "policyServiceName": "atlas",
-                "policyType": "allow",
-                "policyPriority": 1,
-                "policyUsers":
-                [],
-                "policyGroups":
-                [],
-                "policyRoles":
-                [
-                    "$admin",
-                    "$api-token-default-access"
-                ],
-                "policyResourceCategory": "RELATIONSHIP",
-                "policyResources":
-                [
-                    "relationship-type:*",
-                    "end-one-entity-type:DataProduct",
-                    "end-one-entity-classification:*",
-                    "end-one-entity:*",
-                    "end-two-entity-type:Asset",
                     "end-two-entity-classification:*",
                     "end-two-entity:*"
                 ],

--- a/addons/policies/bootstrap_relationship_policies.json
+++ b/addons/policies/bootstrap_relationship_policies.json
@@ -957,6 +957,162 @@
             "typeName": "AuthPolicy",
             "attributes":
             {
+                "name": "LINK_MESH_DATA_DOMAIN_TO_STAKE_HOLDER",
+                "qualifiedName": "LINK_MESH_DATA_DOMAIN_TO_STAKE_HOLDER",
+                "policyCategory": "bootstrap",
+                "policySubCategory": "default",
+                "policyServiceName": "atlas",
+                "policyType": "allow",
+                "policyPriority": 1,
+                "policyUsers":
+                [],
+                "policyGroups":
+                [],
+                "policyRoles":
+                [
+                    "$admin",
+                    "$api-token-default-access"
+                ],
+                "policyResourceCategory": "RELATIONSHIP",
+                "policyResources":
+                [
+                    "relationship-type:*",
+                    "end-one-entity-type:DataDomain",
+                    "end-one-entity-classification:*",
+                    "end-one-entity:*",
+                    "end-two-entity-type:Stakeholder",
+                    "end-two-entity-classification:*",
+                    "end-two-entity:*"
+                ],
+                "policyActions":
+                [
+                    "add-relationship",
+                    "update-relationship",
+                    "remove-relationship"
+                ]
+            }
+        },
+        {
+            "typeName": "AuthPolicy",
+            "attributes":
+            {
+                "name": "LINK_STAKEHOLDER_TITLE_TO_DATA_DOMAIN_STAKEHOLDER",
+                "qualifiedName": "LINK_STAKEHOLDER_TITLE_TO_DATA_DOMAIN_STAKEHOLDER",
+                "policyCategory": "bootstrap",
+                "policySubCategory": "default",
+                "policyServiceName": "atlas",
+                "policyType": "allow",
+                "policyPriority": 1,
+                "policyUsers":
+                [],
+                "policyGroups":
+                [],
+                "policyRoles":
+                [
+                    "$admin",
+                    "$api-token-default-access"
+                ],
+                "policyResourceCategory": "RELATIONSHIP",
+                "policyResources":
+                [
+                    "relationship-type:*",
+                    "end-one-entity-type:StakeholderTitle",
+                    "end-one-entity-classification:*",
+                    "end-one-entity:*",
+                    "end-two-entity-type:Stakeholder",
+                    "end-two-entity-classification:*",
+                    "end-two-entity:*"
+                ],
+                "policyActions":
+                [
+                    "add-relationship",
+                    "update-relationship",
+                    "remove-relationship"
+                ]
+            }
+        },
+        {
+            "typeName": "AuthPolicy",
+            "attributes":
+            {
+                "name": "LINK_ASSET_TO_MESH_DATA_PRODUCT",
+                "qualifiedName": "LINK_ASSET_TO_MESH_DATA_PRODUCT",
+                "policyCategory": "bootstrap",
+                "policySubCategory": "default",
+                "policyServiceName": "atlas",
+                "policyType": "allow",
+                "policyPriority": 1,
+                "policyUsers":
+                [],
+                "policyGroups":
+                [],
+                "policyRoles":
+                [
+                    "$admin",
+                    "$api-token-default-access"
+                ],
+                "policyResourceCategory": "RELATIONSHIP",
+                "policyResources":
+                [
+                    "relationship-type:*",
+                    "end-one-entity-type:Asset",
+                    "end-one-entity-classification:*",
+                    "end-one-entity:*",
+                    "end-two-entity-type:DataProduct",
+                    "end-two-entity-classification:*",
+                    "end-two-entity:*"
+                ],
+                "policyActions":
+                [
+                    "add-relationship",
+                    "update-relationship",
+                    "remove-relationship"
+                ]
+            }
+        },
+        {
+            "typeName": "AuthPolicy",
+            "attributes":
+            {
+                "name": "LINK_MESH_DATA_PRODUCT_TO_ASSET",
+                "qualifiedName": "LINK_MESH_DATA_PRODUCT_TO_ASSET",
+                "policyCategory": "bootstrap",
+                "policySubCategory": "default",
+                "policyServiceName": "atlas",
+                "policyType": "allow",
+                "policyPriority": 1,
+                "policyUsers":
+                [],
+                "policyGroups":
+                [],
+                "policyRoles":
+                [
+                    "$admin",
+                    "$api-token-default-access"
+                ],
+                "policyResourceCategory": "RELATIONSHIP",
+                "policyResources":
+                [
+                    "relationship-type:*",
+                    "end-one-entity-type:DataProduct",
+                    "end-one-entity-classification:*",
+                    "end-one-entity:*",
+                    "end-two-entity-type:Asset",
+                    "end-two-entity-classification:*",
+                    "end-two-entity:*"
+                ],
+                "policyActions":
+                [
+                    "add-relationship",
+                    "update-relationship",
+                    "remove-relationship"
+                ]
+            }
+        },
+        {
+            "typeName": "AuthPolicy",
+            "attributes":
+            {
                 "name": "LINK_RESOURCES_TO_AI_APP_MODELS",
                 "qualifiedName": "LINK_RESOURCES_TO_AI_APP_MODELS",
                 "policyCategory": "bootstrap",

--- a/addons/policies/bootstrap_relationship_policies.json
+++ b/addons/policies/bootstrap_relationship_policies.json
@@ -963,7 +963,7 @@
                 "policySubCategory": "default",
                 "policyServiceName": "atlas",
                 "policyType": "allow",
-                "policyPriority": 1,
+                "policyPriority": 0,
                 "policyUsers":
                 [],
                 "policyGroups":
@@ -1003,7 +1003,7 @@
                 "policySubCategory": "default",
                 "policyServiceName": "atlas",
                 "policyType": "allow",
-                "policyPriority": 1,
+                "policyPriority": 0,
                 "policyUsers":
                 [],
                 "policyGroups":


### PR DESCRIPTION
## Change description

> Admins can create domains, create products, and edit other domain metadata using bootstrap policies, but they can’t edit product metadata and update stakeholders using the bootstrap policies. Admins need domain policies to update product metadata and stakeholders. 

JIRA: [MESH-422](https://atlanhq.atlassian.net/browse/MESH-422), [MESH_413](https://atlanhq.atlassian.net/browse/MESH-413)

Test Doc - [doc](https://atlanhq.atlassian.net/wiki/spaces/dg/pages/695664723/Test+cases+for+MESH-422+Empower+Admins+to+have+access+to+ALL+data+products+functionality+without+needing+any+policies)

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable


[MESH-422]: https://atlanhq.atlassian.net/browse/MESH-422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ