### PR TITLE
MLH-301 | Alcon slowness issue

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,6 +28,7 @@ on:
       - master
       - lineageondemand
       - optimise_classifications_fetch
+      - hotfixalconi
 
 jobs:
   build:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,7 +28,6 @@ on:
       - master
       - lineageondemand
       - optimise_classifications_fetch
-      - hotfixalconi
 
 jobs:
   build:

--- a/common/src/main/java/org/apache/atlas/service/redis/AbstractRedisService.java
+++ b/common/src/main/java/org/apache/atlas/service/redis/AbstractRedisService.java
@@ -67,9 +67,15 @@ public abstract class AbstractRedisService implements RedisService {
         RLock lock = null;
         try {
             lock = redisClient.getFairLock(key);
-            lock.tryLock(waitTimeInMS, leaseTimeInMS, TimeUnit.MILLISECONDS);
-            getLogger().info("Lock with key {} is acquired, host: {}.", key, getHostAddress());
-           return lock;
+            boolean isLockAcquired =  lock.tryLock(waitTimeInMS, leaseTimeInMS, TimeUnit.MILLISECONDS);
+
+            if (isLockAcquired){
+                getLogger().info("Lock with key {} is acquired, host: {}.", key, getHostAddress());
+                return lock;
+            }else {
+                getLogger().info("Attempt failed as fair lock {} is already acquired, host: {}.", key, getHostAddress());
+                return null;
+            }
 
         } catch (InterruptedException e) {
             getLogger().error("Failed to acquire distributed lock for {}, host: {}", key, getHostAddress(), e);

--- a/common/src/main/java/org/apache/atlas/service/redis/RedisService.java
+++ b/common/src/main/java/org/apache/atlas/service/redis/RedisService.java
@@ -2,11 +2,17 @@ package org.apache.atlas.service.redis;
 
 import org.slf4j.Logger;
 
+import java.util.concurrent.locks.Lock;
+
 public interface RedisService {
 
   boolean acquireDistributedLock(String key) throws Exception;
 
+  Lock acquireDistributedLockV2(String key) throws Exception;
+
   void releaseDistributedLock(String key);
+
+  void releaseDistributedLockV2(Lock lock, String key);
 
   String getValue(String key);
 

--- a/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
@@ -143,8 +143,10 @@ public enum AtlasConfiguration {
     OTEL_RESOURCE_ATTRIBUTES("OTEL_RESOURCE_ATTRIBUTES", "service.name=atlas"),
     OTEL_SERVICE_NAME(" OTEL_SERVICE_NAME", "atlas"),
     OTEL_EXPORTER_OTLP_ENDPOINT("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317"),
-    ATLAS_BULK_API_MAX_ENTITIES_ALLOWED("atlas.bulk.api.max.entities.allowed", 10000);
+    ATLAS_BULK_API_MAX_ENTITIES_ALLOWED("atlas.bulk.api.max.entities.allowed", 10000),
 
+    ENABLE_ASYNC_TYPE_UPDATE("atlas.types.update.async.enable", false),
+    MAX_THREADS_TYPE_UPDATE("atlas.types.update.thread.count", 3);
 
 
     private static final Configuration APPLICATION_PROPERTIES;

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasTypeDefGraphStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasTypeDefGraphStore.java
@@ -19,6 +19,7 @@ package org.apache.atlas.repository.store.graph;
 
 import org.apache.atlas.AtlasErrorCode;
 import org.apache.atlas.GraphTransactionInterceptor;
+import org.apache.atlas.RequestContext;
 import org.apache.atlas.annotation.GraphTransaction;
 import org.apache.atlas.authorize.AtlasAuthorizationUtils;
 import org.apache.atlas.authorize.AtlasPrivilege;
@@ -37,6 +38,7 @@ import org.apache.atlas.store.AtlasTypeDefStore;
 import org.apache.atlas.type.*;
 import org.apache.atlas.type.AtlasTypeRegistry.AtlasTransientTypeRegistry;
 import org.apache.atlas.util.AtlasRepositoryConfiguration;
+import org.apache.atlas.utils.AtlasPerfMetrics;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.Predicate;
 import org.apache.commons.lang3.StringUtils;
@@ -494,6 +496,8 @@ public abstract class AtlasTypeDefGraphStore implements AtlasTypeDefStore {
     @Override
     @GraphTransaction
     public AtlasTypesDef updateTypesDef(AtlasTypesDef typesDef) throws AtlasBaseException {
+        AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("updateTypesDef");
+
         if (LOG.isDebugEnabled()) {
             LOG.debug("==> AtlasTypeDefGraphStore.updateTypesDef(enums={}, structs={}, classfications={}, entities={}, relationships{}, businessMetadataDefs={})",
                     CollectionUtils.size(typesDef.getEnumDefs()),
@@ -535,6 +539,7 @@ public abstract class AtlasTypeDefGraphStore implements AtlasTypeDefStore {
                     CollectionUtils.size(typesDef.getBusinessMetadataDefs()));
         }
 
+        RequestContext.get().endMetricRecord(metricRecorder);
         return ret;
 
     }
@@ -839,9 +844,12 @@ public abstract class AtlasTypeDefGraphStore implements AtlasTypeDefStore {
     }
 
     private AtlasTransientTypeRegistry lockTypeRegistryAndReleasePostCommit() throws AtlasBaseException {
+        AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("lockTypeRegistryAndReleasePostCommit");
         AtlasTransientTypeRegistry ttr = typeRegistry.lockTypeRegistryForUpdate(typeUpdateLockMaxWaitTimeSeconds);
 
         new TypeRegistryUpdateHook(ttr);
+
+        RequestContext.get().endMetricRecord(metricRecorder);
 
         return ttr;
     }

--- a/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
@@ -513,7 +513,6 @@ public class TypesREST {
             throw new AtlasBaseException("Error while updating a type definition");
         } finally {
             RequestContext.clear();
-            redisService.releaseDistributedLock(ATLAS_TYPEDEF_LOCK);
             AtlasPerfTracer.log(perf);
         }
     }

--- a/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
@@ -412,16 +412,16 @@ public class TypesREST {
 
             Lock lock = redisService.acquireDistributedLockV2(ATLAS_TYPEDEF_LOCK);
             if (lock == null) {
-                LOG.info("Lock is already acquired. Returning now :: traceId {}", traceId);
+                LOG.info("Lock is already acquired. for key {} : Returning now :: traceId {}", ATLAS_TYPEDEF_LOCK, traceId);
                 throw new AtlasBaseException(AtlasErrorCode.FAILED_TO_OBTAIN_TYPE_UPDATE_LOCK);
             }
-            LOG.info("successfully acquired lock :: traceId {}", traceId);
+            LOG.info("Successfully acquired lock with key {} :: traceId {}", ATLAS_TYPEDEF_LOCK, traceId);
             return lock;
         } catch (AtlasBaseException e) {
             throw e;
         } catch (Exception e) {
             LOG.error("Error while acquiring lock on type-defs :: traceId " + traceId + " ." + e.getMessage(), e);
-            throw new AtlasBaseException("Error while acquiring a lock on type-defs");
+            throw new AtlasBaseException("Error while acquiring a lock on type-defs", e);
         }
     }
 


### PR DESCRIPTION
## Change description

> Description here
- create v2 version to acquire and release locks
- observed  `refreshAllHostCache` takes most of the time 
-  `refreshAllHostCache`  refreshed typedef cache on each pod and hence it is slow operation
- made this method async with 3 retries behind a configuration flag.
- just updated put flow where issue was reported to minimise the changes.

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
