### PR TITLE
MLH-89 | Combined Atlas and Template PolicyConditions

### DIFF
--- a/auth-agents-common/src/main/java/org/apache/atlas/policytransformer/PersonaCachePolicyTransformer.java
+++ b/auth-agents-common/src/main/java/org/apache/atlas/policytransformer/PersonaCachePolicyTransformer.java
@@ -25,6 +25,7 @@ import org.apache.atlas.RequestContext;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.instance.AtlasEntity;
 import org.apache.atlas.model.instance.AtlasEntityHeader;
+import org.apache.atlas.model.instance.AtlasStruct;
 import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
 import org.apache.atlas.utils.AtlasPerfMetrics;
 import org.apache.commons.collections.CollectionUtils;
@@ -101,7 +102,8 @@ public class PersonaCachePolicyTransformer extends AbstractCachePolicyTransforme
                 header.setAttribute(ATTR_POLICY_RESOURCES_CATEGORY, templatePolicy.getPolicyResourceCategory());
                 header.setAttribute(ATTR_POLICY_IS_ENABLED, getIsPolicyEnabled(atlasPolicy));
                 header.setAttribute(ATTR_NAME, "transformed_policy_persona");
-                header.setAttribute(ATTR_POLICY_CONDITIONS, templatePolicy.getPolicyConditions());
+
+                header.setAttribute(ATTR_POLICY_CONDITIONS, buildPolicyConditions(atlasPolicy, templatePolicy));
 
                 if (POLICY_SERVICE_NAME_ABAC.equals(policyServiceName)) {
                     if (policyFilterCriteria != null && !policyFilterCriteria.isEmpty()) {
@@ -179,5 +181,27 @@ public class PersonaCachePolicyTransformer extends AbstractCachePolicyTransforme
         }
 
         return false;
+    }
+
+    private List<AtlasStruct> buildPolicyConditions(AtlasEntityHeader atlasPolicy, PolicyTransformerTemplate.TemplatePolicy templatePolicy) {
+        List<AtlasStruct> combinedConditions = new ArrayList<>();
+
+        try {
+            List<AtlasStruct> atlasConditions = (List<AtlasStruct>) atlasPolicy.getAttribute(ATTR_POLICY_CONDITIONS);
+            if (CollectionUtils.isNotEmpty(atlasConditions)) {
+                combinedConditions.addAll(atlasConditions);
+            }
+
+            List<AtlasStruct> templateConditions = templatePolicy.getPolicyConditions();
+            if (CollectionUtils.isNotEmpty(templateConditions)) {
+                combinedConditions.addAll(templateConditions);
+            }
+
+        } catch (Exception e) {
+            LOG.warn("Error processing policy conditions: {}", e.getMessage());
+            LOG.warn("Exception while processing policy conditions", e);
+        }
+
+        return combinedConditions;
     }
 }


### PR DESCRIPTION
### Change description
## **Context**
Previously, PersonaCachePolicyTransformer only used policy conditions from the **TemplatePolicy** defined in `policy_cache_transformer.json`, ignoring any policyConditions specified in the incoming **AtlasPolicy** **payload**.

## **Change**
Refactoring **PersonaCachePolicyTransformer.java** to consolidate policy conditions from two sources:
1) The original atlas policyConditions defined in the API payload
2) The policyCondition at the templatePolicy defined in policy_cache_transformer.json. 

This ensures that both sources contribute to the final Ranger policy's conditions block, preserving all intended exclusions.

No modifications to existing Authorization evaluator code are required, as it already handles the "excludeEntityTypes" condition type.


## **Testing**
Validated with entity types: Connection, Table, View, MaterializedView, etc.
Scenarios tested:
->No policyConditions in payload
->Payload with single and multiple entityTypes
Confirmed correct access control behavior in all cases.
-> FULL DETAILS-> https://atlanhq.atlassian.net/wiki/spaces/Metastore/pages/867237981/Test+cases+for+MLH-89+-+PR+4735

Jira Ticket -> https://atlanhq.atlassian.net/browse/MLH-89

This change is also compatible with any future plans regarding excluding an entity type while giving access through metadata policy. More details here -> https://atlanhq.atlassian.net/browse/MLH-89?focusedCommentId=407455

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [x] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
