### PR TITLE
MESH-581 | Atlas Changes to correctly update stakeholder qualified name during move domains.

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/AbstractDomainPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/AbstractDomainPreProcessor.java
@@ -197,7 +197,7 @@ public abstract class AbstractDomainPreProcessor implements PreProcessor {
                         updatedAttributes.put(ATTR_DOMAIN_QUALIFIED_NAME, updatedDomainQualifiedNames.get(currentDomainQualifiedName));
 
                         String currentStakeholderQualifiedName = (String) asset.getAttribute(QUALIFIED_NAME);
-                        String updatedStakeholderQualifiedName = getUpdatedStakeholderQualifiedName(currentStakeholderQualifiedName, updatedDomainQualifiedNames);
+                        String updatedStakeholderQualifiedName = getUpdatedStakeholderQualifiedName(currentStakeholderQualifiedName, updatedDomainQualifiedNames, asset);
                         if (updatedStakeholderQualifiedName != null) {
                             entity.setAttribute(QUALIFIED_NAME, updatedStakeholderQualifiedName);
                             updatedAttributes.put(QUALIFIED_NAME, updatedStakeholderQualifiedName);
@@ -232,7 +232,7 @@ public abstract class AbstractDomainPreProcessor implements PreProcessor {
     }
 
     protected String getUpdatedStakeholderQualifiedName(String currentStakeholderQualifiedName, 
-                                                      Map<String, String> updatedDomainQualifiedNames) {
+                                                      Map<String, String> updatedDomainQualifiedNames, AtlasEntityHeader asset) {
         if (currentStakeholderQualifiedName == null) {
             return null;
         }
@@ -240,7 +240,7 @@ public abstract class AbstractDomainPreProcessor implements PreProcessor {
         String[] parts = currentStakeholderQualifiedName.split("/", 3);
         if (parts.length == 3 && "default".equals(parts[0])) {
             String uuid = parts[1];
-            String currentDomainQualifiedName = parts[2];
+            String currentDomainQualifiedName = (String) asset.getAttribute(ATTR_DOMAIN_QUALIFIED_NAME);
 
             String updatedDomainQN = updatedDomainQualifiedNames.get(currentDomainQualifiedName);
             if (updatedDomainQN != null) {


### PR DESCRIPTION
## Change description

> In the Move Domains flow, there's a bug where only the stakeholderDomainQualifiedName is updated, but the stakeholder's actual qualifiedName remains unchanged.

JIRA: [MESH-581](https://atlanhq.atlassian.net/browse/MESH-581)

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable


[MESH-581]: https://atlanhq.atlassian.net/browse/MESH-581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ