### PR TITLE
Skip deleting tags on soft del to match v1 flow

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -1205,7 +1205,14 @@ public abstract class DeleteHandlerV1 {
     private void deleteAllClassificationsV2(AtlasVertex deletionCandidateVertex) throws AtlasBaseException {
         // Create Delete propagation task only for direct tags, propagated tags will be handled in refresh task created later in the same flow
         List<Tag> tags = tagDAO.getAllDirectTagsForVertex(deletionCandidateVertex.getIdForDisplay());
-        tags.forEach(t -> createAndQueueTaskWithoutCheckV2(CLASSIFICATION_PROPAGATION_DELETE, deletionCandidateVertex, null, t.getTagTypeName()));
+        try {
+            if (RequestContext.get().getDeleteType() == DeleteType.HARD || RequestContext.get().getDeleteType() == DeleteType.PURGE)
+                tagDAO.deleteTags(tags);
+            tags.forEach(t -> createAndQueueTaskWithoutCheckV2(CLASSIFICATION_PROPAGATION_DELETE, deletionCandidateVertex, null, t.getTagTypeName()));
+        } catch (AtlasBaseException e) {
+            LOG.error("Error while deleting tags for vertex: {}", deletionCandidateVertex.getIdForDisplay());
+            throw e;
+        }
     }
 
     /**


### PR DESCRIPTION
## Fix for soft delete v1 flow

> The fix skips deleting tags when an asset is deleted. This is to match the v1 flow in Metastore.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)


