### PR TITLE
PLTS-368 | Add guid only level restriction support

### DIFF
--- a/auth-plugin-atlas/src/main/java/org/apache/atlas/authorization/atlas/authorizer/RangerAtlasAuthorizer.java
+++ b/auth-plugin-atlas/src/main/java/org/apache/atlas/authorization/atlas/authorizer/RangerAtlasAuthorizer.java
@@ -19,6 +19,8 @@
 
 package org.apache.atlas.authorization.atlas.authorizer;
 
+import org.apache.atlas.ApplicationProperties;
+import org.apache.atlas.AtlasConfiguration;
 import org.apache.atlas.authorize.AtlasAccessRequest;
 import org.apache.atlas.authorize.AtlasAccessResult;
 import org.apache.atlas.authorize.AtlasAccessorResponse;
@@ -80,6 +82,11 @@ public class RangerAtlasAuthorizer implements AtlasAuthorizer {
         add(AtlasPrivilege.ENTITY_REMOVE_CLASSIFICATION);
         add(AtlasPrivilege.ENTITY_UPDATE_CLASSIFICATION);
     }};
+
+    private static final String READ_RESTRICTION_LEVEL_SCRUB = "scrub";
+    private static final String READ_RESTRICTION_LEVEL_GUID_ONLY = "guid_only";
+    private static final String READ_RESTRICTION_LEVEL_FULL = "full";
+    private static final String readRestrictionLevel = AtlasConfiguration.READ_RESTRICTION_LEVEL.getString();
 
     @Override
     public void init() {
@@ -862,7 +869,18 @@ public class RangerAtlasAuthorizer implements AtlasAuthorizer {
 
             boolean isEntityAccessAllowed  = AtlasAuthorizationUtils.isAccessAllowed(entityAccessRequest, isScrubAuditEnabled);
             if (!isEntityAccessAllowed) {
-                scrubEntityHeader(entity, request.getTypeRegistry());
+                if (READ_RESTRICTION_LEVEL_GUID_ONLY.equals(readRestrictionLevel)) {
+                    entity.setAttributes(new HashMap<>());
+                    entity.setCreatedBy(null);
+                    entity.setUpdatedBy(null);
+                    entity.setDisplayText(null);
+                    entity.setUpdateTime(null);
+                    entity.setCreateTime(null);
+                    entity.setIsIncomplete(null);
+                    entity.setScrubbed(true);
+                } else {
+                    scrubEntityHeader(entity, request.getTypeRegistry());
+                }
             }
         }
     }

--- a/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
@@ -134,6 +134,7 @@ public enum AtlasConfiguration {
     ATLAS_INDEXSEARCH_ENABLE_JANUS_OPTIMISATION_EXTENDED("atlas.indexsearch.enable.janus.optimization.extended", false),
     ATLAS_MAINTENANCE_MODE("atlas.maintenance.mode", false),
     DELTA_BASED_REFRESH_ENABLED("atlas.authorizer.enable.delta_based_refresh", false),
+    READ_RESTRICTION_LEVEL("atlas.authorizer.read.restriction.level", "scrub"),
 
     ATLAS_UD_RELATIONSHIPS_MAX_COUNT("atlas.ud.relationship.max.count", 100),
 


### PR DESCRIPTION
This will be alternative to current scrubbing level restriction

## Change description

> Description here

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

https://atlanhq.atlassian.net/browse/PLTS-368

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
