### PR TITLE
restrict relations

### DIFF
--- a/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
@@ -152,7 +152,7 @@ public enum AtlasConfiguration {
     ENABLE_ASYNC_TYPE_UPDATE("atlas.types.update.async.enable", false),
     MAX_THREADS_TYPE_UPDATE("atlas.types.update.thread.count", 4),
     MAX_EDGES_SUPER_VERTEX("atlas.jg.super.vertex.edge.count", 10000),
-    MIN_EDGES_SUPER_VERTEX("atlas.jg.super.vertex.min.edge.count", 20),
+    MIN_EDGES_SUPER_VERTEX("atlas.jg.super.vertex.min.edge.count", 1000),
     TIMEOUT_SUPER_VERTEX_FETCH("atlas.jg.super.vertex.edge.timeout", 60);
 
     private static final Configuration APPLICATION_PROPERTIES;

--- a/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
@@ -152,6 +152,7 @@ public enum AtlasConfiguration {
     ENABLE_ASYNC_TYPE_UPDATE("atlas.types.update.async.enable", false),
     MAX_THREADS_TYPE_UPDATE("atlas.types.update.thread.count", 4),
     MAX_EDGES_SUPER_VERTEX("atlas.jg.super.vertex.edge.count", 10000),
+    MIN_EDGES_SUPER_VERTEX("atlas.jg.super.vertex.min.edge.count", 20),
     TIMEOUT_SUPER_VERTEX_FETCH("atlas.jg.super.vertex.edge.timeout", 60);
 
     private static final Configuration APPLICATION_PROPERTIES;

--- a/repository/src/main/java/org/apache/atlas/repository/VertexEdgePropertiesCache.java
+++ b/repository/src/main/java/org/apache/atlas/repository/VertexEdgePropertiesCache.java
@@ -1,5 +1,6 @@
 package org.apache.atlas.repository;
 
+import org.apache.atlas.AtlasConfiguration;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
 import org.apache.atlas.type.AtlasStructType;
 import org.apache.commons.collections.CollectionUtils;
@@ -118,6 +119,10 @@ public class VertexEdgePropertiesCache {
         List<EdgeVertexReference> targetElements = edgeLabelToVertexIds
                 .computeIfAbsent(sourceVertexId, k -> new HashMap<>())
                 .computeIfAbsent(edgeLabel, k -> new ArrayList<>());
+
+        if (edgeLabelToVertexIds.get(sourceVertexId).get(edgeLabel).size() >= AtlasConfiguration.MIN_EDGES_SUPER_VERTEX.getLong()) {
+            return;
+        }
 
         for (EdgeVertexReference existingReference : targetElements) {
             if (existingReference.equals(targetElement)) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -1060,12 +1060,18 @@ public class EntityGraphRetriever {
     private void processRelationshipAttribute(AtlasEntityType entityType,
                                               String attribute,
                                               Set<String> edgeLabels) {
+
+        RequestContext context = RequestContext.get();
         if (!entityType.getRelationshipAttributes().containsKey(attribute)) {
             return;
         }
 
         AtlasAttribute atlasAttribute = entityType.getRelationshipAttribute(attribute, null);
         if (atlasAttribute != null && atlasAttribute.getAttributeType() != null) {
+            if (context.isInvokedByIndexSearch() && context.isInvokedByProduct() &&
+                    CollectionUtils.isEmpty(context.getRelationAttrsForSearch())) {
+                return;
+            }
             edgeLabels.add(atlasAttribute.getRelationshipEdgeLabel());
         } else {
             LOG.debug("Ignoring non-relationship type attribute: {}", attribute);
@@ -1540,6 +1546,11 @@ public class EntityGraphRetriever {
 
                             if (attribute == null) {
                                 attribute = entityType.getRelationshipAttribute(attrName, null);
+
+                                if (attribute != null && context.isInvokedByIndexSearch() && context.isInvokedByProduct() &&
+                                        CollectionUtils.isEmpty(context.getRelationAttrsForSearch())) {
+                                    continue;
+                                }
                             }
                         }
 

--- a/server-api/src/main/java/org/apache/atlas/RequestContext.java
+++ b/server-api/src/main/java/org/apache/atlas/RequestContext.java
@@ -25,6 +25,7 @@ import org.apache.atlas.service.metrics.MetricsRegistry;
 import org.apache.atlas.utils.AtlasPerfMetrics;
 import org.apache.atlas.utils.AtlasPerfMetrics.MetricRecorder;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
@@ -116,6 +117,9 @@ public class RequestContext {
     private boolean isInvokedByLineage = false;
     private Map<AtlasClassification, Collection<Object>> deletedClassificationAndVertices = new HashMap<>();
     private Map<AtlasClassification, Collection<Object>> addedClassificationAndVertices = new HashMap<>();
+
+    private static final String X_ATLAN_CLIENT_ORIGIN = "X-Atlan-Client-Origin";
+    private static final String CLIENT_ORIGIN_PRODUCT = "product_webapp";
 
     Map<String, Object> tagsDiff = new HashMap<>();
 
@@ -802,6 +806,13 @@ public class RequestContext {
 
     public boolean isInvokedByIndexSearch() {
         return isInvokedByIndexSearch;
+    }
+
+    public boolean isInvokedByProduct() {
+        Map<String, String> requestContextHeaders = getRequestContextHeaders();
+        return MapUtils.isNotEmpty(requestContextHeaders) &&
+                StringUtils.isNotEmpty(requestContextHeaders.get(X_ATLAN_CLIENT_ORIGIN))
+                && requestContextHeaders.get(X_ATLAN_CLIENT_ORIGIN).equals(CLIENT_ORIGIN_PRODUCT);
     }
 
     public void setIsInvokedByLineage(boolean isInvokedByLineage) {


### PR DESCRIPTION
## Change description

> Description here
- don't process relationship attributes if FE sends relationAttributes as null or empty
- always bound the number of relations attached to a vetex

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
