### PR TITLE
Revert "MESH-407: fixed Indexseacrh error"

### DIFF
--- a/repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java
@@ -987,9 +987,17 @@ public class EntityDiscoveryService implements AtlasDiscoveryService {
     @Override
     public AtlasSearchResult directIndexSearch(SearchParams searchParams) throws AtlasBaseException {
         IndexSearchParams params = (IndexSearchParams) searchParams;
-        setupRequestContext(params);
+        RequestContext.get().setRelationAttrsForSearch(params.getRelationAttributes());
+        RequestContext.get().setAllowDeletedRelationsIndexsearch(params.isAllowDeletedRelations());
+        RequestContext.get().setIncludeRelationshipAttributes(params.isIncludeRelationshipAttributes());
+
+        RequestContext.get().setIncludeMeanings(!searchParams.isExcludeMeanings());
+        RequestContext.get().setIncludeClassifications(!searchParams.isExcludeClassifications());
+        RequestContext.get().setIncludeClassificationNames(searchParams.isIncludeClassificationNames());
 
         AtlasSearchResult ret = new AtlasSearchResult();
+        AtlasIndexQuery indexQuery;
+
         ret.setSearchParameters(searchParams);
         ret.setQueryType(AtlasQueryType.INDEX);
 
@@ -999,14 +1007,28 @@ public class EntityDiscoveryService implements AtlasDiscoveryService {
         }
 
         try {
-            IndexSearchResult searchResult = performDirectIndexSearch(searchParams);
-            if (searchResult.indexQueryResult == null) {
-                return null;
+            if(LOG.isDebugEnabled()){
+                LOG.debug("Performing ES search for the params ({})", searchParams);
             }
 
-            prepareSearchResult(ret, searchResult.indexQueryResult, resultAttributes, true);
-            ret.setAggregations(searchResult.indexQueryResult.getAggregationMap());
-            ret.setApproximateCount(searchResult.indexQuery.vertexTotals());
+            String indexName = getIndexName(params);
+
+            indexQuery = graph.elasticsearchQuery(indexName);
+
+            if (searchParams.getEnableFullRestriction()) {
+                addPreFiltersToSearchQuery(searchParams);
+            }
+
+            AtlasPerfMetrics.MetricRecorder elasticSearchQueryMetric = RequestContext.get().startMetricRecord("elasticSearchQuery");
+            DirectIndexQueryResult indexQueryResult = indexQuery.vertices(searchParams);
+            if (indexQueryResult == null) {
+                return null;
+            }
+            RequestContext.get().endMetricRecord(elasticSearchQueryMetric);
+            prepareSearchResult(ret, indexQueryResult, resultAttributes, true);
+
+            ret.setAggregations(indexQueryResult.getAggregationMap());
+            ret.setApproximateCount(indexQuery.vertexTotals());
         } catch (Exception e) {
             LOG.error("Error while performing direct search for the params ({}), {}", searchParams, e.getMessage());
             throw e;
@@ -1014,19 +1036,36 @@ public class EntityDiscoveryService implements AtlasDiscoveryService {
         return ret;
     }
 
-    public List<AtlasVertex> directVerticesIndexSearch(SearchParams searchParams) throws AtlasBaseException {
+    public List<AtlasVertex> directIndexSearchForVertices(SearchParams searchParams) throws AtlasBaseException {
         IndexSearchParams params = (IndexSearchParams) searchParams;
-        setupRequestContext(params);
+        RequestContext.get().setRelationAttrsForSearch(params.getRelationAttributes());
+        RequestContext.get().setAllowDeletedRelationsIndexsearch(params.isAllowDeletedRelations());
+        RequestContext.get().setIncludeRelationshipAttributes(params.isIncludeRelationshipAttributes());
 
         List<AtlasVertex> ret = new ArrayList<>();
+        AtlasIndexQuery indexQuery;
 
         try {
-            IndexSearchResult searchResult = performDirectIndexSearch(searchParams);
-            if (searchResult.indexQueryResult == null) {
-                return null;
+            if(LOG.isDebugEnabled()){
+                LOG.debug("Performing ES search for the params ({})", searchParams);
             }
 
-            Iterator<Result> iterator = searchResult.indexQueryResult.getIterator();
+            String indexName = getIndexName(params);
+
+            indexQuery = graph.elasticsearchQuery(indexName);
+
+            if (searchParams.getEnableFullRestriction()) {
+                addPreFiltersToSearchQuery(searchParams);
+            }
+
+            AtlasPerfMetrics.MetricRecorder elasticSearchQueryMetric = RequestContext.get().startMetricRecord("elasticSearchQuery");
+            DirectIndexQueryResult indexQueryResult = indexQuery.vertices(searchParams);
+            if (indexQueryResult == null) {
+                return null;
+            }
+            RequestContext.get().endMetricRecord(elasticSearchQueryMetric);
+
+            Iterator<Result> iterator = indexQueryResult.getIterator();
             while (iterator.hasNext()) {
                 Result result = iterator.next();
                 AtlasVertex vertex = result.getVertex();
@@ -1037,35 +1076,6 @@ public class EntityDiscoveryService implements AtlasDiscoveryService {
             throw e;
         }
         return ret;
-    }
-
-    private void setupRequestContext(IndexSearchParams params) {
-        RequestContext.get().setRelationAttrsForSearch(params.getRelationAttributes());
-        RequestContext.get().setAllowDeletedRelationsIndexsearch(params.isAllowDeletedRelations());
-        RequestContext.get().setIncludeRelationshipAttributes(params.isIncludeRelationshipAttributes());
-    }
-
-    private record IndexSearchResult(AtlasIndexQuery indexQuery, DirectIndexQueryResult indexQueryResult) {
-    }
-
-    private IndexSearchResult performDirectIndexSearch(SearchParams searchParams) throws AtlasBaseException {
-        if(LOG.isDebugEnabled()){
-            LOG.debug("Performing ES search for the params ({})", searchParams);
-        }
-
-        IndexSearchParams params = (IndexSearchParams) searchParams;
-        String indexName = getIndexName(params);
-        AtlasIndexQuery indexQuery = graph.elasticsearchQuery(indexName);
-
-        if (searchParams.getEnableFullRestriction()) {
-            addPreFiltersToSearchQuery(searchParams);
-        }
-
-        AtlasPerfMetrics.MetricRecorder elasticSearchQueryMetric = RequestContext.get().startMetricRecord("elasticSearchQuery");
-        DirectIndexQueryResult indexQueryResult = indexQuery.vertices(searchParams);
-        RequestContext.get().endMetricRecord(elasticSearchQueryMetric);
-
-        return new IndexSearchResult(indexQuery, indexQueryResult);
     }
 
     @Override

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/PreProcessorUtils.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/PreProcessorUtils.java
@@ -236,7 +236,7 @@ public class PreProcessorUtils {
             dsl.put("size", size);
             searchParams.setDsl(dsl);
 
-            List<AtlasVertex> vertices = discovery.directVerticesIndexSearch(searchParams);
+            List<AtlasVertex> vertices = discovery.directIndexSearchForVertices(searchParams);
 
             if (CollectionUtils.isNotEmpty(vertices)) {
                 ret.addAll(vertices);


### PR DESCRIPTION
Reverts atlanhq/atlas-metastore#4861
We don’t want to make any changes to the existing directIndexSearch method so reverting the change.