### PR TITLE
MESH-571 | Handle Restoration of Data Mesh Entities

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/RestoreHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/RestoreHandlerV1.java
@@ -54,6 +54,8 @@ import static org.apache.atlas.repository.Constants.*;
 import static org.apache.atlas.repository.graph.GraphHelper.*;
 import static org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2.getIdFromEdge;
 import static org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2.isReference;
+import static org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessorUtils.DATA_DOMAIN_REL_TYPE;
+import static org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessorUtils.PARENT_DOMAIN_REL_TYPE;
 import static org.apache.atlas.type.AtlasStructType.AtlasAttribute.AtlasRelationshipEdgeDirection.OUT;
 
 @Singleton
@@ -109,6 +111,13 @@ public class RestoreHandlerV1 {
                     continue;
                 }
 
+                String typeName = AtlasGraphUtilsV2.getTypeName(instanceVertex);
+                if (typeName.equals(DATA_DOMAIN_ENTITY_TYPE) || typeName.equals(DATA_PRODUCT_ENTITY_TYPE)) {
+                    if (validateDataMeshEntityRestore(typeName, instanceVertex)) {
+                        throw new AtlasBaseException(AtlasErrorCode.OPERATION_NOT_SUPPORTED, "Cannot restore " + typeName + " with guid " + guid + " because it has no parent domain relationship");
+                    }
+                }
+
                 // Record all restoring candidate entities in RequestContext
                 // and gather restoring candidate vertices.
                 for (VertexInfo vertexInfo : getOwnedVertices(instanceVertex)) {
@@ -125,6 +134,17 @@ public class RestoreHandlerV1 {
         } finally {
             RequestContext.get().endMetricRecord(metricRecorder);
         }
+    }
+
+    private boolean validateDataMeshEntityRestore(String typeName, AtlasVertex instanceVertex) throws AtlasBaseException {
+        AtlasEntity entity = entityRetriever.toAtlasEntity(instanceVertex);
+
+        if (typeName.equals(DATA_DOMAIN_ENTITY_TYPE) && entity.getRelationshipAttribute(PARENT_DOMAIN_REL_TYPE) == null) {
+            return true;
+        } else if (typeName.equals(DATA_PRODUCT_ENTITY_TYPE) && entity.getRelationshipAttribute(DATA_DOMAIN_REL_TYPE) == null) {
+            return true;
+        }
+        return false;
     }
 
     private void restoreEdgeBetweenVertices(AtlasVertex outVertex, AtlasVertex inVertex, AtlasStructType.AtlasAttribute attribute) throws AtlasBaseException {


### PR DESCRIPTION
## Change description

> If a Data Product or Subdomain is restored after its parent Domain has been purged, it can become orphaned. This change ensures such entities cannot be marked as active unless a valid parent Domain exists.

JIRA: [MESH-571](https://atlanhq.atlassian.net/browse/MESH-571)

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable


[MESH-571]: https://atlanhq.atlassian.net/browse/MESH-571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ