### PR TITLE
MLH-370 : (feat) Implement caching for Keycloak token introspection to reduce high RPS

### DIFF
--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/APIKeySessionCache.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/APIKeySessionCache.java
@@ -3,27 +3,20 @@ package org.apache.atlas.repository.graphdb.janus;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import org.apache.atlas.AtlasConfiguration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 public class APIKeySessionCache {
-    private static final Logger LOG = LoggerFactory.getLogger(APIKeySessionCache.class);
-    
+
     private static final long TTL_SECONDS = AtlasConfiguration.KEYCLOAK_TOKEN_INTROSPECT_CACHE_TTL_SECOND.getLong();
     private final Cache<String, Boolean> apiKeyCache;
-    private final Set<String> deniedApiKeyTokens;
-    
+
     private static APIKeySessionCache instance;
     
     private APIKeySessionCache() {
         apiKeyCache = Caffeine.newBuilder()
                 .expireAfterWrite(TTL_SECONDS, TimeUnit.SECONDS)
                 .build();
-        deniedApiKeyTokens = ConcurrentHashMap.newKeySet();
     }
     
     public static synchronized APIKeySessionCache getInstance() {
@@ -37,20 +30,9 @@ public class APIKeySessionCache {
         apiKeyCache.put(apiKeyUsername, Boolean.TRUE);
     }
     
-    public void addToDeniedCache(String apiKeyUsername) {
-        deniedApiKeyTokens.add(apiKeyUsername);
-    }
-    
-    public boolean isValid(String apiKeyUsername, String bearerToken) {
-        if (deniedApiKeyTokens.contains(bearerToken)) {
-            return false;
-        }
-        
+    public boolean isValid(String apiKeyUsername) {
         Boolean isPresent = apiKeyCache.getIfPresent(apiKeyUsername);
         return isPresent != null && isPresent;
     }
 
-    public boolean isDenied(String bearerToken) {
-        return deniedApiKeyTokens.contains(bearerToken);
-    }
 }

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/APIKeySessionCache.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/APIKeySessionCache.java
@@ -35,21 +35,22 @@ public class APIKeySessionCache {
     
     public void setCache(String apiKeyUsername) {
         apiKeyCache.put(apiKeyUsername, Boolean.TRUE);
-        LOG.debug("Cached API key for user: {}", apiKeyUsername);
     }
     
     public void addToDeniedCache(String apiKeyUsername) {
         deniedApiKeys.add(apiKeyUsername);
-        LOG.debug("Added API key to denied cache: {}", apiKeyUsername);
     }
     
     public boolean isValid(String apiKeyUsername) {
         if (deniedApiKeys.contains(apiKeyUsername)) {
-            LOG.debug("API key found in denied cache: {}", apiKeyUsername);
             return false;
         }
         
         Boolean isPresent = apiKeyCache.getIfPresent(apiKeyUsername);
         return isPresent != null && isPresent;
+    }
+
+    public boolean isDenied(String apiKeyUsername) {
+        return deniedApiKeys.contains(apiKeyUsername);
     }
 }

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/APIKeySessionCache.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/APIKeySessionCache.java
@@ -1,0 +1,40 @@
+package org.apache.atlas.repository.graphdb.janus;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+public class APIKeySessionCache {
+    private static final Logger LOG = LoggerFactory.getLogger(APIKeySessionCache.class);
+    
+    private static final long TTL_MINUTES = 1;
+    private final Cache<String, Boolean> apiKeyCache;
+    
+    private static APIKeySessionCache instance;
+    
+    private APIKeySessionCache() {
+        apiKeyCache = Caffeine.newBuilder()
+                .expireAfterWrite(TTL_MINUTES, TimeUnit.MINUTES)
+                .build();
+    }
+    
+    public static synchronized APIKeySessionCache getInstance() {
+        if (instance == null) {
+            instance = new APIKeySessionCache();
+        }
+        return instance;
+    }
+    
+    public void setCache(String apiKeyUsername) {
+        apiKeyCache.put(apiKeyUsername, Boolean.TRUE);
+        LOG.debug("Cached API key for user: {}", apiKeyUsername);
+    }
+    
+    public boolean isValid(String apiKeyUsername) {
+        Boolean isPresent = apiKeyCache.getIfPresent(apiKeyUsername);
+        return isPresent != null && isPresent;
+    }
+}

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/APIKeySessionCache.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/APIKeySessionCache.java
@@ -2,23 +2,28 @@ package org.apache.atlas.repository.graphdb.janus;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import org.apache.atlas.AtlasConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 public class APIKeySessionCache {
     private static final Logger LOG = LoggerFactory.getLogger(APIKeySessionCache.class);
     
-    private static final long TTL_MINUTES = 1;
+    private static final long TTL_SECONDS = AtlasConfiguration.KEYCLOAK_TOKEN_INTROSPECT_CACHE_TTL_SECOND.getLong();
     private final Cache<String, Boolean> apiKeyCache;
+    private final Set<String> deniedApiKeys;
     
     private static APIKeySessionCache instance;
     
     private APIKeySessionCache() {
         apiKeyCache = Caffeine.newBuilder()
-                .expireAfterWrite(TTL_MINUTES, TimeUnit.MINUTES)
+                .expireAfterWrite(TTL_SECONDS, TimeUnit.SECONDS)
                 .build();
+        deniedApiKeys = ConcurrentHashMap.newKeySet();
     }
     
     public static synchronized APIKeySessionCache getInstance() {
@@ -33,7 +38,17 @@ public class APIKeySessionCache {
         LOG.debug("Cached API key for user: {}", apiKeyUsername);
     }
     
+    public void addToDeniedCache(String apiKeyUsername) {
+        deniedApiKeys.add(apiKeyUsername);
+        LOG.debug("Added API key to denied cache: {}", apiKeyUsername);
+    }
+    
     public boolean isValid(String apiKeyUsername) {
+        if (deniedApiKeys.contains(apiKeyUsername)) {
+            LOG.debug("API key found in denied cache: {}", apiKeyUsername);
+            return false;
+        }
+        
         Boolean isPresent = apiKeyCache.getIfPresent(apiKeyUsername);
         return isPresent != null && isPresent;
     }

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/APIKeySessionCache.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/APIKeySessionCache.java
@@ -15,7 +15,7 @@ public class APIKeySessionCache {
     
     private static final long TTL_SECONDS = AtlasConfiguration.KEYCLOAK_TOKEN_INTROSPECT_CACHE_TTL_SECOND.getLong();
     private final Cache<String, Boolean> apiKeyCache;
-    private final Set<String> deniedApiKeys;
+    private final Set<String> deniedApiKeyTokens;
     
     private static APIKeySessionCache instance;
     
@@ -23,7 +23,7 @@ public class APIKeySessionCache {
         apiKeyCache = Caffeine.newBuilder()
                 .expireAfterWrite(TTL_SECONDS, TimeUnit.SECONDS)
                 .build();
-        deniedApiKeys = ConcurrentHashMap.newKeySet();
+        deniedApiKeyTokens = ConcurrentHashMap.newKeySet();
     }
     
     public static synchronized APIKeySessionCache getInstance() {
@@ -38,11 +38,11 @@ public class APIKeySessionCache {
     }
     
     public void addToDeniedCache(String apiKeyUsername) {
-        deniedApiKeys.add(apiKeyUsername);
+        deniedApiKeyTokens.add(apiKeyUsername);
     }
     
-    public boolean isValid(String apiKeyUsername) {
-        if (deniedApiKeys.contains(apiKeyUsername)) {
+    public boolean isValid(String apiKeyUsername, String bearerToken) {
+        if (deniedApiKeyTokens.contains(bearerToken)) {
             return false;
         }
         
@@ -50,7 +50,7 @@ public class APIKeySessionCache {
         return isPresent != null && isPresent;
     }
 
-    public boolean isDenied(String apiKeyUsername) {
-        return deniedApiKeys.contains(apiKeyUsername);
+    public boolean isDenied(String bearerToken) {
+        return deniedApiKeyTokens.contains(bearerToken);
     }
 }

--- a/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
@@ -116,6 +116,7 @@ public enum AtlasConfiguration {
     PERSONA_POLICY_ASSET_MAX_LIMIT("atlas.persona.policy.asset.maxlimit", 1000),
     ENABLE_KEYCLOAK_TOKEN_INTROSPECTION("atlas.canary.keycloak.token-introspection", false),
     KEYCLOAK_TOKEN_INTROSPECT_CACHE_TTL_SECOND("atlas.keycloak.token-introspection.cache.ttl", 60),
+    KEYCLOAK_INTROSPECTION_USE_CACHE("atlas.keycloak.introspection.use.cache", false),
     HERACLES_CLIENT_PAGINATION_SIZE("atlas.heracles.admin.resource-pagination-size", 100),
     HERACLES_API_SERVER_URL("atlas.heracles.api.service.url", "http://heracles-service.heracles.svc.cluster.local"),
 

--- a/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
@@ -115,6 +115,7 @@ public enum AtlasConfiguration {
 
     PERSONA_POLICY_ASSET_MAX_LIMIT("atlas.persona.policy.asset.maxlimit", 1000),
     ENABLE_KEYCLOAK_TOKEN_INTROSPECTION("atlas.canary.keycloak.token-introspection", false),
+    KEYCLOAK_TOKEN_INTROSPECT_CACHE_TTL_SECOND("atlas.keycloak.token-introspection.cache.ttl", 60),
     HERACLES_CLIENT_PAGINATION_SIZE("atlas.heracles.admin.resource-pagination-size", 100),
     HERACLES_API_SERVER_URL("atlas.heracles.api.service.url", "http://heracles-service.heracles.svc.cluster.local"),
 

--- a/webapp/src/main/java/org/apache/atlas/web/security/AtlasKeycloakAuthenticationProvider.java
+++ b/webapp/src/main/java/org/apache/atlas/web/security/AtlasKeycloakAuthenticationProvider.java
@@ -102,7 +102,7 @@ public class AtlasKeycloakAuthenticationProvider extends AtlasAbstractAuthentica
               apiKeySessionCache.setCache(authentication.getName());
               authentication.setAuthenticated(true);
             } else {
-                apiKeySessionCache.addToDeniedCache(authentication.getName());
+                apiKeySessionCache.addToDeniedCache(bearerToken);
                 handleInvalidApiKey(authentication);
             }
           }

--- a/webapp/src/main/java/org/apache/atlas/web/security/AtlasKeycloakAuthenticationProvider.java
+++ b/webapp/src/main/java/org/apache/atlas/web/security/AtlasKeycloakAuthenticationProvider.java
@@ -88,15 +88,15 @@ public class AtlasKeycloakAuthenticationProvider extends AtlasAbstractAuthentica
 
       // Validate the token online with keycloak server if token introspection is enabled
       if (isTokenIntrospectionEnabled) {
-        String apiKey = authentication.getName();
+        String apiKeyServiceUserName = authentication.getName();
+        KeycloakAuthenticationToken keycloakToken = (KeycloakAuthenticationToken) authentication;
+        String bearerToken = keycloakToken.getAccount().getKeycloakSecurityContext().getTokenString();
         try {
-          if (apiKeySessionCache.isValid(apiKey)) {
+          if (apiKeySessionCache.isValid(apiKeyServiceUserName, bearerToken)) {
             authentication.setAuthenticated(true);
-          } else if (apiKeySessionCache.isDenied(apiKey)) {
+          } else if (apiKeySessionCache.isDenied(bearerToken)) {
             handleInvalidApiKey(authentication);
           } else {
-            KeycloakAuthenticationToken keycloakToken = (KeycloakAuthenticationToken) authentication;
-            String bearerToken = keycloakToken.getAccount().getKeycloakSecurityContext().getTokenString();
             TokenMetadataRepresentation introspectToken = atlasKeycloakClient.introspectToken(bearerToken);
             if (Objects.nonNull(introspectToken) && introspectToken.isActive()) {
               apiKeySessionCache.setCache(authentication.getName());

--- a/webapp/src/main/java/org/apache/atlas/web/security/AtlasKeycloakAuthenticationProvider.java
+++ b/webapp/src/main/java/org/apache/atlas/web/security/AtlasKeycloakAuthenticationProvider.java
@@ -101,7 +101,8 @@ public class AtlasKeycloakAuthenticationProvider extends AtlasAbstractAuthentica
               apiKeySessionCache.setCache(authentication.getName());
               authentication.setAuthenticated(true);
             } else {
-              handleInvalidApiKey(authentication);
+                apiKeySessionCache.addToDeniedCache(authentication.getName());
+                handleInvalidApiKey(authentication);
             }
           }
         } catch (Exception e) {

--- a/webapp/src/main/java/org/apache/atlas/web/security/AtlasKeycloakAuthenticationProvider.java
+++ b/webapp/src/main/java/org/apache/atlas/web/security/AtlasKeycloakAuthenticationProvider.java
@@ -87,12 +87,13 @@ public class AtlasKeycloakAuthenticationProvider extends AtlasAbstractAuthentica
       Counter.builder("service_account_apikey_request_counter").register(MetricUtils.getMeterRegistry()).increment();
 
       // Validate the token online with keycloak server if token introspection is enabled
-      LOG.info("isTokenIntrospectionEnabled: {}", isTokenIntrospectionEnabled);
       if (isTokenIntrospectionEnabled) {
-        LOG.info("Validating request for clientId: {}", authentication.getName().substring("service-account-".length()));
+        String apiKey = authentication.getName();
         try {
-          if (apiKeySessionCache.isValid(authentication.getName())) {
+          if (apiKeySessionCache.isValid(apiKey)) {
             authentication.setAuthenticated(true);
+          } else if (apiKeySessionCache.isDenied(apiKey)) {
+            handleInvalidApiKey(authentication);
           } else {
             KeycloakAuthenticationToken keycloakToken = (KeycloakAuthenticationToken) authentication;
             String bearerToken = keycloakToken.getAccount().getKeycloakSecurityContext().getTokenString();


### PR DESCRIPTION
## Change description

> To address the high RPS issue with Keycloak when validating API keys, implement a caching mechanism in the Metastore. The cache should store session information for one minute, allowing subsequent requests to use cached data instead of calling the Keycloak introspect endpoint for each request. This will reduce the load on Keycloak and improve performance. The solution needs to be deployed in production by 5PM today.

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
