### PR TITLE
 MLH-215 Kafka notification for opposite asset with mutatedDetails

### DIFF
--- a/intg/src/main/java/org/apache/atlas/model/instance/AtlasEntity.java
+++ b/intg/src/main/java/org/apache/atlas/model/instance/AtlasEntity.java
@@ -559,12 +559,6 @@ public class AtlasEntity extends AtlasStruct implements Serializable {
         this.removedRelationshipAttributes = removedRelationshipAttributes;
     }
 
-    public boolean hasRemovedRelationshipAttribute(String name) {
-        Map<String, Object> r = this.removedRelationshipAttributes;
-
-        return r != null ? r.containsKey(name) : false;
-    }
-
     public void setRemovedRelationshipAttribute(String name, Object value) {
         Map<String, Object> r = this.removedRelationshipAttributes;
 
@@ -576,12 +570,6 @@ public class AtlasEntity extends AtlasStruct implements Serializable {
 
             this.removedRelationshipAttributes = r;
         }
-    }
-
-    public boolean hasAddedRelationshipAttribute(String name) {
-        Map<String, Object> r = this.addedRelationshipAttributes;
-
-        return r != null ? r.containsKey(name) : false;
     }
 
     public Map<String, Object> getAddedRelationshipAttributes() {
@@ -602,6 +590,38 @@ public class AtlasEntity extends AtlasStruct implements Serializable {
             r.put(name, value);
 
             this.addedRelationshipAttributes = r;
+        }
+    }
+
+    public void addOrAppendListAddedRelationshipList(String name, AtlasObjectId value) {
+        if (this.addedRelationshipAttributes == null) {
+            this.addedRelationshipAttributes = new HashMap<>(1);
+        }
+
+        if (this.addedRelationshipAttributes.containsKey(name)) {
+            List<Object> currentList = (List<Object>) this.addedRelationshipAttributes.get(name);
+            currentList.add(value);
+            this.addedRelationshipAttributes.put(name, currentList);
+        } else {
+            List<Object> values = new ArrayList<>();
+            values.add(value);
+            this.addedRelationshipAttributes.put(name, values);
+        }
+    }
+
+    public void addOrAppendListRemovedRelationshipList(String name, AtlasObjectId value) {
+        if (this.removedRelationshipAttributes == null) {
+            this.removedRelationshipAttributes = new HashMap<>(1);
+        }
+
+        if (this.removedRelationshipAttributes.containsKey(name)) {
+            List<Object> currentList = (List<Object>) this.removedRelationshipAttributes.get(name);
+            currentList.add(value);
+            this.removedRelationshipAttributes.put(name, currentList);
+        } else {
+            List<Object> values = new ArrayList<>();
+            values.add(value);
+            this.removedRelationshipAttributes.put(name, values);
         }
     }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -1701,7 +1701,7 @@ public class EntityGraphMapper {
                     Map<String, Object> relationshipAttributes = getRelationshipAttributes(ctx.getValue());
 
                     if (ctx.getCurrentEdge() != null && getStatus(ctx.getCurrentEdge()) != DELETED) {
-                        ret = updateRelationship(ctx.getCurrentEdge(), entityVertex, attributeVertex, attribute.getRelationshipEdgeDirection(), relationshipAttributes);
+                        ret = updateRelationship(ctx, entityVertex, attributeVertex, attribute.getRelationshipEdgeDirection(), relationshipAttributes);
                     } else {
                         String      relationshipName = attribute.getRelationshipName();
                         AtlasVertex fromVertex;
@@ -2997,12 +2997,14 @@ public class EntityGraphMapper {
     }
 
 
-    private AtlasEdge updateRelationship(AtlasEdge currentEdge, final AtlasVertex parentEntityVertex, final AtlasVertex newEntityVertex,
+    private AtlasEdge updateRelationship(AttributeMutationContext ctx, final AtlasVertex parentEntityVertex, final AtlasVertex newEntityVertex,
                                          AtlasRelationshipEdgeDirection edgeDirection,  Map<String, Object> relationshipAttributes)
             throws AtlasBaseException {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Updating entity reference using relationship {} for reference attribute {}", getTypeName(newEntityVertex));
         }
+
+        AtlasEdge currentEdge = ctx.getCurrentEdge();
 
         // Max's manager updated from Jane to Julius (Max.manager --> Jane.subordinates)
         // manager attribute (OUT direction), current manager vertex (Jane) (IN vertex)
@@ -3040,8 +3042,12 @@ public class EntityGraphMapper {
                 ret = getOrCreateRelationship(newEntityVertex, parentEntityVertex, relationshipName, relationshipAttributes);
             }
 
-            //record entity update on new relationship vertex
-            recordEntityUpdate(newEntityVertex);
+            boolean isCreated = graphHelper.getCreatedTime(ret) == RequestContext.get().getRequestTime();
+            if (isCreated) {
+                // This flow is executed even if edge was only updated, or even the different order in payload
+                // Necessary to call recordEntityUpdate for only new edge creation, hence checking `isCreated`
+                recordEntityUpdate(newEntityVertex, ctx, true);
+            }
         }
 
         return ret;
@@ -4555,7 +4561,7 @@ public class EntityGraphMapper {
                     currentEnd = ((AtlasRelationshipDef) type.getStructDef()).getEndDef2();
                 }
 
-                entity.setTypeName(inverseEnd.getType());
+                entity.setTypeName(getTypeName(vertex));
                 AtlasObjectId objectId = new AtlasObjectId(GraphHelper.getGuid(ctx.getReferringVertex()), currentEnd.getType());
 
                 if (Cardinality.SINGLE == inverseEnd.getCardinality()) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -50,7 +50,6 @@ import org.apache.atlas.repository.store.graph.AtlasRelationshipStore;
 import org.apache.atlas.repository.store.graph.EntityGraphDiscoveryContext;
 import org.apache.atlas.repository.store.graph.v1.DeleteHandlerDelegate;
 import org.apache.atlas.repository.store.graph.v2.tasks.ClassificationTask;
-import org.apache.atlas.repository.util.AtlasEntityUtils;
 import org.apache.atlas.tasks.TaskManagement;
 import org.apache.atlas.type.AtlasArrayType;
 import org.apache.atlas.repository.store.graph.v1.RestoreHandlerV1;
@@ -81,8 +80,6 @@ import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
 import java.util.*;
-import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;


### PR DESCRIPTION
## Change description

Please check comment - https://atlanhq.atlassian.net/browse/MLH-215?focusedCommentId=364627

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> https://atlanhq.atlassian.net/browse/MLH-215

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
