### PR TITLE
MESH-578 | Remove asset from inputPorts when same asset gets marked as outputPort

### DIFF
--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -161,8 +161,6 @@ public final class Constants {
     public static final String INPUT_PORT_PRODUCT_EDGE_LABEL = "__Asset.inputPortDataProducts";
     public static final String OUTPUT_PORT_PRODUCT_EDGE_LABEL = "__Asset.outputPortDataProducts";
 
-    public static final String INPUT_PORT_PRODUCT_RELATIONSHIP_LABEL = "inputPortDataProducts";
-
     public static final String OUTPUT_PORTS = "outputPorts";
     public static final String INPUT_PORTS = "inputPorts";
     public static final String ADDED_OUTPUT_PORTS = "addedOutputPorts";

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -2487,17 +2487,11 @@ public class EntityGraphMapper {
             // When adding assets as outputPort, remove them from inputPorts if they already exist there.
             if (CollectionUtils.isNotEmpty(conflictingGuids)) {
                 try {
-                    removeInputPortEdges(toVertex, conflictingGuids);
+                    removeInputPortReferences(toVertex, conflictingGuids);
                 } catch (AtlasBaseException e) {
                     throw new AtlasBaseException(AtlasErrorCode.INTERNAL_ERROR, "Failed to remove input port edges for conflicting GUIDs: " + conflictingGuids, String.valueOf(e));
                 }
-
-                conflictingGuids.forEach(guid ->
-                        AtlasGraphUtilsV2.removeItemFromListPropertyValue(toVertex, INPUT_PORT_GUIDS_ATTR, guid));
-
-                trackInputPortRemoval(toVertex, conflictingGuids);
             }
-
 
             if (CollectionUtils.isNotEmpty(currentElements)) {
                 List<String> currentElementGuids = currentElements.stream()
@@ -2519,7 +2513,7 @@ public class EntityGraphMapper {
             }
         } else if (internalAttr.equals(INPUT_PORT_GUIDS_ATTR)) {
             //  When adding assets as inputPort, fail if they already exist as outputPorts.
-            handleInputPortUpdate(toVertex, addedGuids);
+            validateInputPortUpdate(toVertex, addedGuids);
         }
     }
 
@@ -2536,7 +2530,7 @@ public class EntityGraphMapper {
         return conflictingGuids;
     }
 
-    private void removeInputPortEdges(AtlasVertex toVertex, List<String> conflictingGuids) throws AtlasBaseException {
+    private void removeInputPortReferences(AtlasVertex toVertex, List<String> conflictingGuids) throws AtlasBaseException {
         for (String assetGuid: conflictingGuids) {
             AtlasVertex assetVertex = AtlasGraphUtilsV2.findByGuid(this.graph, assetGuid);
             if (assetVertex == null) {
@@ -2553,39 +2547,12 @@ public class EntityGraphMapper {
                 }
             }
         }
+
+        conflictingGuids.forEach(guid ->
+                AtlasGraphUtilsV2.removeItemFromListPropertyValue(toVertex, INPUT_PORT_GUIDS_ATTR, guid));
     }
 
-    private void trackInputPortRemoval(AtlasVertex toVertex, List<String> conflictingGuids) {
-        String productGuid = toVertex.getProperty("__guid", String.class);
-        AtlasEntity productDiffEntity = RequestContext.get().getDifferentialEntity(productGuid);
-
-        if (productDiffEntity == null) {
-            productDiffEntity = new AtlasEntity();
-            productDiffEntity.setGuid(productGuid);
-            productDiffEntity.setTypeName(TYPE_PRODUCT);
-            RequestContext.get().cacheDifferentialEntity(productDiffEntity);
-        }
-
-        productDiffEntity.setRemovedRelationshipAttribute(INPUT_PORTS, conflictingGuids);
-
-        for (String assetGuid : conflictingGuids) {
-            AtlasVertex assetVertex = AtlasGraphUtilsV2.findByGuid(this.graph, assetGuid);
-            if (assetVertex != null) {
-                AtlasEntity assetDiffEntity = RequestContext.get().getDifferentialEntity(assetGuid);
-                
-                if (assetDiffEntity == null) {
-                    assetDiffEntity = new AtlasEntity();
-                    assetDiffEntity.setGuid(assetGuid);
-                    assetDiffEntity.setTypeName(assetVertex.getProperty("__typeName", String.class));
-                    RequestContext.get().cacheDifferentialEntity(assetDiffEntity);
-                }
-
-                assetDiffEntity.setRemovedRelationshipAttribute(INPUT_PORT_PRODUCT_RELATIONSHIP_LABEL, Collections.singletonList(new AtlasObjectId(productGuid, TYPE_PRODUCT)));
-            }
-        }
-    }
-
-    private void handleInputPortUpdate(AtlasVertex toVertex, List<String> addedGuids) throws AtlasBaseException {
+    private void validateInputPortUpdate(AtlasVertex toVertex, List<String> addedGuids) throws AtlasBaseException {
         if (CollectionUtils.isNotEmpty(addedGuids)) {
             List<String> existingOutputPortGuids = toVertex.getMultiValuedProperty(OUTPUT_PORT_GUIDS_ATTR, String.class);
             if (CollectionUtils.isNotEmpty(existingOutputPortGuids)) {


### PR DESCRIPTION
## Change description

> An incorrect circular lineage issue was reported by Otsuka, caused by assets being incorrectly marked as both inputPort and outputPort. While the lineage API includes validation to prevent such conflicting designations, the bulk API lacks equivalent checks.

JIRA: [MESH-578](https://atlanhq.atlassian.net/browse/MESH-578)
Test: [doc](https://atlanhq.atlassian.net/wiki/spaces/dg/pages/970162238/Test+Cases+for+MESH-578+Remove+asset+from+inputPorts+when+same+asset+gets+marked+as+outputPort)

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable


[MESH-578]: https://atlanhq.atlassian.net/browse/MESH-578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ