### PR TITLE
make refreshAllHostCache async

### DIFF
--- a/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
@@ -459,7 +459,7 @@ public class TypesREST {
             typesDef.getBusinessMetadataDefs().forEach(AtlasBusinessMetadataDef::setRandomNameForEntityAndAttributeDefs);
             typesDef.getClassificationDefs().forEach(AtlasClassificationDef::setRandomNameForEntityAndAttributeDefs);
             AtlasTypesDef atlasTypesDef = typeDefStore.createTypesDef(typesDef);
-            typeCacheRefresher.refreshAllHostCache();
+            refreshAllHostCache(RequestContext.get().getTraceId());
             return atlasTypesDef;
         } catch (AtlasBaseException atlasBaseException) {
             LOG.error("TypesREST.createAtlasTypeDefs:: " + atlasBaseException.getMessage(), atlasBaseException);
@@ -584,7 +584,7 @@ public class TypesREST {
             }
             lock = attemptAcquiringLockV2();
             typeDefStore.deleteTypesDef(typesDef);
-            typeCacheRefresher.refreshAllHostCache();
+            refreshAllHostCache(RequestContext.get().getTraceId());
         } catch (AtlasBaseException atlasBaseException) {
             LOG.error("TypesREST.deleteAtlasTypeDefs:: " + atlasBaseException.getMessage(), atlasBaseException);
             throw atlasBaseException;


### PR DESCRIPTION
## Summary
**PROBLEM**: The POST/PUT/DELETE operations for **custom metadata** are taking a long time — over 40 seconds.

-> This change builds on top of [PR #4673](https://github.com/atlanhq/atlas-metastore/pull/4673).

-> Previously, the refreshAllHostCache was called synchronously for all Typedef - POST, PUT, and DELETE requests.
-> That synchronous refresh updated the typedef cache on each and every pod, which caused delays in processing.
-> PR [#4673](https://github.com/atlanhq/atlas-metastore/pull/4673) fixed this issue for PUT requests.
-> This new PR extends the fix to also cover POST and DELETE requests.

**Note:**
These changes are behind a **feature flag.**
To enable them for a tenant, set the following in the ARGOCD Manifest:
**types_update.async_enable: true**


**JIRA Ticket**: [MLH-498](https://atlanhq.atlassian.net/browse/MLH-498)
**Previous Ticket**: [MLH-301](https://atlanhq.atlassian.net/browse/MLH-301)

 **TESTING in STAGING**

Previously took 34.9 seconds for a POST request.

`2025-05-29 14:46:50.710 | ATLAS_AUDIT - POST http://staging.atlan.com/api/meta/types/typedefs?type=BUSINESS_METADATA 200 34931`

Currently takes 2.6 seconds.

`2025-05-29 14:59:44.633 | ATLAS_AUDIT - POST http://staging.atlan.com/api/meta/types/typedefs?type=BUSINESS_METADATA 200 2609
`

GRAFANA OBSERVABILITY -> [LINK](https://observability.atlan.com/explore?schemaVersion=1&panes=%7B%222tx%22:%7B%22datasource%22:%22e5f48038-5f4f-4b64-9ab3-11ab6d043fbc%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22grafana-clickhouse-datasource%22,%22uid%22:%22e5f48038-5f4f-4b64-9ab3-11ab6d043fbc%22%7D,%22editorType%22:%22sql%22,%22queryType%22:%22logs%22,%22rawSql%22:%22SELECT%20Timestamp%20as%20%5C%22timestamp%5C%22,%20Body%20as%20%5C%22body%5C%22,%20Body,%20LogAttributes%20as%20labels,%20LogAttributes%5Cn--%20SELECT%20%2A%5CnFROM%20otel_logs.service_logs%5CnWHERE%20%28%20Timestamp%20%3E%3D%20$__fromTime%20AND%20Timestamp%20%3C%3D%20$__toTime%20%29%5Cn%20%20%20AND%20TenantName%20%3D%20%27staging-preprod%27%20AND%20ServiceName%20%3D%20%27atlas%27%20AND%20PodName%20IN%20%28%20%27atlas-0%27,%20%27atlas-1%27%29%20--%20%20AND%20SeverityText%20%3D%20%27ERROR%27%5Cn%20%20--AND%20LogAttributes%5B%27trace_id%27%5D%20%3D%20%276fe8e451-6ef1-4a15-bbeb-c4b0aa372e21%27%5Cn%20%20--AND%20LogAttributes%5B%27filter%27%5D%20%3D%20%27atlas-audit%27%20--%20atlas-perf%20atlas-metrics%20atlas-application%20atlas-audit%20atlas-auth-audit%5Cn%5Cn%20%20AND%20Body%20LIKE%20concat%28%27%25%27,%20%27POST%20http:%2F%2Fstaging.atlan.com%2Fapi%2Fmeta%2Ftypes%2Ftypedefs%3Ftype%3DBUSINESS_METADATA%27,%20%27%25%27%29%5CnORDER%20BY%20Timestamp%20DESC,%20TimestampTime%20DESC%20LIMIT%201000;%5Cn%22,%22format%22:2,%22meta%22:%7B%22builderOptions%22:%7B%22database%22:%22%22,%22table%22:%22%22,%22queryType%22:%22table%22,%22columns%22:%5B%5D,%22mode%22:%22list%22,%22limit%22:1000%7D%7D,%22pluginVersion%22:%224.8.2%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D%7D&orgId=1)


## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable


[MLH-498]: https://atlanhq.atlassian.net/browse/MLH-498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MLH-301]: https://atlanhq.atlassian.net/browse/MLH-301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ