### PR TITLE
MESH-578 | Remove asset from inputPorts when same asset gets marked as outputPort

### DIFF
--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -162,6 +162,7 @@ public final class Constants {
     public static final String OUTPUT_PORT_PRODUCT_EDGE_LABEL = "__Asset.outputPortDataProducts";
 
     public static final String OUTPUT_PORTS = "outputPorts";
+    public static final String INPUT_PORTS = "inputPorts";
     public static final String ADDED_OUTPUT_PORTS = "addedOutputPorts";
     public static final String REMOVED_OUTPUT_PORTS = "removedOutputPorts";
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -2550,11 +2550,19 @@ public class EntityGraphMapper {
             RequestContext.get().cacheDifferentialEntity(diffEntity);
         }
 
+        // Track removed input ports in differential entity for change notifications and audit trail
         Map<String, Object> removedAttrs = diffEntity.getRemovedRelationshipAttributes();
         if (removedAttrs == null) {
             removedAttrs = new HashMap<>();
             diffEntity.setRemovedRelationshipAttributes(removedAttrs);
         }
+
+        List<String> existingRemovedInputPorts = (List<String>) removedAttrs.get(INPUT_PORTS);
+        if (existingRemovedInputPorts == null) {
+            existingRemovedInputPorts = new ArrayList<>();
+        }
+        existingRemovedInputPorts.addAll(conflictingGuids);
+        removedAttrs.put(INPUT_PORTS, existingRemovedInputPorts);
     }
 
     private boolean shouldDeleteExistingRelations(AttributeMutationContext ctx, AtlasAttribute attribute) {


### PR DESCRIPTION
## Change description

> Description here

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
