### PR TITLE
MLH-41 | Modified 'integration-tests' workflow

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -316,7 +316,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
 
       - name: Run integration test for ${{ matrix.tests }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -254,25 +254,6 @@ jobs:
           done
           echo "❌ ERROR: Max retries reached. Commit ID did not match the revision."
           exit 1
-  setup-java-sdk:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Java SDK Repo
-        uses: actions/checkout@v4
-        with:
-          repository: atlanhq/atlan-java
-          ref: main
-
-      - name: Set up JDK for SDK
-        uses: actions/setup-java@v4
-        with:
-          java-version: 17
-          distribution: temurin
-
-      - name: Compile
-        uses: burrunan/gradle-cache-action@v1
-        with:
-          arguments: assemble shadowJar test
 
   list-integration-tests:
     runs-on: ubuntu-latest
@@ -289,7 +270,7 @@ jobs:
       - name: List integration tests
         id: test-files
         run: |
-          SKIP_PATTERN="SearchTest.java|RequestsTest.java|SSOTest.java|PersonaTest.java|AdminTest.java|DataMeshTest.java|InsightsTest.java|PurposeTest.java"
+          SKIP_PATTERN="/SearchTest.java|/RequestsTest.java|/SSOTest.java|/PersonaTest.java|/AdminTest.java|/DataMeshTest.java|/InsightsTest.java|/PurposeTest.java"
 
           # List all *Test.java files, exclude the ones that match SKIP_PATTERN
           tests=$(ls integration-tests/src/test/java/com/atlan/java/sdk/*Test.java \
@@ -316,7 +297,6 @@ jobs:
   integration-test:
     needs:
       - wait-for-deployment
-      - setup-java-sdk
       - list-integration-tests
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
## Changes 

**1) Upgraded setting up java-sdk version from 17 to 21.** 
-> There is some discrepancy lately in java 17.
-> Chris also did the same in the workflow he has at atlan-java repo.

2) Improved skip_files logic. 

3) Removed the setup-java-sdk step. 
-> This step is reduntant in the workflow. 
-> Previously, we setup java-sdk and ran unit-tests.
-> Removing this step, as we are concerned only about 'integration-tests'.


## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [x] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
