### PR TITLE
MESH-459 | API for adding products on output port denorm attribute on assets

### DIFF
--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -409,6 +409,7 @@ public final class Constants {
     public static final String DOMAIN_GUIDS_ATTR = "domainGUIDs";
     public static final String ASSET_POLICY_GUIDS  = "assetPolicyGUIDs";
     public static final String PRODUCT_GUIDS_ATTR  = "productGUIDs";
+    public static final String PRODUCT_ASSET_OUTPUT_PORT_ATTR = "outputProductGUIDs";
 
     public static final String NON_COMPLIANT_ASSET_POLICY_GUIDS  = "nonCompliantAssetPolicyGUIDs";
     public static final String ASSET_POLICIES_COUNT  = "assetPoliciesCount";

--- a/intg/src/main/java/org/apache/atlas/model/instance/BusinessLineageRequest.java
+++ b/intg/src/main/java/org/apache/atlas/model/instance/BusinessLineageRequest.java
@@ -23,6 +23,9 @@ import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.PUBLIC_
 public class BusinessLineageRequest implements Serializable {
     private static final long serialVersionUID = 1L;
 
+    private static final String PRODUCT_GUIDS_ATTR = "productGUIDs";
+    private static final String PRODUCT_ASSET_OUTPUT_PORT_ATTR = "outputProductGUIDs";
+
     private List<LineageOperation> lineageOperations;
 
     public List<LineageOperation> getLineageOperations() {
@@ -52,6 +55,7 @@ public class BusinessLineageRequest implements Serializable {
         private String productGuid;
         private OperationType operation;
         private String edgeLabel;
+        private String assetDenormAttribute = PRODUCT_GUIDS_ATTR;
 
         public String getWorkflowId() {
             return workflowId;
@@ -93,6 +97,18 @@ public class BusinessLineageRequest implements Serializable {
             this.edgeLabel = edgeLabel;
         }
 
+        public String getAssetDenormAttribute() {
+            return assetDenormAttribute;
+        }
+
+        public void setAssetDenormAttribute(String assetDenormAttribute) {
+            if (PRODUCT_ASSET_OUTPUT_PORT_ATTR.equals(assetDenormAttribute)) {
+                this.assetDenormAttribute = PRODUCT_ASSET_OUTPUT_PORT_ATTR;
+            } else {
+                this.assetDenormAttribute = PRODUCT_GUIDS_ATTR;
+            }
+        }
+
         @Override
         public String toString() {
             return "LineageOperation{" +
@@ -101,6 +117,7 @@ public class BusinessLineageRequest implements Serializable {
                     ", productGuid='" + productGuid + '\'' +
                     ", operation=" + operation +
                     ", edgeLabel='" + edgeLabel + '\'' +
+                    ", assetDenormAttribute='" + assetDenormAttribute + '\'' +
                     '}';
         }
     }


### PR DESCRIPTION
## Change description

> This PR introduces an API that will allow the addition of productGUIDs in a new asset attribute(`outputProductGUIDs`) where this asset is an outputPort. 

JIRA: [MESH-459](https://atlanhq.atlassian.net/browse/MESH-459)
Test Doc - [doc](https://atlanhq.atlassian.net/wiki/spaces/dg/pages/777224271/Test+Cases+for+MESH-459+API+for+adding+products+on+output+port+de-norm+attribute+on+assets)

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable


[MESH-459]: https://atlanhq.atlassian.net/browse/MESH-459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ