### PR TITLE
MLH-261 : (feat) add BM attr update even if passed through the attributes

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityComparator.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityComparator.java
@@ -217,8 +217,9 @@ public class AtlasEntityComparator {
         }
 
         if (context.isReplaceBusinessAttributes()) {
-            getBusinessMetadataFromEntityAttribute(updatedEntity, entityType);
-            Map<String, Map<String, Object>> newBusinessMetadata  = updatedEntity.getBusinessAttributes() == null ? getBusinessMetadataFromEntityAttribute(updatedEntity, entityType) : updatedEntity.getBusinessAttributes();
+            Map<String, Map<String, Object>> newBusinessMetadata  = updatedEntity.getBusinessAttributes() == null
+                    ? getBusinessMetadataFromEntityAttribute(updatedEntity, entityType)
+                    : updatedEntity.getBusinessAttributes();
             Map<String, Map<String, Object>> currBusinessMetadata = (storedEntity != null)
                     ? storedEntity.getBusinessAttributes()
                     : entityRetriever.getBusinessMetadata(storedVertex);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityComparator.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityComparator.java
@@ -217,7 +217,7 @@ public class AtlasEntityComparator {
         }
 
         if (context.isReplaceBusinessAttributes()) {
-            Map<String, Map<String, Object>> newBusinessMetadata  = updatedEntity.getBusinessAttributes() == null
+            Map<String, Map<String, Object>> newBusinessMetadata = updatedEntity.getBusinessAttributes() == null
                     ? getBusinessMetadataFromEntityAttribute(updatedEntity, entityType)
                     : updatedEntity.getBusinessAttributes();
             Map<String, Map<String, Object>> currBusinessMetadata = (storedEntity != null)


### PR DESCRIPTION
## Change description

> Currently, there is a discrepancy in the events generated when custom metadata (CM) is updated via the bulk endpoint. Sometimes the event is recorded as ENTITY_UPDATE and other times as BUSINESS_ATTRIBUTE_UPDATE. This inconsistency leads to incorrect counts of CM changes post playbook run, sometimes showing changes when none occurred and vice-versa. The task is to ensure that the correct event, ideally BUSINESS_ATTRIBUTE_UPDATE, is consistently generated for CM updates via the bulk endpoint to accurately reflect changes in the playbook run widget.

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> https://atlanhq.atlassian.net/browse/MLH-261

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
