### PR TITLE
MLH-704 NPE while fetching custom relationship

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -2087,9 +2087,10 @@ public class EntityGraphRetriever {
                     relationshipAttributes.put("attributes", relationship.getAttributes());
 
                     if (ret.getAttributes() == null) {
-                        ret.setAttributes(new HashMap<>());
+                        ret.setAttributes(mapOf("relationshipAttributes", relationshipAttributes));
+                    } else {
+                        ret.getAttributes().put("relationshipAttributes", relationshipAttributes);
                     }
-                    ret.getAttributes().put("relationshipAttributes", relationshipAttributes);
                 }
             }
         }


### PR DESCRIPTION
## Change description

> Description here
Fetching an asset with attributes.suserDefRelationshipTo with indexsearch API fails with NPE
```
{
  "errorCode": "ATLAS-500-00-001",
  "errorMessage": "Cannot invoke \"java.util.Map.put(Object, Object)\" because the return value of \"org.apache.atlas.model.instance.AtlasObjectId.getAttributes()\" is null"
}

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix https://atlanhq.atlassian.net/browse/MLH-704?focusedCommentId=425509

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
