### PR TITLE
MLH-262 | Optimise HasLineage

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,6 +28,7 @@ on:
       - master
       - lineageondemand
       - optimise_get_classifications_master
+      - addmetrics
 
 jobs:
   build:

--- a/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
@@ -98,6 +98,7 @@ public enum AtlasConfiguration {
     LINEAGE_ON_DEMAND_ENABLED("atlas.lineage.on.demand.enabled", true),
     LINEAGE_ON_DEMAND_DEFAULT_NODE_COUNT("atlas.lineage.on.demand.default.node.count", 3),
     LINEAGE_MAX_NODE_COUNT("atlas.lineage.max.node.count", 100),
+    USE_OPTIMISED_LINEAGE_CALCULATION("atlas.lineage.optimised.calculation", false),
 
     SUPPORTED_RELATIONSHIP_EVENTS("atlas.notification.relationships.filter", "asset_readme,asset_links"),
     ATLAS_RELATIONSHIP_CLEANUP_SUPPORTED_ASSET_TYPES("atlas.relationship.cleanup.supported.asset.types", "Process,AirflowTask"),

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -1719,7 +1719,7 @@ public abstract class DeleteHandlerV1 {
 
                     // Skip if in deleted list or matches current edge
                     if (RequestContext.get().getDeletedEdgesIdsForResetHasLineage().contains(edgeIdStr) ||
-                            currentEdge.getId().equals(edgeIdStr)) {
+                            currentEdge.getIdForDisplay().equals(edgeIdStr)) {
                         return false;
                     }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -1630,18 +1630,15 @@ public abstract class DeleteHandlerV1 {
 
         removedEdges.forEach(edge -> RequestContext.get().addToDeletedEdgesIdsForResetHasLineage(edge.getIdForDisplay()));
 
-        AtlasPerfMetrics.MetricRecorder metricRecorder1 = RequestContext.get().startMetricRecord("updateAssetHasLineageStatus-edges");
         Iterator<AtlasEdge> edgeIterator = assetVertex.query()
                 .direction(AtlasEdgeDirection.BOTH)
                 .label(PROCESS_EDGE_LABELS)
                 .has(STATE_PROPERTY_KEY, ACTIVE.name())
                 .edges()
                 .iterator();
-        RequestContext.get().endMetricRecord(metricRecorder1);
 
         int processHasLineageCount = 0;
 
-        AtlasPerfMetrics.MetricRecorder metricRecorder2 = RequestContext.get().startMetricRecord("updateAssetHasLineageStatus-getLineage");
         while (edgeIterator.hasNext()) {
             AtlasEdge edge = edgeIterator.next();
             if (!RequestContext.get().getDeletedEdgesIdsForResetHasLineage().contains(edge.getIdForDisplay()) && !currentEdge.equals(edge)) {
@@ -1653,8 +1650,6 @@ public abstract class DeleteHandlerV1 {
                 }
             }
         }
-         RequestContext.get().endMetricRecord(metricRecorder2);
-
 
         if (processHasLineageCount == 0) {
             AtlasGraphUtilsV2.setEncodedProperty(assetVertex, HAS_LINEAGE, false);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -85,6 +85,7 @@ import static org.apache.atlas.type.Constants.HAS_LINEAGE;
 import static org.apache.atlas.type.Constants.PENDING_TASKS_PROPERTY_KEY;
 import static org.apache.atlas.repository.graph.GraphHelper.getTypeName;
 import static org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2.getState;
+import static org.apache.tinkerpop.gremlin.groovy.jsr223.dsl.credential.__.id;
 import static org.apache.tinkerpop.gremlin.groovy.jsr223.dsl.credential.__.outV;
 
 public abstract class DeleteHandlerV1 {
@@ -1709,7 +1710,7 @@ public abstract class DeleteHandlerV1 {
         // Complete the traversal with common operations
         return traversal
                 .project("id", HAS_LINEAGE)
-                .by("id")
+                .by(id())
                 .by(outV().values(HAS_LINEAGE))
                 .toStream()
                 .anyMatch(edge -> {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -1619,8 +1619,10 @@ public abstract class DeleteHandlerV1 {
     private void updateAssetHasLineageStatus(AtlasVertex assetVertex, AtlasEdge currentEdge, Collection<AtlasEdge> removedEdges) {
         if (AtlasConfiguration.USE_OPTIMISED_LINEAGE_CALCULATION.getBoolean()) {
             updateAssetHasLineageStatusV2(assetVertex, currentEdge, removedEdges);
+        }else {
+            updateAssetHasLineageStatusV1(assetVertex, currentEdge, removedEdges);
         }
-        updateAssetHasLineageStatusV1(assetVertex, currentEdge, removedEdges);
+
     }
     private void updateAssetHasLineageStatusV1(AtlasVertex assetVertex, AtlasEdge currentEdge, Collection<AtlasEdge> removedEdges) {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("updateAssetHasLineageStatusV1");

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -1613,14 +1613,18 @@ public abstract class DeleteHandlerV1 {
 
         removedEdges.forEach(edge -> RequestContext.get().addToDeletedEdgesIdsForResetHasLineage(edge.getIdForDisplay()));
 
+        AtlasPerfMetrics.MetricRecorder metricRecorder1 = RequestContext.get().startMetricRecord("updateAssetHasLineageStatus-edges");
         Iterator<AtlasEdge> edgeIterator = assetVertex.query()
                 .direction(AtlasEdgeDirection.BOTH)
                 .label(PROCESS_EDGE_LABELS)
                 .has(STATE_PROPERTY_KEY, ACTIVE.name())
                 .edges()
                 .iterator();
+        RequestContext.get().endMetricRecord(metricRecorder1);
 
         int processHasLineageCount = 0;
+
+        AtlasPerfMetrics.MetricRecorder metricRecorder2 = RequestContext.get().startMetricRecord("updateAssetHasLineageStatus-getLineage");
         while (edgeIterator.hasNext()) {
             AtlasEdge edge = edgeIterator.next();
             if (!RequestContext.get().getDeletedEdgesIdsForResetHasLineage().contains(edge.getIdForDisplay()) && !currentEdge.equals(edge)) {
@@ -1632,6 +1636,8 @@ public abstract class DeleteHandlerV1 {
                 }
             }
         }
+         RequestContext.get().endMetricRecord(metricRecorder2);
+
 
         if (processHasLineageCount == 0) {
             AtlasGraphUtilsV2.setEncodedProperty(assetVertex, HAS_LINEAGE, false);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -59,6 +59,7 @@ import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.slf4j.Logger;
@@ -1666,11 +1667,11 @@ public abstract class DeleteHandlerV1 {
         removedEdges.forEach(edge -> RequestContext.get().addToDeletedEdgesIdsForResetHasLineage(edge.getIdForDisplay()));
 
         // Check for active lineage in outgoing edges first
-        boolean hasActiveLineage = hasActiveLineageInDirection(assetVertex, currentEdge, true);
+        boolean hasActiveLineage = hasActiveLineageDirection(assetVertex, currentEdge, Direction.OUT);
 
         // If no active lineage in outgoing edges, check incoming edges
         if (!hasActiveLineage) {
-            hasActiveLineage = hasActiveLineageInDirection(assetVertex, currentEdge, false);
+            hasActiveLineage = hasActiveLineageDirection(assetVertex, currentEdge, Direction.IN);
         }
 
         // Only update if no active lineage found
@@ -1685,15 +1686,15 @@ public abstract class DeleteHandlerV1 {
      * Helper method to check for active lineage in a specific direction
      * @param assetVertex The vertex to check
      * @param currentEdge The current edge to exclude
-     * @param isOutgoing If true, checks outgoing edges; if false, checks incoming edges
+     * @param direction The edge direction to explore
      * @return True if active lineage exists in the specified direction
      */
-    private boolean hasActiveLineageInDirection(AtlasVertex assetVertex, AtlasEdge currentEdge, boolean isOutgoing) {
+    private boolean hasActiveLineageDirection(AtlasVertex assetVertex, AtlasEdge currentEdge, Direction direction) {
         GraphTraversalSource g = ((AtlasJanusGraph) graph).getGraph().traversal();
         GraphTraversal<Vertex, Edge> traversal;
 
         // Create the appropriate directional traversal
-        if (isOutgoing) {
+        if (direction.equals(Direction.OUT)) {
             traversal = g.V(assetVertex.getId())
                     .outE()
                     .has(STATE_PROPERTY_KEY, ACTIVE_STATE_VALUE);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -42,6 +42,7 @@ import org.apache.atlas.repository.graphdb.AtlasEdge;
 import org.apache.atlas.repository.graphdb.AtlasEdgeDirection;
 import org.apache.atlas.repository.graphdb.AtlasGraph;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
+import org.apache.atlas.repository.graphdb.janus.AtlasJanusGraph;
 import org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2;
 import org.apache.atlas.repository.store.graph.v2.AtlasRelationshipStoreV2;
 import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
@@ -56,10 +57,15 @@ import org.apache.atlas.utils.AtlasPerfMetrics;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static org.apache.atlas.model.TypeCategory.*;
@@ -78,6 +84,7 @@ import static org.apache.atlas.type.Constants.HAS_LINEAGE;
 import static org.apache.atlas.type.Constants.PENDING_TASKS_PROPERTY_KEY;
 import static org.apache.atlas.repository.graph.GraphHelper.getTypeName;
 import static org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2.getState;
+import static org.apache.tinkerpop.gremlin.groovy.jsr223.dsl.credential.__.outV;
 
 public abstract class DeleteHandlerV1 {
     public static final Logger  LOG = LoggerFactory.getLogger(DeleteHandlerV1.class);
@@ -1609,7 +1616,13 @@ public abstract class DeleteHandlerV1 {
     }
 
     private void updateAssetHasLineageStatus(AtlasVertex assetVertex, AtlasEdge currentEdge, Collection<AtlasEdge> removedEdges) {
-        AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("updateAssetHasLineageStatus");
+        if (AtlasConfiguration.USE_OPTIMISED_LINEAGE_CALCULATION.getBoolean()) {
+            updateAssetHasLineageStatusV2(assetVertex, currentEdge, removedEdges);
+        }
+        updateAssetHasLineageStatusV1(assetVertex, currentEdge, removedEdges);
+    }
+    private void updateAssetHasLineageStatusV1(AtlasVertex assetVertex, AtlasEdge currentEdge, Collection<AtlasEdge> removedEdges) {
+        AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("updateAssetHasLineageStatusV1");
 
         removedEdges.forEach(edge -> RequestContext.get().addToDeletedEdgesIdsForResetHasLineage(edge.getIdForDisplay()));
 
@@ -1646,4 +1659,68 @@ public abstract class DeleteHandlerV1 {
         RequestContext.get().endMetricRecord(metricRecorder);
     }
 
+    private void updateAssetHasLineageStatusV2(AtlasVertex assetVertex, AtlasEdge currentEdge, Collection<AtlasEdge> removedEdges) {
+        AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("updateAssetHasLineageStatusV2");
+
+        // Add removed edges to the context
+        removedEdges.forEach(edge -> RequestContext.get().addToDeletedEdgesIdsForResetHasLineage(edge.getIdForDisplay()));
+
+        // Check for active lineage in outgoing edges first
+        boolean hasActiveLineage = hasActiveLineageInDirection(assetVertex, currentEdge, true);
+
+        // If no active lineage in outgoing edges, check incoming edges
+        if (!hasActiveLineage) {
+            hasActiveLineage = hasActiveLineageInDirection(assetVertex, currentEdge, false);
+        }
+
+        // Only update if no active lineage found
+        if (!hasActiveLineage) {
+            AtlasGraphUtilsV2.setEncodedProperty(assetVertex, HAS_LINEAGE, false);
+        }
+
+        RequestContext.get().endMetricRecord(metricRecorder);
+    }
+
+    /**
+     * Helper method to check for active lineage in a specific direction
+     * @param assetVertex The vertex to check
+     * @param currentEdge The current edge to exclude
+     * @param isOutgoing If true, checks outgoing edges; if false, checks incoming edges
+     * @return True if active lineage exists in the specified direction
+     */
+    private boolean hasActiveLineageInDirection(AtlasVertex assetVertex, AtlasEdge currentEdge, boolean isOutgoing) {
+        GraphTraversalSource g = ((AtlasJanusGraph) graph).getGraph().traversal();
+        GraphTraversal<Vertex, Edge> traversal;
+
+        // Create the appropriate directional traversal
+        if (isOutgoing) {
+            traversal = g.V(assetVertex.getId())
+                    .outE()
+                    .has(STATE_PROPERTY_KEY, ACTIVE_STATE_VALUE);
+        } else {
+            traversal = g.V(assetVertex.getId())
+                    .inE()
+                    .has(STATE_PROPERTY_KEY, ACTIVE_STATE_VALUE);
+        }
+
+        // Complete the traversal with common operations
+        return traversal
+                .project("id", HAS_LINEAGE)
+                .by("id")
+                .by(outV().values(HAS_LINEAGE))
+                .toStream()
+                .anyMatch(edge -> {
+                    Object edgeId = edge.get("id");
+                    String edgeIdStr = (edgeId != null) ? edgeId.toString() : "";
+
+                    // Skip if in deleted list or matches current edge
+                    if (RequestContext.get().getDeletedEdgesIdsForResetHasLineage().contains(edgeIdStr) ||
+                            currentEdge.getId().equals(edgeIdStr)) {
+                        return false;
+                    }
+
+                    // Check if this edge has lineage
+                    return Boolean.TRUE.equals(edge.get(HAS_LINEAGE));
+                });
+    }
 }


### PR DESCRIPTION
## Change description

> Description here
- optimised hasLineage calculation 
- rather than computing in both direction, first explore all output edges
- if no lineage exists explore all input edges
- still no lineage found , set Lineage as false for current vertex
- use projected query to get only edgeId and hasLineage property avoid loading complete edge in-memory
- Reference doc for testing : [Doc](https://www.notion.so/atlanhq/__hasLineage-cases-fff874d884954385b6ed669d370f703d)
- Tested following on local and staging

**Initial Lineage Flows**

- Table1 → ProcessA → Table2
Status: Table1: true | Table2: true | ProcessA: true

- Table0, Table1 → ProcessA → Table2
Status: Table0: true | Table1: true | Table2: true | ProcessA: true

**Deletion Scenarios**

- Delete Table2
Status: Table0: false | Table1: false | Table2: true | ProcessA: false

- Table0 → Process0 → Table1 → ProcessA → Table2
Status: Table0: true | Table1: true | Process0: true | ProcessA: true | Table2: true

- Delete Table2
Status: Table0: true | Process0: true | Table1: true | ProcessA: false | Table2: true

- Table1 → ProcessA → Table2, Delete ProcessA
Status: Table1: false | Table2: false | ProcessA: true

**Extended Lineage Flows**

- Table0 → Process0 → Table1 → ProcessA → Table2 → Process2 → Table3
Status: Table0: true | Process0: true | Table1: true | ProcessA: true | Table2: true | Process2: true | Table3: true

- Delete ProcessA
Status: Table0: true | Process0: true | Table1: true | ProcessA: true | Table2: true | Process2: true | Table3: true

Observed performance before and after :
<img width="1318" alt="Screenshot 2025-04-12 at 10 00 26 AM" src="https://github.com/user-attachments/assets/2ee74971-318b-4296-ab2b-4530476accc9" />

<img width="1327" alt="Screenshot 2025-04-12 at 10 00 15 AM" src="https://github.com/user-attachments/assets/72cd6c6b-67d5-4dc4-b698-e33842ccda50" />


## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
