### PR TITLE
MESH-407 | Hard Deletion of Assets and Products

### DIFF
--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -424,6 +424,7 @@ public final class Constants {
     public static final String DOMAIN_GUIDS_ATTR = "domainGUIDs";
     public static final String ASSET_POLICY_GUIDS  = "assetPolicyGUIDs";
     public static final String PRODUCT_GUIDS_ATTR  = "productGUIDs";
+    public static final String PRODUCT_ASSET_OUTPUT_PORT_ATTR = "outputProductGUIDs";
 
     public static final String NON_COMPLIANT_ASSET_POLICY_GUIDS  = "nonCompliantAssetPolicyGUIDs";
     public static final String ASSET_POLICIES_COUNT  = "assetPoliciesCount";

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -1068,6 +1068,8 @@ public abstract class DeleteHandlerV1 {
             }
         }
 
+        cleanupDenormalizedProductReferences(instanceVertex);
+
         _deleteVertex(instanceVertex, force);
     }
 
@@ -1739,5 +1741,28 @@ public abstract class DeleteHandlerV1 {
                     // Check if this edge has lineage
                     return Boolean.TRUE.equals(edge.get(HAS_LINEAGE));
                 });
+    }
+
+    private void cleanupDenormalizedProductReferences(AtlasVertex vertex) {
+        if (isAssetType(vertex)) {
+            String guid = GraphHelper.getGuid(vertex);
+            
+            Iterator<AtlasVertex> products = graph.query()
+                .has("__typeName", "DataProduct")
+                .has("daapOutputPortGuids", guid)
+                .vertices().iterator();
+                
+            while (products.hasNext()) {
+                AtlasVertex product = products.next();
+                AtlasGraphUtilsV2.removeItemFromListPropertyValue(product, "daapOutputPortGuids", guid);
+            }
+        }
+    }
+
+    private boolean isAssetType(AtlasVertex vertex) {
+        String typeName = GraphHelper.getTypeName(vertex);
+        AtlasEntityType entityType = typeRegistry.getEntityTypeByName(typeName);
+        
+        return entityType != null && entityType.getTypeAndAllSuperTypes().contains("Asset");
     }
 }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -1744,6 +1744,11 @@ public abstract class DeleteHandlerV1 {
     }
 
     private void cleanupDenormalizedProductReferences(AtlasVertex vertex) {
+        DeleteType deleteType = RequestContext.get().getDeleteType();
+        if (deleteType != DeleteType.HARD && deleteType != DeleteType.PURGE) {
+            return;
+        }
+
         if (isAssetType(vertex)) {
             String guid = GraphHelper.getGuid(vertex);
             

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -1069,7 +1069,7 @@ public abstract class DeleteHandlerV1 {
             }
         }
 
-        cleanupDenormalizedProductReferences(instanceVertex);
+        cleanupDenormalizedAssetReferencesFromProduct(instanceVertex);
 
         _deleteVertex(instanceVertex, force);
     }
@@ -1744,24 +1744,39 @@ public abstract class DeleteHandlerV1 {
                 });
     }
 
-    private void cleanupDenormalizedProductReferences(AtlasVertex vertex) {
-        DeleteType deleteType = RequestContext.get().getDeleteType();
-        if (deleteType != DeleteType.HARD && deleteType != DeleteType.PURGE) {
-            return;
-        }
-
-        if (isAssetType(vertex)) {
-            String guid = GraphHelper.getGuid(vertex);
-            
-            Iterator<AtlasVertex> products = graph.query()
-                .has("__typeName", DATA_PRODUCT_ENTITY_TYPE)
-                .has(OUTPUT_PORT_GUIDS_ATTR, guid)
-                .vertices().iterator();
-                
-            while (products.hasNext()) {
-                AtlasVertex product = products.next();
-                AtlasGraphUtilsV2.removeItemFromListPropertyValue(product, OUTPUT_PORT_GUIDS_ATTR, guid);
+    private void cleanupDenormalizedAssetReferencesFromProduct(AtlasVertex vertex) {
+        try {
+            DeleteType deleteType = RequestContext.get().getDeleteType();
+            if (deleteType != DeleteType.HARD && deleteType != DeleteType.PURGE) {
+                return;
             }
+
+            if (isAssetType(vertex)) {
+                String guid = GraphHelper.getGuid(vertex);
+                int productRefsRemoved = 0;
+
+                try {
+                    Iterator<AtlasVertex> products = graph.query()
+                        .has("__typeName", DATA_PRODUCT_ENTITY_TYPE)
+                        .has(OUTPUT_PORT_GUIDS_ATTR, guid)
+                        .vertices().iterator();
+
+                    while (products.hasNext()) {
+                        AtlasVertex product = products.next();
+                        AtlasGraphUtilsV2.removeItemFromListPropertyValue(product, OUTPUT_PORT_GUIDS_ATTR, guid);
+                        productRefsRemoved++;
+                    }
+
+                    if (productRefsRemoved > 0) {
+                        LOG.info("cleanupDenormalizedProductReferences: successfully cleaned up {} product references for asset: {}", productRefsRemoved, guid);
+                    }
+                } catch (Exception e) {
+                    LOG.error("cleanupDenormalizedAssetReferencesFromProduct: failed to cleanup reference for asset {} from individual product", guid, e);
+                }
+            }
+        }
+        catch (Exception e) {
+            LOG.error("cleanupDenormalizedAssetReferencesFromProduct: unexpected error during cleanup", e);
         }
     }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -77,6 +77,7 @@ import static org.apache.atlas.model.typedef.AtlasRelationshipDef.PropagateTags.
 import static org.apache.atlas.repository.Constants.*;
 import static org.apache.atlas.repository.graph.GraphHelper.*;
 import static org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2.*;
+import static org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessorUtils.OUTPUT_PORT_GUIDS_ATTR;
 import static org.apache.atlas.repository.store.graph.v2.tasks.ClassificationPropagateTaskFactory.CLASSIFICATION_PROPAGATION_ADD;
 import static org.apache.atlas.repository.store.graph.v2.tasks.ClassificationPropagateTaskFactory.CLASSIFICATION_PROPAGATION_DELETE;
 import static org.apache.atlas.repository.store.graph.v2.tasks.ClassificationPropagateTaskFactory.CLASSIFICATION_REFRESH_PROPAGATION;
@@ -1753,13 +1754,13 @@ public abstract class DeleteHandlerV1 {
             String guid = GraphHelper.getGuid(vertex);
             
             Iterator<AtlasVertex> products = graph.query()
-                .has("__typeName", "DataProduct")
-                .has("daapOutputPortGuids", guid)
+                .has("__typeName", DATA_PRODUCT_ENTITY_TYPE)
+                .has(OUTPUT_PORT_GUIDS_ATTR, guid)
                 .vertices().iterator();
                 
             while (products.hasNext()) {
                 AtlasVertex product = products.next();
-                AtlasGraphUtilsV2.removeItemFromListPropertyValue(product, "daapOutputPortGuids", guid);
+                AtlasGraphUtilsV2.removeItemFromListPropertyValue(product, OUTPUT_PORT_GUIDS_ATTR, guid);
             }
         }
     }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
@@ -549,9 +549,9 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
                     }
                 }
 
-                if (hasLinkedAssets(productGuid, PRODUCT_GUIDS)) {
-                    throw new AtlasBaseException(AtlasErrorCode.OPERATION_NOT_SUPPORTED, "This product can't be deleted right now because it has linked assets that are in the process of being removed. Please try again shortly.");
-                }
+//                if (hasLinkedAssets(productGuid, PRODUCT_GUIDS)) {
+//                    throw new AtlasBaseException(AtlasErrorCode.OPERATION_NOT_SUPPORTED, "This product can't be deleted right now because it has linked assets that are in the process of being removed. Please try again shortly.");
+//                }
 
                 try {
                     cleanupProductReferencesFromAssets(productGuid);


### PR DESCRIPTION
## Change description

> We want to introduce the following hard deletion support on atlas - 
1. If an asset is hard-deleted, then the guid of the asset is removed from the product's `outputPorts` but not from `daapOutputPortGuids`
2. If a product is hard-deleted, then it should be removed from the `productGuids` and `outputProductGuids` of all the assets where it is present


JIRA: [MESH-407](https://atlanhq.atlassian.net/browse/MESH-407), [MESH-525](https://atlanhq.atlassian.net/browse/MESH-525)

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable


[MESH-407]: https://atlanhq.atlassian.net/browse/MESH-407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MESH-525]: https://atlanhq.atlassian.net/browse/MESH-525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ