### PR TITLE
Increased Cassandra driver timeout

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tags/TagDAOCassandraImpl.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tags/TagDAOCassandraImpl.java
@@ -58,6 +58,7 @@ public class TagDAOCassandraImpl implements TagDAO, AutoCloseable {
     private static final int BATCH_SIZE_LIMIT = 100;
     private static final int BATCH_SIZE_LIMIT_FOR_DELETION = 1000;
     private static final Duration CONNECTION_TIMEOUT = Duration.ofSeconds(5);
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(30);
     private static final Duration HEARTBEAT_INTERVAL = Duration.ofSeconds(30);
     public static final String DEFAULT_HOST = "localhost";
     public static final String DATACENTER = "datacenter1";
@@ -111,6 +112,7 @@ public class TagDAOCassandraImpl implements TagDAO, AutoCloseable {
             Map<String, String> replicationConfig = Map.of("class", "SimpleStrategy", "replication_factor", ApplicationProperties.get().getString(CASSANDRA_REPLICATION_FACTOR_PROPERTY, "3"));
 
             DriverConfigLoader configLoader = DriverConfigLoader.programmaticBuilder()
+                    .withDuration(DefaultDriverOption.REQUEST_TIMEOUT, REQUEST_TIMEOUT)
                     .withDuration(DefaultDriverOption.CONNECTION_INIT_QUERY_TIMEOUT, CONNECTION_TIMEOUT)
                     .withDuration(DefaultDriverOption.CONNECTION_CONNECT_TIMEOUT, CONNECTION_TIMEOUT)
                     .withDuration(DefaultDriverOption.CONTROL_CONNECTION_TIMEOUT, CONNECTION_TIMEOUT)

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tags/TagDAOCassandraImpl.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tags/TagDAOCassandraImpl.java
@@ -604,8 +604,8 @@ public class TagDAOCassandraImpl implements TagDAO, AutoCloseable {
                 int fetchedCount = result.getTags().size();
                 allTags.addAll(result.getTags());
                 pagingState = result.getPagingState();
-                LOG.info("Page {}: Fetched {} propagations. Total fetched: {}. Has next page: {}",
-                        pageCount, fetchedCount, allTags.size(), !result.isDone());
+                LOG.info("sourceVertexId={}, tagTypeName={}: Page {}: Fetched {} propagations. Total fetched: {}. Has next page: {}",
+                        sourceVertexId, tagTypeName, pageCount, fetchedCount, allTags.size(), !result.isDone());
             } while (!result.isDone());
 
             if (allTags.isEmpty()) {


### PR DESCRIPTION
## Increasing Cassandra driver timeout 
Hot fix which was needed to handle huge pagination queries in REFRESH PROPAGATION tasks.

Original error: com.datastax.oss.driver.api.core.DriverTimeoutException: Query timed out after PT2S

