### PR TITLE
MLH-216 | Fixed Entity audit details returning 'null' for hard-deleted assets

### DIFF
--- a/intg/src/main/java/org/apache/atlas/model/audit/EntityAuditEventV2.java
+++ b/intg/src/main/java/org/apache/atlas/model/audit/EntityAuditEventV2.java
@@ -327,7 +327,7 @@ public class EntityAuditEventV2 implements Serializable, Clearable {
         if(StringUtils.isNotEmpty(jsonPartFromDetails)) {
             ret = AtlasType.fromJson(jsonPartFromDetails, AtlasEntityHeader.class);
         }
-        if (ret.getTypeName() == null || !ret.getTypeName().equals(typeName)) {
+        if (ret.getTypeName() == null ) {
             ret.setTypeName(typeName);
         }
 

--- a/intg/src/main/java/org/apache/atlas/model/audit/EntityAuditEventV2.java
+++ b/intg/src/main/java/org/apache/atlas/model/audit/EntityAuditEventV2.java
@@ -327,6 +327,10 @@ public class EntityAuditEventV2 implements Serializable, Clearable {
         if(StringUtils.isNotEmpty(jsonPartFromDetails)) {
             ret = AtlasType.fromJson(jsonPartFromDetails, AtlasEntityHeader.class);
         }
+        if (ret.getTypeName() == null || !ret.getTypeName().equals(typeName)) {
+            ret.setTypeName(typeName);
+        }
+
         if(!ret.hasAttribute("qualifiedName")) {
             ret.setAttribute("qualifiedName", entityQualifiedName);
         }

--- a/intg/src/main/java/org/apache/atlas/model/audit/EntityAuditEventV2.java
+++ b/intg/src/main/java/org/apache/atlas/model/audit/EntityAuditEventV2.java
@@ -327,6 +327,9 @@ public class EntityAuditEventV2 implements Serializable, Clearable {
         if(StringUtils.isNotEmpty(jsonPartFromDetails)) {
             ret = AtlasType.fromJson(jsonPartFromDetails, AtlasEntityHeader.class);
         }
+        if(!ret.hasAttribute("qualifiedName")) {
+            ret.setAttribute("qualifiedName", entityQualifiedName);
+        }
         return ret;
     }
 


### PR DESCRIPTION
## Description

**Problem Statement:** 
 detail in `ENTITY_UPDATE` event returns `NULL` for **Hard deleted Assets.** 
 
 **Root cause:**
 -> When auditSearch API is called, Metastore checks for READ permission and decides whether to assign detail as 'NULL' or not. 
 -> Since asset is hard deleted, auth check will always fail as we can not perform READ check on asset instance which is not available in store.
 
 **Solution:** 
 For Persona based policy:
 -> The auth check depends on `entityQualifiedName` in the `entityHeader` attributes. 
 -> So, we just spoof this by adding the `entityQualifiedName` information in the `entityHeader`. 
 
 
 Jira Ticket -> [Link](https://atlanhq.atlassian.net/browse/MLH-216)

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [x] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable


# ADDITIONAL INFO
**Before adding the entityQualifiedName to entityHeader**
```
"action": "ENTITY_UPDATE",
"eventKey": "682ca67b-8a17-47cc-b2d3-3eb90347372a:1744134005027",
"detail": null
```


**After adding the entityQualifiedName to entityHeader**
```
"action": "ENTITY_UPDATE",
"eventKey": "682ca67b-8a17-47cc-b2d3-3eb90347372a:1744134005027",
"detail": {
    "typeName": "Table",
    "attributes": {
        "userDescription": "description12"
    },
    "guid": "682ca67b-8a17-47cc-b2d3-3eb90347372a",
    "isIncomplete": false,
    "provenanceType": 0,
    "updatedBy": "admin",
    "updateTime": 1744134005027,
    "version": 0,
    "proxy": false
},
```