### PR TITLE
MLH-345 : (feat) add cleanup of tombstones from the cleanup

### DIFF
--- a/client-auth/src/main/java/org/apache/atlas/auth/client/jmx/JMXCassandraConnect.java
+++ b/client-auth/src/main/java/org/apache/atlas/auth/client/jmx/JMXCassandraConnect.java
@@ -1,0 +1,76 @@
+package org.apache.atlas.auth.client.jmx;
+
+import org.apache.atlas.ApplicationProperties;
+import org.apache.commons.configuration.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.management.MBeanServerConnection;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+import java.util.HashMap;
+import java.util.Map;
+
+public class JMXCassandraConnect {
+    private static final Logger LOG = LoggerFactory.getLogger(JMXCassandraConnect.class);
+    Configuration configuration;
+
+    MBeanServerConnection mbeanServerConnection;
+
+    public JMXCassandraConnect() {
+        try {
+            configuration = ApplicationProperties.get();
+        } catch (Exception e) {
+            LOG.error("Error initializing configuration: ", e);
+        }
+        String cassandraHost = configuration.getString("atlas.graph.storage.hostname", "atlas-cassandra.atlas.svc.cluster.local");
+        String jmxUrl = String.format("service:jmx:rmi:///jndi/rmi://%s:%d/jmxrmi", cassandraHost, 7199);
+        this.mbeanServerConnection = initConn(jmxUrl);
+    }
+
+    public MBeanServerConnection initConn(String jmxUrl) {
+        try {
+            JMXServiceURL serviceURL = new JMXServiceURL(jmxUrl);
+            Map<String, Object> env = new HashMap<>();
+            JMXConnector jmxConnector = JMXConnectorFactory.connect(serviceURL, env);
+            return jmxConnector.getMBeanServerConnection();
+        } catch (Exception e) {
+            LOG.error("Error connecting to JMX: ", e);
+            return null;
+        }
+    }
+
+    public void invokeCassandraGarbageCollection() throws MalformedObjectNameException {
+        String keyspace = configuration.getString("atlas.graph.storage.cql.keyspace", "atlas");
+        String table = configuration.getString("atlas.graph.storage.cql.table", "edgestore");
+        ObjectName name = new ObjectName("org.apache.cassandra.db:type=StorageService");
+        Object[] params = new Object[]{
+                "NONE",
+                2,
+                keyspace,
+                new String[]{table}
+        };
+        String[] signature = new String[]{
+                String.class.getName(),      // Signature for tombstoneOption (java.lang.String)
+                int.class.getName(),         // Signature for jobs (primitive int)
+                String.class.getName(),      // Signature for keyspace (java.lang.String)
+                String[].class.getName()     // Signature for tableNames ([Ljava.lang.String;) - String array
+        };
+        try {
+            mbeanServerConnection.invoke(name, "garbageCollect", params, signature);
+            LOG.info("Garbage collection initiated successfully for {}.{}", keyspace, table);
+        } catch (Exception e) {
+            LOG.error("Error invoking garbage collection: ", e);
+        }
+    }
+
+
+
+
+
+
+
+}


### PR DESCRIPTION
## Change description

> We are experiencing recurring issues with tombstones in the Autodesk production environment (autodesk-vc2). Each time we clear a batch of tag attachments, new tombstones are being created almost immediately, leading to cleanup failures. This is compounded by the fact that tag attachments continue to be added daily (over 2,000 tasks per day) as the crawlers on the customer tenant have not been stopped. We need to investigate the cause of these recurring tombstones and find a solution to break this cycle and ensure a successful cleanup.

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
