### PR TITLE
MLH-791 Modified Time is empty (Fallback to create time for display)

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -1247,7 +1247,7 @@ public final class GraphHelper {
         try {
             return element.getProperty(MODIFICATION_TIMESTAMP_PROPERTY_KEY, Long.class);
         } catch (Exception e) {
-            LOG.warn("Failed to set modified time for vertex {}. Error: {}", element.getIdForDisplay(), e.getMessage());
+            LOG.warn("Failed to get modified time for vertex {}. Error: {}", element.getIdForDisplay(), e.getMessage());
             // Fallback to created time if modification timestamp is not set
             return element.getProperty(TIMESTAMP_PROPERTY_KEY, Long.class);
         }

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -1244,7 +1244,13 @@ public final class GraphHelper {
     }
 
     public static long getModifiedTime(AtlasElement element){
-        return element.getProperty(MODIFICATION_TIMESTAMP_PROPERTY_KEY, Long.class);
+        try {
+            return element.getProperty(MODIFICATION_TIMESTAMP_PROPERTY_KEY, Long.class);
+        } catch (Exception e) {
+            LOG.warn("Failed to set modified time for vertex {}. Error: {}", element.getIdForDisplay(), e.getMessage());
+            // Fallback to created time if modification timestamp is not set
+            return element.getProperty(TIMESTAMP_PROPERTY_KEY, Long.class);
+        }
     }
 
     public static void setModifiedTime(AtlasElement element, Long modifiedTime) {


### PR DESCRIPTION
## Change description

> For Domo assets in colgate, modified Timestamp seems to be empty for some assets and publish is failing in the workflow for few days
Fix is to fallback to createTime without erroring the entire workflow.

tenant: gcpcolgatepal
workflow: https://colgatepalmolive.atlan.com/api/orchestration/workflows/default/atlan-domo-1709581612-698kd?tab=workflow&nodeId=atlan-domo-1709581612-698kd-3364155156&sidePanel=logs:atlan-domo-1709581612-698kd-3364155156:main&uid=1f430b9b-ad4c-496c-b392-f6b7182c5e66
```
2025-07-10 07:00:28.686 DEBUG connectionpool - _make_request: [http://atlas-ratelimited.atlas.svc.cluster.local:80](http://atlas-ratelimited.atlas.svc.cluster.local/) "POST /api/atlas/v2/entity/bulk?replaceClassifications=false&replaceBusinessAttributes=false&overwriteBusinessAttributes=false HTTP/1.1" 500 None
2025-07-10 07:00:28.687 WARNING api - partial_run: Request failed with status code 500 and exception {"causes":[{"errorType":"java.lang.NullPointerException","errorMessage":"Cannot invoke \"java.lang.Long.longValue()\" because the return value of \"org.apache.atlas.repository.graphdb.AtlasElement.getProperty(String, java.lang.Class)\" is null","location":"org.apache.atlas.repository.graph.GraphHelper.getModifiedTime (GraphHelper.java:1247)"}],"errorId":"424e9b590b0d8962","message":"There was an error processing your request."}
2025-07-10 07:00:28.687 DEBUG execution - execute: Executing for state API_FAIL
2025-07-10 07:00:28.689 DEBUG <string> - <module>: Atlas is unavailable. Performing retry with back-off
2025-07-10 07:00:28.689 DEBUG __init__ - run: Failure handler selected: RETRY
2025-07-10 07:00:28.689 DEBUG __init__ - run: RETRY failure handler already running. Ignoring
2025-07-10 07:00:28.689 DEBUG retry - run: Response failure handler type got inside retry: FailureHandlerType.RETRY
2025-07-10 07:00:28.689 DEBUG retry - run: Response status code got inside retry: 500
2025-07-10 07:00:28.689 DEBUG execution - execute: Executing for state FAILURE
2025-07-10 07:00:28.691 DEBUG __init__ - _output_files_generated: Outputting files generated at /tmp/rest/success/result-gen.txt with value 1
2025-07-10 07:00:28.691 DEBUG __init__ - _output_records_written: Outputting count of records written at /tmp/rest/success/result-count.txt with value 1687
2025-07-10 07:00:28.691 DEBUG __init__ - _output_files_generated: Outputting files generated at /tmp/rest/failure/result-gen.txt with value -1
2025-07-10 07:00:28.691 DEBUG __init__ - _output_records_written: Outputting count of records written at /tmp/rest/failure/result-count.txt with value 0
2025-07-10 07:00:28.692 DEBUG execution - execute: Executing for state END
2025-07-10 07:00:28.693 WARNING __init__ - end: No summary evaluated
2025-07-10 07:00:28.696 INFO logger - add_otel_handler: OpenTelemetry handler added to the logger.
2025-07-10 07:00:28.697 ERROR logger - handle_exception: Traceback (most recent call last):
  File "/app/api/api.py", line 195, in partial_run
    request_kwargs = self.auth_handler.handle_auth_expiry(
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/auth/__init__.py", line 50, in handle_auth_expiry
    self.session, request_config = self.auth_type.handle_auth_expiry(
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/auth/__init__.py", line 135, in handle_auth_expiry
    raise NonAuthError("Non Auth Error")
auth.NonAuthError: Non Auth Error

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
```

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
