### PR TITLE
MLH-712: Add relationship labels for AirflowTask, ConnectionProcess, and SparkJob to restrict lineage mode

### DIFF
--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -462,6 +462,12 @@ public final class Constants {
 
     public static final String CATALOG_PROCESS_INPUT_RELATIONSHIP_LABEL = "__Process.inputs";
     public static final String CATALOG_PROCESS_OUTPUT_RELATIONSHIP_LABEL = "__Process.outputs";
+    public static final String CATALOG_AIRFLOW_INPUT_RELATIONSHIP_LABEL = "__AirflowTask.inputs";
+    public static final String CATALOG_AIRFLOW_OUTPUT_RELATIONSHIP_LABEL = "__AirflowTask.outputs";
+    public static final String CATALOG_CONNECTION_PROCESS_INPUT_RELATIONSHIP_LABEL = "__ConnectionProcess.inputs";
+    public static final String CATALOG_CONNECTION_PROCESS_OUTPUT_RELATIONSHIP_LABEL = "__ConnectionProcess.outputs";
+    public static final String CATALOG_SPARK_JOB_INPUT_RELATIONSHIP_LABEL = "__SparkJob.inputs";
+    public static final String CATALOG_SPARK_JOB_OUTPUT_RELATIONSHIP_LABEL = "__SparkJob.outputs";
     public static final String CLASSIFICATION_PROPAGATION_MODE_DEFAULT  ="DEFAULT";
     public static final String CLASSIFICATION_PROPAGATION_MODE_RESTRICT_LINEAGE  ="RESTRICT_LINEAGE";
 
@@ -471,7 +477,13 @@ public final class Constants {
     public static final HashMap<String, ArrayList<String>> CLASSIFICATION_PROPAGATION_MODE_LABELS_MAP = new HashMap<String, ArrayList<String>>(){{
         put(CLASSIFICATION_PROPAGATION_MODE_RESTRICT_LINEAGE, new ArrayList<>(
                 Arrays.asList(CATALOG_PROCESS_INPUT_RELATIONSHIP_LABEL,
-                CATALOG_PROCESS_OUTPUT_RELATIONSHIP_LABEL
+                        CATALOG_PROCESS_OUTPUT_RELATIONSHIP_LABEL,
+                CATALOG_AIRFLOW_INPUT_RELATIONSHIP_LABEL,
+                CATALOG_AIRFLOW_OUTPUT_RELATIONSHIP_LABEL,
+                CATALOG_CONNECTION_PROCESS_INPUT_RELATIONSHIP_LABEL,
+                CATALOG_CONNECTION_PROCESS_OUTPUT_RELATIONSHIP_LABEL,
+                CATALOG_SPARK_JOB_INPUT_RELATIONSHIP_LABEL,
+                CATALOG_SPARK_JOB_OUTPUT_RELATIONSHIP_LABEL
         )));
         put(CLASSIFICATION_PROPAGATION_MODE_DEFAULT, null);
         put(CLASSIFICATION_PROPAGATION_MODE_RESTRICT_HIERARCHY, new ArrayList<>(


### PR DESCRIPTION
## Summary
This PR extends the classification propagation exclusion list for the RESTRICT_LINEAGE mode to include additional relationship labels for AirflowTask, ConnectionProcess, and SparkJob entities.

## Changes
- Added new relationship label constants:
  - `__AirflowTask.inputs` and `__AirflowTask.outputs`
  - `__ConnectionProcess.inputs` and `__ConnectionProcess.outputs`
  - `__SparkJob.inputs` and `__SparkJob.outputs`
- Updated the `CLASSIFICATION_PROPAGATION_MODE_LABELS_MAP` to include these new labels in the RESTRICT_LINEAGE mode exclusion list

## Impact
When classification propagation mode is set to RESTRICT_LINEAGE, classifications will no longer propagate through the input/output relationships of AirflowTask, ConnectionProcess, and SparkJob entities, in addition to the existing Process entity restrictions.