### PR TITLE
MLH-89 | Added feature to exclude certain EntityTypes from Policy

### DIFF
--- a/addons/models/0000-Area0/0010-base_model.json
+++ b/addons/models/0000-Area0/0010-base_model.json
@@ -729,6 +729,17 @@
           "includeInNotification": true
         },
         {
+          "name": "excludeTypes",
+          "typeName": "array<string>",
+          "indexType": "STRING",
+          "cardinality": "SET",
+          "isIndexable": false,
+          "isOptional": true,
+          "isUnique": false,
+          "skipScrubbing": true,
+          "includeInNotification": true
+        },
+        {
           "name": "policyUsers",
           "typeName": "array<string>",
           "indexType": "STRING",

--- a/auth-agents-common/src/main/java/org/apache/atlas/policytransformer/CachePolicyTransformerImpl.java
+++ b/auth-agents-common/src/main/java/org/apache/atlas/policytransformer/CachePolicyTransformerImpl.java
@@ -109,6 +109,7 @@ public class CachePolicyTransformerImpl {
     public static final String ATTR_POLICY_VALIDITY           = "policyValiditySchedule";
     public static final String ATTR_POLICY_CONDITIONS         = "policyConditions";
     public static final String ATTR_POLICY_MASK_TYPE          = "policyMaskType";
+    public static final String ATTR_POLICY_EXCLUDE_TYPES          = "excludeTypes";
 
     private static final String RESOURCE_SERVICE_DEF_PATH = "/service-defs/";
     private static final String RESOURCE_SERVICE_DEF_PATTERN = RESOURCE_SERVICE_DEF_PATH + "atlas-servicedef-%s.json";
@@ -616,6 +617,7 @@ public class CachePolicyTransformerImpl {
             attributes.add(ATTR_POLICY_CONDITIONS);
             attributes.add(ATTR_POLICY_IS_ENABLED);
             attributes.add(ATTR_POLICY_CONNECTION_QN);
+            attributes.add(ATTR_POLICY_EXCLUDE_TYPES);
 
             Map<String, Object> dsl = getMap("size", 0);
 


### PR DESCRIPTION
## description

**Short summary:**

-> Implement a toggle named 'Exclude Connection' and similar in the metadata policy creation UI.

**-> Details of the technical changes is mentioned in the below link.** 
https://atlanhq.atlassian.net/browse/MLH-89?focusedCommentId=392935

-> Jira ticket Link -> https://atlanhq.atlassian.net/browse/MLH-89


## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues



## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [x] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
