### PR TITLE
Added classification text update on v1 delete flow

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -4326,6 +4326,9 @@ public class EntityGraphMapper {
 
         entityVertex.setProperty(CLASSIFICATION_NAMES_KEY, getClassificationNamesString(traitNames));
 
+        AtlasEntity entity = instanceConverter.getEntity(entityGuid, ENTITY_CHANGE_NOTIFY_IGNORE_RELATIONSHIP_ATTRIBUTES);
+        entityVertex.setProperty(CLASSIFICATION_TEXT_KEY, fullTextMapperV2.getClassificationTextForEntity(entity));
+
         updateModificationMetadata(entityVertex);
 
         if (RequestContext.get().isDelayTagNotifications()) {


### PR DESCRIPTION
## Classification text fix

Bug fix: classification text denorm attribute was not being updated for v1 tag delete flow.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
