### PR TITLE
AIGOV-52 AI asset persona support [master]

### DIFF
--- a/addons/static/templates/policy_cache_transformer_persona.json
+++ b/addons/static/templates/policy_cache_transformer_persona.json
@@ -881,8 +881,7 @@
       "policyType": "ACCESS",
       "policyResourceCategory": "ENTITY",
       "resources": [
-        "entity:{entity}",
-        "entity:{entity}/*",
+        "entity:*",
         "entity-type:AIApplication",
         "entity-classification:*"
       ],
@@ -907,8 +906,7 @@
       "policyResourceCategory": "ENTITY",
       "policyType": "ACCESS",
       "resources": [
-        "entity:{entity}",
-        "entity:{entity}/*",
+        "entity:*",
         "entity:default/ai/aiapplication/*",
         "entity-type:AIApplication",
         "entity-classification:*"
@@ -927,8 +925,7 @@
 
         "end-two-entity-type:AIApplication",
         "end-two-entity-classification:*",
-        "end-two-entity:{entity}",
-        "end-two-entity:{entity}/*"
+        "end-two-entity:*"
       ],
       "actions": ["add-relationship", "update-relationship", "remove-relationship"]
     },
@@ -941,8 +938,7 @@
 
         "end-one-entity-type:AIApplication",
         "end-one-entity-classification:*",
-        "end-one-entity:{entity}",
-        "end-one-entity:{entity}/*",
+        "end-one-entity:*",
 
         "end-two-entity-type:Resource",
         "end-two-entity-classification:*",
@@ -956,8 +952,7 @@
       "policyResourceCategory": "ENTITY",
       "policyType": "ACCESS",
       "resources": [
-        "entity:{entity}",
-        "entity:{entity}/*",
+        "entity:*",
         "entity-type:AIApplication",
         "entity-classification:*"
       ],
@@ -969,8 +964,7 @@
       "policyType": "ACCESS",
       "policyResourceCategory": "ENTITY",
       "resources": [
-        "entity:{entity}",
-        "entity:{entity}/*",
+        "entity:*",
         "entity-type:AIApplication",
         "entity-classification:*",
         "entity-business-metadata:*"
@@ -992,8 +986,7 @@
 
         "end-two-entity-type:AIApplication",
         "end-two-entity-classification:*",
-        "end-two-entity:{entity}",
-        "end-two-entity:{entity}/*"
+        "end-two-entity:*"
       ],
       "actions": ["add-relationship", "update-relationship"]
     }
@@ -1012,8 +1005,7 @@
 
         "end-two-entity-type:AIApplication",
         "end-two-entity-classification:*",
-        "end-two-entity:{entity}",
-        "end-two-entity:{entity}/*"
+        "end-two-entity:*"
       ],
       "actions": ["remove-relationship"]
     }
@@ -1023,8 +1015,7 @@
       "policyResourceCategory": "ENTITY",
       "policyType": "ACCESS",
       "resources": [
-        "entity:{entity}",
-        "entity:{entity}/*",
+        "entity:*",
         "entity-type:AIApplication",
         "entity-classification:*",
         "classification:*"
@@ -1040,8 +1031,7 @@
       "policyResourceCategory": "ENTITY",
       "policyType": "ACCESS",
       "resources": [
-        "entity:{entity}",
-        "entity:{entity}/*",
+        "entity:*",
         "entity-type:AIApplication",
         "entity-classification:*",
         "classification:*"
@@ -1057,8 +1047,7 @@
       "policyType": "ACCESS",
       "policyResourceCategory": "ENTITY",
       "resources": [
-        "entity:{entity}",
-        "entity:{entity}/*",
+        "entity:*",
         "entity-type:AIModel",
         "entity-classification:*"
       ],
@@ -1084,8 +1073,7 @@
       "policyResourceCategory": "ENTITY",
       "policyType": "ACCESS",
       "resources": [
-        "entity:{entity}",
-        "entity:{entity}/*",
+        "entity:*",
         "entity:default/ai/aimodel/*",
         "entity:default/ai/aiapplication/*",
         "entity-type:AIModel",
@@ -1101,8 +1089,7 @@
         "relationship-type:*",
         "end-one-entity-type:AIModel",
         "end-one-entity-classification:*",
-        "end-one-entity:{entity}",
-        "end-one-entity:{entity}/*",
+        "end-one-entity:*",
 
         "end-two-entity-type:AIApplication",
         "end-two-entity-classification:*",
@@ -1119,8 +1106,7 @@
 
         "end-one-entity-type:AIModel",
         "end-one-entity-classification:*",
-        "end-one-entity:{entity}",
-        "end-one-entity:{entity}/*",
+        "end-one-entity:*",
 
         "end-two-entity-type:Resource",
         "end-two-entity-classification:*",
@@ -1147,8 +1133,7 @@
       "policyType": "ACCESS",
       "policyResourceCategory": "ENTITY",
       "resources": [
-        "entity:{entity}",
-        "entity:{entity}/*",
+        "entity:*",
         "entity-type:AIModel",
         "entity-classification:*",
         "entity-business-metadata:*"
@@ -1170,8 +1155,7 @@
 
         "end-two-entity-type:AIModel",
         "end-two-entity-classification:*",
-        "end-two-entity:{entity}",
-        "end-two-entity:{entity}/*"
+        "end-two-entity:*"
       ],
       "actions": ["add-relationship", "update-relationship"]
     }
@@ -1190,8 +1174,7 @@
 
         "end-two-entity-type:AIModel",
         "end-two-entity-classification:*",
-        "end-two-entity:{entity}",
-        "end-two-entity:{entity}/*"
+        "end-two-entity:*"
       ],
       "actions": ["remove-relationship"]
     }
@@ -1201,8 +1184,7 @@
       "policyResourceCategory": "ENTITY",
       "policyType": "ACCESS",
       "resources": [
-        "entity:{entity}",
-        "entity:{entity}/*",
+        "entity:*",
         "entity-type:AIModel",
         "entity-classification:*",
         "classification:*"
@@ -1218,8 +1200,7 @@
       "policyResourceCategory": "ENTITY",
       "policyType": "ACCESS",
       "resources": [
-        "entity:{entity}",
-        "entity:{entity}/*",
+        "entity:*",
         "entity-type:AIModel",
         "entity-classification:*",
         "classification:*"

--- a/addons/static/templates/policy_cache_transformer_persona.json
+++ b/addons/static/templates/policy_cache_transformer_persona.json
@@ -893,7 +893,6 @@
       "policyResourceCategory": "ENTITY",
       "policyType": "ACCESS",
       "resources": [
-        "entity:*",
         "entity:default/ai/aiapplication/*",
         "entity-type:AIApplication",
         "entity-classification:*"
@@ -935,9 +934,7 @@
       "policyResourceCategory": "ENTITY",
       "policyType": "ACCESS",
       "resources": [
-        "entity:*",
         "entity:{entity}",
-        "entity:default/ai/aiapplication/*",
         "entity-type:AIApplication",
         "entity-classification:*"
       ],
@@ -1044,7 +1041,6 @@
       "policyResourceCategory": "ENTITY",
       "policyType": "ACCESS",
       "resources": [
-        "entity:*",
         "entity:default/ai/aimodel/*",
         "entity-type:AIModel",
         "entity-classification:*"
@@ -1072,11 +1068,11 @@
         "relationship-type:*",
         "end-one-entity-type:AIModel",
         "end-one-entity-classification:*",
-        "end-one-entity:*",
+        "end-one-entity:{entity}",
 
         "end-two-entity-type:AIApplication",
         "end-two-entity-classification:*",
-        "end-two-entity:{entity}"
+        "end-two-entity:*"
       ],
       "actions": ["add-relationship", "update-relationship", "remove-relationship"]
     }
@@ -1086,9 +1082,7 @@
       "policyResourceCategory": "ENTITY",
       "policyType": "ACCESS",
       "resources": [
-        "entity:*",
         "entity:{entity}",
-        "entity:default/ai/aimodel/*",
         "entity-type:AIModel",
         "entity-classification:*"
       ],

--- a/addons/static/templates/policy_cache_transformer_persona.json
+++ b/addons/static/templates/policy_cache_transformer_persona.json
@@ -9,9 +9,7 @@
         "entity-type:{entity-type}",
         "entity-classification:*"
       ],
-      "actions": [
-        "entity-read"
-      ]
+      "actions": ["entity-read"]
     }
   ],
   "persona-asset-update": [
@@ -24,19 +22,19 @@
         "entity-type:{entity-type}",
         "entity-classification:*"
       ],
-      "actions": [
-        "entity-update"
-      ]
+      "actions": ["entity-update"]
     },
     {
       "policyType": "ACCESS",
       "policyResourceCategory": "RELATIONSHIP",
       "resources": [
         "relationship-type:*",
+
         "end-one-entity-type:{entity-type}",
         "end-one-entity-classification:*",
         "end-one-entity:{entity}",
         "end-one-entity:{entity}/*",
+
         "end-two-entity-type:Catalog",
         "end-two-entity-type:Connection",
         "end-two-entity-type:Process",
@@ -45,16 +43,14 @@
         "end-two-entity-classification:*",
         "end-two-entity:*"
       ],
-      "actions": [
-        "add-relationship",
-        "remove-relationship"
-      ]
+      "actions": ["add-relationship", "remove-relationship"]
     },
     {
       "policyType": "ACCESS",
       "policyResourceCategory": "RELATIONSHIP",
       "resources": [
         "relationship-type:*",
+
         "end-one-entity-type:Catalog",
         "end-one-entity-type:Connection",
         "end-one-entity-type:Process",
@@ -62,15 +58,13 @@
         "end-one-entity-type:ProcessExecution",
         "end-one-entity-classification:*",
         "end-one-entity:*",
+
         "end-two-entity-type:{entity-type}",
         "end-two-entity-classification:*",
         "end-two-entity:{entity}",
         "end-two-entity:{entity}/*"
       ],
-      "actions": [
-        "add-relationship",
-        "remove-relationship"
-      ]
+      "actions": ["add-relationship", "remove-relationship"]
     }
   ],
   "persona-api-create": [
@@ -83,9 +77,7 @@
         "entity-type:{entity-type}",
         "entity-classification:*"
       ],
-      "actions": [
-        "entity-create"
-      ]
+      "actions": ["entity-create"]
     }
   ],
   "persona-api-delete": [
@@ -98,9 +90,7 @@
         "entity-type:{entity-type}",
         "entity-classification:*"
       ],
-      "actions": [
-        "entity-delete"
-      ]
+      "actions": ["entity-delete"]
     }
   ],
   "persona-business-update-metadata": [
@@ -114,9 +104,7 @@
         "entity-classification:*",
         "entity-business-metadata:*"
       ],
-      "actions": [
-        "entity-update-business-metadata"
-      ]
+      "actions": ["entity-update-business-metadata"]
     }
   ],
   "persona-entity-add-classification": [
@@ -147,9 +135,7 @@
         "entity-classification:*",
         "classification:*"
       ],
-      "actions": [
-        "entity-update-classification"
-      ]
+      "actions": ["entity-update-classification"]
     }
   ],
   "persona-entity-remove-classification": [
@@ -175,17 +161,17 @@
       "policyResourceCategory": "RELATIONSHIP",
       "resources": [
         "relationship-type:*",
+
         "end-one-entity-type:AtlasGlossaryTerm",
         "end-one-entity-classification:*",
         "end-one-entity:*",
+
         "end-two-entity-type:{entity-type}",
         "end-two-entity-classification:*",
         "end-two-entity:{entity}",
         "end-two-entity:{entity}/*"
       ],
-      "actions": [
-        "add-relationship"
-      ]
+      "actions": ["add-relationship"]
     }
   ],
   "persona-remove-terms": [
@@ -194,19 +180,22 @@
       "policyResourceCategory": "RELATIONSHIP",
       "resources": [
         "relationship-type:*",
+
         "end-one-entity-type:AtlasGlossaryTerm",
         "end-one-entity-classification:*",
         "end-one-entity:*",
+
         "end-two-entity-type:{entity-type}",
         "end-two-entity-classification:*",
         "end-two-entity:{entity}",
         "end-two-entity:{entity}/*"
       ],
-      "actions": [
-        "remove-relationship"
-      ]
+      "actions": ["remove-relationship"]
     }
   ],
+
+
+
   "persona-glossary-read": [
     {
       "policyType": "ACCESS",
@@ -218,31 +207,27 @@
         "entity-type:AtlasGlossaryCategory",
         "entity-classification:*"
       ],
-      "actions": [
-        "entity-read"
-      ]
+      "actions": ["entity-read"]
     },
     {
       "policyType": "ACCESS",
       "policyResourceCategory": "RELATIONSHIP",
       "resources": [
         "relationship-type:*",
+
         "end-one-entity-type:AtlasGlossary",
         "end-one-entity-type:AtlasGlossaryTerm",
         "end-one-entity-type:AtlasGlossaryCategory",
         "end-one-entity-classification:*",
         "end-one-entity:*{entity}",
+
         "end-two-entity-type:AtlasGlossary",
         "end-two-entity-type:AtlasGlossaryTerm",
         "end-two-entity-type:AtlasGlossaryCategory",
         "end-two-entity-classification:*",
         "end-two-entity:*{entity}"
       ],
-      "actions": [
-        "add-relationship",
-        "update-relationship",
-        "remove-relationship"
-      ]
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
     }
   ],
   "persona-glossary-update": [
@@ -256,47 +241,41 @@
         "entity-type:AtlasGlossaryCategory",
         "entity-classification:*"
       ],
-      "actions": [
-        "entity-update"
-      ]
+      "actions": ["entity-update"]
     },
     {
       "policyType": "ACCESS",
       "policyResourceCategory": "RELATIONSHIP",
       "resources": [
         "relationship-type:*",
+
         "end-one-entity-type:AtlasGlossary",
         "end-one-entity-type:AtlasGlossaryTerm",
         "end-one-entity-type:AtlasGlossaryCategory",
         "end-one-entity-classification:*",
         "end-one-entity:*{entity}",
+
         "end-two-entity-type:*",
         "end-two-entity-classification:*",
         "end-two-entity:*"
       ],
-      "actions": [
-        "add-relationship",
-        "update-relationship",
-        "remove-relationship"
-      ]
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
     },
     {
       "policyType": "ACCESS",
       "policyResourceCategory": "RELATIONSHIP",
       "resources": [
         "relationship-type:*",
+
         "end-one-entity-type:*",
         "end-one-entity-classification:*",
         "end-one-entity:*",
+
         "end-two-entity-type:*",
         "end-two-entity-classification:*",
         "end-two-entity:*{entity}"
       ],
-      "actions": [
-        "add-relationship",
-        "update-relationship",
-        "remove-relationship"
-      ]
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
     }
   ],
   "persona-glossary-create": [
@@ -310,9 +289,7 @@
         "entity-type:AtlasGlossaryCategory",
         "entity-classification:*"
       ],
-      "actions": [
-        "entity-create"
-      ]
+      "actions": ["entity-create"]
     }
   ],
   "persona-glossary-delete": [
@@ -326,9 +303,7 @@
         "entity-type:AtlasGlossaryCategory",
         "entity-classification:*"
       ],
-      "actions": [
-        "entity-delete"
-      ]
+      "actions": ["entity-delete"]
     }
   ],
   "persona-glossary-update-custom-metadata": [
@@ -343,9 +318,7 @@
         "entity-classification:*",
         "entity-business-metadata:*"
       ],
-      "actions": [
-        "entity-update-business-metadata"
-      ]
+      "actions": ["entity-update-business-metadata"]
     }
   ],
   "persona-glossary-add-classifications": [
@@ -378,9 +351,7 @@
         "entity-classification:*",
         "classification:*"
       ],
-      "actions": [
-        "entity-update-classification"
-      ]
+      "actions": ["entity-update-classification"]
     }
   ],
   "persona-glossary-delete-classifications": [
@@ -401,6 +372,7 @@
       ]
     }
   ],
+
   "persona-domain-read": [
     {
       "policyType": "ACCESS",
@@ -412,9 +384,7 @@
         "entity-type:DataProduct",
         "entity-classification:*"
       ],
-      "actions": [
-        "entity-read"
-      ]
+      "actions": ["entity-read"]
     }
   ],
   "persona-domain-update": [
@@ -454,61 +424,58 @@
       "policyResourceCategory": "RELATIONSHIP",
       "policyType": "ACCESS",
       "description": "Link/unlink Stakeholder to this Domain",
+
       "resources": [
         "relationship-type:*",
+
         "end-one-entity-type:DataDomain",
         "end-one-entity-classification:*",
         "end-one-entity:{entity}",
+
         "end-two-entity-type:Stakeholder",
         "end-two-entity-classification:*",
         "end-two-entity:default/*/{entity}"
       ],
-      "actions": [
-        "add-relationship",
-        "update-relationship",
-        "remove-relationship"
-      ]
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
     },
     {
       "policyResourceCategory": "RELATIONSHIP",
       "policyType": "ACCESS",
       "description": "Link/unlink any Stakeholder Title to this Domain's Stakeholder",
+
       "resources": [
         "relationship-type:*",
+
         "end-one-entity-type:StakeholderTitle",
         "end-one-entity-classification:*",
         "end-one-entity:*",
+
         "end-two-entity-type:Stakeholder",
         "end-two-entity-classification:*",
         "end-two-entity:default/*/{entity}"
       ],
-      "actions": [
-        "add-relationship",
-        "update-relationship",
-        "remove-relationship"
-      ]
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
     },
     {
       "policyResourceCategory": "RELATIONSHIP",
       "policyType": "ACCESS",
       "description": "Link/unlink any DataDomain, DataProduct OR DataContract to this Domain",
+
       "resources": [
         "relationship-type:*",
+
         "end-one-entity-type:DataDomain",
         "end-two-entity-type:DataProduct",
         "end-one-entity-classification:*",
         "end-one-entity:{entity}",
         "end-one-entity:{entity}/*",
+
         "end-two-entity-type:DataDomain",
         "end-two-entity-type:DataProduct",
         "end-two-entity-classification:*",
         "end-two-entity:*"
       ],
-      "actions": [
-        "add-relationship",
-        "update-relationship",
-        "remove-relationship"
-      ]
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
     },
     {
       "policyResourceCategory": "RELATIONSHIP",
@@ -516,21 +483,19 @@
       "description": "Link/unlink any DataDomain, DataProduct OR DataContract to this Domain",
       "resources": [
         "relationship-type:*",
+
         "end-one-entity-type:DataDomain",
         "end-one-entity-type:DataProduct",
         "end-one-entity-classification:*",
         "end-one-entity:*",
+
         "end-two-entity-type:DataDomain",
         "end-two-entity-type:DataProduct",
         "end-two-entity-classification:*",
         "end-two-entity:{entity}",
         "end-two-entity:{entity}/*"
       ],
-      "actions": [
-        "add-relationship",
-        "update-relationship",
-        "remove-relationship"
-      ]
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
     },
     {
       "policyResourceCategory": "RELATIONSHIP",
@@ -538,18 +503,16 @@
       "description": "Link/unlink resource to this Domain",
       "resources": [
         "relationship-type:*",
+
         "end-one-entity-type:DataDomain",
         "end-one-entity-classification:*",
         "end-one-entity:{entity}",
+
         "end-two-entity-type:Resource",
         "end-two-entity-classification:*",
         "end-two-entity:*"
       ],
-      "actions": [
-        "add-relationship",
-        "update-relationship",
-        "remove-relationship"
-      ]
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
     },
     {
       "policyResourceCategory": "RELATIONSHIP",
@@ -557,18 +520,16 @@
       "description": "Link/unlink term to this Sub Domain",
       "resources": [
         "relationship-type:*",
+
         "end-one-entity-type:AtlasGlossaryTerm",
         "end-one-entity-classification:*",
         "end-one-entity:*",
+
         "end-two-entity-type:DataDomain",
         "end-two-entity-classification:*",
         "end-two-entity:{entity}"
       ],
-      "actions": [
-        "add-relationship",
-        "update-relationship",
-        "remove-relationship"
-      ]
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
     }
   ],
   "persona-domain-business-update-metadata": [
@@ -581,11 +542,10 @@
         "entity-classification:*",
         "entity-business-metadata:*"
       ],
-      "actions": [
-        "entity-update-business-metadata"
-      ]
+      "actions": ["entity-update-business-metadata"]
     }
   ],
+
   "persona-domain-sub-domain-read": [
     {
       "policyResourceCategory": "ENTITY",
@@ -595,9 +555,7 @@
         "entity-type:DataDomain",
         "entity-classification:*"
       ],
-      "actions": [
-        "entity-read"
-      ]
+      "actions": ["entity-read"]
     }
   ],
   "persona-domain-sub-domain-create": [
@@ -609,9 +567,7 @@
         "entity-type:DataDomain",
         "entity-classification:*"
       ],
-      "actions": [
-        "entity-create"
-      ]
+      "actions": ["entity-create"]
     },
     {
       "policyResourceCategory": "RELATIONSHIP",
@@ -619,20 +575,18 @@
       "description": "Link/unlink this DataProduct to any parent Domain",
       "resources": [
         "relationship-type:*",
+        
         "end-one-entity:{entity}/*",
         "end-one-entity:{entity}",
         "end-one-entity-type:DataDomain",
         "end-one-entity-classification:*",
+        
         "end-two-entity:{entity}/*",
         "end-one-entity:{entity}",
         "end-two-entity-type:DataDomain",
         "end-two-entity-classification:*"
       ],
-      "actions": [
-        "add-relationship",
-        "update-relationship",
-        "remove-relationship"
-      ]
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
     }
   ],
   "persona-domain-sub-domain-update": [
@@ -656,6 +610,7 @@
       "policyResourceCategory": "ENTITY",
       "policyType": "ACCESS",
       "description": "Create Stakeholder for Sub Domains",
+
       "resources": [
         "entity:default/*/{entity}/*",
         "entity-type:Stakeholder",
@@ -672,39 +627,37 @@
       "policyResourceCategory": "RELATIONSHIP",
       "policyType": "ACCESS",
       "description": "Link/unlink Stakeholder to Sub Domains",
+
       "resources": [
         "relationship-type:*",
+
         "end-one-entity-type:DataDomain",
         "end-one-entity-classification:*",
         "end-one-entity:{entity}/*domain/*",
+
         "end-two-entity-type:Stakeholder",
         "end-two-entity-classification:*",
         "end-two-entity:default/*/{entity}/*"
       ],
-      "actions": [
-        "add-relationship",
-        "update-relationship",
-        "remove-relationship"
-      ]
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
     },
     {
       "policyResourceCategory": "RELATIONSHIP",
       "policyType": "ACCESS",
       "description": "Link/unlink any Stakeholder Title to sub-domains's Stakeholder",
+
       "resources": [
         "relationship-type:*",
+
         "end-one-entity-type:StakeholderTitle",
         "end-one-entity-classification:*",
         "end-one-entity:*",
+
         "end-two-entity-type:Stakeholder",
         "end-two-entity-classification:*",
         "end-two-entity:default/*/{entity}/*"
       ],
-      "actions": [
-        "add-relationship",
-        "update-relationship",
-        "remove-relationship"
-      ]
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
     },
     {
       "policyResourceCategory": "RELATIONSHIP",
@@ -712,18 +665,16 @@
       "description": "Link/unlink resource to this Sub Domain",
       "resources": [
         "relationship-type:*",
+
         "end-one-entity-type:DataDomain",
         "end-one-entity-classification:*",
         "end-one-entity:{entity}/*domain/*",
+
         "end-two-entity-type:Resource",
         "end-two-entity-classification:*",
         "end-two-entity:*"
       ],
-      "actions": [
-        "add-relationship",
-        "update-relationship",
-        "remove-relationship"
-      ]
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
     },
     {
       "policyResourceCategory": "RELATIONSHIP",
@@ -731,18 +682,16 @@
       "description": "Link/unlink term to this Sub Domain",
       "resources": [
         "relationship-type:*",
+
         "end-one-entity-type:AtlasGlossaryTerm",
         "end-one-entity-classification:*",
         "end-one-entity:*",
+
         "end-two-entity-type:DataDomain",
         "end-two-entity-classification:*",
         "end-two-entity:{entity}/*domain/*"
       ],
-      "actions": [
-        "add-relationship",
-        "update-relationship",
-        "remove-relationship"
-      ]
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
     }
   ],
   "persona-domain-sub-domain-delete": [
@@ -754,9 +703,7 @@
         "entity-type:DataDomain",
         "entity-classification:*"
       ],
-      "actions": [
-        "entity-delete"
-      ]
+      "actions": ["entity-delete"]
     }
   ],
   "persona-domain-sub-domain-business-update-metadata": [
@@ -769,11 +716,10 @@
         "entity-classification:*",
         "entity-business-metadata:*"
       ],
-      "actions": [
-        "entity-update-business-metadata"
-      ]
+      "actions": ["entity-update-business-metadata"]
     }
   ],
+
   "persona-domain-product-read": [
     {
       "policyResourceCategory": "ENTITY",
@@ -783,9 +729,7 @@
         "entity-type:DataProduct",
         "entity-classification:*"
       ],
-      "actions": [
-        "entity-read"
-      ]
+      "actions": ["entity-read"]
     }
   ],
   "persona-domain-product-create": [
@@ -797,9 +741,7 @@
         "entity-type:DataProduct",
         "entity-classification:*"
       ],
-      "actions": [
-        "entity-create"
-      ]
+      "actions": ["entity-create"]
     },
     {
       "policyResourceCategory": "RELATIONSHIP",
@@ -807,38 +749,36 @@
       "description": "Link/unlink this DataProduct to any parent Domain",
       "resources": [
         "relationship-type:*",
+        
         "end-one-entity:{entity}/*",
         "end-one-entity:{entity}",
         "end-one-entity-type:DataDomain",
         "end-one-entity-classification:*",
+        
         "end-two-entity:{entity}/*",
         "end-two-entity-type:DataProduct",
         "end-two-entity-classification:*"
       ],
-      "actions": [
-        "add-relationship",
-        "update-relationship",
-        "remove-relationship"
-      ]
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
     },
     {
       "policyResourceCategory": "RELATIONSHIP",
       "policyType": "ACCESS",
       "description": "Link/unlink any Asset to this DataProduct",
+
       "resources": [
         "relationship-type:*",
+
         "end-one-entity-type:Asset",
         "end-one-entity-classification:*",
         "end-one-entity:*",
+
         "end-two-entity-type:DataProduct",
         "end-two-entity-classification:*",
         "end-two-entity:{entity}/*product/*"
       ],
-      "actions": [
-        "add-relationship",
-        "update-relationship",
-        "remove-relationship"
-      ]
+
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
     }
   ],
   "persona-domain-product-update": [
@@ -862,39 +802,39 @@
       "policyResourceCategory": "RELATIONSHIP",
       "policyType": "ACCESS",
       "description": "Link/unlink any Asset to this DataProduct",
+
       "resources": [
         "relationship-type:*",
+
         "end-one-entity-type:Asset",
         "end-one-entity-classification:*",
         "end-one-entity:*",
+
         "end-two-entity-type:DataProduct",
         "end-two-entity-classification:*",
         "end-two-entity:{entity}/*product/*"
       ],
-      "actions": [
-        "add-relationship",
-        "update-relationship",
-        "remove-relationship"
-      ]
+
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
     },
     {
       "policyResourceCategory": "RELATIONSHIP",
       "policyType": "ACCESS",
       "description": "Link/unlink any Asset to this DataProduct",
+
       "resources": [
         "relationship-type:*",
+
         "end-one-entity-type:DataProduct",
         "end-one-entity-classification:*",
         "end-one-entity:{entity}/*product/*",
+
         "end-two-entity-type:Asset",
         "end-two-entity-classification:*",
         "end-two-entity:*"
       ],
-      "actions": [
-        "add-relationship",
-        "update-relationship",
-        "remove-relationship"
-      ]
+
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
     }
   ],
   "persona-domain-product-delete": [
@@ -906,9 +846,7 @@
         "entity-type:DataProduct",
         "entity-classification:*"
       ],
-      "actions": [
-        "entity-delete"
-      ]
+      "actions": ["entity-delete"]
     }
   ],
   "persona-domain-product-business-update-metadata": [
@@ -921,11 +859,10 @@
         "entity-classification:*",
         "entity-business-metadata:*"
       ],
-      "actions": [
-        "entity-update-business-metadata"
-      ]
+      "actions": ["entity-update-business-metadata"]
     }
   ],
+
   "select": [
     {
       "policyType": "ACCESS",
@@ -935,11 +872,10 @@
         "entity:{entity}/*",
         "entity-type:{entity-type}"
       ],
-      "actions": [
-        "select"
-      ]
+      "actions": ["select"]
     }
   ],
+  
   "persona-aiasset-read": [
     {
       "policyType": "ACCESS",

--- a/addons/static/templates/policy_cache_transformer_persona.json
+++ b/addons/static/templates/policy_cache_transformer_persona.json
@@ -9,7 +9,9 @@
         "entity-type:{entity-type}",
         "entity-classification:*"
       ],
-      "actions": ["entity-read"]
+      "actions": [
+        "entity-read"
+      ]
     }
   ],
   "persona-asset-update": [
@@ -22,19 +24,19 @@
         "entity-type:{entity-type}",
         "entity-classification:*"
       ],
-      "actions": ["entity-update"]
+      "actions": [
+        "entity-update"
+      ]
     },
     {
       "policyType": "ACCESS",
       "policyResourceCategory": "RELATIONSHIP",
       "resources": [
         "relationship-type:*",
-
         "end-one-entity-type:{entity-type}",
         "end-one-entity-classification:*",
         "end-one-entity:{entity}",
         "end-one-entity:{entity}/*",
-
         "end-two-entity-type:Catalog",
         "end-two-entity-type:Connection",
         "end-two-entity-type:Process",
@@ -43,14 +45,16 @@
         "end-two-entity-classification:*",
         "end-two-entity:*"
       ],
-      "actions": ["add-relationship", "remove-relationship"]
+      "actions": [
+        "add-relationship",
+        "remove-relationship"
+      ]
     },
     {
       "policyType": "ACCESS",
       "policyResourceCategory": "RELATIONSHIP",
       "resources": [
         "relationship-type:*",
-
         "end-one-entity-type:Catalog",
         "end-one-entity-type:Connection",
         "end-one-entity-type:Process",
@@ -58,13 +62,15 @@
         "end-one-entity-type:ProcessExecution",
         "end-one-entity-classification:*",
         "end-one-entity:*",
-
         "end-two-entity-type:{entity-type}",
         "end-two-entity-classification:*",
         "end-two-entity:{entity}",
         "end-two-entity:{entity}/*"
       ],
-      "actions": ["add-relationship", "remove-relationship"]
+      "actions": [
+        "add-relationship",
+        "remove-relationship"
+      ]
     }
   ],
   "persona-api-create": [
@@ -77,7 +83,9 @@
         "entity-type:{entity-type}",
         "entity-classification:*"
       ],
-      "actions": ["entity-create"]
+      "actions": [
+        "entity-create"
+      ]
     }
   ],
   "persona-api-delete": [
@@ -90,7 +98,9 @@
         "entity-type:{entity-type}",
         "entity-classification:*"
       ],
-      "actions": ["entity-delete"]
+      "actions": [
+        "entity-delete"
+      ]
     }
   ],
   "persona-business-update-metadata": [
@@ -104,7 +114,9 @@
         "entity-classification:*",
         "entity-business-metadata:*"
       ],
-      "actions": ["entity-update-business-metadata"]
+      "actions": [
+        "entity-update-business-metadata"
+      ]
     }
   ],
   "persona-entity-add-classification": [
@@ -135,7 +147,9 @@
         "entity-classification:*",
         "classification:*"
       ],
-      "actions": ["entity-update-classification"]
+      "actions": [
+        "entity-update-classification"
+      ]
     }
   ],
   "persona-entity-remove-classification": [
@@ -161,17 +175,17 @@
       "policyResourceCategory": "RELATIONSHIP",
       "resources": [
         "relationship-type:*",
-
         "end-one-entity-type:AtlasGlossaryTerm",
         "end-one-entity-classification:*",
         "end-one-entity:*",
-
         "end-two-entity-type:{entity-type}",
         "end-two-entity-classification:*",
         "end-two-entity:{entity}",
         "end-two-entity:{entity}/*"
       ],
-      "actions": ["add-relationship"]
+      "actions": [
+        "add-relationship"
+      ]
     }
   ],
   "persona-remove-terms": [
@@ -180,22 +194,19 @@
       "policyResourceCategory": "RELATIONSHIP",
       "resources": [
         "relationship-type:*",
-
         "end-one-entity-type:AtlasGlossaryTerm",
         "end-one-entity-classification:*",
         "end-one-entity:*",
-
         "end-two-entity-type:{entity-type}",
         "end-two-entity-classification:*",
         "end-two-entity:{entity}",
         "end-two-entity:{entity}/*"
       ],
-      "actions": ["remove-relationship"]
+      "actions": [
+        "remove-relationship"
+      ]
     }
   ],
-
-
-
   "persona-glossary-read": [
     {
       "policyType": "ACCESS",
@@ -207,27 +218,31 @@
         "entity-type:AtlasGlossaryCategory",
         "entity-classification:*"
       ],
-      "actions": ["entity-read"]
+      "actions": [
+        "entity-read"
+      ]
     },
     {
       "policyType": "ACCESS",
       "policyResourceCategory": "RELATIONSHIP",
       "resources": [
         "relationship-type:*",
-
         "end-one-entity-type:AtlasGlossary",
         "end-one-entity-type:AtlasGlossaryTerm",
         "end-one-entity-type:AtlasGlossaryCategory",
         "end-one-entity-classification:*",
         "end-one-entity:*{entity}",
-
         "end-two-entity-type:AtlasGlossary",
         "end-two-entity-type:AtlasGlossaryTerm",
         "end-two-entity-type:AtlasGlossaryCategory",
         "end-two-entity-classification:*",
         "end-two-entity:*{entity}"
       ],
-      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+      "actions": [
+        "add-relationship",
+        "update-relationship",
+        "remove-relationship"
+      ]
     }
   ],
   "persona-glossary-update": [
@@ -241,41 +256,47 @@
         "entity-type:AtlasGlossaryCategory",
         "entity-classification:*"
       ],
-      "actions": ["entity-update"]
+      "actions": [
+        "entity-update"
+      ]
     },
     {
       "policyType": "ACCESS",
       "policyResourceCategory": "RELATIONSHIP",
       "resources": [
         "relationship-type:*",
-
         "end-one-entity-type:AtlasGlossary",
         "end-one-entity-type:AtlasGlossaryTerm",
         "end-one-entity-type:AtlasGlossaryCategory",
         "end-one-entity-classification:*",
         "end-one-entity:*{entity}",
-
         "end-two-entity-type:*",
         "end-two-entity-classification:*",
         "end-two-entity:*"
       ],
-      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+      "actions": [
+        "add-relationship",
+        "update-relationship",
+        "remove-relationship"
+      ]
     },
     {
       "policyType": "ACCESS",
       "policyResourceCategory": "RELATIONSHIP",
       "resources": [
         "relationship-type:*",
-
         "end-one-entity-type:*",
         "end-one-entity-classification:*",
         "end-one-entity:*",
-
         "end-two-entity-type:*",
         "end-two-entity-classification:*",
         "end-two-entity:*{entity}"
       ],
-      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+      "actions": [
+        "add-relationship",
+        "update-relationship",
+        "remove-relationship"
+      ]
     }
   ],
   "persona-glossary-create": [
@@ -289,7 +310,9 @@
         "entity-type:AtlasGlossaryCategory",
         "entity-classification:*"
       ],
-      "actions": ["entity-create"]
+      "actions": [
+        "entity-create"
+      ]
     }
   ],
   "persona-glossary-delete": [
@@ -303,7 +326,9 @@
         "entity-type:AtlasGlossaryCategory",
         "entity-classification:*"
       ],
-      "actions": ["entity-delete"]
+      "actions": [
+        "entity-delete"
+      ]
     }
   ],
   "persona-glossary-update-custom-metadata": [
@@ -318,7 +343,9 @@
         "entity-classification:*",
         "entity-business-metadata:*"
       ],
-      "actions": ["entity-update-business-metadata"]
+      "actions": [
+        "entity-update-business-metadata"
+      ]
     }
   ],
   "persona-glossary-add-classifications": [
@@ -351,7 +378,9 @@
         "entity-classification:*",
         "classification:*"
       ],
-      "actions": ["entity-update-classification"]
+      "actions": [
+        "entity-update-classification"
+      ]
     }
   ],
   "persona-glossary-delete-classifications": [
@@ -372,7 +401,6 @@
       ]
     }
   ],
-
   "persona-domain-read": [
     {
       "policyType": "ACCESS",
@@ -384,10 +412,12 @@
         "entity-type:DataProduct",
         "entity-classification:*"
       ],
-      "actions": ["entity-read"]
+      "actions": [
+        "entity-read"
+      ]
     }
   ],
-  "persona-domain-update": [ 
+  "persona-domain-update": [
     {
       "policyResourceCategory": "ENTITY",
       "policyType": "ACCESS",
@@ -424,58 +454,61 @@
       "policyResourceCategory": "RELATIONSHIP",
       "policyType": "ACCESS",
       "description": "Link/unlink Stakeholder to this Domain",
-
       "resources": [
         "relationship-type:*",
-
         "end-one-entity-type:DataDomain",
         "end-one-entity-classification:*",
         "end-one-entity:{entity}",
-
         "end-two-entity-type:Stakeholder",
         "end-two-entity-classification:*",
         "end-two-entity:default/*/{entity}"
       ],
-      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+      "actions": [
+        "add-relationship",
+        "update-relationship",
+        "remove-relationship"
+      ]
     },
     {
       "policyResourceCategory": "RELATIONSHIP",
       "policyType": "ACCESS",
       "description": "Link/unlink any Stakeholder Title to this Domain's Stakeholder",
-
       "resources": [
         "relationship-type:*",
-
         "end-one-entity-type:StakeholderTitle",
         "end-one-entity-classification:*",
         "end-one-entity:*",
-
         "end-two-entity-type:Stakeholder",
         "end-two-entity-classification:*",
         "end-two-entity:default/*/{entity}"
       ],
-      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+      "actions": [
+        "add-relationship",
+        "update-relationship",
+        "remove-relationship"
+      ]
     },
     {
       "policyResourceCategory": "RELATIONSHIP",
       "policyType": "ACCESS",
       "description": "Link/unlink any DataDomain, DataProduct OR DataContract to this Domain",
-
       "resources": [
         "relationship-type:*",
-
         "end-one-entity-type:DataDomain",
         "end-two-entity-type:DataProduct",
         "end-one-entity-classification:*",
         "end-one-entity:{entity}",
         "end-one-entity:{entity}/*",
-
         "end-two-entity-type:DataDomain",
         "end-two-entity-type:DataProduct",
         "end-two-entity-classification:*",
         "end-two-entity:*"
       ],
-      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+      "actions": [
+        "add-relationship",
+        "update-relationship",
+        "remove-relationship"
+      ]
     },
     {
       "policyResourceCategory": "RELATIONSHIP",
@@ -483,19 +516,21 @@
       "description": "Link/unlink any DataDomain, DataProduct OR DataContract to this Domain",
       "resources": [
         "relationship-type:*",
-
         "end-one-entity-type:DataDomain",
         "end-one-entity-type:DataProduct",
         "end-one-entity-classification:*",
         "end-one-entity:*",
-
         "end-two-entity-type:DataDomain",
         "end-two-entity-type:DataProduct",
         "end-two-entity-classification:*",
         "end-two-entity:{entity}",
         "end-two-entity:{entity}/*"
       ],
-      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+      "actions": [
+        "add-relationship",
+        "update-relationship",
+        "remove-relationship"
+      ]
     },
     {
       "policyResourceCategory": "RELATIONSHIP",
@@ -503,16 +538,18 @@
       "description": "Link/unlink resource to this Domain",
       "resources": [
         "relationship-type:*",
-
         "end-one-entity-type:DataDomain",
         "end-one-entity-classification:*",
         "end-one-entity:{entity}",
-
         "end-two-entity-type:Resource",
         "end-two-entity-classification:*",
         "end-two-entity:*"
       ],
-      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+      "actions": [
+        "add-relationship",
+        "update-relationship",
+        "remove-relationship"
+      ]
     },
     {
       "policyResourceCategory": "RELATIONSHIP",
@@ -520,16 +557,18 @@
       "description": "Link/unlink term to this Sub Domain",
       "resources": [
         "relationship-type:*",
-
         "end-one-entity-type:AtlasGlossaryTerm",
         "end-one-entity-classification:*",
         "end-one-entity:*",
-
         "end-two-entity-type:DataDomain",
         "end-two-entity-classification:*",
         "end-two-entity:{entity}"
       ],
-      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+      "actions": [
+        "add-relationship",
+        "update-relationship",
+        "remove-relationship"
+      ]
     }
   ],
   "persona-domain-business-update-metadata": [
@@ -542,10 +581,11 @@
         "entity-classification:*",
         "entity-business-metadata:*"
       ],
-      "actions": ["entity-update-business-metadata"]
+      "actions": [
+        "entity-update-business-metadata"
+      ]
     }
   ],
-
   "persona-domain-sub-domain-read": [
     {
       "policyResourceCategory": "ENTITY",
@@ -555,7 +595,9 @@
         "entity-type:DataDomain",
         "entity-classification:*"
       ],
-      "actions": ["entity-read"]
+      "actions": [
+        "entity-read"
+      ]
     }
   ],
   "persona-domain-sub-domain-create": [
@@ -567,7 +609,9 @@
         "entity-type:DataDomain",
         "entity-classification:*"
       ],
-      "actions": ["entity-create"]
+      "actions": [
+        "entity-create"
+      ]
     },
     {
       "policyResourceCategory": "RELATIONSHIP",
@@ -575,18 +619,20 @@
       "description": "Link/unlink this DataProduct to any parent Domain",
       "resources": [
         "relationship-type:*",
-        
         "end-one-entity:{entity}/*",
         "end-one-entity:{entity}",
         "end-one-entity-type:DataDomain",
         "end-one-entity-classification:*",
-        
         "end-two-entity:{entity}/*",
         "end-one-entity:{entity}",
         "end-two-entity-type:DataDomain",
         "end-two-entity-classification:*"
       ],
-      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+      "actions": [
+        "add-relationship",
+        "update-relationship",
+        "remove-relationship"
+      ]
     }
   ],
   "persona-domain-sub-domain-update": [
@@ -610,7 +656,6 @@
       "policyResourceCategory": "ENTITY",
       "policyType": "ACCESS",
       "description": "Create Stakeholder for Sub Domains",
-
       "resources": [
         "entity:default/*/{entity}/*",
         "entity-type:Stakeholder",
@@ -627,37 +672,39 @@
       "policyResourceCategory": "RELATIONSHIP",
       "policyType": "ACCESS",
       "description": "Link/unlink Stakeholder to Sub Domains",
-
       "resources": [
         "relationship-type:*",
-
         "end-one-entity-type:DataDomain",
         "end-one-entity-classification:*",
         "end-one-entity:{entity}/*domain/*",
-
         "end-two-entity-type:Stakeholder",
         "end-two-entity-classification:*",
         "end-two-entity:default/*/{entity}/*"
       ],
-      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+      "actions": [
+        "add-relationship",
+        "update-relationship",
+        "remove-relationship"
+      ]
     },
     {
       "policyResourceCategory": "RELATIONSHIP",
       "policyType": "ACCESS",
       "description": "Link/unlink any Stakeholder Title to sub-domains's Stakeholder",
-
       "resources": [
         "relationship-type:*",
-
         "end-one-entity-type:StakeholderTitle",
         "end-one-entity-classification:*",
         "end-one-entity:*",
-
         "end-two-entity-type:Stakeholder",
         "end-two-entity-classification:*",
         "end-two-entity:default/*/{entity}/*"
       ],
-      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+      "actions": [
+        "add-relationship",
+        "update-relationship",
+        "remove-relationship"
+      ]
     },
     {
       "policyResourceCategory": "RELATIONSHIP",
@@ -665,16 +712,18 @@
       "description": "Link/unlink resource to this Sub Domain",
       "resources": [
         "relationship-type:*",
-
         "end-one-entity-type:DataDomain",
         "end-one-entity-classification:*",
         "end-one-entity:{entity}/*domain/*",
-
         "end-two-entity-type:Resource",
         "end-two-entity-classification:*",
         "end-two-entity:*"
       ],
-      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+      "actions": [
+        "add-relationship",
+        "update-relationship",
+        "remove-relationship"
+      ]
     },
     {
       "policyResourceCategory": "RELATIONSHIP",
@@ -682,16 +731,18 @@
       "description": "Link/unlink term to this Sub Domain",
       "resources": [
         "relationship-type:*",
-
         "end-one-entity-type:AtlasGlossaryTerm",
         "end-one-entity-classification:*",
         "end-one-entity:*",
-
         "end-two-entity-type:DataDomain",
         "end-two-entity-classification:*",
         "end-two-entity:{entity}/*domain/*"
       ],
-      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+      "actions": [
+        "add-relationship",
+        "update-relationship",
+        "remove-relationship"
+      ]
     }
   ],
   "persona-domain-sub-domain-delete": [
@@ -703,7 +754,9 @@
         "entity-type:DataDomain",
         "entity-classification:*"
       ],
-      "actions": ["entity-delete"]
+      "actions": [
+        "entity-delete"
+      ]
     }
   ],
   "persona-domain-sub-domain-business-update-metadata": [
@@ -716,10 +769,11 @@
         "entity-classification:*",
         "entity-business-metadata:*"
       ],
-      "actions": ["entity-update-business-metadata"]
+      "actions": [
+        "entity-update-business-metadata"
+      ]
     }
   ],
-
   "persona-domain-product-read": [
     {
       "policyResourceCategory": "ENTITY",
@@ -729,7 +783,9 @@
         "entity-type:DataProduct",
         "entity-classification:*"
       ],
-      "actions": ["entity-read"]
+      "actions": [
+        "entity-read"
+      ]
     }
   ],
   "persona-domain-product-create": [
@@ -741,7 +797,9 @@
         "entity-type:DataProduct",
         "entity-classification:*"
       ],
-      "actions": ["entity-create"]
+      "actions": [
+        "entity-create"
+      ]
     },
     {
       "policyResourceCategory": "RELATIONSHIP",
@@ -749,36 +807,38 @@
       "description": "Link/unlink this DataProduct to any parent Domain",
       "resources": [
         "relationship-type:*",
-        
         "end-one-entity:{entity}/*",
         "end-one-entity:{entity}",
         "end-one-entity-type:DataDomain",
         "end-one-entity-classification:*",
-        
         "end-two-entity:{entity}/*",
         "end-two-entity-type:DataProduct",
         "end-two-entity-classification:*"
       ],
-      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+      "actions": [
+        "add-relationship",
+        "update-relationship",
+        "remove-relationship"
+      ]
     },
     {
       "policyResourceCategory": "RELATIONSHIP",
       "policyType": "ACCESS",
       "description": "Link/unlink any Asset to this DataProduct",
-
       "resources": [
         "relationship-type:*",
-
         "end-one-entity-type:Asset",
         "end-one-entity-classification:*",
         "end-one-entity:*",
-
         "end-two-entity-type:DataProduct",
         "end-two-entity-classification:*",
         "end-two-entity:{entity}/*product/*"
       ],
-
-      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+      "actions": [
+        "add-relationship",
+        "update-relationship",
+        "remove-relationship"
+      ]
     }
   ],
   "persona-domain-product-update": [
@@ -802,39 +862,39 @@
       "policyResourceCategory": "RELATIONSHIP",
       "policyType": "ACCESS",
       "description": "Link/unlink any Asset to this DataProduct",
-
       "resources": [
         "relationship-type:*",
-
         "end-one-entity-type:Asset",
         "end-one-entity-classification:*",
         "end-one-entity:*",
-
         "end-two-entity-type:DataProduct",
         "end-two-entity-classification:*",
         "end-two-entity:{entity}/*product/*"
       ],
-
-      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+      "actions": [
+        "add-relationship",
+        "update-relationship",
+        "remove-relationship"
+      ]
     },
     {
       "policyResourceCategory": "RELATIONSHIP",
       "policyType": "ACCESS",
       "description": "Link/unlink any Asset to this DataProduct",
-
       "resources": [
         "relationship-type:*",
-
         "end-one-entity-type:DataProduct",
         "end-one-entity-classification:*",
         "end-one-entity:{entity}/*product/*",
-
         "end-two-entity-type:Asset",
         "end-two-entity-classification:*",
         "end-two-entity:*"
       ],
-
-      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+      "actions": [
+        "add-relationship",
+        "update-relationship",
+        "remove-relationship"
+      ]
     }
   ],
   "persona-domain-product-delete": [
@@ -846,7 +906,9 @@
         "entity-type:DataProduct",
         "entity-classification:*"
       ],
-      "actions": ["entity-delete"]
+      "actions": [
+        "entity-delete"
+      ]
     }
   ],
   "persona-domain-product-business-update-metadata": [
@@ -859,10 +921,11 @@
         "entity-classification:*",
         "entity-business-metadata:*"
       ],
-      "actions": ["entity-update-business-metadata"]
+      "actions": [
+        "entity-update-business-metadata"
+      ]
     }
   ],
-
   "select": [
     {
       "policyType": "ACCESS",
@@ -872,11 +935,12 @@
         "entity:{entity}/*",
         "entity-type:{entity-type}"
       ],
-      "actions": ["select"]
+      "actions": [
+        "select"
+      ]
     }
   ],
-
-  "persona-aiapplication-read": [
+  "persona-aiasset-read": [
     {
       "policyType": "ACCESS",
       "policyResourceCategory": "ENTITY",
@@ -884,57 +948,43 @@
         "entity:{entity}",
         "entity:{entity}/*",
         "entity-type:AIApplication",
+        "entity-type:AIModel",
         "entity-classification:*"
       ],
-      "actions": ["entity-read"]
+      "actions": [
+        "entity-read"
+      ]
     }
   ],
-  "persona-aiapplication-create": [
-    {
-      "policyResourceCategory": "ENTITY",
-      "policyType": "ACCESS",
-      "resources": [
-        "entity:{entity}/*ai/*",
-        "entity-type:AIApplication",
-        "entity-classification:*"
-      ],
-      "actions": ["entity-create"]
-    },
-    {
-      "policyResourceCategory": "RELATIONSHIP",
-      "policyType": "ACCESS",
-      "description": "Link/unlink AIModel to any AIApplication",
-      "resources": [
-        "relationship-type:*",
-        
-        "end-one-entity:{entity}/*",
-        "end-one-entity:{entity}",
-        "end-one-entity-type:AIApplication",
-        "end-one-entity-classification:*",
-        
-        "end-two-entity:{entity}/*",
-        "end-one-entity:{entity}",
-        "end-two-entity-type:AIModel",
-        "end-two-entity-classification:*"
-      ],
-      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
-    }
-  ],
-  "persona-aiapplication-update": [
+  "persona-aiasset-create": [
     {
       "policyResourceCategory": "ENTITY",
       "policyType": "ACCESS",
       "resources": [
         "entity:{entity}",
+        "entity:{entity}/*",
         "entity-type:AIApplication",
-        "entity-classification:*",
-        "classification:*"
+        "entity-type:AIModel",
+        "entity-classification:*"
       ],
       "actions": [
-        "entity-update",
-        "entity-add-classification",
-        "entity-update-classification",
-        "entity-remove-classification"
+        "entity-create"
+      ]
+    }
+  ],
+  "persona-aiasset-update": [
+    {
+      "policyResourceCategory": "ENTITY",
+      "policyType": "ACCESS",
+      "resources": [
+        "entity:{entity}",
+        "entity:{entity}/*",
+        "entity-type:AIApplication",
+        "entity-type:AIModel",
+        "entity-classification:*"
+      ],
+      "actions": [
+        "entity-update"
       ]
     },
     {
@@ -946,213 +996,184 @@
         "end-one-entity-type:AIApplication",
         "end-one-entity-classification:*",
         "end-one-entity:*",
-
         "end-two-entity-type:AIModel",
         "end-two-entity-classification:*",
         "end-two-entity:{entity}",
         "end-two-entity:{entity}/*"
       ],
-      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+      "actions": [
+        "add-relationship",
+        "update-relationship",
+        "remove-relationship"
+      ]
     },
     {
       "policyResourceCategory": "RELATIONSHIP",
       "policyType": "ACCESS",
-      "description": "Link/unlink resource to this AIApplication",
+      "description": "Link/unlink resource to AI assets",
       "resources": [
         "relationship-type:*",
-
         "end-one-entity-type:AIApplication",
+        "end-one-entity-type:AIModel",
         "end-one-entity-classification:*",
         "end-one-entity:{entity}",
-
         "end-two-entity-type:Resource",
         "end-two-entity-classification:*",
         "end-two-entity:*"
       ],
-      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
-    },
+      "actions": [
+        "add-relationship",
+        "update-relationship",
+        "remove-relationship"
+      ]
+    }
+  ],
+  "persona-aiasset-delete": [
+    {
+      "policyResourceCategory": "ENTITY",
+      "policyType": "ACCESS",
+      "resources": [
+        "entity:{entity}",
+        "entity:{entity}/*",
+        "entity-type:AIApplication",
+        "entity-type:AIModel",
+        "entity-classification:*"
+      ],
+      "actions": [
+        "entity-delete"
+      ]
+    }
+  ],
+  "persona-aiasset-business-update-metadata": [
+    {
+      "policyType": "ACCESS",
+      "policyResourceCategory": "ENTITY",
+      "resources": [
+        "entity:{entity}",
+        "entity:{entity}/*",
+        "entity-type:AIApplication",
+        "entity-type:AIModel",
+        "entity-classification:*",
+        "entity-business-metadata:*"
+      ],
+      "actions": [
+        "entity-update-business-metadata"
+      ]
+    }
+  ],
+  "persona-aiasset-add-terms": [
     {
       "policyResourceCategory": "RELATIONSHIP",
       "policyType": "ACCESS",
-      "description": "Link/unlink term to this AIApplication",
+      "description": "Link term to this AI asset",
       "resources": [
         "relationship-type:*",
-
         "end-one-entity-type:AtlasGlossaryTerm",
+        "entity-type:AtlasGlossaryTerm",
         "end-one-entity-classification:*",
         "end-one-entity:*",
-
         "end-two-entity-type:AIApplication",
+        "end-two-entity-type:AIModel",
         "end-two-entity-classification:*",
         "end-two-entity:{entity}"
       ],
-      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+      "actions": [
+        "add-relationship",
+        "entity-read"
+      ]
     }
   ],
-  "persona-aiapplication-delete": [
-    {
-      "policyResourceCategory": "ENTITY",
-      "policyType": "ACCESS",
-      "resources": [
-        "entity:{entity}/*ai/*",
-        "entity-type:AIApplication",
-        "entity-classification:*"
-      ],
-      "actions": ["entity-delete"]
-    }
-  ],
-  "persona-aiapplication-business-update-metadata": [
-    {
-      "policyType": "ACCESS",
-      "policyResourceCategory": "ENTITY",
-      "resources": [
-        "entity:{entity}/*ai/*",
-        "entity-type:AIApplication",
-        "entity-classification:*",
-        "entity-business-metadata:*"
-      ],
-      "actions": ["entity-update-business-metadata"]
-    }
-  ],
-  "persona-aimodel-read": [
-    {
-      "policyType": "ACCESS",
-      "policyResourceCategory": "ENTITY",
-      "resources": [
-        "entity:{entity}",
-        "entity:{entity}/*",
-        "entity-type:AIModel",
-        "entity-classification:*"
-      ],
-      "actions": ["entity-read"]
-    }
-  ],
-  "persona-aimodel-create": [
-    {
-      "policyResourceCategory": "ENTITY",
-      "policyType": "ACCESS",
-      "resources": [
-        "entity:{entity}/*ai/*",
-        "entity-type:AIModel",
-        "entity-classification:*"
-      ],
-      "actions": ["entity-create"]
-    },
+  "persona-aiasset-update-terms": [
     {
       "policyResourceCategory": "RELATIONSHIP",
       "policyType": "ACCESS",
-      "description": "Link/unlink AIModel to any AIApplication",
+      "description": "Unlink term to this AI asset",
       "resources": [
         "relationship-type:*",
-        
-        "end-one-entity:{entity}/*",
-        "end-one-entity:{entity}",
-        "end-one-entity-type:AIApplication",
+        "end-one-entity-type:AtlasGlossaryTerm",
         "end-one-entity-classification:*",
-        
-        "end-two-entity:{entity}/*",
-        "end-one-entity:{entity}",
+        "end-one-entity:*",
+        "end-two-entity-type:AIApplication",
         "end-two-entity-type:AIModel",
-        "end-two-entity-classification:*"
+        "end-two-entity-classification:*",
+        "end-two-entity:{entity}"
       ],
-      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+      "actions": [
+        "update-relationship"
+      ]
     }
   ],
-  "persona-aimodel-update": [
+  "persona-aiasset-remove-terms": [
+    {
+      "policyResourceCategory": "RELATIONSHIP",
+      "policyType": "ACCESS",
+      "description": "Link/unlink term to this AI asset",
+      "resources": [
+        "relationship-type:*",
+        "end-one-entity-type:AtlasGlossaryTerm",
+        "end-one-entity-classification:*",
+        "end-one-entity:*",
+        "end-two-entity-type:AIApplication",
+        "end-two-entity-type:AIModel",
+        "end-two-entity-classification:*",
+        "end-two-entity:{entity}"
+      ],
+      "actions": [
+        "remove-relationship"
+      ]
+    }
+  ],
+  "persona-aiasset-add-classification": [
     {
       "policyResourceCategory": "ENTITY",
       "policyType": "ACCESS",
       "resources": [
         "entity:{entity}",
+        "entity:{entity}/*",
+        "entity-type:AIApplication",
         "entity-type:AIModel",
         "entity-classification:*",
         "classification:*"
       ],
       "actions": [
-        "entity-update",
         "entity-add-classification",
+        "entity-update-classification"
+      ]
+    }
+  ],
+  "persona-aiasset-update-classification": [
+    {
+      "policyResourceCategory": "ENTITY",
+      "policyType": "ACCESS",
+      "resources": [
+        "entity:{entity}",
+        "entity:{entity}/*",
+        "entity-type:AIApplication",
+        "entity-type:AIModel",
+        "entity-classification:*",
+        "classification:*"
+      ],
+      "actions": [
+        "entity-update-classification"
+      ]
+    }
+  ],
+  "persona-aiasset-remove-classification": [
+    {
+      "policyResourceCategory": "ENTITY",
+      "policyType": "ACCESS",
+      "resources": [
+        "entity:{entity}",
+        "entity:{entity}/*",
+        "entity-type:AIApplication",
+        "entity-type:AIModel",
+        "entity-classification:*",
+        "classification:*"
+      ],
+      "actions": [
         "entity-update-classification",
         "entity-remove-classification"
       ]
-    },
-    {
-      "policyResourceCategory": "RELATIONSHIP",
-      "policyType": "ACCESS",
-      "description": "Link/unlink any DataDomain, DataProduct OR DataContract to this Domain",
-      "resources": [
-        "relationship-type:*",
-
-        "end-one-entity-type:DataDomain",
-        "end-one-entity-type:DataProduct",
-        "end-one-entity-classification:*",
-        "end-one-entity:*",
-
-        "end-two-entity-type:DataDomain",
-        "end-two-entity-type:DataProduct",
-        "end-two-entity-classification:*",
-        "end-two-entity:{entity}",
-        "end-two-entity:{entity}/*"
-      ],
-      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
-    },
-    {
-      "policyResourceCategory": "RELATIONSHIP",
-      "policyType": "ACCESS",
-      "description": "Link/unlink resource to this Domain",
-      "resources": [
-        "relationship-type:*",
-
-        "end-one-entity-type:DataDomain",
-        "end-one-entity-classification:*",
-        "end-one-entity:{entity}",
-
-        "end-two-entity-type:Resource",
-        "end-two-entity-classification:*",
-        "end-two-entity:*"
-      ],
-      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
-    },
-    {
-      "policyResourceCategory": "RELATIONSHIP",
-      "policyType": "ACCESS",
-      "description": "Link/unlink term to this Sub Domain",
-      "resources": [
-        "relationship-type:*",
-
-        "end-one-entity-type:AtlasGlossaryTerm",
-        "end-one-entity-classification:*",
-        "end-one-entity:*",
-
-        "end-two-entity-type:DataDomain",
-        "end-two-entity-classification:*",
-        "end-two-entity:{entity}"
-      ],
-      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
-    }
-  ],
-  "persona-aimodel-delete": [
-    {
-      "policyResourceCategory": "ENTITY",
-      "policyType": "ACCESS",
-      "resources": [
-        "entity:{entity}/*ai/*",
-        "entity-type:AIModel",
-        "entity-classification:*"
-      ],
-      "actions": ["entity-delete"]
-    }
-  ],
-  "persona-aimodel-business-update-metadata": [
-    {
-      "policyType": "ACCESS",
-      "policyResourceCategory": "ENTITY",
-      "resources": [
-        "entity:{entity}/*ai/*",
-        "entity-type:AIModel",
-        "entity-classification:*",
-        "entity-business-metadata:*"
-      ],
-      "actions": ["entity-update-business-metadata"]
     }
   ]
 }

--- a/addons/static/templates/policy_cache_transformer_persona.json
+++ b/addons/static/templates/policy_cache_transformer_persona.json
@@ -882,6 +882,7 @@
       "policyResourceCategory": "ENTITY",
       "resources": [
         "entity:{entity}",
+        "entity:{entity}/*",
         "entity-type:AIApplication",
         "entity-classification:*"
       ],
@@ -906,6 +907,7 @@
       "policyType": "ACCESS",
       "resources": [
         "entity:{entity}",
+        "entity:{entity}/*",
         "entity:default/ai/aiapplication/*",
         "entity-type:AIApplication",
         "entity-classification:*"
@@ -924,7 +926,8 @@
 
         "end-two-entity-type:AIApplication",
         "end-two-entity-classification:*",
-        "end-two-entity:{entity}"
+        "end-two-entity:{entity}",
+        "end-two-entity:{entity}/*"
       ],
       "actions": ["add-relationship", "update-relationship", "remove-relationship"]
     },
@@ -938,11 +941,10 @@
         "end-one-entity-type:AIApplication",
         "end-one-entity-classification:*",
         "end-one-entity:{entity}",
+        "end-one-entity:{entity}/*",
 
         "end-two-entity-type:Resource",
         "end-two-entity-classification:*",
-        "end-two-entity-type:Readme",
-        "end-two-entity-type:Link",
         "end-two-entity:*"
       ],
       "actions": ["add-relationship", "update-relationship", "remove-relationship"]
@@ -954,6 +956,7 @@
       "policyType": "ACCESS",
       "resources": [
         "entity:{entity}",
+        "entity:{entity}/*",
         "entity-type:AIApplication",
         "entity-classification:*"
       ],
@@ -966,6 +969,7 @@
       "policyResourceCategory": "ENTITY",
       "resources": [
         "entity:{entity}",
+        "entity:{entity}/*",
         "entity-type:AIApplication",
         "entity-classification:*",
         "entity-business-metadata:*"
@@ -987,7 +991,8 @@
 
         "end-two-entity-type:AIApplication",
         "end-two-entity-classification:*",
-        "end-two-entity:{entity}"
+        "end-two-entity:{entity}",
+        "end-two-entity:{entity}/*"
       ],
       "actions": ["add-relationship", "update-relationship"]
     }
@@ -1006,7 +1011,8 @@
 
         "end-two-entity-type:AIApplication",
         "end-two-entity-classification:*",
-        "end-two-entity:{entity}"
+        "end-two-entity:{entity}",
+        "end-two-entity:{entity}/*"
       ],
       "actions": ["remove-relationship"]
     }
@@ -1017,6 +1023,7 @@
       "policyType": "ACCESS",
       "resources": [
         "entity:{entity}",
+        "entity:{entity}/*",
         "entity-type:AIApplication",
         "entity-classification:*",
         "classification:*"
@@ -1033,6 +1040,7 @@
       "policyType": "ACCESS",
       "resources": [
         "entity:{entity}",
+        "entity:{entity}/*",
         "entity-type:AIApplication",
         "entity-classification:*",
         "classification:*"
@@ -1049,6 +1057,7 @@
       "policyResourceCategory": "ENTITY",
       "resources": [
         "entity:{entity}",
+        "entity:{entity}/*",
         "entity-type:AIModel",
         "entity-classification:*"
       ],
@@ -1073,6 +1082,7 @@
       "policyType": "ACCESS",
       "resources": [
         "entity:{entity}",
+        "entity:{entity}/*",
         "entity:default/ai/aimodel/*",
         "entity-type:AIModel",
         "entity-classification:*"
@@ -1088,6 +1098,7 @@
         "end-one-entity-type:AIModel",
         "end-one-entity-classification:*",
         "end-one-entity:{entity}",
+        "end-one-entity:{entity}/*",
 
         "end-two-entity-type:AIApplication",
         "end-two-entity-classification:*",
@@ -1105,11 +1116,10 @@
         "end-one-entity-type:AIModel",
         "end-one-entity-classification:*",
         "end-one-entity:{entity}",
+        "end-one-entity:{entity}/*",
 
         "end-two-entity-type:Resource",
         "end-two-entity-classification:*",
-        "end-two-entity-type:Readme",
-        "end-two-entity-type:Link",
         "end-two-entity:*"
       ],
       "actions": ["add-relationship", "update-relationship", "remove-relationship"]
@@ -1121,6 +1131,7 @@
       "policyType": "ACCESS",
       "resources": [
         "entity:{entity}",
+        "entity:{entity}/*",
         "entity-type:AIModel",
         "entity-classification:*"
       ],
@@ -1133,6 +1144,7 @@
       "policyResourceCategory": "ENTITY",
       "resources": [
         "entity:{entity}",
+        "entity:{entity}/*",
         "entity-type:AIModel",
         "entity-classification:*",
         "entity-business-metadata:*"
@@ -1154,7 +1166,8 @@
 
         "end-two-entity-type:AIModel",
         "end-two-entity-classification:*",
-        "end-two-entity:{entity}"
+        "end-two-entity:{entity}",
+        "end-two-entity:{entity}/*"
       ],
       "actions": ["add-relationship", "update-relationship"]
     }
@@ -1173,7 +1186,8 @@
 
         "end-two-entity-type:AIModel",
         "end-two-entity-classification:*",
-        "end-two-entity:{entity}"
+        "end-two-entity:{entity}",
+        "end-two-entity:{entity}/*"
       ],
       "actions": ["remove-relationship"]
     }
@@ -1184,6 +1198,7 @@
       "policyType": "ACCESS",
       "resources": [
         "entity:{entity}",
+        "entity:{entity}/*",
         "entity-type:AIModel",
         "entity-classification:*",
         "classification:*"
@@ -1200,6 +1215,7 @@
       "policyType": "ACCESS",
       "resources": [
         "entity:{entity}",
+        "entity:{entity}/*",
         "entity-type:AIModel",
         "entity-classification:*",
         "classification:*"

--- a/addons/static/templates/policy_cache_transformer_persona.json
+++ b/addons/static/templates/policy_cache_transformer_persona.json
@@ -882,7 +882,6 @@
       "policyResourceCategory": "ENTITY",
       "resources": [
         "entity:{entity}",
-        "entity:{entity}/*",
         "entity-type:AIApplication",
         "entity-type:AIModel",
         "entity-classification:*"
@@ -895,8 +894,7 @@
       "policyResourceCategory": "ENTITY",
       "policyType": "ACCESS",
       "resources": [
-        "entity:{entity}",
-        "entity:{entity}/*",
+        "entity:*",
         "entity-type:AIApplication",
         "entity-type:AIModel",
         "entity-classification:*"
@@ -909,8 +907,7 @@
       "policyResourceCategory": "ENTITY",
       "policyType": "ACCESS",
       "resources": [
-        "entity:{entity}",
-        "entity:{entity}/*",
+        "entity:*",
         "entity-type:AIApplication",
         "entity-type:AIModel",
         "entity-classification:*"
@@ -959,7 +956,6 @@
       "policyType": "ACCESS",
       "resources": [
         "entity:{entity}",
-        "entity:{entity}/*",
         "entity-type:AIApplication",
         "entity-type:AIModel",
         "entity-classification:*"
@@ -973,7 +969,6 @@
       "policyResourceCategory": "ENTITY",
       "resources": [
         "entity:{entity}",
-        "entity:{entity}/*",
         "entity-type:AIApplication",
         "entity-type:AIModel",
         "entity-classification:*",
@@ -1049,7 +1044,6 @@
       "policyType": "ACCESS",
       "resources": [
         "entity:{entity}",
-        "entity:{entity}/*",
         "entity-type:AIApplication",
         "entity-type:AIModel",
         "entity-classification:*",
@@ -1067,7 +1061,6 @@
       "policyType": "ACCESS",
       "resources": [
         "entity:{entity}",
-        "entity:{entity}/*",
         "entity-type:AIApplication",
         "entity-type:AIModel",
         "entity-classification:*",
@@ -1084,7 +1077,6 @@
       "policyType": "ACCESS",
       "resources": [
         "entity:{entity}",
-        "entity:{entity}/*",
         "entity-type:AIApplication",
         "entity-type:AIModel",
         "entity-classification:*",

--- a/addons/static/templates/policy_cache_transformer_persona.json
+++ b/addons/static/templates/policy_cache_transformer_persona.json
@@ -876,43 +876,223 @@
     }
   ],
   
-  "persona-aiasset-read": [
+  "persona-ai-application-read": [
     {
       "policyType": "ACCESS",
       "policyResourceCategory": "ENTITY",
       "resources": [
         "entity:{entity}",
         "entity-type:AIApplication",
-        "entity-type:AIModel",
         "entity-classification:*"
       ],
       "actions": ["entity-read"]
     }
   ],
-  "persona-aiasset-create": [
+  "persona-ai-application-create": [
     {
       "policyResourceCategory": "ENTITY",
       "policyType": "ACCESS",
       "resources": [
         "entity:*",
         "entity:default/ai/aiapplication/*",
-        "entity:default/ai/aimodel/*",
         "entity-type:AIApplication",
-        "entity-type:AIModel",
         "entity-classification:*"
       ],
       "actions": ["entity-create", "entity-update"]
     }
   ],
-  "persona-aiasset-update": [
+  "persona-ai-application-update": [
     {
       "policyResourceCategory": "ENTITY",
       "policyType": "ACCESS",
       "resources": [
         "entity:{entity}",
         "entity:default/ai/aiapplication/*",
-        "entity:default/ai/aimodel/*",
         "entity-type:AIApplication",
+        "entity-classification:*"
+      ],
+      "actions": ["entity-update"]
+    },
+    {
+      "policyResourceCategory": "RELATIONSHIP",
+      "policyType": "ACCESS",
+      "description": "Link/unlink AIModel to any AIApplication",
+      "resources": [
+        "relationship-type:*",
+        "end-one-entity-type:AIModel",
+        "end-one-entity-classification:*",
+        "end-one-entity:*",
+
+        "end-two-entity-type:AIApplication",
+        "end-two-entity-classification:*",
+        "end-two-entity:{entity}"
+      ],
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+    }
+  ],
+  "persona-ai-application-delete": [
+    {
+      "policyResourceCategory": "ENTITY",
+      "policyType": "ACCESS",
+      "resources": [
+        "entity:*",
+        "entity:{entity}",
+        "entity:default/ai/aiapplication/*",
+        "entity-type:AIApplication",
+        "entity-classification:*"
+      ],
+      "actions": ["entity-delete"]
+    }
+  ],
+  "persona-ai-application-business-update-metadata": [
+    {
+      "policyType": "ACCESS",
+      "policyResourceCategory": "ENTITY",
+      "resources": [
+        "entity:{entity}",
+        "entity-type:AIApplication",
+        "entity-classification:*",
+        "entity-business-metadata:*"
+      ],
+      "actions": ["entity-update-business-metadata"]
+    }
+  ],
+  "persona-ai-application-add-terms": [
+    {
+      "policyResourceCategory": "RELATIONSHIP",
+      "policyType": "ACCESS",
+      "description": "Link term to this AI asset",
+      "resources": [
+        "relationship-type:*",
+
+        "end-one-entity-type:AtlasGlossaryTerm",
+        "end-one-entity-classification:*",
+        "end-one-entity:*",
+
+        "end-two-entity-type:AIApplication",
+        "end-two-entity-classification:*",
+        "end-two-entity:{entity}"
+      ],
+      "actions": ["add-relationship"]
+    }
+  ],
+  "persona-ai-application-update-terms": [
+    {
+      "policyResourceCategory": "RELATIONSHIP",
+      "policyType": "ACCESS",
+      "description": "Unlink term to this AI asset",
+      "resources": [
+        "relationship-type:*",
+
+        "end-one-entity-type:AtlasGlossaryTerm",
+        "end-one-entity-classification:*",
+        "end-one-entity:*",
+
+        "end-two-entity-type:AIApplication",
+        "end-two-entity-classification:*",
+        "end-two-entity:{entity}"
+      ],
+      "actions": ["update-relationship"]
+    }
+  ],
+  "persona-ai-application-remove-terms": [
+    {
+      "policyResourceCategory": "RELATIONSHIP",
+      "policyType": "ACCESS",
+      "description": "Link/unlink term to this AI asset",
+      "resources": [
+        "relationship-type:*",
+
+        "end-one-entity-type:AtlasGlossaryTerm",
+        "end-one-entity-classification:*",
+        "end-one-entity:*",
+
+        "end-two-entity-type:AIApplication",
+        "end-two-entity-classification:*",
+        "end-two-entity:{entity}"
+      ],
+      "actions": ["remove-relationship"]
+    }
+  ],
+  "persona-ai-application-add-classification": [
+    {
+      "policyResourceCategory": "ENTITY",
+      "policyType": "ACCESS",
+      "resources": [
+        "entity:{entity}",
+        "entity-type:AIApplication",
+        "entity-classification:*",
+        "classification:*"
+      ],
+      "actions": [
+        "entity-add-classification",
+        "entity-update-classification"
+      ]
+    }
+  ],
+  "persona-ai-application-update-classification": [
+    {
+      "policyResourceCategory": "ENTITY",
+      "policyType": "ACCESS",
+      "resources": [
+        "entity:{entity}",
+        "entity-type:AIApplication",
+        "entity-classification:*",
+        "classification:*"
+      ],
+      "actions": [
+        "entity-update-classification"
+      ]
+    }
+  ],
+  "persona-ai-application-remove-classification": [
+    {
+      "policyResourceCategory": "ENTITY",
+      "policyType": "ACCESS",
+      "resources": [
+        "entity:{entity}",
+        "entity-type:AIApplication",
+        "entity-classification:*",
+        "classification:*"
+      ],
+      "actions": [
+        "entity-update-classification",
+        "entity-remove-classification"
+      ]
+    }
+  ],
+  "persona-ai-model-read": [
+    {
+      "policyType": "ACCESS",
+      "policyResourceCategory": "ENTITY",
+      "resources": [
+        "entity:{entity}",
+        "entity-type:AIModel",
+        "entity-classification:*"
+      ],
+      "actions": ["entity-read"]
+    }
+  ],
+  "persona-ai-model-create": [
+    {
+      "policyResourceCategory": "ENTITY",
+      "policyType": "ACCESS",
+      "resources": [
+        "entity:*",
+        "entity:default/ai/aimodel/*",
+        "entity-type:AIModel",
+        "entity-classification:*"
+      ],
+      "actions": ["entity-create", "entity-update"]
+    }
+  ],
+  "persona-ai-model-update": [
+    {
+      "policyResourceCategory": "ENTITY",
+      "policyType": "ACCESS",
+      "resources": [
+        "entity:{entity}",
+        "entity:default/ai/aimodel/*",
         "entity-type:AIModel",
         "entity-classification:*"
       ],
@@ -935,29 +1115,26 @@
       "actions": ["add-relationship", "update-relationship", "remove-relationship"]
     }
   ],
-  "persona-aiasset-delete": [
+  "persona-ai-model-delete": [
     {
       "policyResourceCategory": "ENTITY",
       "policyType": "ACCESS",
       "resources": [
         "entity:*",
         "entity:{entity}",
-        "entity:default/ai/aiapplication/*",
         "entity:default/ai/aimodel/*",
-        "entity-type:AIApplication",
         "entity-type:AIModel",
         "entity-classification:*"
       ],
       "actions": ["entity-delete"]
     }
   ],
-  "persona-aiasset-business-update-metadata": [
+  "persona-ai-model-business-update-metadata": [
     {
       "policyType": "ACCESS",
       "policyResourceCategory": "ENTITY",
       "resources": [
         "entity:{entity}",
-        "entity-type:AIApplication",
         "entity-type:AIModel",
         "entity-classification:*",
         "entity-business-metadata:*"
@@ -965,7 +1142,7 @@
       "actions": ["entity-update-business-metadata"]
     }
   ],
-  "persona-aiasset-add-terms": [
+  "persona-ai-model-add-terms": [
     {
       "policyResourceCategory": "RELATIONSHIP",
       "policyType": "ACCESS",
@@ -977,7 +1154,6 @@
         "end-one-entity-classification:*",
         "end-one-entity:*",
 
-        "end-two-entity-type:AIApplication",
         "end-two-entity-type:AIModel",
         "end-two-entity-classification:*",
         "end-two-entity:{entity}"
@@ -985,7 +1161,7 @@
       "actions": ["add-relationship"]
     }
   ],
-  "persona-aiasset-update-terms": [
+  "persona-ai-model-update-terms": [
     {
       "policyResourceCategory": "RELATIONSHIP",
       "policyType": "ACCESS",
@@ -997,7 +1173,6 @@
         "end-one-entity-classification:*",
         "end-one-entity:*",
 
-        "end-two-entity-type:AIApplication",
         "end-two-entity-type:AIModel",
         "end-two-entity-classification:*",
         "end-two-entity:{entity}"
@@ -1005,7 +1180,7 @@
       "actions": ["update-relationship"]
     }
   ],
-  "persona-aiasset-remove-terms": [
+  "persona-ai-model-remove-terms": [
     {
       "policyResourceCategory": "RELATIONSHIP",
       "policyType": "ACCESS",
@@ -1017,7 +1192,6 @@
         "end-one-entity-classification:*",
         "end-one-entity:*",
 
-        "end-two-entity-type:AIApplication",
         "end-two-entity-type:AIModel",
         "end-two-entity-classification:*",
         "end-two-entity:{entity}"
@@ -1025,13 +1199,12 @@
       "actions": ["remove-relationship"]
     }
   ],
-  "persona-aiasset-add-classification": [
+  "persona-ai-model-add-classification": [
     {
       "policyResourceCategory": "ENTITY",
       "policyType": "ACCESS",
       "resources": [
         "entity:{entity}",
-        "entity-type:AIApplication",
         "entity-type:AIModel",
         "entity-classification:*",
         "classification:*"
@@ -1042,13 +1215,12 @@
       ]
     }
   ],
-  "persona-aiasset-update-classification": [
+  "persona-ai-model-update-classification": [
     {
       "policyResourceCategory": "ENTITY",
       "policyType": "ACCESS",
       "resources": [
         "entity:{entity}",
-        "entity-type:AIApplication",
         "entity-type:AIModel",
         "entity-classification:*",
         "classification:*"
@@ -1058,13 +1230,12 @@
       ]
     }
   ],
-  "persona-aiasset-remove-classification": [
+  "persona-ai-model-remove-classification": [
     {
       "policyResourceCategory": "ENTITY",
       "policyType": "ACCESS",
       "resources": [
         "entity:{entity}",
-        "entity-type:AIApplication",
         "entity-type:AIModel",
         "entity-classification:*",
         "classification:*"
@@ -1075,4 +1246,5 @@
       ]
     }
   ]
+
 }

--- a/addons/static/templates/policy_cache_transformer_persona.json
+++ b/addons/static/templates/policy_cache_transformer_persona.json
@@ -1114,8 +1114,7 @@
       "policyResourceCategory": "ENTITY",
       "policyType": "ACCESS",
       "resources": [
-        "entity:{entity}",
-        "entity:{entity}/*",
+        "entity:*",
         "entity-type:AIModel",
         "entity-classification:*"
       ],

--- a/addons/static/templates/policy_cache_transformer_persona.json
+++ b/addons/static/templates/policy_cache_transformer_persona.json
@@ -894,6 +894,7 @@
       "policyResourceCategory": "ENTITY",
       "policyType": "ACCESS",
       "resources": [
+        "entity:*",
         "entity:default/ai/aiapplication/*",
         "entity-type:AIApplication",
         "entity-classification:*"
@@ -1069,6 +1070,7 @@
       "policyResourceCategory": "ENTITY",
       "policyType": "ACCESS",
       "resources": [
+        "entity:*",
         "entity:default/ai/aimodel/*",
         "entity:default/ai/aiapplication/*",
         "entity-type:AIModel",

--- a/addons/static/templates/policy_cache_transformer_persona.json
+++ b/addons/static/templates/policy_cache_transformer_persona.json
@@ -899,7 +899,7 @@
         "entity-type:AIModel",
         "entity-classification:*"
       ],
-      "actions": ["entity-create"]
+      "actions": ["entity-create", "entity-update"]
     }
   ],
   "persona-aiasset-update": [
@@ -907,7 +907,7 @@
       "policyResourceCategory": "ENTITY",
       "policyType": "ACCESS",
       "resources": [
-        "entity:*",
+        "entity:{entity}",
         "entity-type:AIApplication",
         "entity-type:AIModel",
         "entity-classification:*"

--- a/addons/static/templates/policy_cache_transformer_persona.json
+++ b/addons/static/templates/policy_cache_transformer_persona.json
@@ -940,7 +940,10 @@
       "policyResourceCategory": "ENTITY",
       "policyType": "ACCESS",
       "resources": [
+        "entity:*",
         "entity:{entity}",
+        "entity:default/ai/aiapplication/*",
+        "entity:default/ai/aimodel/*",
         "entity-type:AIApplication",
         "entity-type:AIModel",
         "entity-classification:*"

--- a/addons/static/templates/policy_cache_transformer_persona.json
+++ b/addons/static/templates/policy_cache_transformer_persona.json
@@ -973,26 +973,7 @@
         "end-two-entity-classification:*",
         "end-two-entity:{entity}"
       ],
-      "actions": ["add-relationship"]
-    }
-  ],
-  "persona-ai-application-update-terms": [
-    {
-      "policyResourceCategory": "RELATIONSHIP",
-      "policyType": "ACCESS",
-      "description": "Unlink term to this AI asset",
-      "resources": [
-        "relationship-type:*",
-
-        "end-one-entity-type:AtlasGlossaryTerm",
-        "end-one-entity-classification:*",
-        "end-one-entity:*",
-
-        "end-two-entity-type:AIApplication",
-        "end-two-entity-classification:*",
-        "end-two-entity:{entity}"
-      ],
-      "actions": ["update-relationship"]
+      "actions": ["add-relationship", "update-relationship"]
     }
   ],
   "persona-ai-application-remove-terms": [
@@ -1026,21 +1007,6 @@
       ],
       "actions": [
         "entity-add-classification",
-        "entity-update-classification"
-      ]
-    }
-  ],
-  "persona-ai-application-update-classification": [
-    {
-      "policyResourceCategory": "ENTITY",
-      "policyType": "ACCESS",
-      "resources": [
-        "entity:{entity}",
-        "entity-type:AIApplication",
-        "entity-classification:*",
-        "classification:*"
-      ],
-      "actions": [
         "entity-update-classification"
       ]
     }
@@ -1158,26 +1124,7 @@
         "end-two-entity-classification:*",
         "end-two-entity:{entity}"
       ],
-      "actions": ["add-relationship"]
-    }
-  ],
-  "persona-ai-model-update-terms": [
-    {
-      "policyResourceCategory": "RELATIONSHIP",
-      "policyType": "ACCESS",
-      "description": "Unlink term to this AI asset",
-      "resources": [
-        "relationship-type:*",
-
-        "end-one-entity-type:AtlasGlossaryTerm",
-        "end-one-entity-classification:*",
-        "end-one-entity:*",
-
-        "end-two-entity-type:AIModel",
-        "end-two-entity-classification:*",
-        "end-two-entity:{entity}"
-      ],
-      "actions": ["update-relationship"]
+      "actions": ["add-relationship", "update-relationship"]
     }
   ],
   "persona-ai-model-remove-terms": [
@@ -1211,21 +1158,6 @@
       ],
       "actions": [
         "entity-add-classification",
-        "entity-update-classification"
-      ]
-    }
-  ],
-  "persona-ai-model-update-classification": [
-    {
-      "policyResourceCategory": "ENTITY",
-      "policyType": "ACCESS",
-      "resources": [
-        "entity:{entity}",
-        "entity-type:AIModel",
-        "entity-classification:*",
-        "classification:*"
-      ],
-      "actions": [
         "entity-update-classification"
       ]
     }

--- a/addons/static/templates/policy_cache_transformer_persona.json
+++ b/addons/static/templates/policy_cache_transformer_persona.json
@@ -894,7 +894,6 @@
       "policyType": "ACCESS",
       "resources": [
         "entity:*",
-        "entity:default/ai/aiapplication/*",
         "entity-type:AIApplication",
         "entity-classification:*"
       ],
@@ -907,7 +906,6 @@
       "policyType": "ACCESS",
       "resources": [
         "entity:*",
-        "entity:default/ai/aiapplication/*",
         "entity-type:AIApplication",
         "entity-classification:*"
       ],
@@ -1060,8 +1058,6 @@
       "policyType": "ACCESS",
       "resources": [
         "entity:*",
-        "entity:default/ai/aimodel/*",
-        "entity:default/ai/aiapplication/*",
         "entity-type:AIModel",
         "entity-classification:*"
       ],
@@ -1074,8 +1070,6 @@
       "policyType": "ACCESS",
       "resources": [
         "entity:*",
-        "entity:default/ai/aimodel/*",
-        "entity:default/ai/aiapplication/*",
         "entity-type:AIModel",
         "entity-classification:*"
       ],

--- a/addons/static/templates/policy_cache_transformer_persona.json
+++ b/addons/static/templates/policy_cache_transformer_persona.json
@@ -951,9 +951,7 @@
         "entity-type:AIModel",
         "entity-classification:*"
       ],
-      "actions": [
-        "entity-read"
-      ]
+      "actions": ["entity-read"]
     }
   ],
   "persona-aiasset-create": [
@@ -967,9 +965,7 @@
         "entity-type:AIModel",
         "entity-classification:*"
       ],
-      "actions": [
-        "entity-create"
-      ]
+      "actions": ["entity-create"]
     }
   ],
   "persona-aiasset-update": [
@@ -983,9 +979,7 @@
         "entity-type:AIModel",
         "entity-classification:*"
       ],
-      "actions": [
-        "entity-update"
-      ]
+      "actions": ["entity-update"]
     },
     {
       "policyResourceCategory": "RELATIONSHIP",
@@ -996,16 +990,13 @@
         "end-one-entity-type:AIApplication",
         "end-one-entity-classification:*",
         "end-one-entity:*",
+
         "end-two-entity-type:AIModel",
         "end-two-entity-classification:*",
         "end-two-entity:{entity}",
         "end-two-entity:{entity}/*"
       ],
-      "actions": [
-        "add-relationship",
-        "update-relationship",
-        "remove-relationship"
-      ]
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
     },
     {
       "policyResourceCategory": "RELATIONSHIP",
@@ -1013,19 +1004,17 @@
       "description": "Link/unlink resource to AI assets",
       "resources": [
         "relationship-type:*",
+
         "end-one-entity-type:AIApplication",
         "end-one-entity-type:AIModel",
         "end-one-entity-classification:*",
         "end-one-entity:{entity}",
+
         "end-two-entity-type:Resource",
         "end-two-entity-classification:*",
         "end-two-entity:*"
       ],
-      "actions": [
-        "add-relationship",
-        "update-relationship",
-        "remove-relationship"
-      ]
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
     }
   ],
   "persona-aiasset-delete": [
@@ -1039,9 +1028,7 @@
         "entity-type:AIModel",
         "entity-classification:*"
       ],
-      "actions": [
-        "entity-delete"
-      ]
+      "actions": ["entity-delete"]
     }
   ],
   "persona-aiasset-business-update-metadata": [
@@ -1056,9 +1043,7 @@
         "entity-classification:*",
         "entity-business-metadata:*"
       ],
-      "actions": [
-        "entity-update-business-metadata"
-      ]
+      "actions": ["entity-update-business-metadata"]
     }
   ],
   "persona-aiasset-add-terms": [
@@ -1068,19 +1053,18 @@
       "description": "Link term to this AI asset",
       "resources": [
         "relationship-type:*",
+
         "end-one-entity-type:AtlasGlossaryTerm",
         "entity-type:AtlasGlossaryTerm",
         "end-one-entity-classification:*",
         "end-one-entity:*",
+
         "end-two-entity-type:AIApplication",
         "end-two-entity-type:AIModel",
         "end-two-entity-classification:*",
         "end-two-entity:{entity}"
       ],
-      "actions": [
-        "add-relationship",
-        "entity-read"
-      ]
+      "actions": ["add-relationship", "entity-read"]
     }
   ],
   "persona-aiasset-update-terms": [
@@ -1090,17 +1074,17 @@
       "description": "Unlink term to this AI asset",
       "resources": [
         "relationship-type:*",
+
         "end-one-entity-type:AtlasGlossaryTerm",
         "end-one-entity-classification:*",
         "end-one-entity:*",
+
         "end-two-entity-type:AIApplication",
         "end-two-entity-type:AIModel",
         "end-two-entity-classification:*",
         "end-two-entity:{entity}"
       ],
-      "actions": [
-        "update-relationship"
-      ]
+      "actions": ["update-relationship"]
     }
   ],
   "persona-aiasset-remove-terms": [
@@ -1110,17 +1094,17 @@
       "description": "Link/unlink term to this AI asset",
       "resources": [
         "relationship-type:*",
+
         "end-one-entity-type:AtlasGlossaryTerm",
         "end-one-entity-classification:*",
         "end-one-entity:*",
+
         "end-two-entity-type:AIApplication",
         "end-two-entity-type:AIModel",
         "end-two-entity-classification:*",
         "end-two-entity:{entity}"
       ],
-      "actions": [
-        "remove-relationship"
-      ]
+      "actions": ["remove-relationship"]
     }
   ],
   "persona-aiasset-add-classification": [

--- a/addons/static/templates/policy_cache_transformer_persona.json
+++ b/addons/static/templates/policy_cache_transformer_persona.json
@@ -1070,6 +1070,7 @@
       "policyType": "ACCESS",
       "resources": [
         "entity:default/ai/aimodel/*",
+        "entity:default/ai/aiapplication/*",
         "entity-type:AIModel",
         "entity-classification:*"
       ],
@@ -1084,6 +1085,7 @@
         "entity:{entity}",
         "entity:{entity}/*",
         "entity:default/ai/aimodel/*",
+        "entity:default/ai/aiapplication/*",
         "entity-type:AIModel",
         "entity-classification:*"
       ],

--- a/addons/static/templates/policy_cache_transformer_persona.json
+++ b/addons/static/templates/policy_cache_transformer_persona.json
@@ -927,6 +927,25 @@
         "end-two-entity:{entity}"
       ],
       "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+    },
+    {
+      "policyResourceCategory": "RELATIONSHIP",
+      "policyType": "ACCESS",
+      "description": "Link/unlink resource to this AIApplication",
+      "resources": [
+        "relationship-type:*",
+
+        "end-one-entity-type:AIApplication",
+        "end-one-entity-classification:*",
+        "end-one-entity:{entity}",
+
+        "end-two-entity-type:Resource",
+        "end-two-entity-classification:*",
+        "end-two-entity-type:Readme",
+        "end-two-entity-type:Link",
+        "end-two-entity:*"
+      ],
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
     }
   ],
   "persona-ai-application-delete": [
@@ -1072,6 +1091,25 @@
 
         "end-two-entity-type:AIApplication",
         "end-two-entity-classification:*",
+        "end-two-entity:*"
+      ],
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+    },
+    {
+      "policyResourceCategory": "RELATIONSHIP",
+      "policyType": "ACCESS",
+      "description": "Link/unlink resource to this AIModel",
+      "resources": [
+        "relationship-type:*",
+
+        "end-one-entity-type:AIModel",
+        "end-one-entity-classification:*",
+        "end-one-entity:{entity}",
+
+        "end-two-entity-type:Resource",
+        "end-two-entity-classification:*",
+        "end-two-entity-type:Readme",
+        "end-two-entity-type:Link",
         "end-two-entity:*"
       ],
       "actions": ["add-relationship", "update-relationship", "remove-relationship"]

--- a/addons/static/templates/policy_cache_transformer_persona.json
+++ b/addons/static/templates/policy_cache_transformer_persona.json
@@ -387,7 +387,7 @@
       "actions": ["entity-read"]
     }
   ],
-  "persona-domain-update": [
+  "persona-domain-update": [ 
     {
       "policyResourceCategory": "ENTITY",
       "policyType": "ACCESS",
@@ -873,6 +873,286 @@
         "entity-type:{entity-type}"
       ],
       "actions": ["select"]
+    }
+  ],
+
+  "persona-aiapplication-read": [
+    {
+      "policyType": "ACCESS",
+      "policyResourceCategory": "ENTITY",
+      "resources": [
+        "entity:{entity}",
+        "entity:{entity}/*",
+        "entity-type:AIApplication",
+        "entity-classification:*"
+      ],
+      "actions": ["entity-read"]
+    }
+  ],
+  "persona-aiapplication-create": [
+    {
+      "policyResourceCategory": "ENTITY",
+      "policyType": "ACCESS",
+      "resources": [
+        "entity:{entity}/*ai/*",
+        "entity-type:AIApplication",
+        "entity-classification:*"
+      ],
+      "actions": ["entity-create"]
+    },
+    {
+      "policyResourceCategory": "RELATIONSHIP",
+      "policyType": "ACCESS",
+      "description": "Link/unlink AIModel to any AIApplication",
+      "resources": [
+        "relationship-type:*",
+        
+        "end-one-entity:{entity}/*",
+        "end-one-entity:{entity}",
+        "end-one-entity-type:AIApplication",
+        "end-one-entity-classification:*",
+        
+        "end-two-entity:{entity}/*",
+        "end-one-entity:{entity}",
+        "end-two-entity-type:AIModel",
+        "end-two-entity-classification:*"
+      ],
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+    }
+  ],
+  "persona-aiapplication-update": [
+    {
+      "policyResourceCategory": "ENTITY",
+      "policyType": "ACCESS",
+      "resources": [
+        "entity:{entity}",
+        "entity-type:AIApplication",
+        "entity-classification:*",
+        "classification:*"
+      ],
+      "actions": [
+        "entity-update",
+        "entity-add-classification",
+        "entity-update-classification",
+        "entity-remove-classification"
+      ]
+    },
+    {
+      "policyResourceCategory": "RELATIONSHIP",
+      "policyType": "ACCESS",
+      "description": "Link/unlink AIModel to any AIApplication",
+      "resources": [
+        "relationship-type:*",
+        "end-one-entity-type:AIApplication",
+        "end-one-entity-classification:*",
+        "end-one-entity:*",
+
+        "end-two-entity-type:AIModel",
+        "end-two-entity-classification:*",
+        "end-two-entity:{entity}",
+        "end-two-entity:{entity}/*"
+      ],
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+    },
+    {
+      "policyResourceCategory": "RELATIONSHIP",
+      "policyType": "ACCESS",
+      "description": "Link/unlink resource to this AIApplication",
+      "resources": [
+        "relationship-type:*",
+
+        "end-one-entity-type:AIApplication",
+        "end-one-entity-classification:*",
+        "end-one-entity:{entity}",
+
+        "end-two-entity-type:Resource",
+        "end-two-entity-classification:*",
+        "end-two-entity:*"
+      ],
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+    },
+    {
+      "policyResourceCategory": "RELATIONSHIP",
+      "policyType": "ACCESS",
+      "description": "Link/unlink term to this AIApplication",
+      "resources": [
+        "relationship-type:*",
+
+        "end-one-entity-type:AtlasGlossaryTerm",
+        "end-one-entity-classification:*",
+        "end-one-entity:*",
+
+        "end-two-entity-type:AIApplication",
+        "end-two-entity-classification:*",
+        "end-two-entity:{entity}"
+      ],
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+    }
+  ],
+  "persona-aiapplication-delete": [
+    {
+      "policyResourceCategory": "ENTITY",
+      "policyType": "ACCESS",
+      "resources": [
+        "entity:{entity}/*ai/*",
+        "entity-type:AIApplication",
+        "entity-classification:*"
+      ],
+      "actions": ["entity-delete"]
+    }
+  ],
+  "persona-aiapplication-business-update-metadata": [
+    {
+      "policyType": "ACCESS",
+      "policyResourceCategory": "ENTITY",
+      "resources": [
+        "entity:{entity}/*ai/*",
+        "entity-type:AIApplication",
+        "entity-classification:*",
+        "entity-business-metadata:*"
+      ],
+      "actions": ["entity-update-business-metadata"]
+    }
+  ],
+  "persona-aimodel-read": [
+    {
+      "policyType": "ACCESS",
+      "policyResourceCategory": "ENTITY",
+      "resources": [
+        "entity:{entity}",
+        "entity:{entity}/*",
+        "entity-type:AIModel",
+        "entity-classification:*"
+      ],
+      "actions": ["entity-read"]
+    }
+  ],
+  "persona-aimodel-create": [
+    {
+      "policyResourceCategory": "ENTITY",
+      "policyType": "ACCESS",
+      "resources": [
+        "entity:{entity}/*ai/*",
+        "entity-type:AIModel",
+        "entity-classification:*"
+      ],
+      "actions": ["entity-create"]
+    },
+    {
+      "policyResourceCategory": "RELATIONSHIP",
+      "policyType": "ACCESS",
+      "description": "Link/unlink AIModel to any AIApplication",
+      "resources": [
+        "relationship-type:*",
+        
+        "end-one-entity:{entity}/*",
+        "end-one-entity:{entity}",
+        "end-one-entity-type:AIApplication",
+        "end-one-entity-classification:*",
+        
+        "end-two-entity:{entity}/*",
+        "end-one-entity:{entity}",
+        "end-two-entity-type:AIModel",
+        "end-two-entity-classification:*"
+      ],
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+    }
+  ],
+  "persona-aimodel-update": [
+    {
+      "policyResourceCategory": "ENTITY",
+      "policyType": "ACCESS",
+      "resources": [
+        "entity:{entity}",
+        "entity-type:AIModel",
+        "entity-classification:*",
+        "classification:*"
+      ],
+      "actions": [
+        "entity-update",
+        "entity-add-classification",
+        "entity-update-classification",
+        "entity-remove-classification"
+      ]
+    },
+    {
+      "policyResourceCategory": "RELATIONSHIP",
+      "policyType": "ACCESS",
+      "description": "Link/unlink any DataDomain, DataProduct OR DataContract to this Domain",
+      "resources": [
+        "relationship-type:*",
+
+        "end-one-entity-type:DataDomain",
+        "end-one-entity-type:DataProduct",
+        "end-one-entity-classification:*",
+        "end-one-entity:*",
+
+        "end-two-entity-type:DataDomain",
+        "end-two-entity-type:DataProduct",
+        "end-two-entity-classification:*",
+        "end-two-entity:{entity}",
+        "end-two-entity:{entity}/*"
+      ],
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+    },
+    {
+      "policyResourceCategory": "RELATIONSHIP",
+      "policyType": "ACCESS",
+      "description": "Link/unlink resource to this Domain",
+      "resources": [
+        "relationship-type:*",
+
+        "end-one-entity-type:DataDomain",
+        "end-one-entity-classification:*",
+        "end-one-entity:{entity}",
+
+        "end-two-entity-type:Resource",
+        "end-two-entity-classification:*",
+        "end-two-entity:*"
+      ],
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+    },
+    {
+      "policyResourceCategory": "RELATIONSHIP",
+      "policyType": "ACCESS",
+      "description": "Link/unlink term to this Sub Domain",
+      "resources": [
+        "relationship-type:*",
+
+        "end-one-entity-type:AtlasGlossaryTerm",
+        "end-one-entity-classification:*",
+        "end-one-entity:*",
+
+        "end-two-entity-type:DataDomain",
+        "end-two-entity-classification:*",
+        "end-two-entity:{entity}"
+      ],
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+    }
+  ],
+  "persona-aimodel-delete": [
+    {
+      "policyResourceCategory": "ENTITY",
+      "policyType": "ACCESS",
+      "resources": [
+        "entity:{entity}/*ai/*",
+        "entity-type:AIModel",
+        "entity-classification:*"
+      ],
+      "actions": ["entity-delete"]
+    }
+  ],
+  "persona-aimodel-business-update-metadata": [
+    {
+      "policyType": "ACCESS",
+      "policyResourceCategory": "ENTITY",
+      "resources": [
+        "entity:{entity}/*ai/*",
+        "entity-type:AIModel",
+        "entity-classification:*",
+        "entity-business-metadata:*"
+      ],
+      "actions": ["entity-update-business-metadata"]
     }
   ]
 }

--- a/addons/static/templates/policy_cache_transformer_persona.json
+++ b/addons/static/templates/policy_cache_transformer_persona.json
@@ -895,6 +895,8 @@
       "policyType": "ACCESS",
       "resources": [
         "entity:*",
+        "entity:default/ai/aiapplication/*",
+        "entity:default/ai/aimodel/*",
         "entity-type:AIApplication",
         "entity-type:AIModel",
         "entity-classification:*"
@@ -908,6 +910,8 @@
       "policyType": "ACCESS",
       "resources": [
         "entity:{entity}",
+        "entity:default/ai/aiapplication/*",
+        "entity:default/ai/aimodel/*",
         "entity-type:AIApplication",
         "entity-type:AIModel",
         "entity-classification:*"

--- a/addons/static/templates/policy_cache_transformer_persona.json
+++ b/addons/static/templates/policy_cache_transformer_persona.json
@@ -920,32 +920,13 @@
       "description": "Link/unlink AIModel to any AIApplication",
       "resources": [
         "relationship-type:*",
-        "end-one-entity-type:AIApplication",
+        "end-one-entity-type:AIModel",
         "end-one-entity-classification:*",
         "end-one-entity:*",
 
-        "end-two-entity-type:AIModel",
+        "end-two-entity-type:AIApplication",
         "end-two-entity-classification:*",
-        "end-two-entity:{entity}",
-        "end-two-entity:{entity}/*"
-      ],
-      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
-    },
-    {
-      "policyResourceCategory": "RELATIONSHIP",
-      "policyType": "ACCESS",
-      "description": "Link/unlink resource to AI assets",
-      "resources": [
-        "relationship-type:*",
-
-        "end-one-entity-type:AIApplication",
-        "end-one-entity-type:AIModel",
-        "end-one-entity-classification:*",
-        "end-one-entity:{entity}",
-
-        "end-two-entity-type:Resource",
-        "end-two-entity-classification:*",
-        "end-two-entity:*"
+        "end-two-entity:{entity}"
       ],
       "actions": ["add-relationship", "update-relationship", "remove-relationship"]
     }
@@ -986,7 +967,6 @@
         "relationship-type:*",
 
         "end-one-entity-type:AtlasGlossaryTerm",
-        "entity-type:AtlasGlossaryTerm",
         "end-one-entity-classification:*",
         "end-one-entity:*",
 
@@ -995,7 +975,7 @@
         "end-two-entity-classification:*",
         "end-two-entity:{entity}"
       ],
-      "actions": ["add-relationship", "entity-read"]
+      "actions": ["add-relationship"]
     }
   ],
   "persona-aiasset-update-terms": [

--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -143,6 +143,9 @@ public final class Constants {
     public static final String DATA_DOMAIN_ENTITY_TYPE     = "DataDomain";
     public static final String DATA_PRODUCT_ENTITY_TYPE    = "DataProduct";
 
+    public static final String AI_APPLICATION       = "AIApplication";
+    public static final String AI_MODEL             = "AIModel";
+    
     public static final String STAKEHOLDER_ENTITY_TYPE       = "Stakeholder";
     public static final String STAKEHOLDER_TITLE_ENTITY_TYPE = "StakeholderTitle";
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
@@ -273,30 +273,13 @@ public class ESAliasStore implements IndexAliasStore {
                         allowClauseList.add(mapOf("bool", mapOf("must", mustMap)));
                     }
                 } else if (policyActions.contains(ACCESS_READ_PERSONA_AI_APP) || policyActions.contains(ACCESS_READ_PERSONA_AI_MODEL)) {
+                    // access is given across the resource as per entity-type for AI asset
                     List<String> resources = getPolicyResources(policy);
                     List<String> typeResources = getFilteredPolicyResources(resources, RESOURCES_ENTITY_TYPE);
+                    List<Map<String, Object>> mustMap = new ArrayList<>();
                     if (CollectionUtils.isNotEmpty(typeResources)) {
-                        List<String> typeTerms = new ArrayList<>();
-                        List<Map<String, Object>> mustMap = new ArrayList<>();
-                        if (typeResources.contains(AI_APPLICATION)) {
-                            typeTerms.add(AI_APPLICATION);
-                        } 
-                        if (typeResources.contains(AI_MODEL)) {
-                            typeTerms.add(AI_MODEL);
-                        }
-                        if (CollectionUtils.isNotEmpty(typeTerms)) {
-                            mustMap.add(mapOf("terms", mapOf("__typeName.keyword", typeTerms)));
-                            allowClauseList.add(mapOf("bool", mapOf("must", mustMap)));
-                        }
-                    }
-                    
-                    for (String asset : assets) {
-                        if (StringUtils.isNotEmpty(asset)) {
-                            List<Map<String, Object>> mustMap = new ArrayList<>();
-                            mustMap.add(mapOf("wildcard", mapOf(QUALIFIED_NAME, asset)));
-                            mustMap.add(mapOf("terms", mapOf("__typeName.keyword", Arrays.asList(AI_APPLICATION, AI_MODEL))));
-                            allowClauseList.add(mapOf("bool", mapOf("must", mustMap)));
-                        }
+                        mustMap.add(mapOf("terms", mapOf("__typeName.keyword", typeResources)));
+                        allowClauseList.add(mapOf("bool", mapOf("must", mustMap)));
                     }
                 }
             }

--- a/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
@@ -200,8 +200,10 @@ public class ESAliasStore implements IndexAliasStore {
                 if (!getIsAllowPolicy(policy)) {
                     continue;
                 }
+
+                List<String> policyActions = getPolicyActions(policy);
                 
-                if (getPolicyActions(policy).contains(ACCESS_READ_PERSONA_METADATA)) {
+                if (policyActions.contains(ACCESS_READ_PERSONA_METADATA)) {
 
                     String connectionQName = getPolicyConnectionQN(policy);
                     if (StringUtils.isEmpty(connectionQName)) {
@@ -237,12 +239,12 @@ public class ESAliasStore implements IndexAliasStore {
 
                     terms.add(connectionQName);
 
-                } else if (getPolicyActions(policy).contains(ACCESS_READ_PERSONA_GLOSSARY)) {
+                } else if (policyActions.contains(ACCESS_READ_PERSONA_GLOSSARY)) {
                     if (CollectionUtils.isNotEmpty(assets)) {
                         terms.addAll(assets);
                         glossaryQualifiedNames.addAll(assets);
                     }
-                } else if (getPolicyActions(policy).contains(ACCESS_READ_PERSONA_DOMAIN)) {
+                } else if (policyActions.contains(ACCESS_READ_PERSONA_DOMAIN)) {
                     for (String asset : assets) {
                         if(!isAllDomain(asset)) {
                             terms.add(asset);
@@ -252,7 +254,7 @@ public class ESAliasStore implements IndexAliasStore {
                         allowClauseList.add(mapOf("wildcard", mapOf(QUALIFIED_NAME, asset + "*")));
                     }
 
-                } else if (getPolicyActions(policy).contains(ACCESS_READ_PERSONA_SUB_DOMAIN)) {
+                } else if (policyActions.contains(ACCESS_READ_PERSONA_SUB_DOMAIN)) {
                     for (String asset : assets) {
                         //terms.add(asset);
                         List<Map<String, Object>> mustMap = new ArrayList<>();
@@ -261,7 +263,7 @@ public class ESAliasStore implements IndexAliasStore {
                         allowClauseList.add(mapOf("bool", mapOf("must", mustMap)));
                     }
 
-                } else if (getPolicyActions(policy).contains(ACCESS_READ_PERSONA_PRODUCT)) {
+                } else if (policyActions.contains(ACCESS_READ_PERSONA_PRODUCT)) {
                     for (String asset : assets) {
                         //terms.add(asset);
                         List<Map<String, Object>> mustMap = new ArrayList<>();
@@ -269,10 +271,10 @@ public class ESAliasStore implements IndexAliasStore {
                         mustMap.add(mapOf("term", mapOf("__typeName.keyword", "DataProduct")));
                         allowClauseList.add(mapOf("bool", mapOf("must", mustMap)));
                     }
-                } else if (getPolicyActions(policy).contains(ACCESS_READ_PERSONA_AI_ASSET)) {
+                } else if (policyActions.contains(ACCESS_READ_PERSONA_AI_ASSET)) {
                     List<String> resources = getPolicyResources(policy);
                     List<String> typeResources = getFilteredPolicyResources(resources, RESOURCES_ENTITY_TYPE);
-                    if (typeResources.size() > 0) {
+                    if (CollectionUtils.isNotEmpty(typeResources)) {
                         List<String> typeTerms = new ArrayList<>();
                         List<Map<String, Object>> mustMap = new ArrayList<>();
                         if (typeResources.contains(AI_APPLICATION)) {
@@ -281,14 +283,14 @@ public class ESAliasStore implements IndexAliasStore {
                         if (typeResources.contains(AI_MODEL)) {
                             typeTerms.add(AI_MODEL);
                         }
-                        if (typeTerms.size() > 0) {
+                        if (CollectionUtils.isNotEmpty(typeTerms)) {
                             mustMap.add(mapOf("terms", mapOf("__typeName.keyword", typeTerms)));
                             allowClauseList.add(mapOf("bool", mapOf("must", mustMap)));
                         }
                     }
                     
                     for (String asset : assets) {
-                        if (asset.length() > 0) {
+                        if (StringUtils.isNotEmpty(asset)) {
                             List<Map<String, Object>> mustMap = new ArrayList<>();
                             mustMap.add(mapOf("wildcard", mapOf(QUALIFIED_NAME, asset)));
                             mustMap.add(mapOf("terms", mapOf("__typeName.keyword", Arrays.asList(AI_APPLICATION, AI_MODEL))));

--- a/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
@@ -56,7 +56,8 @@ import static org.apache.atlas.repository.util.AccessControlUtils.ACCESS_READ_PE
 import static org.apache.atlas.repository.util.AccessControlUtils.ACCESS_READ_PERSONA_GLOSSARY;
 import static org.apache.atlas.repository.util.AccessControlUtils.ACCESS_READ_PERSONA_PRODUCT;
 import static org.apache.atlas.repository.util.AccessControlUtils.ACCESS_READ_PERSONA_SUB_DOMAIN;
-import static org.apache.atlas.repository.util.AccessControlUtils.ACCESS_READ_PERSONA_AI_ASSET;
+import static org.apache.atlas.repository.util.AccessControlUtils.ACCESS_READ_PERSONA_AI_APP;
+import static org.apache.atlas.repository.util.AccessControlUtils.ACCESS_READ_PERSONA_AI_MODEL;
 import static org.apache.atlas.repository.util.AccessControlUtils.RESOURCES_ENTITY_TYPE;
 import static org.apache.atlas.repository.util.AccessControlUtils.getConnectionQualifiedNameFromPolicyAssets;
 import static org.apache.atlas.repository.util.AccessControlUtils.getESAliasName;
@@ -271,7 +272,7 @@ public class ESAliasStore implements IndexAliasStore {
                         mustMap.add(mapOf("term", mapOf("__typeName.keyword", "DataProduct")));
                         allowClauseList.add(mapOf("bool", mapOf("must", mustMap)));
                     }
-                } else if (policyActions.contains(ACCESS_READ_PERSONA_AI_ASSET)) {
+                } else if (policyActions.contains(ACCESS_READ_PERSONA_AI_APP) || policyActions.contains(ACCESS_READ_PERSONA_AI_MODEL)) {
                     List<String> resources = getPolicyResources(policy);
                     List<String> typeResources = getFilteredPolicyResources(resources, RESOURCES_ENTITY_TYPE);
                     if (CollectionUtils.isNotEmpty(typeResources)) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/AuthPolicyPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/AuthPolicyPreProcessor.java
@@ -122,7 +122,7 @@ public class AuthPolicyPreProcessor implements PreProcessor {
         if (POLICY_CATEGORY_PERSONA.equals(policyCategory)) {
             String policySubCategory = getPolicySubCategory(policy);
 
-            if (!POLICY_SUB_CATEGORY_DOMAIN.equals(policySubCategory)) {
+            if (!POLICY_SUB_CATEGORY_DOMAIN.equals(policySubCategory) && !POLICY_SUB_CATEGORY_AI.equals(policySubCategory)) {
                 validator.validate(policy, null, parentEntity, CREATE);
                 validateConnectionAdmin(policy);
             } else {
@@ -201,7 +201,7 @@ public class AuthPolicyPreProcessor implements PreProcessor {
 
             String policySubCategory = getPolicySubCategory(policy);
 
-            if (!POLICY_SUB_CATEGORY_DOMAIN.equals(policySubCategory)) {
+            if (!POLICY_SUB_CATEGORY_DOMAIN.equals(policySubCategory) && !POLICY_SUB_CATEGORY_AI.equals(policySubCategory)) {
                 validator.validate(policy, existingPolicy, parentEntity, UPDATE);
                 validateConnectionAdmin(policy);
             } else {
@@ -246,6 +246,8 @@ public class AuthPolicyPreProcessor implements PreProcessor {
             parent.addReferredEntity(policy);
 
         } else if (POLICY_CATEGORY_DATAMESH.equals(policyCategory)) {
+            validator.validate(policy, existingPolicy, null, UPDATE);
+        } else if (POLICY_CATEGORY_AI.equals(policyCategory)) {
             validator.validate(policy, existingPolicy, null, UPDATE);
         } else {
             validator.validate(policy, null, null, UPDATE);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/AuthPolicyPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/AuthPolicyPreProcessor.java
@@ -247,8 +247,6 @@ public class AuthPolicyPreProcessor implements PreProcessor {
 
         } else if (POLICY_CATEGORY_DATAMESH.equals(policyCategory)) {
             validator.validate(policy, existingPolicy, null, UPDATE);
-        } else if (POLICY_CATEGORY_AI.equals(policyCategory)) {
-            validator.validate(policy, existingPolicy, null, UPDATE);
         } else {
             validator.validate(policy, null, null, UPDATE);
         }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/AuthPolicyPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/AuthPolicyPreProcessor.java
@@ -122,7 +122,7 @@ public class AuthPolicyPreProcessor implements PreProcessor {
         if (POLICY_CATEGORY_PERSONA.equals(policyCategory)) {
             String policySubCategory = getPolicySubCategory(policy);
 
-            if (!POLICY_SUB_CATEGORY_DOMAIN.equals(policySubCategory) && !POLICY_SUB_CATEGORY_AI.equals(policySubCategory)) {
+            if (!POLICY_SUB_CATEGORY_DOMAIN.equals(policySubCategory)) {
                 validator.validate(policy, null, parentEntity, CREATE);
                 validateConnectionAdmin(policy);
             } else {
@@ -201,7 +201,7 @@ public class AuthPolicyPreProcessor implements PreProcessor {
 
             String policySubCategory = getPolicySubCategory(policy);
 
-            if (!POLICY_SUB_CATEGORY_DOMAIN.equals(policySubCategory) && !POLICY_SUB_CATEGORY_AI.equals(policySubCategory)) {
+            if (!POLICY_SUB_CATEGORY_DOMAIN.equals(policySubCategory)) {
                 validator.validate(policy, existingPolicy, parentEntity, UPDATE);
                 validateConnectionAdmin(policy);
             } else {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/AuthPolicyValidator.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/AuthPolicyValidator.java
@@ -151,7 +151,7 @@ public class AuthPolicyValidator {
             policyCategory = getPolicyCategory(existingPolicy);
         }
 
-        if (POLICY_CATEGORY_PERSONA.equals(policyCategory) || POLICY_CATEGORY_PURPOSE.equals(policyCategory) || POLICY_CATEGORY_DATAMESH.equals(policyCategory)|| POLICY_CATEGORY_AI.equals(policyCategory)) {
+        if (POLICY_CATEGORY_PERSONA.equals(policyCategory) || POLICY_CATEGORY_PURPOSE.equals(policyCategory) || POLICY_CATEGORY_DATAMESH.equals(policyCategory)) {
 
             if (operation == CREATE) {
                 String policySubCategory = getPolicySubCategory(policy);
@@ -230,18 +230,6 @@ public class AuthPolicyValidator {
 
                     //validate datamesh policy actions
                     Set<String> validActions = DATAMESH_POLICY_VALID_ACTIONS.get(policySubCategory);
-                    List<String> copyOfActions = new ArrayList<>(policyActions);
-                    copyOfActions.removeAll(validActions);
-                    validateParam (CollectionUtils.isNotEmpty(copyOfActions),
-                            "Please provide valid values for attribute " + ATTR_POLICY_ACTIONS + ": Invalid actions "+ copyOfActions);
-                }
-
-                if (POLICY_CATEGORY_AI.equals(policyCategory)) {
-                    validateParam (!AI_POLICY_VALID_SUB_CATEGORIES.contains(policySubCategory),
-                            "Please provide valid value for attribute " + ATTR_POLICY_SUB_CATEGORY + ":"+ AI_POLICY_VALID_SUB_CATEGORIES);
-
-                    //validate ai policy actions
-                    Set<String> validActions = AI_POLICY_VALID_ACTIONS.get(policySubCategory);
                     List<String> copyOfActions = new ArrayList<>(policyActions);
                     copyOfActions.removeAll(validActions);
                     validateParam (CollectionUtils.isNotEmpty(copyOfActions),
@@ -333,18 +321,6 @@ public class AuthPolicyValidator {
 
                 }
 
-                if (POLICY_CATEGORY_AI.equals(policyCategory)) {
-                    validateParam (!AI_POLICY_VALID_SUB_CATEGORIES.contains(policySubCategory),
-                            "Please provide valid value for attribute " + ATTR_POLICY_SUB_CATEGORY + ":"+ AI_POLICY_VALID_SUB_CATEGORIES);
-
-                    //validate ai policy actions
-                    Set<String> validActions = AI_POLICY_VALID_ACTIONS.get(policySubCategory);
-                    List<String> copyOfActions = new ArrayList<>(policyActions);
-                    copyOfActions.removeAll(validActions);
-                    validateParam (CollectionUtils.isNotEmpty(copyOfActions),
-                            "Please provide valid values for attribute " + ATTR_POLICY_ACTIONS + ": Invalid actions "+ copyOfActions);
-
-                }
             }
 
         } else {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/AuthPolicyValidator.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/AuthPolicyValidator.java
@@ -86,17 +86,29 @@ public class AuthPolicyValidator {
     }};
 
     private static final Set<String> AI_POLICY_ACTIONS = new HashSet<String>(){{
-        add("persona-aiasset-read");
-        add("persona-aiasset-create");
-        add("persona-aiasset-update");
-        add("persona-aiasset-delete");
-        add("persona-aiasset-business-update-metadata");
-        add("persona-aiasset-add-terms");
-        add("persona-aiasset-update-terms");
-        add("persona-aiasset-remove-terms");
-        add("persona-aiasset-add-classification");
-        add("persona-aiasset-update-classification");
-        add("persona-aiasset-remove-classification"); 
+        add("persona-ai-application-read");
+        add("persona-ai-application-create");
+        add("persona-ai-application-update");
+        add("persona-ai-application-delete");
+        add("persona-ai-application-business-update-metadata");
+        add("persona-ai-application-add-terms");
+        add("persona-ai-application-update-terms");
+        add("persona-ai-application-remove-terms");
+        add("persona-ai-application-add-classification");
+        add("persona-ai-application-update-classification");
+        add("persona-ai-application-remove-classification"); 
+
+        add("persona-ai-model-read");
+        add("persona-ai-model-create");
+        add("persona-ai-model-update");
+        add("persona-ai-model-delete");
+        add("persona-ai-model-business-update-metadata");
+        add("persona-ai-model-add-terms");
+        add("persona-ai-model-update-terms");
+        add("persona-ai-model-remove-terms");
+        add("persona-ai-model-add-classification");
+        add("persona-ai-model-update-classification");
+        add("persona-ai-model-remove-classification"); 
     }};
 
     private static final Map<String, Set<String>> PERSONA_POLICY_VALID_ACTIONS = new HashMap<String, Set<String>>(){{

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/AuthPolicyValidator.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/AuthPolicyValidator.java
@@ -45,6 +45,7 @@ public class AuthPolicyValidator {
         add(POLICY_SUB_CATEGORY_METADATA);
         add(POLICY_SUB_CATEGORY_DATA);
         add(POLICY_SUB_CATEGORY_GLOSSARY);
+        add(POLICY_SUB_CATEGORY_AI);
     }};
 
     private static final Set<String> PURPOSE_POLICY_VALID_SUB_CATEGORIES = new HashSet<String>(){{
@@ -54,10 +55,6 @@ public class AuthPolicyValidator {
 
     private static final Set<String> DATAMESH_POLICY_VALID_SUB_CATEGORIES = new HashSet<String>(){{
         add(POLICY_SUB_CATEGORY_PRODUCT);
-    }};
-
-    private static final Set<String> AI_POLICY_VALID_SUB_CATEGORIES = new HashSet<String>(){{
-        add(POLICY_SUB_CATEGORY_AI);
     }};
 
     private static final Set<String> PERSONA_METADATA_POLICY_ACTIONS = new HashSet<String>(){{
@@ -88,10 +85,25 @@ public class AuthPolicyValidator {
         add("persona-glossary-delete-classifications");
     }};
 
+    private static final Set<String> AI_POLICY_ACTIONS = new HashSet<String>(){{
+        add("persona-aiasset-read");
+        add("persona-aiasset-create");
+        add("persona-aiasset-update");
+        add("persona-aiasset-delete");
+        add("persona-aiasset-business-update-metadata");
+        add("persona-aiasset-add-terms");
+        add("persona-aiasset-update-terms");
+        add("persona-aiasset-remove-terms");
+        add("persona-aiasset-add-classification");
+        add("persona-aiasset-update-classification");
+        add("persona-aiasset-remove-classification"); 
+    }};
+
     private static final Map<String, Set<String>> PERSONA_POLICY_VALID_ACTIONS = new HashMap<String, Set<String>>(){{
         put(POLICY_SUB_CATEGORY_METADATA, PERSONA_METADATA_POLICY_ACTIONS);
         put(POLICY_SUB_CATEGORY_DATA, DATA_POLICY_ACTIONS);
         put(POLICY_SUB_CATEGORY_GLOSSARY, PERSONA_GLOSSARY_POLICY_ACTIONS);
+        put(POLICY_SUB_CATEGORY_AI, AI_POLICY_ACTIONS);
     }};
 
     private static final Set<String> PURPOSE_METADATA_POLICY_ACTIONS = new HashSet<String>(){{
@@ -115,21 +127,6 @@ public class AuthPolicyValidator {
 
     private static final Set<String> DATAMESH_POLICY_ACTIONS = new HashSet<String>(){{
         add(ENTITY_READ.getType());
-    }};
-
-    private static final Set<String> AI_POLICY_ACTIONS = new HashSet<String>(){{
-        add(ENTITY_READ.getType());
-        add("persona-aiasset-read");
-        add("persona-aiasset-create");
-        add("persona-aiasset-update");
-        add("persona-aiasset-delete");
-        add("persona-aiasset-business-update-metadata");
-        add("persona-aiasset-add-terms");
-        add("persona-aiasset-update-terms");
-        add("persona-aiasset-remove-terms");
-        add("persona-aiasset-add-classification");
-        add("persona-aiasset-update-classification");
-        add("persona-aiasset-remove-classification"); 
     }};
 
     private static final Map<String, Set<String>> DATAMESH_POLICY_VALID_ACTIONS = new HashMap<String, Set<String>>(){{

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/AuthPolicyValidator.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/AuthPolicyValidator.java
@@ -92,10 +92,8 @@ public class AuthPolicyValidator {
         add("persona-ai-application-delete");
         add("persona-ai-application-business-update-metadata");
         add("persona-ai-application-add-terms");
-        add("persona-ai-application-update-terms");
         add("persona-ai-application-remove-terms");
         add("persona-ai-application-add-classification");
-        add("persona-ai-application-update-classification");
         add("persona-ai-application-remove-classification"); 
 
         add("persona-ai-model-read");
@@ -104,10 +102,8 @@ public class AuthPolicyValidator {
         add("persona-ai-model-delete");
         add("persona-ai-model-business-update-metadata");
         add("persona-ai-model-add-terms");
-        add("persona-ai-model-update-terms");
         add("persona-ai-model-remove-terms");
         add("persona-ai-model-add-classification");
-        add("persona-ai-model-update-classification");
         add("persona-ai-model-remove-classification"); 
     }};
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/AuthPolicyValidator.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/AuthPolicyValidator.java
@@ -56,6 +56,10 @@ public class AuthPolicyValidator {
         add(POLICY_SUB_CATEGORY_PRODUCT);
     }};
 
+    private static final Set<String> AI_POLICY_VALID_SUB_CATEGORIES = new HashSet<String>(){{
+        add(POLICY_SUB_CATEGORY_AI);
+    }};
+
     private static final Set<String> PERSONA_METADATA_POLICY_ACTIONS = new HashSet<String>(){{
         add("persona-asset-read");
         add("persona-asset-update");
@@ -113,6 +117,21 @@ public class AuthPolicyValidator {
         add(ENTITY_READ.getType());
     }};
 
+    private static final Set<String> AI_POLICY_ACTIONS = new HashSet<String>(){{
+        add(ENTITY_READ.getType());
+        add("persona-aiasset-read");
+        add("persona-aiasset-create");
+        add("persona-aiasset-update");
+        add("persona-aiasset-delete");
+        add("persona-aiasset-business-update-metadata");
+        add("persona-aiasset-add-terms");
+        add("persona-aiasset-update-terms");
+        add("persona-aiasset-remove-terms");
+        add("persona-aiasset-add-classification");
+        add("persona-aiasset-update-classification");
+        add("persona-aiasset-remove-classification"); 
+    }};
+
     private static final Map<String, Set<String>> DATAMESH_POLICY_VALID_ACTIONS = new HashMap<String, Set<String>>(){{
         put(POLICY_SUB_CATEGORY_PRODUCT, DATAMESH_POLICY_ACTIONS);
     }};
@@ -132,7 +151,7 @@ public class AuthPolicyValidator {
             policyCategory = getPolicyCategory(existingPolicy);
         }
 
-        if (POLICY_CATEGORY_PERSONA.equals(policyCategory) || POLICY_CATEGORY_PURPOSE.equals(policyCategory) || POLICY_CATEGORY_DATAMESH.equals(policyCategory)) {
+        if (POLICY_CATEGORY_PERSONA.equals(policyCategory) || POLICY_CATEGORY_PURPOSE.equals(policyCategory) || POLICY_CATEGORY_DATAMESH.equals(policyCategory)|| POLICY_CATEGORY_AI.equals(policyCategory)) {
 
             if (operation == CREATE) {
                 String policySubCategory = getPolicySubCategory(policy);
@@ -217,6 +236,18 @@ public class AuthPolicyValidator {
                             "Please provide valid values for attribute " + ATTR_POLICY_ACTIONS + ": Invalid actions "+ copyOfActions);
                 }
 
+                if (POLICY_CATEGORY_AI.equals(policyCategory)) {
+                    validateParam (!AI_POLICY_VALID_SUB_CATEGORIES.contains(policySubCategory),
+                            "Please provide valid value for attribute " + ATTR_POLICY_SUB_CATEGORY + ":"+ AI_POLICY_VALID_SUB_CATEGORIES);
+
+                    //validate ai policy actions
+                    Set<String> validActions = AI_POLICY_VALID_ACTIONS.get(policySubCategory);
+                    List<String> copyOfActions = new ArrayList<>(policyActions);
+                    copyOfActions.removeAll(validActions);
+                    validateParam (CollectionUtils.isNotEmpty(copyOfActions),
+                            "Please provide valid values for attribute " + ATTR_POLICY_ACTIONS + ": Invalid actions "+ copyOfActions);
+                }
+
             } else {
 
                 validateOperation (StringUtils.isNotEmpty(policyCategory) && !policyCategory.equals(getPolicyCategory(existingPolicy)),
@@ -295,6 +326,19 @@ public class AuthPolicyValidator {
 
                     //validate datamesh policy actions
                     Set<String> validActions = DATAMESH_POLICY_VALID_ACTIONS.get(policySubCategory);
+                    List<String> copyOfActions = new ArrayList<>(policyActions);
+                    copyOfActions.removeAll(validActions);
+                    validateParam (CollectionUtils.isNotEmpty(copyOfActions),
+                            "Please provide valid values for attribute " + ATTR_POLICY_ACTIONS + ": Invalid actions "+ copyOfActions);
+
+                }
+
+                if (POLICY_CATEGORY_AI.equals(policyCategory)) {
+                    validateParam (!AI_POLICY_VALID_SUB_CATEGORIES.contains(policySubCategory),
+                            "Please provide valid value for attribute " + ATTR_POLICY_SUB_CATEGORY + ":"+ AI_POLICY_VALID_SUB_CATEGORIES);
+
+                    //validate ai policy actions
+                    Set<String> validActions = AI_POLICY_VALID_ACTIONS.get(policySubCategory);
                     List<String> copyOfActions = new ArrayList<>(policyActions);
                     copyOfActions.removeAll(validActions);
                     validateParam (CollectionUtils.isNotEmpty(copyOfActions),

--- a/repository/src/main/java/org/apache/atlas/repository/util/AccessControlUtils.java
+++ b/repository/src/main/java/org/apache/atlas/repository/util/AccessControlUtils.java
@@ -99,7 +99,6 @@ public final class AccessControlUtils {
     public static final String POLICY_CATEGORY_PERSONA  = "persona";
     public static final String POLICY_CATEGORY_PURPOSE  = "purpose";
     public static final String POLICY_CATEGORY_DATAMESH = "datamesh";
-    public static final String POLICY_CATEGORY_AI = "ai";
     public static final String POLICY_CATEGORY_BOOTSTRAP  = "bootstrap";
 
     public static final String POLICY_SUB_CATEGORY_COLLECTION = "collection";

--- a/repository/src/main/java/org/apache/atlas/repository/util/AccessControlUtils.java
+++ b/repository/src/main/java/org/apache/atlas/repository/util/AccessControlUtils.java
@@ -93,10 +93,13 @@ public final class AccessControlUtils {
     public static final String ACCESS_READ_PERSONA_DOMAIN = "persona-domain-read";
     public static final String ACCESS_READ_PERSONA_SUB_DOMAIN = "persona-domain-sub-domain-read";
     public static final String ACCESS_READ_PERSONA_PRODUCT = "persona-domain-product-read";
+    public static final String ACCESS_READ_PERSONA_AI_ASSET = "persona-aiasset-read";
+
 
     public static final String POLICY_CATEGORY_PERSONA  = "persona";
     public static final String POLICY_CATEGORY_PURPOSE  = "purpose";
     public static final String POLICY_CATEGORY_DATAMESH = "datamesh";
+    public static final String POLICY_CATEGORY_AI = "ai";
     public static final String POLICY_CATEGORY_BOOTSTRAP  = "bootstrap";
 
     public static final String POLICY_SUB_CATEGORY_COLLECTION = "collection";
@@ -110,6 +113,7 @@ public final class AccessControlUtils {
     public static final String POLICY_SUB_CATEGORY_DOMAIN  = "domain";
     public static final String POLICY_SUB_CATEGORY_DATA  = "data";
     public static final String POLICY_SUB_CATEGORY_PRODUCT  = "dataProduct";
+    public static final String POLICY_SUB_CATEGORY_AI = "ai";
 
     public static final String RESOURCES_ENTITY = "entity:";
     public static final String RESOURCES_ENTITY_TYPE = "entity-type:";

--- a/repository/src/main/java/org/apache/atlas/repository/util/AccessControlUtils.java
+++ b/repository/src/main/java/org/apache/atlas/repository/util/AccessControlUtils.java
@@ -93,7 +93,8 @@ public final class AccessControlUtils {
     public static final String ACCESS_READ_PERSONA_DOMAIN = "persona-domain-read";
     public static final String ACCESS_READ_PERSONA_SUB_DOMAIN = "persona-domain-sub-domain-read";
     public static final String ACCESS_READ_PERSONA_PRODUCT = "persona-domain-product-read";
-    public static final String ACCESS_READ_PERSONA_AI_ASSET = "persona-aiasset-read";
+    public static final String ACCESS_READ_PERSONA_AI_APP = "persona-ai-application-read";
+    public static final String ACCESS_READ_PERSONA_AI_MODEL = "persona-ai-model-read";
 
 
     public static final String POLICY_CATEGORY_PERSONA  = "persona";


### PR DESCRIPTION
## Change description

> Persona support for AI assets (`policySubCategory-AI`)
> AI assets typedefs [here](https://github.com/atlanhq/models/pull/1385/files)
> qualifiedName pattern- `default/ai/aiapplication/{uuid}, default/ai/aimodel/{uuid}`
> Details on test cases [here](https://atlanhq.atlassian.net/wiki/spaces/dg/pages/762216981/AI+Governance+Persona+Test+Cases)

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
