### PR TITLE
PLTS-336 | Handle parent domain extraction for product QNs and add product permissions

### DIFF
--- a/addons/static/templates/policy_cache_transformer_persona.json
+++ b/addons/static/templates/policy_cache_transformer_persona.json
@@ -774,15 +774,6 @@
       "policyType": "ACCESS",
       "resources": [
         "entity:{entity}/*product/*",
-        "entity-type:DataProduct",
-        "entity-classification:*"
-      ],
-      "actions": ["entity-read"]
-    },
-    {
-      "policyResourceCategory": "ENTITY",
-      "policyType": "ACCESS",
-      "resources": [
         "entity:{entity}",
         "entity-type:DataProduct",
         "entity-classification:*"
@@ -845,6 +836,7 @@
       "policyType": "ACCESS",
       "resources": [
         "entity:{entity}/*product/*",
+        "entity:{entity}",
         "entity-type:DataProduct",
         "entity-classification:*",
         "classification:*"
@@ -870,6 +862,7 @@
 
         "end-two-entity-type:DataProduct",
         "end-two-entity-classification:*",
+        "end-two-entity:{entity}",
         "end-two-entity:{entity}/*product/*"
       ],
 
@@ -885,6 +878,7 @@
 
         "end-one-entity-type:DataProduct",
         "end-one-entity-classification:*",
+        "end-one-entity:{entity}",
         "end-one-entity:{entity}/*product/*",
 
         "end-two-entity-type:Asset",
@@ -892,56 +886,6 @@
         "end-two-entity:*"
       ],
 
-      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
-    },
-    {
-      "policyResourceCategory": "ENTITY",
-      "policyType": "ACCESS",
-      "resources": [
-        "entity:{entity}",
-        "entity-type:DataProduct",
-        "entity-classification:*",
-        "classification:*"
-      ],
-      "actions": [
-        "entity-update",
-        "entity-add-classification",
-        "entity-update-classification",
-        "entity-remove-classification"
-      ]
-    },
-    {
-      "policyResourceCategory": "RELATIONSHIP",
-      "policyType": "ACCESS",
-      "description": "Link/unlink any Asset to this DataProduct",
-      "resources": [
-        "relationship-type:*",
-
-        "end-one-entity-type:Asset",
-        "end-one-entity-classification:*",
-        "end-one-entity:*",
-
-        "end-two-entity-type:DataProduct",
-        "end-two-entity-classification:*",
-        "end-two-entity:{entity}"
-      ],
-      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
-    },
-    {
-      "policyResourceCategory": "RELATIONSHIP",
-      "policyType": "ACCESS",
-      "description": "Link/unlink any Asset to this DataProduct",
-      "resources": [
-        "relationship-type:*",
-
-        "end-one-entity-type:DataProduct",
-        "end-one-entity-classification:*",
-        "end-one-entity:{entity}",
-
-        "end-two-entity-type:Asset",
-        "end-two-entity-classification:*",
-        "end-two-entity:*"
-      ],
       "actions": ["add-relationship", "update-relationship", "remove-relationship"]
     }
   ],
@@ -951,15 +895,6 @@
       "policyType": "ACCESS",
       "resources": [
         "entity:{entity}/*product/*",
-        "entity-type:DataProduct",
-        "entity-classification:*"
-      ],
-      "actions": ["entity-delete"]
-    },
-    {
-      "policyResourceCategory": "ENTITY",
-      "policyType": "ACCESS",
-      "resources": [
         "entity:{entity}",
         "entity-type:DataProduct",
         "entity-classification:*"
@@ -973,16 +908,6 @@
       "policyResourceCategory": "ENTITY",
       "resources": [
         "entity:{entity}/*product/*",
-        "entity-type:DataProduct",
-        "entity-classification:*",
-        "entity-business-metadata:*"
-      ],
-      "actions": ["entity-update-business-metadata"]
-    },
-    {
-      "policyType": "ACCESS",
-      "policyResourceCategory": "ENTITY",
-      "resources": [
         "entity:{entity}",
         "entity-type:DataProduct",
         "entity-classification:*",

--- a/addons/static/templates/policy_cache_transformer_persona.json
+++ b/addons/static/templates/policy_cache_transformer_persona.json
@@ -778,6 +778,16 @@
         "entity-classification:*"
       ],
       "actions": ["entity-read"]
+    },
+    {
+      "policyResourceCategory": "ENTITY",
+      "policyType": "ACCESS",
+      "resources": [
+        "entity:{entity}",
+        "entity-type:DataProduct",
+        "entity-classification:*"
+      ],
+      "actions": ["entity-read"]
     }
   ],
   "persona-domain-product-create": [
@@ -883,6 +893,56 @@
       ],
 
       "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+    },
+    {
+      "policyResourceCategory": "ENTITY",
+      "policyType": "ACCESS",
+      "resources": [
+        "entity:{entity}",
+        "entity-type:DataProduct",
+        "entity-classification:*",
+        "classification:*"
+      ],
+      "actions": [
+        "entity-update",
+        "entity-add-classification",
+        "entity-update-classification",
+        "entity-remove-classification"
+      ]
+    },
+    {
+      "policyResourceCategory": "RELATIONSHIP",
+      "policyType": "ACCESS",
+      "description": "Link/unlink any Asset to this DataProduct",
+      "resources": [
+        "relationship-type:*",
+
+        "end-one-entity-type:Asset",
+        "end-one-entity-classification:*",
+        "end-one-entity:*",
+
+        "end-two-entity-type:DataProduct",
+        "end-two-entity-classification:*",
+        "end-two-entity:{entity}"
+      ],
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+    },
+    {
+      "policyResourceCategory": "RELATIONSHIP",
+      "policyType": "ACCESS",
+      "description": "Link/unlink any Asset to this DataProduct",
+      "resources": [
+        "relationship-type:*",
+
+        "end-one-entity-type:DataProduct",
+        "end-one-entity-classification:*",
+        "end-one-entity:{entity}",
+
+        "end-two-entity-type:Asset",
+        "end-two-entity-classification:*",
+        "end-two-entity:*"
+      ],
+      "actions": ["add-relationship", "update-relationship", "remove-relationship"]
     }
   ],
   "persona-domain-product-delete": [
@@ -895,6 +955,16 @@
         "entity-classification:*"
       ],
       "actions": ["entity-delete"]
+    },
+    {
+      "policyResourceCategory": "ENTITY",
+      "policyType": "ACCESS",
+      "resources": [
+        "entity:{entity}",
+        "entity-type:DataProduct",
+        "entity-classification:*"
+      ],
+      "actions": ["entity-delete"]
     }
   ],
   "persona-domain-product-business-update-metadata": [
@@ -903,6 +973,17 @@
       "policyResourceCategory": "ENTITY",
       "resources": [
         "entity:{entity}/*product/*",
+        "entity-type:DataProduct",
+        "entity-classification:*",
+        "entity-business-metadata:*"
+      ],
+      "actions": ["entity-update-business-metadata"]
+    },
+    {
+      "policyType": "ACCESS",
+      "policyResourceCategory": "ENTITY",
+      "resources": [
+        "entity:{entity}",
         "entity-type:DataProduct",
         "entity-classification:*",
         "entity-business-metadata:*"

--- a/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/aliasstore/ESAliasStore.java
@@ -59,7 +59,7 @@ import static org.apache.atlas.repository.util.AccessControlUtils.ACCESS_READ_PE
 import static org.apache.atlas.repository.util.AccessControlUtils.ACCESS_READ_PERSONA_AI_MODEL;
 import static org.apache.atlas.repository.util.AccessControlUtils.RESOURCES_ENTITY_TYPE;
 import static org.apache.atlas.repository.util.AccessControlUtils.ATTR_POLICY_SERVICE_NAME;
-import static org.apache.atlas.repository.util.AccessControlUtils.ACCESS_READ_PURPOSE_METADATA;
+import static org.apache.atlas.repository.util.AccessControlUtils.POLICY_SUB_CATEGORY_METADATA;
 import static org.apache.atlas.repository.util.AccessControlUtils.POLICY_SERVICE_NAME_ABAC;
 import static org.apache.atlas.repository.util.AccessControlUtils.ATTR_POLICY_FILTER_CRITERIA;
 import static org.apache.atlas.repository.util.AccessControlUtils.getConnectionQualifiedNameFromPolicyAssets;
@@ -72,6 +72,7 @@ import static org.apache.atlas.repository.util.AccessControlUtils.getPolicyResou
 import static org.apache.atlas.repository.util.AccessControlUtils.getFilteredPolicyResources;
 import static org.apache.atlas.repository.util.AccessControlUtils.getPolicyConnectionQN;
 import static org.apache.atlas.repository.util.AccessControlUtils.getPurposeTags;
+import static org.apache.atlas.repository.util.AccessControlUtils.getPolicySubCategory;
 import static org.apache.atlas.repository.util.AtlasEntityUtils.mapOf;
 import static org.apache.atlas.type.Constants.GLOSSARY_PROPERTY_KEY;
 
@@ -227,6 +228,11 @@ public class ESAliasStore implements IndexAliasStore {
                 }
 
                 if (policyActions.contains(ACCESS_READ_PERSONA_METADATA)) {
+
+                    if (!POLICY_SUB_CATEGORY_METADATA.equals(getPolicySubCategory(policy))) {
+                        terms.addAll(assets);
+                        continue;
+                    }
 
                     String connectionQName = getPolicyConnectionQN(policy);
                     if (StringUtils.isEmpty(connectionQName)) {


### PR DESCRIPTION
## Change description

Handle parent domain extraction for product QNs and add product permissions
Test cases:
- Domain is visible if sub domain access is given via domain policy.
- Domain is visible if product access if given via domain policy.
- Only the allowed products are returned in indexsearch if persona is passed in the indexsearch.

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> https://atlanhq.atlassian.net/browse/PLTS-336

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
