### PR TITLE
MLH-662 CM update API taking longer

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/converters/AtlasInstanceConverter.java
+++ b/repository/src/main/java/org/apache/atlas/repository/converters/AtlasInstanceConverter.java
@@ -66,12 +66,14 @@ public class AtlasInstanceConverter {
     private final AtlasFormatConverters instanceFormatters;
     private final EntityGraphRetriever  entityGraphRetriever;
     private final EntityGraphRetriever  entityGraphRetrieverIgnoreRelationshipAttrs;
+    private final EntityGraphRetriever  entityGraphRetrieverIncludeMandatoryRelAttrs;
 
     @Inject
     public AtlasInstanceConverter(AtlasGraph graph, AtlasTypeRegistry typeRegistry, AtlasFormatConverters instanceFormatters) {
         this.typeRegistry                                = typeRegistry;
         this.instanceFormatters                          = instanceFormatters;
         this.entityGraphRetriever                        = new EntityGraphRetriever(graph, typeRegistry);
+        this.entityGraphRetrieverIncludeMandatoryRelAttrs= new EntityGraphRetriever(graph, typeRegistry, false, true);
         this.entityGraphRetrieverIgnoreRelationshipAttrs = new EntityGraphRetriever(graph, typeRegistry, true);
     }
 
@@ -259,6 +261,17 @@ public class AtlasInstanceConverter {
                     LOG.debug("Cache miss -> GUID = {}", guid);
                 }
             }
+        }
+
+        return entity;
+    }
+
+    public AtlasEntity getEntityWithMandatoryRelations(String guid) throws AtlasBaseException {
+        RequestContext context = RequestContext.get();
+        AtlasEntity    entity  = context.getEntity(guid);
+
+        if (entity == null) {
+            entity = entityGraphRetrieverIncludeMandatoryRelAttrs.toAtlasEntity(guid);
         }
 
         return entity;

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityChangeNotifier.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityChangeNotifier.java
@@ -366,7 +366,7 @@ public class AtlasEntityChangeNotifier implements IAtlasEntityChangeNotifier {
     @Override
     public void onBusinessAttributesUpdated(String entityGuid, Map<String, Map<String, Object>> updatedBusinessAttributes) throws AtlasBaseException{
         if (isV2EntityNotificationEnabled) {
-            AtlasEntity entity = instanceConverter.getAndCacheEntity(entityGuid);
+            AtlasEntity entity = instanceConverter.getEntityWithMandatoryRelations(entityGuid);
 
             for (EntityChangeListenerV2 listener : entityChangeListenersV2) {
                 listener.onBusinessAttributesUpdated(entity, updatedBusinessAttributes);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -142,7 +142,7 @@ public class EntityGraphRetriever {
     private final AtlasTypeRegistry typeRegistry;
 
     private final boolean ignoreRelationshipAttr;
-    private final boolean onlyMandatoryRelationshipAttr;
+    private final boolean fetchOnlyMandatoryRelationshipAttr;
     private final AtlasGraph graph;
 
     @Inject
@@ -155,15 +155,15 @@ public class EntityGraphRetriever {
         this.graphHelper            = new GraphHelper(graph);
         this.typeRegistry           = typeRegistry;
         this.ignoreRelationshipAttr = ignoreRelationshipAttr;
-        this.onlyMandatoryRelationshipAttr = false;
+        this.fetchOnlyMandatoryRelationshipAttr = false;
     }
 
-    public EntityGraphRetriever(AtlasGraph graph, AtlasTypeRegistry typeRegistry, boolean ignoreRelationshipAttr, boolean onlyMandatoryRelationshipAttr) {
+    public EntityGraphRetriever(AtlasGraph graph, AtlasTypeRegistry typeRegistry, boolean ignoreRelationshipAttr, boolean fetchOnlyMandatoryRelationshipAttr) {
         this.graph                  = graph;
         this.graphHelper            = new GraphHelper(graph);
         this.typeRegistry           = typeRegistry;
         this.ignoreRelationshipAttr = ignoreRelationshipAttr;
-        this.onlyMandatoryRelationshipAttr = onlyMandatoryRelationshipAttr;
+        this.fetchOnlyMandatoryRelationshipAttr = fetchOnlyMandatoryRelationshipAttr;
     }
 
     public AtlasEntity toAtlasEntity(String guid, boolean includeReferences) throws AtlasBaseException {
@@ -988,7 +988,7 @@ public class EntityGraphRetriever {
             mapAttributes(entityVertex, entity, entityExtInfo, isMinExtInfo, includeReferences);
 
             if (!ignoreRelationshipAttr) { // only map when really needed
-                if (onlyMandatoryRelationshipAttr) {
+                if (fetchOnlyMandatoryRelationshipAttr) {
                     // map only mandatory relationships
                     mapMandatoryRelationshipAttributes(entityVertex, entity);
                 } else {


### PR DESCRIPTION
## Change description

CM update on assets having large number of relations taking longer
Reason being the relationship fetch part for sending Kafka notifications, it fetches all relationships but actually filters out the non-mandatory relationships from list.

Fix added to only map the mandatory relationships for BM updates notifications. This avoids unnecessary extractions of non-mandatory relationships

Tested on staging:
Mandatory relations are still part of notifications
Non-mandatory relations are not being extracted from graph
Tested time reduction with a Process having large number of inputs
Other sanity testing

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix https://atlanhq.atlassian.net/browse/MLH-662

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
