### PR TITLE
MLH-213 | Reuse cassandra optimization across indexsearch

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,7 +27,7 @@ on:
       - development
       - master
       - lineageondemand
-      - cassandrapoliciesoptimisation
+      - cassaop
       - ixop
 
 jobs:

--- a/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
@@ -126,6 +126,7 @@ public enum AtlasConfiguration {
     ATLAS_INDEXSEARCH_ENABLE_API_LIMIT("atlas.indexsearch.enable.api.limit", false),
     ATLAS_INDEXSEARCH_ENABLE_JANUS_OPTIMISATION("atlas.indexsearch.enable.janus.optimization", false),
     ATLAS_INDEXSEARCH_ENABLE_JANUS_OPTIMISATION_FOR_RELATIONS("atlas.indexsearch.enable.janus.optimization.for.relationship", false),
+    ATLAS_INDEXSEARCH_ENABLE_JANUS_OPTIMISATION_EXTENDED("atlas.indexsearch.enable.janus.optimization.extended", false),
     ATLAS_MAINTENANCE_MODE("atlas.maintenance.mode", false),
     DELTA_BASED_REFRESH_ENABLED("atlas.authorizer.enable.delta_based_refresh", false),
 

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -2056,7 +2056,7 @@ public final class GraphHelper {
         }
     }
 
-    private static Set<String> parseLabelsString(String labels) {
+    public static Set<String> parseLabelsString(String labels) {
         Set<String> ret = new HashSet<>();
 
         if (StringUtils.isNotEmpty(labels)) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -1525,7 +1525,7 @@ public class EntityGraphRetriever {
         return ret;
     }
 
-    public List<AtlasTermAssignmentHeader> mapAssignedTerms(AtlasVertex entityVertex) {
+    public List<AtlasTermAssignmentHeader> mapAssignedTerms(AtlasVertex entityVertex) throws AtlasBaseException {
         List<AtlasTermAssignmentHeader> ret = new ArrayList<>();
 
         Iterable edges = entityVertex.query().direction(AtlasEdgeDirection.IN).label(TERM_ASSIGNMENT_LABEL).edges();

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -1047,14 +1047,10 @@ public class EntityGraphRetriever {
                 retrieveEdgeLabels(entityVertex, attributes, relationshipsLookup, propertiesMap);
             }
 
-            // don't fetch relation properties for non entityType
-            // rather directly put a marker for passed attribute
-            // as attributes are passed by BE to load complex attributes
-            if (!(structType instanceof AtlasEntityType)) {
-                attributes.forEach(attribute -> {
-                    propertiesMap.putIfAbsent(attribute, StringUtils.SPACE);
-                });
-            }
+            // for attributes that are complexType and passed by BE, set them to empty string
+            attributes.forEach(attribute -> {
+                propertiesMap.putIfAbsent(attribute, StringUtils.SPACE);
+            });
 
             // Iterate through the resulting VertexProperty objects
             while (traversal.hasNext()) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -1565,8 +1565,10 @@ public class EntityGraphRetriever {
             String typeName = edge.getProperty(Constants.TYPE_NAME_PROPERTY_KEY, String.class); //properties.get returns null
             AtlasEntityType entityType = typeRegistry.getEntityTypeByName(typeName);
             Map<String, Object> referenceProperties = preloadProperties(termVertex, entityType, Collections.emptySet(), false);
-            String relationGuid = referenceProperties.get(Constants.RELATIONSHIP_GUID_PROPERTY_KEY) != null ? (String) referenceProperties.get(Constants.RELATIONSHIP_GUID_PROPERTY_KEY) : null;
-            if (StringUtils.isNotEmpty(relationGuid)) {
+
+            //relationshipGuid is not retrieved via referenceProperties
+            String relationGuid = edge.getProperty(Constants.RELATIONSHIP_GUID_PROPERTY_KEY, String.class);
+            if (relationGuid != null) {
                 ret.setRelationGuid(relationGuid);
             }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -1048,9 +1048,12 @@ public class EntityGraphRetriever {
             }
 
             // for attributes that are complexType and passed by BE, set them to empty string
-            attributes.forEach(attribute -> {
-                propertiesMap.putIfAbsent(attribute, StringUtils.SPACE);
-            });
+            if (!fetchEdgeLabels){
+                attributes.forEach(attribute -> {
+                    propertiesMap.putIfAbsent(attribute, StringUtils.SPACE);
+                });
+
+            }
 
             // Iterate through the resulting VertexProperty objects
             while (traversal.hasNext()) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -54,6 +54,7 @@ import org.apache.atlas.repository.util.AccessControlUtils;
 import org.apache.atlas.type.AtlasArrayType;
 import org.apache.atlas.type.AtlasBuiltInTypes.AtlasObjectIdType;
 import org.apache.atlas.type.AtlasBusinessMetadataType.AtlasBusinessAttribute;
+import org.apache.atlas.type.AtlasClassificationType;
 import org.apache.atlas.type.AtlasEntityType;
 import org.apache.atlas.type.AtlasMapType;
 import org.apache.atlas.type.AtlasRelationshipType;
@@ -1044,6 +1045,14 @@ public class EntityGraphRetriever {
                 //  retrieve all the valid relationships for this entityType
                 Map<String, Set<String>> relationshipsLookup = fetchEdgeNames((AtlasEntityType) structType);
                 retrieveEdgeLabels(entityVertex, attributes, relationshipsLookup, propertiesMap);
+            }
+
+            // Fetch relation properties for classification
+            // attributes are passed by BE to load complex attributes
+            if (structType instanceof AtlasClassificationType) {
+                attributes.forEach(attribute -> {
+                    propertiesMap.putIfAbsent(attribute, StringUtils.SPACE);
+                });
             }
 
             // Iterate through the resulting VertexProperty objects

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -1049,7 +1049,7 @@ public class EntityGraphRetriever {
             // Iterate through the resulting VertexProperty objects
             while (traversal.hasNext()) {
                 try {
-                    Property<Object> property = traversal.next();
+                    VertexProperty<Object> property = traversal.next();
 
                     AtlasAttribute attribute = structType.getAttribute(property.key()) != null ? structType.getAttribute(property.key()) : null;
                     TypeCategory typeCategory = attribute != null ? attribute.getAttributeType().getTypeCategory() : null;
@@ -1117,7 +1117,7 @@ public class EntityGraphRetriever {
         }
 
     }
-    private void updateAttrValue( Map<String, Object> propertiesMap, Property<Object> property){
+    private void updateAttrValue( Map<String, Object> propertiesMap, VertexProperty<Object> property){
         Object value = propertiesMap.get(property.key());
         if (value instanceof List) {
             ((List) value).add(property.value());

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -393,7 +393,7 @@ public class EntityGraphRetriever {
                 ret.setRemovePropagationsOnEntityDelete(referenceProperties.get(CLASSIFICATION_VERTEX_REMOVE_PROPAGATIONS_KEY) != null ? (Boolean) referenceProperties.get(CLASSIFICATION_VERTEX_REMOVE_PROPAGATIONS_KEY) : true);
                 ret.setRestrictPropagationThroughLineage(referenceProperties.get(CLASSIFICATION_VERTEX_RESTRICT_PROPAGATE_THROUGH_LINEAGE) != null ? (Boolean) referenceProperties.get(CLASSIFICATION_VERTEX_RESTRICT_PROPAGATE_THROUGH_LINEAGE) : false);
                 ret.setRestrictPropagationThroughHierarchy(referenceProperties.get(CLASSIFICATION_VERTEX_RESTRICT_PROPAGATE_THROUGH_HIERARCHY) != null ? (Boolean) referenceProperties.get(CLASSIFICATION_VERTEX_RESTRICT_PROPAGATE_THROUGH_HIERARCHY) : false);
-                strValidityPeriods = (String) referenceProperties.get(CLASSIFICATION_VALIDITY_PERIODS_KEY);
+                strValidityPeriods = referenceProperties.get(CLASSIFICATION_VALIDITY_PERIODS_KEY)!=null ? (String) referenceProperties.get(CLASSIFICATION_VALIDITY_PERIODS_KEY) : null;
             } else {
                 ret.setEntityGuid(AtlasGraphUtilsV2.getEncodedProperty(classificationVertex, CLASSIFICATION_ENTITY_GUID, String.class));
                 ret.setEntityStatus(getClassificationEntityStatus(classificationVertex));
@@ -1397,11 +1397,11 @@ public class EntityGraphRetriever {
                 if (enableJanusOptimization) {
                     String typeName = entityVertex.getProperty(Constants.TYPE_NAME_PROPERTY_KEY, String.class);
                     AtlasEntityType entityType = typeRegistry.getEntityTypeByName(typeName);
-                    Map<String, Object> properties = preloadProperties(entityVertex,  entityType, Collections.emptySet(), false);
+                    Map<String, Object> properties = preloadProperties(entityVertex, entityType, Collections.emptySet(), false);
 
                     entity.setGuid((String) properties.get(GUID_PROPERTY_KEY));
                     entity.setTypeName(typeName);
-                    String state = (String)properties.get(Constants.STATE_PROPERTY_KEY);
+                    String state = (String) properties.get(Constants.STATE_PROPERTY_KEY);
                     Id.EntityState entityState = state == null ? null : Id.EntityState.valueOf(state);
                     entity.setStatus((entityState == Id.EntityState.DELETED) ? AtlasEntity.Status.DELETED : AtlasEntity.Status.ACTIVE);
                     entity.setVersion(properties.get(VERSION_PROPERTY_KEY) != null ? (Long) properties.get(VERSION_PROPERTY_KEY) : 0);
@@ -1409,26 +1409,26 @@ public class EntityGraphRetriever {
                     entity.setCreatedBy(properties.get(CREATED_BY_KEY) != null ? (String) properties.get(CREATED_BY_KEY) : null);
                     entity.setUpdatedBy(properties.get(MODIFIED_BY_KEY) != null ? (String) properties.get(MODIFIED_BY_KEY) : null);
 
-                    entity.setCreateTime(properties.get(TIMESTAMP_PROPERTY_KEY) != null ? new Date((Long)properties.get(TIMESTAMP_PROPERTY_KEY)) : null);
-                    entity.setUpdateTime(properties.get(MODIFICATION_TIMESTAMP_PROPERTY_KEY) != null ? new Date((Long)properties.get(MODIFICATION_TIMESTAMP_PROPERTY_KEY)) : null);
+                    entity.setCreateTime(properties.get(TIMESTAMP_PROPERTY_KEY) != null ? new Date((Long) properties.get(TIMESTAMP_PROPERTY_KEY)) : null);
+                    entity.setUpdateTime(properties.get(MODIFICATION_TIMESTAMP_PROPERTY_KEY) != null ? new Date((Long) properties.get(MODIFICATION_TIMESTAMP_PROPERTY_KEY)) : null);
 
 
                     entity.setHomeId(properties.get(HOME_ID_KEY) != null ? (String) properties.get(HOME_ID_KEY) : null);
 
                     entity.setIsProxy(properties.get(IS_PROXY_KEY) != null ? (Boolean) properties.get(IS_PROXY_KEY) : false);
-                    Integer value = (Integer)properties.get(Constants.IS_INCOMPLETE_PROPERTY_KEY);
-                    Boolean isIncomplete = value != null && value.equals(INCOMPLETE_ENTITY_VALUE) ? Boolean.TRUE : Boolean.FALSE;
+                    Integer value = properties.get(Constants.IS_INCOMPLETE_PROPERTY_KEY) != null ? (Integer) properties.get(Constants.IS_INCOMPLETE_PROPERTY_KEY) : 0;
+                    Boolean isIncomplete = value.equals(INCOMPLETE_ENTITY_VALUE) ? Boolean.TRUE : Boolean.FALSE;
                     entity.setIsIncomplete(isIncomplete);
 
                     entity.setProvenanceType(properties.get(PROVENANCE_TYPE_KEY) != null ? (int) properties.get(PROVENANCE_TYPE_KEY) : 0);
-                    String customAttrsString = (String) properties.get(CUSTOM_ATTRIBUTES_PROPERTY_KEY);
-                    entity.setCustomAttributes(StringUtils.isNotEmpty(customAttrsString) ?  AtlasType.fromJson(customAttrsString, Map.class) : null);
+                    String customAttrsString = properties.get(CUSTOM_ATTRIBUTES_PROPERTY_KEY) != null ? (String) properties.get(CUSTOM_ATTRIBUTES_PROPERTY_KEY) : null;
+                    entity.setCustomAttributes(StringUtils.isNotEmpty(customAttrsString) ? AtlasType.fromJson(customAttrsString, Map.class) : null);
 
-                    String labels = (String) properties.get(LABELS_PROPERTY_KEY);
+                    String labels = properties.get(LABELS_PROPERTY_KEY) != null ? (String) properties.get(LABELS_PROPERTY_KEY) : null;
                     entity.setLabels(GraphHelper.parseLabelsString(labels));
-                    Object pendingTasks =  properties.get(PENDING_TASKS_PROPERTY_KEY);
+                    Object pendingTasks = properties.get(PENDING_TASKS_PROPERTY_KEY);
                     if (pendingTasks instanceof List) {
-                        entity.setPendingTasks(new HashSet<>( (List<String>) pendingTasks));
+                        entity.setPendingTasks(new HashSet<>((List<String>) pendingTasks));
                     }
 
                 } else {
@@ -1565,43 +1565,43 @@ public class EntityGraphRetriever {
             String typeName = edge.getProperty(Constants.TYPE_NAME_PROPERTY_KEY, String.class); //properties.get returns null
             AtlasEntityType entityType = typeRegistry.getEntityTypeByName(typeName);
             Map<String, Object> referenceProperties = preloadProperties(termVertex, entityType, Collections.emptySet(), false);
-            String relationGuid = (String) referenceProperties.get(Constants.RELATIONSHIP_GUID_PROPERTY_KEY);
+            String relationGuid = referenceProperties.get(Constants.RELATIONSHIP_GUID_PROPERTY_KEY) != null ? (String) referenceProperties.get(Constants.RELATIONSHIP_GUID_PROPERTY_KEY) : null;
             if (StringUtils.isNotEmpty(relationGuid)) {
                 ret.setRelationGuid(relationGuid);
             }
 
-            String description = (String) referenceProperties.get(TERM_ASSIGNMENT_ATTR_DESCRIPTION);
+            String description = referenceProperties.get(TERM_ASSIGNMENT_ATTR_DESCRIPTION) != null ? (String) referenceProperties.get(TERM_ASSIGNMENT_ATTR_DESCRIPTION) : null;
             if (StringUtils.isNotEmpty(description)) {
                 ret.setDescription(description);
             }
 
-            String expression = (String) referenceProperties.get(TERM_ASSIGNMENT_ATTR_EXPRESSION);
+            String expression = referenceProperties.get(TERM_ASSIGNMENT_ATTR_EXPRESSION) != null ? (String) referenceProperties.get(TERM_ASSIGNMENT_ATTR_EXPRESSION) : null;
             if (StringUtils.isNotEmpty(expression)) {
                 ret.setExpression(expression);
             }
 
-            String status = (String) referenceProperties.get(TERM_ASSIGNMENT_ATTR_STATUS);
+            String status = referenceProperties.get(TERM_ASSIGNMENT_ATTR_STATUS) != null ? (String) referenceProperties.get(TERM_ASSIGNMENT_ATTR_STATUS) : null;
             if (StringUtils.isNotEmpty(status)) {
                 AtlasTermAssignmentStatus assignmentStatus = AtlasTermAssignmentStatus.valueOf(status);
                 ret.setStatus(assignmentStatus);
             }
 
-            Integer confidence = (Integer) referenceProperties.get(TERM_ASSIGNMENT_ATTR_CONFIDENCE);
+            Integer confidence = referenceProperties.get(TERM_ASSIGNMENT_ATTR_CONFIDENCE) != null ? (Integer) referenceProperties.get(TERM_ASSIGNMENT_ATTR_CONFIDENCE) : null;
             if (Objects.nonNull(confidence)) {
                 ret.setConfidence(confidence);
             }
 
-            String createdBy = (String) referenceProperties.get(TERM_ASSIGNMENT_ATTR_CREATED_BY);
+            String createdBy = referenceProperties.get(TERM_ASSIGNMENT_ATTR_CREATED_BY) != null ? (String) referenceProperties.get(TERM_ASSIGNMENT_ATTR_CREATED_BY) : null;
             if (StringUtils.isNotEmpty(createdBy)) {
                 ret.setCreatedBy(createdBy);
             }
 
-            String steward = (String) referenceProperties.get(TERM_ASSIGNMENT_ATTR_STEWARD);
+            String steward = referenceProperties.get(TERM_ASSIGNMENT_ATTR_STEWARD) != null ? (String) referenceProperties.get(TERM_ASSIGNMENT_ATTR_STEWARD) : null;
             if (StringUtils.isNotEmpty(steward)) {
                 ret.setSteward(steward);
             }
 
-            String source = (String) referenceProperties.get(TERM_ASSIGNMENT_ATTR_SOURCE);
+            String source = referenceProperties.get(TERM_ASSIGNMENT_ATTR_SOURCE) != null ? (String) referenceProperties.get(TERM_ASSIGNMENT_ATTR_SOURCE) : null;
             if (StringUtils.isNotEmpty(source)) {
                 ret.setSource(source);
             }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -1047,9 +1047,10 @@ public class EntityGraphRetriever {
                 retrieveEdgeLabels(entityVertex, attributes, relationshipsLookup, propertiesMap);
             }
 
-            // Fetch relation properties for classification
-            // attributes are passed by BE to load complex attributes
-            if (structType instanceof AtlasClassificationType) {
+            // don't fetch relation properties for non entityType
+            // rather directly put a marker for passed attribute
+            // as attributes are passed by BE to load complex attributes
+            if (!(structType instanceof AtlasEntityType)) {
                 attributes.forEach(attribute -> {
                     propertiesMap.putIfAbsent(attribute, StringUtils.SPACE);
                 });

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -1524,7 +1524,7 @@ public class EntityGraphRetriever {
         return ret;
     }
 
-    public List<AtlasTermAssignmentHeader> mapAssignedTerms(AtlasVertex entityVertex) throws AtlasBaseException {
+    public List<AtlasTermAssignmentHeader> mapAssignedTerms(AtlasVertex entityVertex) {
         List<AtlasTermAssignmentHeader> ret = new ArrayList<>();
 
         Iterable edges = entityVertex.query().direction(AtlasEdgeDirection.IN).label(TERM_ASSIGNMENT_LABEL).edges();

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -385,7 +385,7 @@ public class EntityGraphRetriever {
             String strValidityPeriods;
 
             if (enableJanusOptimisation) {
-                referenceProperties = preloadProperties(classificationVertex, typeRegistry.getEntityTypeByName(classificationName), Collections.emptySet(), false);
+                referenceProperties = preloadProperties(classificationVertex, typeRegistry.getClassificationTypeByName(classificationName), Collections.emptySet(), false);
                 ret.setEntityGuid((String) referenceProperties.get(Constants.CLASSIFICATION_ENTITY_GUID));
                 ret.setEntityStatus(referenceProperties.get(Constants.CLASSIFICATION_ENTITY_STATUS) != null ?
                         AtlasEntity.Status.valueOf((String) referenceProperties.get(Constants.CLASSIFICATION_ENTITY_STATUS)) : null);
@@ -1025,31 +1025,25 @@ public class EntityGraphRetriever {
         return mapVertexToAtlasEntityHeader(entityVertex, Collections.<String>emptySet());
     }
 
-    private Map<String, Object> preloadProperties(AtlasElement atlasElement,  AtlasEntityType entityType, Set<String> attributes, boolean fetchEdgeLabels) throws AtlasBaseException {
+    private Map<String, Object> preloadProperties(AtlasVertex entityVertex,  AtlasStructType structType, Set<String> attributes, boolean fetchEdgeLabels) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("preloadProperties");
 
         try {
-            if (entityType == null) {
+            if (structType == null) {
                 return new HashMap<>();
             }
 
-            Iterator<? extends Property<Object>> traversal = null;
-
+            // Execute the traversal to fetch properties
+            Iterator<VertexProperty<Object>> traversal = ((AtlasJanusVertex)entityVertex).getWrappedElement().properties();
             Map<String, Object> propertiesMap = new HashMap<>();
-            if (atlasElement instanceof AtlasJanusVertex) {
-                traversal = ((AtlasJanusVertex) atlasElement).getWrappedElement().properties();
-            } else {
-                traversal = ((AtlasJanusEdge) atlasElement).getWrappedElement().properties();
-            }
-
 
             // Fetch edges in both directions
             // if the vertex in scope is root then call below otherwise skip
             // we don't support relation attributes of a relation
-            if (fetchEdgeLabels) {
+            if (fetchEdgeLabels && structType instanceof AtlasEntityType) {
                 //  retrieve all the valid relationships for this entityType
-                Map<String, Set<String>> relationshipsLookup = fetchEdgeNames(entityType);
-                retrieveEdgeLabels( (AtlasVertex) atlasElement, attributes, relationshipsLookup, propertiesMap);
+                Map<String, Set<String>> relationshipsLookup = fetchEdgeNames((AtlasEntityType) structType);
+                retrieveEdgeLabels(entityVertex, attributes, relationshipsLookup, propertiesMap);
             }
 
             // Iterate through the resulting VertexProperty objects
@@ -1057,7 +1051,7 @@ public class EntityGraphRetriever {
                 try {
                     Property<Object> property = traversal.next();
 
-                    AtlasAttribute attribute = entityType.getAttribute(property.key()) != null ? entityType.getAttribute(property.key()) : null;
+                    AtlasAttribute attribute = structType.getAttribute(property.key()) != null ? structType.getAttribute(property.key()) : null;
                     TypeCategory typeCategory = attribute != null ? attribute.getAttributeType().getTypeCategory() : null;
                     TypeCategory elementTypeCategory = attribute != null && attribute.getAttributeType().getTypeCategory() == TypeCategory.ARRAY ? ((AtlasArrayType) attribute.getAttributeType()).getElementType().getTypeCategory() : null;
 
@@ -1075,7 +1069,7 @@ public class EntityGraphRetriever {
                         }
                     }
                 } catch (RuntimeException e) {
-                    LOG.error("Error preloading properties for janus element: {}", atlasElement.getId(), e);
+                    LOG.error("Error preloading properties for entityVertex: {}", entityVertex.getId(), e);
                     throw e; // Re-throw the exception after logging it
                 }
             }
@@ -1480,12 +1474,10 @@ public class EntityGraphRetriever {
 
         AtlasStructType structType = (AtlasStructType) objType;
         Map<String,Object> referenceProperties = Collections.emptyMap();
-        boolean enableJanusOptimisation = AtlasConfiguration.ATLAS_INDEXSEARCH_ENABLE_JANUS_OPTIMISATION.getBoolean() && RequestContext.get().isInvokedByIndexSearch();
+        boolean enableJanusOptimisation = AtlasConfiguration.ATLAS_INDEXSEARCH_ENABLE_JANUS_OPTIMISATION_EXTENDED.getBoolean() && RequestContext.get().isInvokedByIndexSearch();
 
         if (enableJanusOptimisation){
-            String typeName = entityVertex.getProperty(Constants.TYPE_NAME_PROPERTY_KEY, String.class); //properties.get returns null
-            AtlasEntityType entityType = typeRegistry.getEntityTypeByName(typeName);
-            referenceProperties = preloadProperties(entityVertex, entityType, structType.getAllAttributes().keySet(), false);
+            referenceProperties = preloadProperties(entityVertex, structType, structType.getAllAttributes().keySet(), false);
         }
 
         for (AtlasAttribute attribute : structType.getAllAttributes().values()) {
@@ -1547,8 +1539,7 @@ public class EntityGraphRetriever {
 
         return ret;
     }
-
-    private AtlasTermAssignmentHeader toTermAssignmentHeader(final AtlasEdge edge) throws AtlasBaseException {
+    private AtlasTermAssignmentHeader toTermAssignmentHeader(final AtlasEdge edge) {
         AtlasTermAssignmentHeader ret = new AtlasTermAssignmentHeader();
 
         AtlasVertex termVertex = edge.getOutVertex();
@@ -1558,100 +1549,50 @@ public class EntityGraphRetriever {
             ret.setTermGuid(guid);
         }
 
-        boolean enableJanusOptimisation = AtlasConfiguration.ATLAS_INDEXSEARCH_ENABLE_JANUS_OPTIMISATION_EXTENDED.getBoolean()
-                && RequestContext.get().isInvokedByIndexSearch();
-
-        if (enableJanusOptimisation) {
-            String typeName = edge.getProperty(Constants.TYPE_NAME_PROPERTY_KEY, String.class); //properties.get returns null
-            AtlasEntityType entityType = typeRegistry.getEntityTypeByName(typeName);
-            Map<String, Object> referenceProperties = preloadProperties(termVertex, entityType, Collections.emptySet(), false);
-
-            //relationshipGuid is not retrieved via referenceProperties
-            String relationGuid = edge.getProperty(Constants.RELATIONSHIP_GUID_PROPERTY_KEY, String.class);
-            if (relationGuid != null) {
-                ret.setRelationGuid(relationGuid);
-            }
-
-            String description = referenceProperties.get(TERM_ASSIGNMENT_ATTR_DESCRIPTION) != null ? (String) referenceProperties.get(TERM_ASSIGNMENT_ATTR_DESCRIPTION) : null;
-            if (StringUtils.isNotEmpty(description)) {
-                ret.setDescription(description);
-            }
-
-            String expression = referenceProperties.get(TERM_ASSIGNMENT_ATTR_EXPRESSION) != null ? (String) referenceProperties.get(TERM_ASSIGNMENT_ATTR_EXPRESSION) : null;
-            if (StringUtils.isNotEmpty(expression)) {
-                ret.setExpression(expression);
-            }
-
-            String status = referenceProperties.get(TERM_ASSIGNMENT_ATTR_STATUS) != null ? (String) referenceProperties.get(TERM_ASSIGNMENT_ATTR_STATUS) : null;
-            if (StringUtils.isNotEmpty(status)) {
-                AtlasTermAssignmentStatus assignmentStatus = AtlasTermAssignmentStatus.valueOf(status);
-                ret.setStatus(assignmentStatus);
-            }
-
-            Integer confidence = referenceProperties.get(TERM_ASSIGNMENT_ATTR_CONFIDENCE) != null ? (Integer) referenceProperties.get(TERM_ASSIGNMENT_ATTR_CONFIDENCE) : null;
-            if (Objects.nonNull(confidence)) {
-                ret.setConfidence(confidence);
-            }
-
-            String createdBy = referenceProperties.get(TERM_ASSIGNMENT_ATTR_CREATED_BY) != null ? (String) referenceProperties.get(TERM_ASSIGNMENT_ATTR_CREATED_BY) : null;
-            if (StringUtils.isNotEmpty(createdBy)) {
-                ret.setCreatedBy(createdBy);
-            }
-
-            String steward = referenceProperties.get(TERM_ASSIGNMENT_ATTR_STEWARD) != null ? (String) referenceProperties.get(TERM_ASSIGNMENT_ATTR_STEWARD) : null;
-            if (StringUtils.isNotEmpty(steward)) {
-                ret.setSteward(steward);
-            }
-
-            String source = referenceProperties.get(TERM_ASSIGNMENT_ATTR_SOURCE) != null ? (String) referenceProperties.get(TERM_ASSIGNMENT_ATTR_SOURCE) : null;
-            if (StringUtils.isNotEmpty(source)) {
-                ret.setSource(source);
-            }
-        }else {
-            String relationGuid = edge.getProperty(Constants.RELATIONSHIP_GUID_PROPERTY_KEY, String.class);
-            if (relationGuid != null) {
-                ret.setRelationGuid(relationGuid);
-            }
-            String description = edge.getProperty(TERM_ASSIGNMENT_ATTR_DESCRIPTION, String.class);
-            if (description != null) {
-                ret.setDescription(description);
-            }
-
-            String expression    = edge.getProperty(TERM_ASSIGNMENT_ATTR_EXPRESSION, String.class);
-            if (expression != null) {
-                ret.setExpression(expression);
-            }
-
-            String status = edge.getProperty(TERM_ASSIGNMENT_ATTR_STATUS, String.class);
-            if (status != null) {
-                AtlasTermAssignmentStatus assignmentStatus = AtlasTermAssignmentStatus.valueOf(status);
-                ret.setStatus(assignmentStatus);
-            }
-
-            Integer confidence = edge.getProperty(TERM_ASSIGNMENT_ATTR_CONFIDENCE, Integer.class);
-            if (confidence != null) {
-                ret.setConfidence(confidence);
-            }
-
-            String createdBy = edge.getProperty(TERM_ASSIGNMENT_ATTR_CREATED_BY, String.class);
-            if (createdBy != null) {
-                ret.setCreatedBy(createdBy);
-            }
-
-            String steward = edge.getProperty(TERM_ASSIGNMENT_ATTR_STEWARD, String.class);
-            if (steward != null) {
-                ret.setSteward(steward);
-            }
-
-            String source = edge.getProperty(TERM_ASSIGNMENT_ATTR_SOURCE, String.class);
-            if (source != null) {
-                ret.setSource(source);
-            }
+        String relationGuid = edge.getProperty(Constants.RELATIONSHIP_GUID_PROPERTY_KEY, String.class);
+        if (relationGuid != null) {
+            ret.setRelationGuid(relationGuid);
         }
 
         Object displayName = AtlasGraphUtilsV2.getEncodedProperty(termVertex, GLOSSARY_TERM_DISPLAY_NAME_ATTR, Object.class);
         if (displayName instanceof String) {
             ret.setDisplayText((String) displayName);
+        }
+
+        String description = edge.getProperty(TERM_ASSIGNMENT_ATTR_DESCRIPTION, String.class);
+        if (description != null) {
+            ret.setDescription(description);
+        }
+
+        String expression    = edge.getProperty(TERM_ASSIGNMENT_ATTR_EXPRESSION, String.class);
+        if (expression != null) {
+            ret.setExpression(expression);
+        }
+
+        String status = edge.getProperty(TERM_ASSIGNMENT_ATTR_STATUS, String.class);
+        if (status != null) {
+            AtlasTermAssignmentStatus assignmentStatus = AtlasTermAssignmentStatus.valueOf(status);
+            ret.setStatus(assignmentStatus);
+        }
+
+        Integer confidence = edge.getProperty(TERM_ASSIGNMENT_ATTR_CONFIDENCE, Integer.class);
+        if (confidence != null) {
+            ret.setConfidence(confidence);
+        }
+
+        String createdBy = edge.getProperty(TERM_ASSIGNMENT_ATTR_CREATED_BY, String.class);
+        if (createdBy != null) {
+            ret.setCreatedBy(createdBy);
+        }
+
+        String steward = edge.getProperty(TERM_ASSIGNMENT_ATTR_STEWARD, String.class);
+        if (steward != null) {
+            ret.setSteward(steward);
+        }
+
+        String source = edge.getProperty(TERM_ASSIGNMENT_ATTR_SOURCE, String.class);
+        if (source != null) {
+            ret.setSource(source);
         }
 
         return ret;


### PR DESCRIPTION
## Change description

> Description here
1. Reuse cassandra optimisation 
- struct attributes
- system attributes
- classification attributes

## Testing Notes
1. Validated integration tests on staging 

-    https://github.com/atlanhq/atlan-java/blob/main/integration-tests/src/test/java/com/atlan/java/sdk/TableSearchTest.java

-    https://github.com/atlanhq/atlan-java/blob/8fb6baf8902deaaeecae4401f63c2397e2c1ae17/integration-tests/src/test/java/com/atlan/java/sdk/CustomMetadataTest.java#L1350
-  https://atlanhq.atlassian.net/browse/MLH-186

2. Validated classifications across meanings
3. Validated meanings across table
4.  Did before and after comparison of indexsearch API response for table and glossary

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
