### PR TITLE
Fixed class text updation on v1 flow via setClassifications API

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/ClassificationAssociator.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/ClassificationAssociator.java
@@ -33,6 +33,7 @@ import org.apache.atlas.repository.graph.GraphHelper;
 import org.apache.atlas.repository.graphdb.AtlasGraph;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
 import org.apache.atlas.repository.store.graph.AtlasEntityStore;
+import org.apache.atlas.service.FeatureFlagStore;
 import org.apache.atlas.type.AtlasEntityType;
 import org.apache.atlas.type.AtlasTypeRegistry;
 import org.apache.atlas.utils.AtlasPerfMetrics;
@@ -238,7 +239,9 @@ public class ClassificationAssociator {
                 }
             }
 
-            //entityGraphMapper.updateClassificationText(null, allVertices);
+            if (!FeatureFlagStore.isTagV2Enabled()) {
+                entityGraphMapper.updateClassificationText(null, allVertices);
+            }
             transactionInterceptHelper.intercept();
 
             RequestContext.get().endMetricRecord(recorder);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -4364,9 +4364,6 @@ public class EntityGraphMapper {
 
         entityVertex.setProperty(CLASSIFICATION_NAMES_KEY, getClassificationNamesString(traitNames));
 
-        AtlasEntity entity = instanceConverter.getEntity(entityGuid, ENTITY_CHANGE_NOTIFY_IGNORE_RELATIONSHIP_ATTRIBUTES);
-        entityVertex.setProperty(CLASSIFICATION_TEXT_KEY, fullTextMapperV2.getClassificationTextForEntity(entity));
-
         updateModificationMetadata(entityVertex);
 
         if (RequestContext.get().isDelayTagNotifications()) {


### PR DESCRIPTION
## Fixes classification text updation in setClassifications API
Problem: On the new v1 tags flow the code for updating classification text in ES was commented out.
The PR fixes a bug for this. Spotted on internal tenant.
