### PR TITLE
BL-5430 | master | change regex to accept . and - in the slack channel domain name

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/accesscontrol/AccessControlPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/accesscontrol/AccessControlPreProcessor.java
@@ -23,8 +23,7 @@ public class AccessControlPreProcessor implements PreProcessor {
     private static final Logger LOG = LoggerFactory.getLogger(AccessControlPreProcessor.class);
 
     // Regex reference - https://atlanhq.atlassian.net/browse/DG-1907?focusedCommentId=270252
-    private static final Pattern REGEX_SLACK_CHANNEL_LINK = Pattern.compile("^https://(?<domain>\\w+\\.slack\\.com)/archives/(?<channel>C\\w{8,})(?:/p(?<timestamp>\\d{10}))?$");
-
+    private static final Pattern REGEX_SLACK_CHANNEL_LINK = Pattern.compile("^https://(?<domain>[\\w.-]+\\.slack\\.com)/archives/(?<channel>C\\w{8,})(?:/p(?<timestamp>\\d{10}))?$");
     @Override
     public void processAttributes(AtlasStruct entityStruct, EntityMutationContext context, EntityMutations.EntityOperation operation) throws AtlasBaseException {
         if (LOG.isDebugEnabled()) {


### PR DESCRIPTION
## change regex to accept . and - in the slack channel domain name

> currently if there is a . or - in the slack domain and then trying to link the channel in persona it is failing due to regex issue

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> https://atlanhq.atlassian.net/browse/BL-5430

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
