### PR TITLE
MESH-459 | API for adding products on output port denorm attribute on assets

### DIFF
--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -409,7 +409,6 @@ public final class Constants {
     public static final String DOMAIN_GUIDS_ATTR = "domainGUIDs";
     public static final String ASSET_POLICY_GUIDS  = "assetPolicyGUIDs";
     public static final String PRODUCT_GUIDS_ATTR  = "productGUIDs";
-    public static final String PRODUCT_ASSET_OUTPUT_PORT_ATTR = "outputProductGUIDs";
 
     public static final String NON_COMPLIANT_ASSET_POLICY_GUIDS  = "nonCompliantAssetPolicyGUIDs";
     public static final String ASSET_POLICIES_COUNT  = "assetPoliciesCount";

--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -409,6 +409,7 @@ public final class Constants {
     public static final String DOMAIN_GUIDS_ATTR = "domainGUIDs";
     public static final String ASSET_POLICY_GUIDS  = "assetPolicyGUIDs";
     public static final String PRODUCT_GUIDS_ATTR  = "productGUIDs";
+    public static final String PRODUCT_ASSET_OUTPUT_PORT_ATTR = "outputProductGUIDs";
 
     public static final String NON_COMPLIANT_ASSET_POLICY_GUIDS  = "nonCompliantAssetPolicyGUIDs";
     public static final String ASSET_POLICIES_COUNT  = "assetPoliciesCount";

--- a/intg/src/main/java/org/apache/atlas/model/instance/BusinessLineageRequest.java
+++ b/intg/src/main/java/org/apache/atlas/model/instance/BusinessLineageRequest.java
@@ -23,6 +23,9 @@ import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.PUBLIC_
 public class BusinessLineageRequest implements Serializable {
     private static final long serialVersionUID = 1L;
 
+    private static final String PRODUCT_GUIDS_ATTR = "productGUIDs";
+    private static final String PRODUCT_ASSET_OUTPUT_PORT_ATTR = "outputProductGUIDs";
+
     private List<LineageOperation> lineageOperations;
 
     public List<LineageOperation> getLineageOperations() {
@@ -52,6 +55,7 @@ public class BusinessLineageRequest implements Serializable {
         private String productGuid;
         private OperationType operation;
         private String edgeLabel;
+        private String assetDenormAttribute = PRODUCT_GUIDS_ATTR;
 
         public String getWorkflowId() {
             return workflowId;
@@ -93,6 +97,18 @@ public class BusinessLineageRequest implements Serializable {
             this.edgeLabel = edgeLabel;
         }
 
+        public String getAssetDenormAttribute() {
+            return assetDenormAttribute;
+        }
+
+        public void setAssetDenormAttribute(String assetDenormAttribute) {
+            if (PRODUCT_ASSET_OUTPUT_PORT_ATTR.equals(assetDenormAttribute)) {
+                this.assetDenormAttribute = PRODUCT_ASSET_OUTPUT_PORT_ATTR;
+            } else {
+                this.assetDenormAttribute = PRODUCT_GUIDS_ATTR;
+            }
+        }
+
         @Override
         public String toString() {
             return "LineageOperation{" +
@@ -101,6 +117,7 @@ public class BusinessLineageRequest implements Serializable {
                     ", productGuid='" + productGuid + '\'' +
                     ", operation=" + operation +
                     ", edgeLabel='" + edgeLabel + '\'' +
+                    ", assetDenormAttribute='" + assetDenormAttribute + '\'' +
                     '}';
         }
     }

--- a/repository/src/main/java/org/apache/atlas/repository/businesslineage/BusinessLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/repository/businesslineage/BusinessLineageService.java
@@ -113,21 +113,15 @@ public class BusinessLineageService implements AtlasBusinessLineageService {
                             assetGuid, productGuid, operation, edgeLabel);
                 }
 
-                if (assetDenormAttribute.equals(PRODUCT_ASSET_OUTPUT_PORT_ATTR)) {
+                if (StringUtils.isEmpty(edgeLabel)) {
                     AtlasVertex updatedVertex = processProductAssetLink(assetGuid, productGuid, operation, assetDenormAttribute);
                     if (!updatedVertices.contains(updatedVertex)) {
                         updatedVertices.add(updatedVertex);
                     }
                 } else {
-                    if (StringUtils.isEmpty(edgeLabel)) {
-                        AtlasVertex updatedVertex = processProductAssetLink(assetGuid, productGuid, operation, assetDenormAttribute);
-                        if (!updatedVertices.contains(updatedVertex)) {
-                            updatedVertices.add(updatedVertex);
-                        }
-                    } else {
-                        processProductAssetInputRelation(assetGuid, productGuid, operation, edgeLabel);
-                    }
+                    processProductAssetInputRelation(assetGuid, productGuid, operation, edgeLabel);
                 }
+
             }
             handleEntityMutation(updatedVertices);
             commitChanges();

--- a/repository/src/main/java/org/apache/atlas/repository/businesslineage/BusinessLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/repository/businesslineage/BusinessLineageService.java
@@ -67,6 +67,7 @@ public class BusinessLineageService implements AtlasBusinessLineageService {
     private final AtlasRelationshipStoreV2 relationshipStoreV2;
     private final IAtlasMinimalChangeNotifier atlasAlternateChangeNotifier;
     private static final Set<String> excludedTypes = new HashSet<>(Arrays.asList(TYPE_GLOSSARY, TYPE_CATEGORY, TYPE_TERM, TYPE_PRODUCT, TYPE_DOMAIN));
+    private static final HashMap<String, AtlasEntity> guidEntityMap = new HashMap<>();
 
 
 
@@ -291,7 +292,16 @@ public class BusinessLineageService implements AtlasBusinessLineageService {
     }
 
     private void cacheDifferentialMeshEntity(AtlasVertex ev, Set<String> existingValues, String assetDenormAttribute) {
-        AtlasEntity diffEntity = new AtlasEntity(ev.getProperty(TYPE_NAME_PROPERTY_KEY, String.class));
+        AtlasEntity diffEntity;
+        String assetGuid = ev.getProperty(GUID_PROPERTY_KEY, String.class);
+
+        if (guidEntityMap.containsKey(assetGuid)) {
+            diffEntity = guidEntityMap.get(assetGuid);
+        } else {
+            diffEntity = new AtlasEntity(ev.getProperty(TYPE_NAME_PROPERTY_KEY, String.class));
+            guidEntityMap.put(assetGuid, diffEntity);
+        }
+
         diffEntity.setGuid(ev.getProperty(GUID_PROPERTY_KEY, String.class));
         diffEntity.setUpdatedBy(ev.getProperty(MODIFIED_BY_KEY, String.class));
         diffEntity.setUpdateTime(new Date(RequestContext.get().getRequestTime()));


### PR DESCRIPTION
## Change description

> This PR introduces an API that will allow the addition of productGUIDs in a new asset attribute(`outputProductGUIDs`) where this asset is an outputPort. 

JIRA: [MESH-459](https://atlanhq.atlassian.net/browse/MESH-459)
Test Doc - [doc](https://atlanhq.atlassian.net/wiki/spaces/dg/pages/777224271/Test+Cases+for+MESH-459+API+for+adding+products+on+output+port+de-norm+attribute+on+assets)

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable


[MESH-459]: https://atlanhq.atlassian.net/browse/MESH-459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ