### PR TITLE
MESH-508 : Skip events with null product/asset vertex instead of throwing error.

### DIFF
--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -298,6 +298,7 @@ public final class Constants {
     public static final String INDEX_SEARCH_VERTEX_PREFIX_PROPERTY     = "atlas.graph.index.search.vertex.prefix";
     public static final String INDEX_SEARCH_VERTEX_PREFIX_DEFAULT      = "$v$";
     public static final String DOMAIN_GUIDS                            = "domainGUIDs";
+    public static final String PRODUCT_GUIDS                           = "productGUIDs";
 
     public static final String ATTR_TENANT_ID = "tenantId";
     public static final String DEFAULT_TENANT_ID = "default";

--- a/repository/src/main/java/org/apache/atlas/repository/businesslineage/BusinessLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/repository/businesslineage/BusinessLineageService.java
@@ -134,12 +134,22 @@ public class BusinessLineageService implements AtlasBusinessLineageService {
 
     public AtlasVertex processProductAssetLink (String assetGuid, String productGuid, BusinessLineageRequest.OperationType operation, String assetDenormAttribute) throws AtlasBaseException {
         try {
-            AtlasVertex assetVertex = entityRetriever.getEntityVertex(assetGuid);
-            AtlasVertex productVertex = entityRetriever.getEntityVertex(productGuid);
+            AtlasVertex assetVertex;
+            AtlasVertex productVertex;
+            try{
+                assetVertex = entityRetriever.getEntityVertex(assetGuid);
+                if (assetVertex == null) {
+                    LOG.warn("Asset not found for assetGuid: {}", assetGuid);
+                    return null;
+                }
 
-
-            if (assetVertex == null || productVertex == null) {
-                LOG.warn("Asset or Product not found for assetGuid: {}, productGuid: {}", assetGuid, productGuid);
+                productVertex = entityRetriever.getEntityVertex(productGuid);
+                if (productVertex == null) {
+                    LOG.warn("Product not found for productGuid: {}", productGuid);
+                    return null;
+                }
+            } catch (AtlasBaseException e){
+                LOG.warn("Entity Vertex not found", e);
                 return null;
             }
 
@@ -163,11 +173,22 @@ public class BusinessLineageService implements AtlasBusinessLineageService {
 
     public void processProductAssetInputRelation(String assetGuid, String productGuid, BusinessLineageRequest.OperationType operation, String edgeLabel) throws AtlasBaseException, RepositoryException {
         try {
-             AtlasVertex assetVertex = entityRetriever.getEntityVertex(assetGuid);
-             AtlasVertex productVertex = entityRetriever.getEntityVertex(productGuid);
+            AtlasVertex assetVertex;
+            AtlasVertex productVertex;
+            try{
+                assetVertex = entityRetriever.getEntityVertex(assetGuid);
+                if (assetVertex == null) {
+                    LOG.warn("Asset not found for assetGuid: {}", assetGuid);
+                    return;
+                }
 
-            if (assetVertex == null || productVertex == null) {
-                LOG.warn("Asset or Product not found for assetGuid: {}, productGuid: {}", assetGuid, productGuid);
+                productVertex = entityRetriever.getEntityVertex(productGuid);
+                if (productVertex == null) {
+                    LOG.warn("Product not found for productGuid: {}", productGuid);
+                    return;
+                }
+            } catch (AtlasBaseException e){
+                LOG.warn("Entity Vertex not found", e);
                 return;
             }
 

--- a/repository/src/main/java/org/apache/atlas/repository/businesslineage/BusinessLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/repository/businesslineage/BusinessLineageService.java
@@ -115,7 +115,7 @@ public class BusinessLineageService implements AtlasBusinessLineageService {
 
                 if (StringUtils.isEmpty(edgeLabel)) {
                     AtlasVertex updatedVertex = processProductAssetLink(assetGuid, productGuid, operation, assetDenormAttribute);
-                    if (!updatedVertices.contains(updatedVertex)) {
+                    if (!updatedVertices.contains(updatedVertex) && updatedVertex != null) {
                         updatedVertices.add(updatedVertex);
                     }
                 } else {
@@ -139,7 +139,8 @@ public class BusinessLineageService implements AtlasBusinessLineageService {
 
 
             if (assetVertex == null || productVertex == null) {
-                throw new AtlasBaseException(AtlasErrorCode.INSTANCE_GUID_NOT_FOUND, assetGuid + " or " + productGuid);
+                LOG.warn("Asset or Product not found for assetGuid: {}, productGuid: {}", assetGuid, productGuid);
+                return null;
             }
 
             switch (operation) {
@@ -166,7 +167,8 @@ public class BusinessLineageService implements AtlasBusinessLineageService {
              AtlasVertex productVertex = entityRetriever.getEntityVertex(productGuid);
 
             if (assetVertex == null || productVertex == null) {
-                throw new AtlasBaseException(AtlasErrorCode.INSTANCE_GUID_NOT_FOUND, assetGuid + " or " + productGuid);
+                LOG.warn("Asset or Product not found for assetGuid: {}, productGuid: {}", assetGuid, productGuid);
+                return;
             }
 
             switch (operation) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/AbstractDomainPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/AbstractDomainPreProcessor.java
@@ -70,7 +70,7 @@ public abstract class AbstractDomainPreProcessor implements PreProcessor {
 
     private static final Set<String> POLICY_ATTRIBUTES_FOR_SEARCH = new HashSet<>(Arrays.asList(ATTR_POLICY_RESOURCES));
     private static final Set<String> STAKEHOLDER_ATTRIBUTES_FOR_SEARCH = new HashSet<>(Arrays.asList(ATTR_DOMAIN_QUALIFIED_NAMES, ATTR_DOMAIN_QUALIFIED_NAME));
-    private static final Set<String> DOMAIN_GUID_ATTR = new HashSet<>(Arrays.asList(DOMAIN_GUIDS));
+    private static final Set<String> DOMAIN_GUID_ATTR = new HashSet<>(Arrays.asList(DOMAIN_GUIDS, PRODUCT_GUIDS));
 
     static final Set<String> PARENT_ATTRIBUTES            = new HashSet<>(Arrays.asList(SUPER_DOMAIN_QN_ATTR, PARENT_DOMAIN_QN_ATTR));
 
@@ -287,11 +287,11 @@ public abstract class AbstractDomainPreProcessor implements PreProcessor {
         }
     }
 
-    protected Boolean hasLinkedAssets(String domainGuid) throws AtlasBaseException {
+    protected Boolean hasLinkedAssets(String entityGuid, String attribute) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("isAssetLinked");
         try {
             List<Map<String, Object>> mustClauseList = new ArrayList<>();
-            mustClauseList.add(mapOf("term", mapOf(DOMAIN_GUIDS, domainGuid)));
+            mustClauseList.add(mapOf("term", mapOf(attribute, entityGuid)));
 
             Map<String, Object> bool = new HashMap<>();
             bool.put("must", mustClauseList);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataDomainPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataDomainPreProcessor.java
@@ -420,7 +420,7 @@ public class DataDomainPreProcessor extends AbstractDomainPreProcessor {
             LOG.debug("DataDomainPreProcessor.processDelete: pre processing {}", domainGuid);
         }
 
-        if (hasLinkedAssets(domainGuid)) {
+        if (hasLinkedAssets(domainGuid, DOMAIN_GUIDS)) {
             throw new AtlasBaseException(AtlasErrorCode.OPERATION_NOT_SUPPORTED, "Domain cannot be deleted because some assets are linked to this domain");
         }
     }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
@@ -5,6 +5,7 @@ import org.apache.atlas.DeleteType;
 import org.apache.atlas.RequestContext;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.instance.*;
+import org.apache.atlas.repository.graph.GraphHelper;
 import org.apache.atlas.repository.graphdb.AtlasEdge;
 import org.apache.atlas.repository.graphdb.AtlasEdgeDirection;
 import org.apache.atlas.repository.graphdb.AtlasGraph;
@@ -473,6 +474,10 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
                     if(!exp.getAtlasErrorCode().equals(AtlasErrorCode.INSTANCE_BY_UNIQUE_ATTRIBUTE_NOT_FOUND)){
                         throw exp;
                     }
+                }
+
+                if (hasLinkedAssets(productGuid, PRODUCT_GUIDS)) {
+                    throw new AtlasBaseException(AtlasErrorCode.OPERATION_NOT_SUPPORTED, "Product cannot be hard deleted because some assets are linked to this product");
                 }
             }
             if(RequestContext.get().getDeleteType() == DeleteType.SOFT || RequestContext.get().getDeleteType() == DeleteType.DEFAULT){

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
@@ -477,7 +477,7 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
                 }
 
                 if (hasLinkedAssets(productGuid, PRODUCT_GUIDS)) {
-                    throw new AtlasBaseException(AtlasErrorCode.OPERATION_NOT_SUPPORTED, "Product cannot be hard deleted because some assets are linked to this product");
+                    throw new AtlasBaseException(AtlasErrorCode.OPERATION_NOT_SUPPORTED, "This product can't be deleted right now because it has linked assets that are in the process of being removed. Please try again shortly.");
                 }
             }
             if(RequestContext.get().getDeleteType() == DeleteType.SOFT || RequestContext.get().getDeleteType() == DeleteType.DEFAULT){


### PR DESCRIPTION
## Change description

> The reason for DLQ events was a Hard deleted Product coming in batch and reason for that batch failing. I have made API changes to LOG and skip such events instead of throwing errors as a immediate fix. Once this API changes are synced I will retry DLQ events for all tenants, except redhatin01

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
