### PR TITLE
MLH-796 log only specific header names

### DIFF
--- a/webapp/src/main/java/org/apache/atlas/web/filters/HeadersUtil.java
+++ b/webapp/src/main/java/org/apache/atlas/web/filters/HeadersUtil.java
@@ -52,7 +52,8 @@ public class HeadersUtil {
     public static final String X_REQUESTED_WITH_VALUE = "XMLHttpRequest";
     public static final int SC_AUTHENTICATION_TIMEOUT = 419;
 
-    private static final Set<String> LOG_HEADER_NAMES = Set.of("x-atlan-", "origin", "x-amzn-trace-id", "content-length");
+    private static final String ATLAN_HEADER_PREFIX_PATTERN = "x-atlan-";
+    private static final Set<String> LOG_HEADER_NAMES = Set.of("origin", "x-amzn-trace-id", "content-length");
 
 
     HeadersUtil() {
@@ -81,7 +82,7 @@ public class HeadersUtil {
 
         while (headerNames.hasMoreElements()) {
             String headerName = headerNames.nextElement();
-            if (LOG_HEADER_NAMES.contains(headerName.toLowerCase())) {
+            if (headerName.toLowerCase().startsWith(ATLAN_HEADER_PREFIX_PATTERN.toLowerCase()) || LOG_HEADER_NAMES.contains(headerName.toLowerCase())) {
                 MDC.put(headerName, request.getHeader(headerName)); // Log the header for debugging purposes
                 context.addRequestContextHeader(headerName, request.getHeader(headerName));
             }

--- a/webapp/src/main/java/org/apache/atlas/web/filters/HeadersUtil.java
+++ b/webapp/src/main/java/org/apache/atlas/web/filters/HeadersUtil.java
@@ -21,12 +21,11 @@ import org.apache.atlas.AtlasConfiguration;
 import org.apache.atlas.RequestContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 
 import javax.servlet.http.HttpServletRequest;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 @Component
 public class HeadersUtil {
@@ -53,7 +52,7 @@ public class HeadersUtil {
     public static final String X_REQUESTED_WITH_VALUE = "XMLHttpRequest";
     public static final int SC_AUTHENTICATION_TIMEOUT = 419;
 
-    private static final String ATLAN_HEADER_PREFIX_PATTERN = "x-atlan-";
+    private static final Set<String> LOG_HEADER_NAMES = Set.of("x-atlan-", "origin", "x-amzn-trace-id", "content-length");
 
 
     HeadersUtil() {
@@ -82,8 +81,8 @@ public class HeadersUtil {
 
         while (headerNames.hasMoreElements()) {
             String headerName = headerNames.nextElement();
-
-            if (headerName.startsWith(ATLAN_HEADER_PREFIX_PATTERN)) {
+            if (LOG_HEADER_NAMES.contains(headerName.toLowerCase())) {
+                MDC.put(headerName, request.getHeader(headerName)); // Log the header for debugging purposes
                 context.addRequestContextHeader(headerName, request.getHeader(headerName));
             }
         }


### PR DESCRIPTION
## Change description

> Log only exclusive headers
Headers starting with x-atlan- ignoring case
"origin", "x-amzn-trace-id", "content-length"

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues
https://atlanhq.atlassian.net/browse/MLH-796
> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
