### PR TITLE
MLH-332 | Reducing noise in search_logs

### DIFF
--- a/webapp/src/main/java/org/apache/atlas/web/rest/DiscoveryREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/DiscoveryREST.java
@@ -416,7 +416,7 @@ public class DiscoveryREST {
 
             if (StringUtils.isEmpty(parameters.getQuery())) {
                 AtlasBaseException abe = new AtlasBaseException(AtlasErrorCode.BAD_REQUEST, "Invalid search query");
-                if (enableSearchLogging && parameters.isSaveSearchLog()) {
+                if (enableSearchLogging && parameters.isSaveSearchLog() && !shouldSkipSearchLog(parameters)) {
                     logSearchLog(parameters, servletRequest, abe, System.currentTimeMillis() - startTime);
                 }
                 throw abe;
@@ -431,19 +431,19 @@ public class DiscoveryREST {
             }
             long endTime = System.currentTimeMillis();
 
-            if (enableSearchLogging && parameters.isSaveSearchLog()) {
+            if (enableSearchLogging && parameters.isSaveSearchLog() && !shouldSkipSearchLog(parameters)) {
                 logSearchLog(parameters, result, servletRequest, endTime - startTime);
             }
 
             return result;
         } catch (AtlasBaseException abe) {
-            if (enableSearchLogging && parameters.isSaveSearchLog()) {
+            if (enableSearchLogging && parameters.isSaveSearchLog() && !shouldSkipSearchLog(parameters)) {
                 logSearchLog(parameters, servletRequest, abe, System.currentTimeMillis() - startTime);
             }
             throw abe;
         } catch (Exception e) {
             AtlasBaseException abe = new AtlasBaseException(e.getMessage(), e.getCause());
-            if (enableSearchLogging && parameters.isSaveSearchLog()) {
+            if (enableSearchLogging && parameters.isSaveSearchLog() && !shouldSkipSearchLog(parameters)) {
                 logSearchLog(parameters, servletRequest, abe, System.currentTimeMillis() - startTime);
             }
             abe.setStackTrace(e.getStackTrace());
@@ -1048,5 +1048,34 @@ public class DiscoveryREST {
                 .setResponseTime(requestTime);
 
         loggerManagement.log(builder.build());
+    }
+
+    private boolean shouldSkipSearchLog(IndexSearchParams parameters) {
+
+        // Skip if utmTags contain specific landing page patterns
+        Set<String> utmTags = parameters.getUtmTags();
+        if (CollectionUtils.isNotEmpty(utmTags)) {
+            // Pattern 1: Bootstrap/landing page load
+            if (utmTags.contains("project_webapp") &&
+                    utmTags.contains("action_bootstrap") &&
+                    utmTags.contains("action_fetch_starred_assets")) {
+                return true;
+            }
+
+            // Pattern 2: Page loading
+            if (utmTags.contains("project_webapp") &&
+                    utmTags.contains("action_searched_on_load")) {
+                return true;
+            }
+
+            // Pattern 3: Assets page with search input empty
+            if (utmTags.contains("project_webapp") &&
+                    utmTags.contains("page_assets") &&
+                    utmTags.contains("action_searched")) {
+                return StringUtils.isEmpty(parameters.getSearchInput());
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
## Description

-> **Ignored noise** before saving IndexSearch calls info in the search_logs.
-> Full document:
 https://atlanhq.atlassian.net/wiki/spaces/Metastore/pages/825131749/WIP+-+Reducing+Search+Logs+Storage+in+Atlas


-> The indexSearch API calls for which I am ignoring saving the search_logs. 
1) **Main Landing Page** with action_fetch_starred_assets and action_bootstrap. 
2) **Asset landing page** with action_searched_on_load.
3) **Keyword search** with action_searched and **search_input empty.**


Reference:
https://atlanhq.atlassian.net/wiki/spaces/Metastore/pages/825131749/WIP+-+Reducing+Search+Logs+Storage+in+Atlas#UI-Based-API-Calls


## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues


## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [x] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
