### PR TITLE
Fix Tag propagation issues

### DIFF
--- a/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
@@ -85,6 +85,7 @@ public enum AtlasConfiguration {
     DSL_CACHED_TRANSLATOR("atlas.dsl.cached.translator", true),
     DEBUG_METRICS_ENABLED("atlas.debug.metrics.enabled", false),
     TASKS_USE_ENABLED("atlas.tasks.enabled", true),
+    TASKS_PENDING_TASK_QUERY_SIZE_PAGE_SIZE("atlas.tasks.pending.tasks.query.page.size", 100),
     ATLAS_DISTRIBUTED_TASK_ENABLED("atlas.distributed.task.enabled", false),
     TASKS_REQUEUE_GRAPH_QUERY("atlas.tasks.requeue.graph.query", false),
     TASKS_IN_PROGRESS_GRAPH_QUERY("atlas.tasks.inprogress.graph.query", false),

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -1003,7 +1003,9 @@ public final class GraphHelper {
 
         if ((edge != null && getStatus(edge) != DELETED) || RequestContext.get().getCurrentTask() != null) {
             AtlasVertex vertex = getPropagatingVertex(edge);
-            ret.addAll(tagDAO.getAllClassificationsForVertex(vertex.getIdForDisplay()));
+            if (vertex != null) {
+                ret.addAll(tagDAO.getAllClassificationsForVertex(vertex.getIdForDisplay()));
+            }
         }
 
         return ret;

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -115,7 +115,8 @@ public final class GraphHelper {
         try {
             tagDAO = getTagDAO();
         } catch (AtlasBaseException e) {
-            throw new RuntimeException(e);
+            LOG.error("Failed to load TagDAO is static block", e);
+            throw new RuntimeException("Failed to load TagDAO is static block", e);
         }
     }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -46,9 +46,9 @@ import org.apache.atlas.repository.graphdb.janus.AtlasJanusGraph;
 import org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2;
 import org.apache.atlas.repository.store.graph.v2.AtlasRelationshipStoreV2;
 import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
-import org.apache.atlas.repository.store.graph.v2.tags.TagDAO;
 import org.apache.atlas.repository.store.graph.v2.tasks.ClassificationTask;
 import org.apache.atlas.repository.store.graph.v2.tasks.TaskUtil;
+import org.apache.atlas.service.FeatureFlagStore;
 import org.apache.atlas.tasks.TaskManagement;
 import org.apache.atlas.type.*;
 import org.apache.atlas.type.AtlasStructType.AtlasAttribute;
@@ -67,13 +67,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static org.apache.atlas.model.TypeCategory.*;
 import static org.apache.atlas.model.instance.AtlasEntity.Status.ACTIVE;
 import static org.apache.atlas.model.instance.AtlasEntity.Status.DELETED;
 import static org.apache.atlas.model.instance.AtlasEntity.Status.PURGED;
+import static org.apache.atlas.model.tasks.AtlasTask.Status.PENDING;
 import static org.apache.atlas.model.typedef.AtlasRelationshipDef.PropagateTags.ONE_TO_TWO;
 import static org.apache.atlas.repository.Constants.*;
 import static org.apache.atlas.repository.graph.GraphHelper.*;
@@ -105,6 +105,10 @@ public abstract class DeleteHandlerV1 {
     private   final AtlasGraph           graph;
     private   final TaskUtil             taskUtil;
 
+    protected final boolean              janusOptimisationEnabled;
+
+    private static final List<String> taskTypesToSkip = Arrays.asList(CLASSIFICATION_REFRESH_PROPAGATION, CLASSIFICATION_PROPAGATION_DELETE);
+
     public DeleteHandlerV1(AtlasGraph graph, AtlasTypeRegistry typeRegistry, boolean shouldUpdateInverseReference, boolean softDelete,
                            TaskManagement taskManagement, EntityGraphRetriever entityRetriever) {
         this.typeRegistry                  = typeRegistry;
@@ -115,6 +119,7 @@ public abstract class DeleteHandlerV1 {
         this.taskManagement                = taskManagement;
         this.graph                         = graph;
         this.taskUtil                      = new TaskUtil(graph);
+        this.janusOptimisationEnabled      = StringUtils.isNotEmpty(FeatureFlagStore.getFlag("ENABLE_JANUS_OPTIMISATION"));
     }
 
     /**
@@ -169,6 +174,7 @@ public abstract class DeleteHandlerV1 {
 
             deleteTypeVertex(deletionCandidateVertex, isInternalType(deletionCandidateVertex));
 
+            // TODO: Why do we need following createAndQueueClassificationRefreshPropagationTask?
             if (DEFERRED_ACTION_ENABLED) {
                 Set<String> deletedEdgeIds = RequestContext.get().getDeletedEdgesIds();
                 for (String deletedEdgeId : deletedEdgeIds) {
@@ -455,7 +461,7 @@ public abstract class DeleteHandlerV1 {
         //below needs to be forked ?
         if(getJanusOptimisationEnabled()) {
             // foreground
-            // classifcationTypeName can be empty
+            // classificationTypeName can be empty
             createAndQueueTaskWithoutCheckV2(CLASSIFICATION_PROPAGATION_ADD, fromVertex, toVertex, "");
         } else {
             final List<AtlasVertex> classificationVertices = getPropagationEnabledClassificationVertices(fromVertex);
@@ -1444,26 +1450,56 @@ public abstract class DeleteHandlerV1 {
             return;
         }
 
-        List<AtlasVertex> currentClassificationVertices = GraphHelper.getPropagatableClassifications(edge);
-        for (AtlasVertex currentClassificationVertex : currentClassificationVertices) {
-            String currentClassificationId = currentClassificationVertex.getIdForDisplay();
-            String classificationTypeName      = getTypeName(currentClassificationVertex);
-            boolean removePropagationOnEntityDelete = GraphHelper.getRemovePropagations(currentClassificationVertex);
+        if (!janusOptimisationEnabled) {
+            // Existing flow as it is
+            List<AtlasVertex> currentClassificationVertices = GraphHelper.getPropagatableClassifications(edge);
+            for (AtlasVertex currentClassificationVertex : currentClassificationVertices) {
+                String currentClassificationId = currentClassificationVertex.getIdForDisplay();
+                String classificationTypeName = getTypeName(currentClassificationVertex);
+                boolean removePropagationOnEntityDelete = GraphHelper.getRemovePropagations(currentClassificationVertex);
 
-            if (!(isTermEntityEdge || removePropagationOnEntityDelete)) {
-                LOG.debug("This edge is not term edge or remove propagation isn't enabled");
-                continue;
+                if (!(isTermEntityEdge || removePropagationOnEntityDelete)) {
+                    LOG.debug("This edge is not term edge or remove propagation isn't enabled");
+                    continue;
+                }
+
+                if (skipClassificationTaskCreation(currentClassificationId)) {
+                    LOG.info("Task is already scheduled for classification id {}, no need to schedule task for edge {}", currentClassificationId, edge.getIdForDisplay());
+                    continue;
+                }
+
+                Map<String, Object> taskParams = ClassificationTask.toParameters(currentClassificationVertex.getIdForDisplay());
+                AtlasTask task = taskManagement.createTask(CLASSIFICATION_REFRESH_PROPAGATION, currentUser, taskParams, currentClassificationId, classificationTypeName, GraphHelper.getGuid(referenceVertex));
+
+                RequestContext.get().queueTask(task);
             }
+        } else {
+            // V2 for tag optimisations
+            List<AtlasClassification> currentClassificationVertices = GraphHelper.getPropagatableClassificationsV2(edge);
+            for (AtlasClassification tag : currentClassificationVertices) {
+                String entityGuid = tag.getEntityGuid();
+                String tagTypeName = tag.getTypeName();
+                boolean removePropagationOnEntityDelete = tag.getRemovePropagationsOnEntityDelete() != null && tag.getRemovePropagationsOnEntityDelete();
 
-            if(skipClassificationTaskCreation(currentClassificationId)) {
-                LOG.info("Task is already scheduled for classification id {}, no need to schedule task for edge {}", currentClassificationId, edge.getIdForDisplay());
-                continue;
+                if (!(isTermEntityEdge || removePropagationOnEntityDelete)) {
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("This edge is not term edge or remove propagation isn't enabled");
+                    continue;
+                }
+                if (skipClassificationTaskCreationV2(entityGuid, tagTypeName)) {
+                    LOG.info("Task is already scheduled for tag:entity pair {}:{}, no need to schedule task for edge {}", tagTypeName, entityGuid, edge.getIdForDisplay());
+                    continue;
+                }
+
+                Map<String, Object> taskParams = new HashMap<>() {{
+                                        put(PARAM_ENTITY_GUID, entityGuid);
+                                        put(PARAM_CLASSIFICATION_NAME, tagTypeName);
+                                    }};
+
+                AtlasTask task = taskManagement.createTaskV2(CLASSIFICATION_REFRESH_PROPAGATION, currentUser, taskParams, tagTypeName, entityGuid);
+
+                RequestContext.get().queueTask(task);
             }
-
-            Map<String, Object> taskParams = ClassificationTask.toParameters(currentClassificationVertex.getIdForDisplay());
-            AtlasTask task  =  taskManagement.createTask(CLASSIFICATION_REFRESH_PROPAGATION, currentUser, taskParams, currentClassificationId, classificationTypeName,GraphHelper.getGuid(referenceVertex));
-
-            RequestContext.get().queueTask(task);
         }
 
     }
@@ -1484,7 +1520,7 @@ public abstract class DeleteHandlerV1 {
                     tasksInRequestContext != null &&
                     tasksInRequestContext.stream().filter(Objects::nonNull)
                     .anyMatch(task -> task.getClassificationId().equals(classificationId)
-                            && taskTypes.contains(task.getType()) && task.getStatus().equals(AtlasTask.Status.PENDING))
+                            && taskTypes.contains(task.getType()) && task.getStatus().equals(PENDING))
             ) {
                 return true;
             }
@@ -1511,7 +1547,7 @@ public abstract class DeleteHandlerV1 {
                     pendingTasks.stream()
                     .filter(Objects::nonNull)
                     .anyMatch(task -> task.getClassificationId().equals(classificationId)
-                            && taskTypes.contains(task.getType()) && task.getStatus().equals(AtlasTask.Status.PENDING))
+                            && taskTypes.contains(task.getType()) && task.getStatus().equals(PENDING))
             ) {
                 return true;
             } else {
@@ -1527,7 +1563,6 @@ public abstract class DeleteHandlerV1 {
 
         return false;
     }
-
 
     public void removeHasLineageOnDelete(Collection<AtlasVertex> vertices) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("removeHasLineageOnDelete");
@@ -1561,7 +1596,6 @@ public abstract class DeleteHandlerV1 {
         }
         RequestContext.get().endMetricRecord(metricRecorder);
     }
-
 
     public void resetHasLineageOnInputOutputDelete(Collection<AtlasEdge> removedEdges, AtlasVertex deletedVertex) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("resetHasLineageOnInputOutputDelete");
@@ -1639,6 +1673,68 @@ public abstract class DeleteHandlerV1 {
         }
         RequestContext.get().endMetricRecord(metricRecorder);
     }
+
+    private boolean skipClassificationTaskCreationV2(String entityGuid, String tagTypeName) throws AtlasBaseException {
+        AtlasPerfMetrics.MetricRecorder metric = RequestContext.get().startMetricRecord("skipClassificationTaskCreationV2");
+        /*
+        If any of,
+        1. CLASSIFICATION_PROPAGATION_DELETE
+        2. CLASSIFICATION_REFRESH_PROPAGATION task scheduled already
+        skip classification task creation
+         */
+        try {
+            List<AtlasTask> tasksInRequestContext = RequestContext.get().getQueuedTasks();
+            if (tasksInRequestContext != null) {
+                if (hasDuplicateTask(tasksInRequestContext, entityGuid, tagTypeName))
+                    return true;
+            }
+
+            TaskSearchResult taskSearchResult = taskUtil.findDuplicatePendingTasksV2(0, 2, entityGuid, tagTypeName, taskTypesToSkip);
+
+            List<AtlasTask> pendingTasks = taskSearchResult.getTasks();
+            if(CollectionUtils.isEmpty(pendingTasks)) {
+                return false;
+            }
+
+            List<AtlasTask> pendingRefreshPropagationTasks = pendingTasks.stream()
+                    .filter(task -> CLASSIFICATION_REFRESH_PROPAGATION.equals(task.getType()))
+                    .collect(Collectors.toList());
+
+            // Ideally there should be only refresh propagation task
+            if (pendingRefreshPropagationTasks.size() > 1) {
+                LOG.warn("More than one {} task found for tag:entity pair {}:{}", CLASSIFICATION_REFRESH_PROPAGATION, tagTypeName, entityGuid);
+            }
+
+            // if any task have status as PENDING, then skip task creation
+            if (hasDuplicateTask(pendingTasks, entityGuid, tagTypeName)) {
+                return true;
+            } else {
+                LOG.warn("There is inconsistency in task queue, there are no pending tasks for tag:entity pair {}:{} but there are tasks in queue", tagTypeName, entityGuid);
+            }
+        } catch (AtlasBaseException e) {
+            LOG.error("Error while checking if classification task creation is required for tag:entity pair {}:{}", tagTypeName, entityGuid, e);
+            throw e;
+        } finally {
+            RequestContext.get().endMetricRecord(metric);
+        }
+
+        return false;
+    }
+
+    private boolean hasDuplicateTask(List<AtlasTask> tasks, String entityGuid, String tagTypeName) {
+        return tasks.stream()
+                .filter(Objects::nonNull)
+                .anyMatch(task -> isDuplicateTask(task, entityGuid, tagTypeName));
+    }
+
+    private boolean isDuplicateTask(AtlasTask task, String entityGuid, String tagTypeName) {
+        return task != null
+                && task.getEntityGuid().equals(entityGuid)
+                && task.getTagTypeName().equals(tagTypeName)
+                && taskTypesToSkip.contains(task.getType())
+                && task.getStatus().equals(PENDING);
+    }
+
     private boolean isRequestFromWorkFlow() {
         String workflowID = RequestContext.get().getRequestContextHeaders().getOrDefault("x-atlan-agent-workflow-id", "");
         boolean isWorkFlowRequest = !workflowID.isEmpty();

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/SoftDeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/SoftDeleteHandlerV1.java
@@ -35,11 +35,14 @@ import org.apache.commons.collections.CollectionUtils;
 
 import javax.inject.Inject;
 
+import java.util.Collection;
+
 import static org.apache.atlas.model.instance.AtlasEntity.Status.DELETED;
 import static org.apache.atlas.repository.Constants.MODIFICATION_TIMESTAMP_PROPERTY_KEY;
 import static org.apache.atlas.repository.Constants.MODIFIED_BY_KEY;
 import static org.apache.atlas.repository.Constants.STATE_PROPERTY_KEY;
 import static org.apache.atlas.repository.graph.GraphHelper.getPropagatableClassifications;
+import static org.apache.atlas.repository.graph.GraphHelper.getPropagatableClassificationsV2;
 
 public class SoftDeleteHandlerV1 extends DeleteHandlerV1 {
 
@@ -78,7 +81,10 @@ public class SoftDeleteHandlerV1 extends DeleteHandlerV1 {
 
 
             if (DEFERRED_ACTION_ENABLED && RequestContext.get().getCurrentTask() == null) {
-                if (CollectionUtils.isNotEmpty(getPropagatableClassifications(edge))) {
+                Collection propagatableTags = janusOptimisationEnabled
+                        ? getPropagatableClassificationsV2(edge)
+                        : getPropagatableClassifications(edge);
+                if (CollectionUtils.isNotEmpty(propagatableTags)) {
                     RequestContext.get().addToDeletedEdgesIds(edge.getIdForDisplay());
                 }
             } else {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -4062,7 +4062,7 @@ public class EntityGraphMapper {
                         impactedVertices = impactedVerticesMap.get(propagationMode);
                         LOG.info("Impacted vertices for propagation mode {} already exists", propagationMode);
                     }
-                    processClassificationPropagationAdditionV2(parameters, toVertex.getIdForDisplay(), impactedVertices, tag.toAtlasClassification());
+                    processClassificationPropagationAdditionV2(parameters, fromVertex.getIdForDisplay(), impactedVertices, tag.toAtlasClassification());
                 }
             }
         }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tasks/ClassificationPropagateTaskFactory.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tasks/ClassificationPropagateTaskFactory.java
@@ -42,15 +42,6 @@ public class ClassificationPropagateTaskFactory implements TaskFactory {
     //This should be used when referencing vertex to which classification is directly attached
     public static final String CLASSIFICATION_PROPAGATION_DELETE              = "CLASSIFICATION_PROPAGATION_DELETE";
 
-    /* This should be used when referencing vertex to which classification is not directly attached but it is propagated
-     * e.g. t0 -> p0 -> t1
-     * tag is on t0 propagating to p0,t1,
-     * deleting p0 should remove all propagations further to p0 for tag which is propagating from t0
-     */
-    public static final String CLASSIFICATION_ONLY_PROPAGATION_DELETE         = "CLASSIFICATION_ONLY_PROPAGATION_DELETE";
-
-    public static final String CLASSIFICATION_ONLY_PROPAGATION_DELETE_ON_HARD_DELETE =  "CLASSIFICATION_ONLY_PROPAGATION_DELETE_ON_HARD_DELETE";
-
     public static final String CLASSIFICATION_REFRESH_PROPAGATION = "CLASSIFICATION_REFRESH_PROPAGATION";
 
     public static final String CLASSIFICATION_PROPAGATION_RELATIONSHIP_UPDATE = "CLASSIFICATION_PROPAGATION_RELATIONSHIP_UPDATE";
@@ -63,8 +54,6 @@ public class ClassificationPropagateTaskFactory implements TaskFactory {
         add(CLASSIFICATION_PROPAGATION_TEXT_UPDATE);
         add(CLASSIFICATION_PROPAGATION_ADD);
         add(CLASSIFICATION_PROPAGATION_DELETE);
-        add(CLASSIFICATION_ONLY_PROPAGATION_DELETE);
-        add(CLASSIFICATION_ONLY_PROPAGATION_DELETE_ON_HARD_DELETE);
         add(CLASSIFICATION_REFRESH_PROPAGATION);
         add(CLASSIFICATION_PROPAGATION_RELATIONSHIP_UPDATE);
         add(CLEANUP_CLASSIFICATION_PROPAGATION);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tasks/ClassificationTask.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tasks/ClassificationTask.java
@@ -136,21 +136,6 @@ public abstract class ClassificationTask extends AbstractTask {
         }};
     }
 
-    public static Map<String, Object> toParameters(String deletedEdgeId, String classificationVertexId) {
-        return new HashMap<String, Object>() {{
-            put(PARAM_DELETED_EDGE_ID, deletedEdgeId);
-            put(PARAM_CLASSIFICATION_VERTEX_ID, classificationVertexId);
-        }};
-    }
-
-    public static Map<String, Object> toParameters(String classificationVertexId, String referencedVertexId, boolean isTermEntityEdge) {
-        return new HashMap<String, Object>() {{
-            put(PARAM_CLASSIFICATION_VERTEX_ID, classificationVertexId);
-            put(PARAM_REFERENCED_VERTEX_ID, referencedVertexId);
-            put(PARAM_IS_TERM_ENTITY_EDGE, isTermEntityEdge);
-        }};
-    }
-
     public static Map<String, Object> toParameters(String relationshipEdgeId, AtlasRelationship relationship) {
         return new HashMap<String, Object>() {{
             put(PARAM_RELATIONSHIP_EDGE_ID, relationshipEdgeId);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tasks/TaskUtil.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tasks/TaskUtil.java
@@ -55,7 +55,6 @@ public class TaskUtil {
     }
 
     public List<AtlasTask> getAllTasksByCondition(int size, String entityGuid, String tagTypeName, List<String> types) throws AtlasBaseException {
-        AtlasPerfMetrics.MetricRecorder recorder = RequestContext.get().startMetricRecord("findDuplicatePendingTasksV2");
         List<Map<String,Object>> mustConditions = new ArrayList<>();
 
         if (StringUtils.isNotEmpty(entityGuid))
@@ -69,8 +68,6 @@ public class TaskUtil {
         }
 
         mustConditions.add(getMap("term", getMap(TASK_STATUS + ".keyword", TASK_STATUS_PENDING)));
-
-        RequestContext.get().endMetricRecord(recorder);
 
         return taskService.getAllTasksByCondition(size, mustConditions);
     }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tasks/TaskUtil.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tasks/TaskUtil.java
@@ -2,6 +2,7 @@ package org.apache.atlas.repository.store.graph.v2.tasks;
 
 import org.apache.atlas.RequestContext;
 import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.model.tasks.AtlasTask;
 import org.apache.atlas.model.tasks.TaskSearchResult;
 import org.apache.atlas.repository.graphdb.AtlasGraph;
 import org.apache.atlas.tasks.AtlasTaskService;
@@ -53,7 +54,7 @@ public class TaskUtil {
 
     }
 
-    public TaskSearchResult findDuplicatePendingTasksV2(int from, int size, String entityGuid, String tagTypeName, List<String> types) throws AtlasBaseException {
+    public List<AtlasTask> getAllTasksByCondition(int size, String entityGuid, String tagTypeName, List<String> types) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder recorder = RequestContext.get().startMetricRecord("findDuplicatePendingTasksV2");
         List<Map<String,Object>> mustConditions = new ArrayList<>();
 
@@ -71,7 +72,7 @@ public class TaskUtil {
 
         RequestContext.get().endMetricRecord(recorder);
 
-        return taskService.getTasksByCondition(from, size, mustConditions, Collections.emptyList(), Collections.emptyList());
+        return taskService.getAllTasksByCondition(size, mustConditions);
     }
 
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tasks/TaskUtil.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tasks/TaskUtil.java
@@ -1,13 +1,16 @@
 package org.apache.atlas.repository.store.graph.v2.tasks;
 
+import org.apache.atlas.RequestContext;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.tasks.TaskSearchResult;
 import org.apache.atlas.repository.graphdb.AtlasGraph;
 import org.apache.atlas.tasks.AtlasTaskService;
+import org.apache.atlas.utils.AtlasPerfMetrics;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -49,6 +52,28 @@ public class TaskUtil {
         return taskService.getTasksByCondition(from, size, mustConditions, shouldConditions, excludeConditions);
 
     }
+
+    public TaskSearchResult findDuplicatePendingTasksV2(int from, int size, String entityGuid, String tagTypeName, List<String> types) throws AtlasBaseException {
+        AtlasPerfMetrics.MetricRecorder recorder = RequestContext.get().startMetricRecord("findDuplicatePendingTasksV2");
+        List<Map<String,Object>> mustConditions = new ArrayList<>();
+
+        if (StringUtils.isNotEmpty(entityGuid))
+            mustConditions.add(getMap("term", getMap(TASK_ENTITY_GUID, entityGuid)));
+
+        if (StringUtils.isNotEmpty(tagTypeName))
+            mustConditions.add(getMap("term", getMap(TASK_CLASSIFICATION_TYPENAME, tagTypeName)));
+
+        if (CollectionUtils.isNotEmpty(types)) {
+            mustConditions.add(getMap("terms", getMap(TASK_TYPE, types)));
+        }
+
+        mustConditions.add(getMap("term", getMap(TASK_STATUS + ".keyword", TASK_STATUS_PENDING)));
+
+        RequestContext.get().endMetricRecord(recorder);
+
+        return taskService.getTasksByCondition(from, size, mustConditions, Collections.emptyList(), Collections.emptyList());
+    }
+
 
     private Map<String, Object> getMap(String key, Object value) {
         Map<String, Object> map = new HashMap<>();

--- a/repository/src/main/java/org/apache/atlas/tasks/AtlasTaskService.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/AtlasTaskService.java
@@ -107,6 +107,36 @@ public class AtlasTaskService implements TaskService {
         return tasks;
     }
 
+    @Override
+    public List<AtlasTask> getAllTasksByCondition(int batchSize, List<Map<String,Object>> mustConditions) throws AtlasBaseException {
+        List<AtlasTask> tasks = new ArrayList<>(0);
+        long from = 0;
+
+        Map<String, Object> dsl = mapOf("size", batchSize);
+        dsl.put("from", from);
+
+        dsl.put("query", mapOf("bool", mapOf("must", mustConditions)));
+        TaskSearchParams taskSearchParams = new TaskSearchParams();
+        taskSearchParams.setDsl(dsl);
+
+        boolean hasNext = true;
+
+        while (hasNext) {
+            TaskSearchResult page = getTasks(taskSearchParams);
+            if (page == null || CollectionUtils.isEmpty(page.getTasks()) || page.getTasks().size() < batchSize) {
+                hasNext = false;
+            } else {
+                tasks.addAll(page.getTasks());
+
+                from += batchSize;
+                dsl.put("from", from);
+                taskSearchParams.setDsl(dsl);
+            }
+        }
+
+        return tasks;
+    }
+
     private Map<String, Object> getMap(String key, Object value) {
         Map<String, Object> map = new HashMap<>();
         map.put(key, value);

--- a/repository/src/main/java/org/apache/atlas/tasks/TaskService.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/TaskService.java
@@ -50,6 +50,13 @@ public interface TaskService {
      */
     TaskSearchResult getTasksByCondition(int from, int size, List<Map<String,Object>> mustConditions, List<Map<String,Object>> shouldConditions,
                                          List<Map<String,Object>> mustNotConditions) throws AtlasBaseException;
+
+    /*
+    * Returns all tasks mathing the criteria with paginated requests
+    * */
+    List<AtlasTask> getAllTasksByCondition(int batchSize, List<Map<String,Object>> mustConditions) throws AtlasBaseException;
+
+
     /**
      * Retry the task by changing its status to PENDING and increment attempt count
      * @param taskGuid Guid of the task

--- a/webapp/src/main/java/org/apache/atlas/web/service/AtlasDebugMetricsSource.java
+++ b/webapp/src/main/java/org/apache/atlas/web/service/AtlasDebugMetricsSource.java
@@ -650,7 +650,6 @@ public class AtlasDebugMetricsSource {
                 break;
 
             default:
-                LOG.error("The signature '{}' is not handled!", name);
                 break;
         }
     }


### PR DESCRIPTION
1. NPE when checking for duplicate task in creation task flow
2.  Duplicate tags 
    * Initially we had changed `toVertex` to `fromVertex` when calling propagateClassificationV2.processClassificationPropagationAdditionV2 in flow `handle add classifications fromVertex to toVertex`
   * Finally fixed all cases by changing `fromVertex` to `sourceVertex`
   * Added relevant comment in code explaining the scenario
3. Removed redundant methods & commented code

Latest change:
1. Added taskUtil.getAllTasksByCondition to fetch all PENDING tasks instead of just checking 2 or 20 initial tasks, only applicable to V2 flow
2. Null safe comparisons
3. Formatted message & added error log as well for GraphHelper static block