### PR TITLE
MLH-458 | Add lock v2 configuration in all tyoes

### DIFF
--- a/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
@@ -146,7 +146,7 @@ public enum AtlasConfiguration {
     ATLAS_BULK_API_MAX_ENTITIES_ALLOWED("atlas.bulk.api.max.entities.allowed", 10000),
 
     ENABLE_ASYNC_TYPE_UPDATE("atlas.types.update.async.enable", false),
-    MAX_THREADS_TYPE_UPDATE("atlas.types.update.thread.count", 3);
+    MAX_THREADS_TYPE_UPDATE("atlas.types.update.thread.count", 4);
 
 
     private static final Configuration APPLICATION_PROPERTIES;


### PR DESCRIPTION
## Change description

> Description here
**- Issue Summary:**
The customer is experiencing long response times (15–20 seconds) and intermittent 500 errors when using the Create/Update/Delete Custom Metadata APIs.
A recent error they received repeatedly was:
500 Internal Server Error   {   "errorCode":"ATLAS-500-00-005",   "errorMessage":"Failed to get the lock; another type update might be in progress. Please try again" } 

**- Fix**
  Reuse the v2 version of acquiring and releasing locks across CUD methods for typesdef

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
