### PR TITLE
MLH-213 | Honour method parameters

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -1491,10 +1491,10 @@ public class EntityGraphRetriever {
 
         for (AtlasAttribute attribute : structType.getAllAttributes().values()) {
             Object attrValue;
-            if (enableJanusOptimisation){
-                attrValue = getVertexAttributePreFetchCache(entityVertex, attribute,referenceProperties);
-            }else {
-               attrValue = mapVertexToAttribute(entityVertex, attribute, entityExtInfo, isMinExtInfo, includeReferences);
+            if (enableJanusOptimisation) {
+                attrValue = getVertexAttributePreFetchCache(entityVertex, attribute, referenceProperties, entityExtInfo, isMinExtInfo, includeReferences);
+            } else {
+                attrValue = mapVertexToAttribute(entityVertex, attribute, entityExtInfo, isMinExtInfo, includeReferences);
             }
 
             struct.setAttribute(attribute.getName(), attrValue);
@@ -2060,7 +2060,7 @@ public class EntityGraphRetriever {
         return vertex != null && attribute != null ? mapVertexToAttribute(vertex, attribute, null, false) : null;
     }
 
-    public Object getVertexAttributePreFetchCache(AtlasVertex vertex, AtlasAttribute attribute, Map<String, Object> properties) throws AtlasBaseException {
+    public Object getVertexAttributePreFetchCache(AtlasVertex vertex, AtlasAttribute attribute, Map<String, Object> properties,  AtlasEntityExtInfo entityExtInfo, final boolean isMinExtInfo, final boolean includeReferences) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("getVertexAttributePreFetchCache");
 
         try{
@@ -2094,7 +2094,7 @@ public class EntityGraphRetriever {
 
             // value is present as marker , fetch the value from the vertex
             if (properties.get(attribute.getName()) != null && properties.get(attribute.getName()).equals(StringUtils.SPACE)) {
-                return mapVertexToAttribute(vertex, attribute, null, false);
+                return mapVertexToAttribute(vertex, attribute, entityExtInfo , isMinExtInfo, includeReferences);
             }
 
             return null;
@@ -2102,6 +2102,11 @@ public class EntityGraphRetriever {
             RequestContext.get().endMetricRecord(metricRecorder);
         }
     }
+
+    public Object getVertexAttributePreFetchCache(AtlasVertex vertex, AtlasAttribute attribute, Map<String, Object> properties) throws AtlasBaseException {
+        return getVertexAttributePreFetchCache(vertex, attribute, properties, null, false, true);
+    }
+
 
     private Object getVertexAttributeIgnoreInactive(AtlasVertex vertex, AtlasAttribute attribute) throws AtlasBaseException {
         return vertex != null && attribute != null ? mapVertexToAttribute(vertex, attribute, null, false, true, true) : null;


### PR DESCRIPTION
## Change description

> Description here
- Honour method parameters
- to be deployed behind feature gate
- slowness effort
- Earlier we were using `getVertexAttributePreFetchCache(vertex, attribute, properties, null, false, true)`. Some values 
  were hardcoded. Added a overloaded method 
  `getVertexAttributePreFetchCache(AtlasVertex vertex, AtlasAttribute attribute, Map<String, Object> properties, AtlasEntityExtInfo entityExtInfo, final boolean isMinExtInfo, final boolean includeReferences)`
  to honour parameters passed in user request i.e  AtlasEntityExtInfo, isMinExtInfo, includeReferences

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
