### PR TITLE
MLH-796 add all headers to MDC and match headers start with x-atlan (case insensitive)

### DIFF
--- a/webapp/src/main/java/org/apache/atlas/web/filters/HeadersUtil.java
+++ b/webapp/src/main/java/org/apache/atlas/web/filters/HeadersUtil.java
@@ -21,6 +21,7 @@ import org.apache.atlas.AtlasConfiguration;
 import org.apache.atlas.RequestContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 
 import javax.servlet.http.HttpServletRequest;
@@ -82,8 +83,8 @@ public class HeadersUtil {
 
         while (headerNames.hasMoreElements()) {
             String headerName = headerNames.nextElement();
-
-            if (headerName.startsWith(ATLAN_HEADER_PREFIX_PATTERN)) {
+            MDC.put(headerName, request.getHeader(headerName)); // Log the header for debugging purposes
+            if (headerName.toLowerCase().startsWith(ATLAN_HEADER_PREFIX_PATTERN.toLowerCase())) {
                 context.addRequestContextHeader(headerName, request.getHeader(headerName));
             }
         }


### PR DESCRIPTION

## Change description

> add all headers to MDC 
match headers start with x-atlan (case insensitive)
bring additional headers that workflow today is brining. there could be numaflow headers too
```
x-atlan-agent = workflow
x-atlan-agent-package-name = name of the package
x-atlan-agent-workflow-id = name of a unique run of the package
x-atlan-agent-id = (can't remember how this differs from the above)
user-agent = details of the calling "thing", with runtime context (example below)
X-Atlan-Client-User-Agent = same as user-agent
x-atlan-client-origin = product_sdk
```

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
