### PR TITLE
PLTS-460 | Ignore additional props in keycloak response

### DIFF
--- a/client-auth/src/main/java/org/apache/atlas/auth/client/auth/AbstractAuthClient.java
+++ b/client-auth/src/main/java/org/apache/atlas/auth/client/auth/AbstractAuthClient.java
@@ -1,7 +1,5 @@
 package org.apache.atlas.auth.client.auth;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micrometer.core.instrument.Timer;
 import org.apache.atlas.auth.client.config.AuthConfig;
 import org.apache.atlas.auth.client.heracles.RetrofitHeraclesClient;
@@ -69,11 +67,11 @@ public class AbstractAuthClient {
                 .build();
         this.retrofitKeycloakClient = new Retrofit.Builder().client(okHttpClient)
                 .baseUrl(this.authConfig.getAuthServerUrl())
-                .addConverterFactory(JacksonConverterFactory.create(new ObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES))).build()
+                .addConverterFactory(JacksonConverterFactory.create(ObjectMapperUtils.OBJECT_MAPPER)).build()
                 .create(RetrofitKeycloakClient.class);
         this.retrofitHeraclesClient = new Retrofit.Builder().client(okHttpClient)
                 .baseUrl(this.authConfig.getHeraclesApiServerUrl())
-                .addConverterFactory(JacksonConverterFactory.create(new ObjectMapper().disable(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES))).build()
+                .addConverterFactory(JacksonConverterFactory.create(ObjectMapperUtils.OBJECT_MAPPER)).build()
                 .create(RetrofitHeraclesClient.class);
         authService = new KeycloakAuthenticationService(authConfig);
     }

--- a/client-auth/src/main/java/org/apache/atlas/auth/client/auth/AbstractAuthClient.java
+++ b/client-auth/src/main/java/org/apache/atlas/auth/client/auth/AbstractAuthClient.java
@@ -69,7 +69,7 @@ public class AbstractAuthClient {
                 .build();
         this.retrofitKeycloakClient = new Retrofit.Builder().client(okHttpClient)
                 .baseUrl(this.authConfig.getAuthServerUrl())
-                .addConverterFactory(JacksonConverterFactory.create(new ObjectMapper())).build()
+                .addConverterFactory(JacksonConverterFactory.create(new ObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES))).build()
                 .create(RetrofitKeycloakClient.class);
         this.retrofitHeraclesClient = new Retrofit.Builder().client(okHttpClient)
                 .baseUrl(this.authConfig.getHeraclesApiServerUrl())

--- a/client-auth/src/main/java/org/apache/atlas/auth/client/auth/AbstractAuthClient.java
+++ b/client-auth/src/main/java/org/apache/atlas/auth/client/auth/AbstractAuthClient.java
@@ -67,11 +67,11 @@ public class AbstractAuthClient {
                 .build();
         this.retrofitKeycloakClient = new Retrofit.Builder().client(okHttpClient)
                 .baseUrl(this.authConfig.getAuthServerUrl())
-                .addConverterFactory(JacksonConverterFactory.create(ObjectMapperUtils.OBJECT_MAPPER)).build()
+                .addConverterFactory(JacksonConverterFactory.create(ObjectMapperUtils.KEYCLOAK_OBJECT_MAPPER)).build()
                 .create(RetrofitKeycloakClient.class);
         this.retrofitHeraclesClient = new Retrofit.Builder().client(okHttpClient)
                 .baseUrl(this.authConfig.getHeraclesApiServerUrl())
-                .addConverterFactory(JacksonConverterFactory.create(ObjectMapperUtils.OBJECT_MAPPER)).build()
+                .addConverterFactory(JacksonConverterFactory.create(ObjectMapperUtils.HERACLES_OBJECT_MAPPER)).build()
                 .create(RetrofitHeraclesClient.class);
         authService = new KeycloakAuthenticationService(authConfig);
     }

--- a/client-auth/src/main/java/org/apache/atlas/auth/client/auth/KeycloakAuthenticationService.java
+++ b/client-auth/src/main/java/org/apache/atlas/auth/client/auth/KeycloakAuthenticationService.java
@@ -1,7 +1,5 @@
 package org.apache.atlas.auth.client.auth;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.*;
 import okhttp3.logging.HttpLoggingInterceptor;
 import org.apache.atlas.auth.client.config.AuthConfig;
@@ -39,7 +37,7 @@ public final class KeycloakAuthenticationService {
         this.authConfig = authConfig;
         this.retrofit = new Retrofit.Builder().client(getOkHttpClient())
                 .baseUrl(this.authConfig.getAuthServerUrl())
-                .addConverterFactory(JacksonConverterFactory.create(new ObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES))).build()
+                .addConverterFactory(JacksonConverterFactory.create(ObjectMapperUtils.OBJECT_MAPPER)).build()
                 .create(RetrofitKeycloakClient.class);
     }
 

--- a/client-auth/src/main/java/org/apache/atlas/auth/client/auth/KeycloakAuthenticationService.java
+++ b/client-auth/src/main/java/org/apache/atlas/auth/client/auth/KeycloakAuthenticationService.java
@@ -37,7 +37,7 @@ public final class KeycloakAuthenticationService {
         this.authConfig = authConfig;
         this.retrofit = new Retrofit.Builder().client(getOkHttpClient())
                 .baseUrl(this.authConfig.getAuthServerUrl())
-                .addConverterFactory(JacksonConverterFactory.create(ObjectMapperUtils.OBJECT_MAPPER)).build()
+                .addConverterFactory(JacksonConverterFactory.create(ObjectMapperUtils.KEYCLOAK_OBJECT_MAPPER)).build()
                 .create(RetrofitKeycloakClient.class);
     }
 

--- a/client-auth/src/main/java/org/apache/atlas/auth/client/auth/KeycloakAuthenticationService.java
+++ b/client-auth/src/main/java/org/apache/atlas/auth/client/auth/KeycloakAuthenticationService.java
@@ -1,5 +1,6 @@
 package org.apache.atlas.auth.client.auth;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.*;
 import okhttp3.logging.HttpLoggingInterceptor;
@@ -38,7 +39,7 @@ public final class KeycloakAuthenticationService {
         this.authConfig = authConfig;
         this.retrofit = new Retrofit.Builder().client(getOkHttpClient())
                 .baseUrl(this.authConfig.getAuthServerUrl())
-                .addConverterFactory(JacksonConverterFactory.create(new ObjectMapper())).build()
+                .addConverterFactory(JacksonConverterFactory.create(new ObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES))).build()
                 .create(RetrofitKeycloakClient.class);
     }
 

--- a/client-auth/src/main/java/org/apache/atlas/auth/client/auth/ObjectMapperUtils.java
+++ b/client-auth/src/main/java/org/apache/atlas/auth/client/auth/ObjectMapperUtils.java
@@ -3,11 +3,27 @@ package org.apache.atlas.auth.client.auth;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-
+/**
+ * Utility class providing shared ObjectMapper instances for auth clients.
+ * Using static instances to avoid expensive ObjectMapper creation overhead.
+ */
 final class ObjectMapperUtils {
 
-    static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+    /**
+     * ObjectMapper configured for Keycloak clients - ignores unknown properties.
+     * This handles cases where the Keycloak API returns additional fields not defined in client representation classes.
+     * Example: Keycloak admin events returning "id" field not present in AdminEventRepresentation.
+     */
+    static final ObjectMapper KEYCLOAK_OBJECT_MAPPER = new ObjectMapper()
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+    /**
+     * ObjectMapper configured for Heracles clients - ignores ignored properties.
+     * This handles cases where JSON contains fields marked with @JsonIgnore in the target class.
+     * Preserves the original behavior for Heracles client compatibility.
+     */
+    static final ObjectMapper HERACLES_OBJECT_MAPPER = new ObjectMapper()
+            .disable(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES);
 
     private ObjectMapperUtils() {
         // Utility class - prevent instantiation

--- a/client-auth/src/main/java/org/apache/atlas/auth/client/auth/ObjectMapperUtils.java
+++ b/client-auth/src/main/java/org/apache/atlas/auth/client/auth/ObjectMapperUtils.java
@@ -1,0 +1,15 @@
+package org.apache.atlas.auth.client.auth;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+
+final class ObjectMapperUtils {
+
+    static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+    private ObjectMapperUtils() {
+        // Utility class - prevent instantiation
+    }
+}


### PR DESCRIPTION
## Change description
Keycloak version is getting upgraded and the new version adds an additional column `id` in admin events response, which is breaking the keycloak API call in atlas. This change should ignore the additional columns instead of breaking.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Fixes https://atlanhq.atlassian.net/browse/PLTS-460 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
