### PR TITLE
APP-6770 | Change error code for type lock to 423 rather than 500

### DIFF
--- a/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
@@ -247,7 +247,7 @@ public enum AtlasErrorCode {
     INDEX_CREATION_FAILED(500, "ATLAS-500-00-002", "Index creation failed for {0}"),
     INDEX_ROLLBACK_FAILED(500, "ATLAS-500-00-003", "Index rollback failed for {0}"),
     DISCOVERY_QUERY_FAILED(500, "ATLAS-500-00-004", "Discovery query failed {0}"),
-    FAILED_TO_OBTAIN_TYPE_UPDATE_LOCK(500, "ATLAS-500-00-005", "Failed to get the lock; another type update might be in progress. Please try again"),
+    FAILED_TO_OBTAIN_TYPE_UPDATE_LOCK(423, "ATLAS-423-00-001", "Failed to get the lock; another type update might be in progress. Please try again"),
     FAILED_TO_OBTAIN_IMPORT_EXPORT_LOCK(409, "ATLAS-500-00-006", "Another import or export is in progress. Please try again"),
     NOTIFICATION_FAILED(500, "ATLAS-500-00-007", "Failed to notify {0} for change {1}"),
     FAILED_TO_OBTAIN_GREMLIN_SCRIPT_ENGINE(500, "ATLAS-500-00-008", "Failed to obtain gremlin script engine: {0}"),


### PR DESCRIPTION
## Change description

Changes the error code and numeric response for type locking from a `500` (generic Internal Server Error) to a `423` (Locked) to give a more interpretable semantic indication of what's happening.

Intent: this will make it easier for any clients (including SDKs) to detect this specific condition and handle automatically retrying accordingly (e.g. significant increasing any wait (+ jitter) to avoid battering and deadlocking)

## Type of change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

- https://atlanhq.atlassian.net/browse/APP-6770

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [x] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
