### PR TITLE
MESH-578 | Remove asset from inputPorts when same asset gets marked as outputPort

### DIFF
--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -162,6 +162,7 @@ public final class Constants {
     public static final String OUTPUT_PORT_PRODUCT_EDGE_LABEL = "__Asset.outputPortDataProducts";
 
     public static final String OUTPUT_PORTS = "outputPorts";
+    public static final String INPUT_PORTS = "inputPorts";
     public static final String ADDED_OUTPUT_PORTS = "addedOutputPorts";
     public static final String REMOVED_OUTPUT_PORTS = "removedOutputPorts";
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -2541,11 +2541,19 @@ public class EntityGraphMapper {
             RequestContext.get().cacheDifferentialEntity(diffEntity);
         }
 
+        // Track removed input ports in differential entity for change notifications and audit trail
         Map<String, Object> removedAttrs = diffEntity.getRemovedRelationshipAttributes();
         if (removedAttrs == null) {
             removedAttrs = new HashMap<>();
             diffEntity.setRemovedRelationshipAttributes(removedAttrs);
         }
+
+        List<String> existingRemovedInputPorts = (List<String>) removedAttrs.get(INPUT_PORTS);
+        if (existingRemovedInputPorts == null) {
+            existingRemovedInputPorts = new ArrayList<>();
+        }
+        existingRemovedInputPorts.addAll(conflictingGuids);
+        removedAttrs.put(INPUT_PORTS, existingRemovedInputPorts);
     }
 
     private boolean shouldDeleteExistingRelations(AttributeMutationContext ctx, AtlasAttribute attribute) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -2473,29 +2473,24 @@ public class EntityGraphMapper {
 
         // Add more info to outputPort update event.
         if (internalAttr.equals(OUTPUT_PORT_GUIDS_ATTR)) {
+            List<String> conflictingGuids = fetchConflictingGuids(currentElements, toVertex, addedGuids);
+
             // When adding assets as outputPort, remove them from inputPorts if they already exist there.
-            if (CollectionUtils.isNotEmpty(addedGuids)) {
-                List<String> existingInputPortGuids = toVertex.getMultiValuedProperty(INPUT_PORT_GUIDS_ATTR, String.class);
-                if (CollectionUtils.isNotEmpty(existingInputPortGuids)) {
-                    List<String> conflictingGuids = addedGuids.stream()
-                            .filter(existingInputPortGuids::contains)
-                            .collect(Collectors.toList());
-                    
-                    if (CollectionUtils.isNotEmpty(conflictingGuids)) {
-                        try {
-                            removeInputPortEdges(toVertex, conflictingGuids);
-                        } catch (AtlasBaseException e) {
-                            LOG.error("Failed to remove input port edges for conflicting GUIDs: {}", conflictingGuids, e);
-                            throw e;
-                        }
-
-                        conflictingGuids.forEach(guid ->
-                            AtlasGraphUtilsV2.removeItemFromListPropertyValue(toVertex, INPUT_PORT_GUIDS_ATTR, guid));
-
-                        trackInputPortRemoval(toVertex, conflictingGuids);
-                    }
+            if (CollectionUtils.isNotEmpty(conflictingGuids)) {
+                try {
+                    removeInputPortEdges(toVertex, conflictingGuids);
+                } catch (AtlasBaseException e) {
+                    LOG.error("Failed to remove input port edges for conflicting GUIDs: {}", conflictingGuids, e);
+                    throw e;
                 }
+
+                conflictingGuids.forEach(guid ->
+                        AtlasGraphUtilsV2.removeItemFromListPropertyValue(toVertex, INPUT_PORT_GUIDS_ATTR, guid));
+
+                trackInputPortRemoval(toVertex, conflictingGuids);
             }
+
+
             if (CollectionUtils.isNotEmpty(currentElements)) {
                 List<String> currentElementGuids = currentElements.stream()
                         .filter(x -> ((AtlasEdge) x).getProperty(STATE_PROPERTY_KEY, String.class).equals("ACTIVE"))
@@ -2515,20 +2510,24 @@ public class EntityGraphMapper {
                 diffEntity.setRemovedRelationshipAttribute(OUTPUT_PORTS, removedGuids);
             }
         } else if (internalAttr.equals(INPUT_PORT_GUIDS_ATTR)) {
-            // When adding assets as inputPort, fail if they already exist as outputPorts.
-            if (CollectionUtils.isNotEmpty(addedGuids)) {
-                List<String> existingOutputPortGuids = toVertex.getMultiValuedProperty(OUTPUT_PORT_GUIDS_ATTR, String.class);
-                if (CollectionUtils.isNotEmpty(existingOutputPortGuids)) {
-                    List<String> conflictingGuids = addedGuids.stream()
-                            .filter(existingOutputPortGuids::contains)
-                            .collect(Collectors.toList());
+            //  When adding assets as inputPort, fail if they already exist as outputPorts.
+            //  Follows atomic transaction i.e if any of the inputPort assets already exist as outputPorts, then
+            //  complete inputPort batch fails
+            handleInputPortUpdate(toVertex, addedGuids);
+        }
+    }
 
-                    if (CollectionUtils.isNotEmpty(conflictingGuids)) {
-                        throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST, "Cannot add input ports that already exist as output ports: " + conflictingGuids);
-                    }
-                }
+    private List<String> fetchConflictingGuids(List<Object> currentElements, AtlasVertex toVertex, List<String> addedGuids) {
+        List<String> conflictingGuids = new ArrayList<>();
+        if (CollectionUtils.isNotEmpty(addedGuids)) {
+            List<String> existingInputPortGuids = toVertex.getMultiValuedProperty(INPUT_PORT_GUIDS_ATTR, String.class);
+            if (CollectionUtils.isNotEmpty(existingInputPortGuids)) {
+                conflictingGuids = addedGuids.stream()
+                        .filter(existingInputPortGuids::contains)
+                        .collect(Collectors.toList());
             }
         }
+        return conflictingGuids;
     }
 
     private void removeInputPortEdges(AtlasVertex toVertex, List<String> conflictingGuids) throws AtlasBaseException {
@@ -2574,6 +2573,21 @@ public class EntityGraphMapper {
         }
         existingRemovedInputPorts.addAll(conflictingGuids);
         removedAttrs.put(INPUT_PORTS, existingRemovedInputPorts);
+    }
+
+    private void handleInputPortUpdate(AtlasVertex toVertex, List<String> addedGuids) throws AtlasBaseException {
+        if (CollectionUtils.isNotEmpty(addedGuids)) {
+            List<String> existingOutputPortGuids = toVertex.getMultiValuedProperty(OUTPUT_PORT_GUIDS_ATTR, String.class);
+            if (CollectionUtils.isNotEmpty(existingOutputPortGuids)) {
+                List<String> conflictingGuids = addedGuids.stream()
+                        .filter(existingOutputPortGuids::contains)
+                        .collect(Collectors.toList());
+
+                if (CollectionUtils.isNotEmpty(conflictingGuids)) {
+                    throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST, "Cannot add input ports that already exist as output ports: " + conflictingGuids);
+                }
+            }
+        }
     }
 
     private boolean shouldDeleteExistingRelations(AttributeMutationContext ctx, AtlasAttribute attribute) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -2458,7 +2458,7 @@ public class EntityGraphMapper {
         RequestContext.get().endMetricRecord(metricRecorder);
     }
 
-    private void addOrRemoveDaapInternalAttr(AtlasVertex toVertex, String internalAttr, List<Object> createdElements, List<AtlasEdge> deletedElements, List<Object> currentElements) {
+    private void addOrRemoveDaapInternalAttr(AtlasVertex toVertex, String internalAttr, List<Object> createdElements, List<AtlasEdge> deletedElements, List<Object> currentElements) throws AtlasBaseException {
         List<String> addedGuids = new ArrayList<>();
         List<String> removedGuids = new ArrayList<>();
         if (CollectionUtils.isNotEmpty(createdElements)) {
@@ -2485,7 +2485,12 @@ public class EntityGraphMapper {
                         conflictingGuids.forEach(guid ->
                             AtlasGraphUtilsV2.removeItemFromListPropertyValue(toVertex, INPUT_PORT_GUIDS_ATTR, guid));
 
-                        removeInputPortEdges(toVertex, conflictingGuids);
+                        try {
+                            removeInputPortEdges(toVertex, conflictingGuids);
+                        } catch (AtlasBaseException e) {
+                            LOG.error("Failed to remove input port edges for conflicting GUIDs: {}", conflictingGuids, e);
+                            throw e;
+                        }
 
                         trackInputPortRemoval(toVertex, conflictingGuids);
                     }
@@ -2512,20 +2517,21 @@ public class EntityGraphMapper {
         }
     }
 
-    private void removeInputPortEdges(AtlasVertex toVertex, List<String> conflictingGuids) {
+    private void removeInputPortEdges(AtlasVertex toVertex, List<String> conflictingGuids) throws AtlasBaseException {
         for (String assetGuid: conflictingGuids) {
-            try {
-                AtlasVertex assetVertex = AtlasGraphUtilsV2.findByGuid(this.graph, assetGuid);
-                Iterator<AtlasEdge> outEdges = assetVertex.getEdges(AtlasEdgeDirection.OUT, INPUT_PORT_PRODUCT_EDGE_LABEL).iterator();
-                while(outEdges.hasNext()) {
-                    AtlasEdge edge = outEdges.next();
-                    if (edge.getInVertex().equals(toVertex)) {
-                        deleteDelegate.getHandler(DeleteType.HARD).deleteEdgeReference(edge, TypeCategory.ENTITY, true,
-                                true, AtlasRelationshipEdgeDirection.OUT, assetVertex);
-                    }
+            AtlasVertex assetVertex = AtlasGraphUtilsV2.findByGuid(this.graph, assetGuid);
+            if (assetVertex == null) {
+                LOG.warn("Asset vertex not found for GUID: {}, skipping edge removal", assetGuid);
+                continue;
+            }
+
+            Iterator<AtlasEdge> outEdges = assetVertex.getEdges(AtlasEdgeDirection.OUT, INPUT_PORT_PRODUCT_EDGE_LABEL).iterator();
+            while(outEdges.hasNext()) {
+                AtlasEdge edge = outEdges.next();
+                if (edge.getInVertex().equals(toVertex)) {
+                    deleteDelegate.getHandler(DeleteType.HARD).deleteEdgeReference(edge, TypeCategory.ENTITY, true,
+                            true, AtlasRelationshipEdgeDirection.OUT, assetVertex);
                 }
-            } catch (AtlasBaseException e) {
-                throw new RuntimeException(e);
             }
         }
     }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -2473,6 +2473,24 @@ public class EntityGraphMapper {
 
         // Add more info to outputPort update event.
         if (internalAttr.equals(OUTPUT_PORT_GUIDS_ATTR)) {
+            // When adding assets as outputPort, remove them from inputPorts if they already exist there.
+            if (CollectionUtils.isNotEmpty(addedGuids)) {
+                List<String> existingInputPortGuids = toVertex.getMultiValuedProperty(INPUT_PORT_GUIDS_ATTR, String.class);
+                if (CollectionUtils.isNotEmpty(existingInputPortGuids)) {
+                    List<String> conflictingGuids = addedGuids.stream()
+                            .filter(existingInputPortGuids::contains)
+                            .collect(Collectors.toList());
+                    
+                    if (CollectionUtils.isNotEmpty(conflictingGuids)) {
+                        conflictingGuids.forEach(guid ->
+                            AtlasGraphUtilsV2.removeItemFromListPropertyValue(toVertex, INPUT_PORT_GUIDS_ATTR, guid));
+
+                        removeInputPortEdges(toVertex, conflictingGuids);
+
+                        trackInputPortRemoval(toVertex, conflictingGuids);
+                    }
+                }
+            }
             if (CollectionUtils.isNotEmpty(currentElements)) {
                 List<String> currentElementGuids = currentElements.stream()
                         .filter(x -> ((AtlasEdge) x).getProperty(STATE_PROPERTY_KEY, String.class).equals("ACTIVE"))
@@ -2491,6 +2509,42 @@ public class EntityGraphMapper {
                 diffEntity.setAddedRelationshipAttribute(OUTPUT_PORTS, addedGuids);
                 diffEntity.setRemovedRelationshipAttribute(OUTPUT_PORTS, removedGuids);
             }
+        }
+    }
+
+    private void removeInputPortEdges(AtlasVertex toVertex, List<String> conflictingGuids) {
+        for (String assetGuid: conflictingGuids) {
+            try {
+                AtlasVertex assetVertex = AtlasGraphUtilsV2.findByGuid(this.graph, assetGuid);
+                Iterator<AtlasEdge> outEdges = assetVertex.getEdges(AtlasEdgeDirection.OUT, INPUT_PORT_PRODUCT_EDGE_LABEL).iterator();
+                while(outEdges.hasNext()) {
+                    AtlasEdge edge = outEdges.next();
+                    if (edge.getInVertex().equals(toVertex)) {
+                        deleteDelegate.getHandler(DeleteType.HARD).deleteEdgeReference(edge, TypeCategory.ENTITY, true,
+                                true, AtlasRelationshipEdgeDirection.OUT, assetVertex);
+                    }
+                }
+            } catch (AtlasBaseException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private void trackInputPortRemoval(AtlasVertex toVertex, List<String> conflictingGuids) {
+        String productGuid = toVertex.getProperty("__guid", String.class);
+        AtlasEntity diffEntity = RequestContext.get().getDifferentialEntity(productGuid);
+
+        if (diffEntity == null) {
+            diffEntity = new AtlasEntity();
+            diffEntity.setGuid(productGuid);
+            diffEntity.setTypeName(TYPE_PRODUCT);
+            RequestContext.get().cacheDifferentialEntity(diffEntity);
+        }
+
+        Map<String, Object> removedAttrs = diffEntity.getRemovedRelationshipAttributes();
+        if (removedAttrs == null) {
+            removedAttrs = new HashMap<>();
+            diffEntity.setRemovedRelationshipAttributes(removedAttrs);
         }
     }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -2482,15 +2482,15 @@ public class EntityGraphMapper {
                             .collect(Collectors.toList());
                     
                     if (CollectionUtils.isNotEmpty(conflictingGuids)) {
-                        conflictingGuids.forEach(guid ->
-                            AtlasGraphUtilsV2.removeItemFromListPropertyValue(toVertex, INPUT_PORT_GUIDS_ATTR, guid));
-
                         try {
                             removeInputPortEdges(toVertex, conflictingGuids);
                         } catch (AtlasBaseException e) {
                             LOG.error("Failed to remove input port edges for conflicting GUIDs: {}", conflictingGuids, e);
                             throw e;
                         }
+
+                        conflictingGuids.forEach(guid ->
+                            AtlasGraphUtilsV2.removeItemFromListPropertyValue(toVertex, INPUT_PORT_GUIDS_ATTR, guid));
 
                         trackInputPortRemoval(toVertex, conflictingGuids);
                     }
@@ -2513,6 +2513,20 @@ public class EntityGraphMapper {
                 // make change to not add following attributes to diff entity if they are empty
                 diffEntity.setAddedRelationshipAttribute(OUTPUT_PORTS, addedGuids);
                 diffEntity.setRemovedRelationshipAttribute(OUTPUT_PORTS, removedGuids);
+            }
+        } else if (internalAttr.equals(INPUT_PORT_GUIDS_ATTR)) {
+            // When adding assets as inputPort, fail if they already exist as outputPorts.
+            if (CollectionUtils.isNotEmpty(addedGuids)) {
+                List<String> existingOutputPortGuids = toVertex.getMultiValuedProperty(OUTPUT_PORT_GUIDS_ATTR, String.class);
+                if (CollectionUtils.isNotEmpty(existingOutputPortGuids)) {
+                    List<String> conflictingGuids = addedGuids.stream()
+                            .filter(existingOutputPortGuids::contains)
+                            .collect(Collectors.toList());
+
+                    if (CollectionUtils.isNotEmpty(conflictingGuids)) {
+                        throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST, "Cannot add input ports that already exist as output ports: " + conflictingGuids);
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Change description

> Description here

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
