### PR TITLE
MLH-726 fix entity_audits template

### DIFF
--- a/addons/elasticsearch/es-audit-mappings.json
+++ b/addons/elasticsearch/es-audit-mappings.json
@@ -31,11 +31,25 @@
     },
     "dynamic_templates": [
       {
+        "ignore_random_id_objects": {
+          "path_match":    "detail.attributes.*",
+          "match_pattern": "regex",
+          "match":         "^[a-zA-Z](?=.*\\\\d)[a-zA-Z0-9]{21}$",
+          "mapping":       { "enabled": false }
+        }
+      },
+      {
         "atlan_headers_as_keyword": {
           "path_match": "headers.x-atlan-*",
-          "mapping": {
-            "type": "keyword"
-          }
+          "mapping":    { "type": "keyword" }
+        }
+      },
+      {
+        "suppress_attribute_hashes": {
+          "path_match": "detail.classifications.*",
+          "match_pattern": "regex",
+          "match":         "^[a-zA-Z](?=.*\\\\d)[a-zA-Z0-9]{21}$",
+          "mapping":    { "enabled": false }
         }
       },
       {
@@ -46,7 +60,12 @@
             "enabled": false
           }
         }
-      }
+      },
+      { "allow_strings":  { "path_match":"detail.attributes.*", "match_mapping_type":"string",  "mapping":{ "type":"keyword", "ignore_above":256 }}},
+      { "allow_longs":    { "path_match":"detail.attributes.*", "match_mapping_type":"long",    "mapping":{ "type":"long"    }}},
+      { "allow_doubles":  { "path_match":"detail.attributes.*", "match_mapping_type":"double",  "mapping":{ "type":"double"  }}},
+      { "allow_booleans": { "path_match":"detail.attributes.*", "match_mapping_type":"boolean", "mapping":{ "type":"boolean" }}},
+      { "allow_dates":    { "path_match":"detail.attributes.*", "match_mapping_type":"date",    "mapping":{ "type":"date", "format":"strict_date_optional_time||epoch_millis" }}}
     ],
     "date_detection": false,
     "numeric_detection": false

--- a/addons/elasticsearch/es-audit-mappings.json
+++ b/addons/elasticsearch/es-audit-mappings.json
@@ -52,14 +52,6 @@
           "mapping":    { "enabled": false }
         }
       },
-      {
-        "ignore_random_id_objects_custom_attr": {
-          "path_match":    "detail.customAttributes.*",
-          "match_pattern": "regex",
-          "match":         "^[a-zA-Z](?=.*\\\\d)[a-zA-Z0-9]{21}$",
-          "mapping":       { "enabled": false }
-        }
-      },
       { "allow_strings":  { "path_match":"detail.attributes.*", "match_mapping_type":"string",  "mapping":{ "type":"keyword", "ignore_above":256 }}},
       { "allow_longs":    { "path_match":"detail.attributes.*", "match_mapping_type":"long",    "mapping":{ "type":"long"    }}},
       { "allow_doubles":  { "path_match":"detail.attributes.*", "match_mapping_type":"double",  "mapping":{ "type":"double"  }}},

--- a/addons/elasticsearch/es-audit-mappings.json
+++ b/addons/elasticsearch/es-audit-mappings.json
@@ -53,12 +53,11 @@
         }
       },
       {
-        "suppress_attribute_hashes": {
-          "path_match": "detail.classifications.properties.attributes.*",
-          "mapping": {
-            "type": "object",
-            "enabled": false
-          }
+        "ignore_random_id_objects_custom_attr": {
+          "path_match":    "detail.customAttributes.*",
+          "match_pattern": "regex",
+          "match":         "^[a-zA-Z](?=.*\\\\d)[a-zA-Z0-9]{21}$",
+          "mapping":       { "enabled": false }
         }
       },
       { "allow_strings":  { "path_match":"detail.attributes.*", "match_mapping_type":"string",  "mapping":{ "type":"keyword", "ignore_above":256 }}},


### PR DESCRIPTION
## Change description

> Change entity_audits to avoid field explosion.
Ignore any 22 char pattern that is tagTypeName, custom
Below is metric of vmo qa after applying this template.
Also apply the same rule for customAttributes

Total mapped fields: 2 253
↳ well under the 5 000 soft-limit ✅
	•	22-char “hash” roots: 918 objects
↳ 21 of those still have 4-6 child fields each (legacy tags).
↳ All new random IDs now add just 1 field (object disabled).
	•	Business / normal fields: ≈ 1 335 (indexes, headers, timestamps, etc.)

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues
https://atlanhq.atlassian.net/browse/MLH-726

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
