### PR TITLE
MESH-522 | Broken Product Sidebar

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
@@ -249,12 +249,22 @@ public class ESAliasStore implements IndexAliasStore {
                     for (String asset : assets) {
                         if(!isAllDomain(asset)) {
                             terms.add(asset);
+
+                            // Add all parent domains in the hierarchy
+                            String currentPath = asset;
+                            while (currentPath.contains("/")) {
+                                allowClauseList.add(mapOf("term", mapOf(QUALIFIED_NAME, currentPath)));
+                                currentPath = currentPath.substring(0, currentPath.lastIndexOf("/"));
+                            }
+
+                            if (!currentPath.isEmpty()) {
+                                allowClauseList.add(mapOf("term", mapOf(QUALIFIED_NAME, currentPath)));
+                            }
                         } else {
                             asset = NEW_WILDCARD_DOMAIN_SUPER;
                         }
                         allowClauseList.add(mapOf("wildcard", mapOf(QUALIFIED_NAME, asset + "*")));
                     }
-
                 } else if (policyActions.contains(ACCESS_READ_PERSONA_SUB_DOMAIN)) {
                     for (String asset : assets) {
                         //terms.add(asset);


### PR DESCRIPTION
## Change description

> 
Current Behavior:
When only sub-domains (i.e., child domains that are not root-level) are selected in domain-level policies, the product sidebar fails to render any content, resulting in a broken or blank page for the user. (Refer to the associated ticket for more details.)

Proposed Behavior:
We intend to enhance the experience by rendering only the selected child domain(s) along with their direct parent domains in the upward hierarchy. The access rules will be as follows:

Selected Sub-domains: Full access as defined by the policy.

Parent Domains: Read-only access will be granted to parent domains solely for navigational context.

Sibling Domains: At any level, sibling domains (i.e., domains at the same level that are not part of the policy) should remain completely inaccessible.

This ensures a clear and secure hierarchical view without exposing unrelated domains, maintaining both usability and compliance with domain-based access policies.

JIRA: [ticket](https://atlanhq.atlassian.net/browse/MESH-522)
Test Doc: [doc](https://atlanhq.atlassian.net/wiki/spaces/dg/pages/855775194/Test+Cases+for+MESH-522+Broken+domain-subdomain+hierarchy+navigation+when+Persona+has+access+to+subset+of+subdomains)

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
