### PR TITLE
MLH-512 : (feat) add logic to set hasLineage correctly for append and remove relation flow

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -525,6 +525,12 @@ public class EntityGraphMapper {
                 AtlasVertex vertex = context.getVertex(guid);
                 AtlasEntityType entityType = context.getType(guid);
                 mapAppendRemoveRelationshipAttributes(entity, entityType, vertex, UPDATE, context, true, false);
+
+                // Update __hasLineage for edges impacted during append operation
+                Set<AtlasEdge> newlyCreatedEdges = getNewCreatedInputOutputEdges(guid);
+                if (CollectionUtils.isNotEmpty(newlyCreatedEdges)) {
+                    addHasLineage(newlyCreatedEdges, false);
+                }
             }
         }
 
@@ -534,6 +540,12 @@ public class EntityGraphMapper {
                 AtlasVertex vertex = context.getVertex(guid);
                 AtlasEntityType entityType = context.getType(guid);
                 mapAppendRemoveRelationshipAttributes(entity, entityType, vertex, UPDATE, context, false, true);
+
+                // Update __hasLineage for edges impacted during remove operation
+                Set<AtlasEdge> removedEdges = getRemovedInputOutputEdges(guid);
+                if (CollectionUtils.isNotEmpty(removedEdges)) {
+                    deleteDelegate.getHandler().resetHasLineageOnInputOutputDelete(removedEdges, null);
+                }
             }
         }
 


### PR DESCRIPTION
## 🎯 Summary

This PR fixes the issue where `__hasLineage` property was not being updated correctly during append/remove relationship operations, causing lineage calculation errors.

## 🐛 Problem

When using `appendRelationship` and `removeRelationship` operations, the `__hasLineage` property on edges was not being updated. This led to:
- Incorrect lineage calculations
- Assets showing as having lineage when they shouldn't (or vice versa)
- Count mismatches in lineage traversal

## 🔧 Solution

Added logic to update `__hasLineage` property for affected edges during both append and remove operations:

### For Append Operations:
- Get all newly created input/output edges after relationship append
- Update `__hasLineage` property on these edges using `addHasLineage()`

### For Remove Operations:
- Get all removed input/output edges after relationship removal
- Reset `__hasLineage` property on these edges using `resetHasLineageOnInputOutputDelete()`

## 📝 Changes

- Modified `appendRelationshipAttributes()` to update `__hasLineage` for newly created edges
- Modified `removeRelationshipAttributes()` to reset `__hasLineage` for removed edges
- Ensures lineage metadata stays consistent with actual relationship state

## 🧪 Testing

- [x] Verified `__hasLineage` is set correctly when appending relationships
- [x] Verified `__hasLineage` is reset when removing relationships
- [x] Tested lineage calculations work correctly after append/remove operations
- [x] Verified no duplicate relationships are created

## 🔗 Related Issues

- Fixes MLH-512
- Related to MLH-499 (previous lineage calculation fix)