### PR TITLE
APP-6774 change ephemeral network errors to 500 rather than 400

### DIFF
--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusGraph.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusGraph.java
@@ -95,7 +95,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.apache.atlas.AtlasErrorCode.INDEX_SEARCH_FAILED;
+import static org.apache.atlas.AtlasErrorCode.INDEX_SEARCH_CLIENT_NOT_INITIATED;
 import static org.apache.atlas.AtlasErrorCode.RELATIONSHIP_CREATE_INVALID_PARAMS;
 import static org.apache.atlas.ESAliasRequestBuilder.ESAliasAction.REMOVE;
 import static org.apache.atlas.repository.Constants.*;
@@ -331,7 +331,7 @@ public class AtlasJanusGraph implements AtlasGraph<AtlasJanusVertex, AtlasJanusE
     public AtlasIndexQuery<AtlasJanusVertex, AtlasJanusEdge> elasticsearchQuery(String indexName, SearchParams searchParams) throws AtlasBaseException {
         if (restClient == null) {
             LOG.error("restClient is not initiated, failed to run query on ES");
-            throw new AtlasBaseException(INDEX_SEARCH_FAILED, "restClient is not initiated");
+            throw new AtlasBaseException(INDEX_SEARCH_CLIENT_NOT_INITIATED);
         }
         return new AtlasElasticsearchQuery(this, restClient, INDEX_PREFIX + indexName, searchParams, esUiClusterClient, esNonUiClusterClient);
     }
@@ -387,7 +387,7 @@ public class AtlasJanusGraph implements AtlasGraph<AtlasJanusVertex, AtlasJanusE
     public AtlasIndexQuery elasticsearchQuery(String indexName) throws AtlasBaseException {
         if (restClient == null) {
             LOG.error("restClient is not initiated, failed to run query on ES");
-            throw new AtlasBaseException(INDEX_SEARCH_FAILED, "restClient is not initiated");
+            throw new AtlasBaseException(INDEX_SEARCH_CLIENT_NOT_INITIATED);
         }
         return new AtlasElasticsearchQuery(this, indexName, restClient, esUiClusterClient, esNonUiClusterClient);
     }

--- a/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
@@ -266,7 +266,8 @@ public enum AtlasErrorCode {
     FAILED_TO_CREATE_GLOSSARY_TERM(500, "ATLAS-500-00-016", "Error occurred while creating glossary term: {0}"),
     FAILED_TO_UPDATE_GLOSSARY_TERM(500, "ATLAS-500-00-017", "Error occurred while updating glossary term: {0}"),
     REPAIR_INDEX_FAILED(500, "ATLAS-500-00-018", "Error occurred while repairing indices: {0}"),
-    INDEX_SEARCH_FAILED(400, "ATLAS-400-00-102", "Error occurred while running direct index query on ES: {0}"),
+    INDEX_SEARCH_FAILED(500, "ATLAS-500-00-102", "Error occurred while running direct index query on ES: {0}"),
+    INDEX_SEARCH_CLIENT_NOT_INITIATED(500, "ATLAS-500-00-103", "Error occurred while running direct index query on ES: restClient is not initiated"),
 
     INDEX_SEARCH_FAILED_DUE_TO_TIMEOUT(429, "ATLAS-400-00-502", "ES query exceeded timeout: {0}"),
     INDEX_SEARCH_GATEWAY_TIMEOUT(504, "ATLAS-504-00-001", "ES query gateway timeout: {0}"),


### PR DESCRIPTION
## Change description

Changes the response code for ephemeral service outages to a `500` rather than a `400`. This is because a `400` indicates a fatal ("your request will never work") problem with the request that a client made. In the case of a back-end outage, this is not accurate — the same request _will_ work, as soon as the back-end service is restored. Hence this should be an indication that it's a server-side issue (`5xx`) and not a client request issue (`400`).

Why is this important?

SDKs and most standard utilities will all treat `5xx` errors as retry-able, whereas a `400` is not. In the case of a backend outage, the request should be automatically retry-able — it should not immediately fail.

There are reported instances where these ephemeral outages cause long-running processes to fail, because of this non-retry-able `400` response.

## Type of change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

[https://atlanhq.atlassian.net/browse/APP-6774](APP-6774 Intermittent failure of asset export WF)

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [x] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
