### PR TITLE
PLTS-426 | Add support for tag key value in abac conditions

### DIFF
--- a/repository/src/main/java/org/apache/atlas/authorizer/JsonToElasticsearchQuery.java
+++ b/repository/src/main/java/org/apache/atlas/authorizer/JsonToElasticsearchQuery.java
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.apache.atlas.authorizer.authorizers.AuthorizerCommonUtil.isTagKeyValueFormat;
 import static org.apache.atlas.repository.util.AccessControlUtils.POLICY_FILTER_CRITERIA_AND;
 import static org.apache.atlas.repository.util.AccessControlUtils.POLICY_FILTER_CRITERIA_OR;
 import static org.apache.atlas.repository.util.AccessControlUtils.POLICY_FILTER_CRITERIA_EQUALS;
@@ -37,7 +38,7 @@ public class JsonToElasticsearchQuery {
         } else if (condition.equals(POLICY_FILTER_CRITERIA_OR)) {
             return mapper.createObjectNode()
                     .set("bool", mapper.createObjectNode()
-                            .set("should", mapper.createArrayNode()));
+                    .set("should", mapper.createArrayNode()));
         } else {
             throw new IllegalArgumentException("Unsupported condition: " + condition);
         }
@@ -62,7 +63,7 @@ public class JsonToElasticsearchQuery {
                 String operator = crit.get("operator").asText();
                 String attributeName = crit.get("attributeName").asText();
                 JsonNode attributeValueNode = crit.get("attributeValue");
-
+                
                 List<String> relatedAttributes = EntityAuthorizer.getRelatedAttributes(attributeName);
 
                 ArrayNode queryArray = ((ArrayNode) query.get("bool").get(getConditionClause(condition)));
@@ -90,6 +91,12 @@ public class JsonToElasticsearchQuery {
     private static JsonNode createAttributeQuery(String operator, String attributeName, JsonNode attributeValueNode) {
         ObjectNode queryNode = mapper.createObjectNode();
         String attributeValue = attributeValueNode.asText();
+
+        // handle special attribute value requirement like tag key value
+        if (isTagKeyValueFormat(attributeValueNode)) {
+            return createQueryWithOperatorForTag(operator, attributeName, attributeValueNode);
+        }
+
         switch (operator) {
             case POLICY_FILTER_CRITERIA_EQUALS:
                 if (attributeValueNode.isArray()) {
@@ -103,7 +110,7 @@ public class JsonToElasticsearchQuery {
                 break;
 
             case POLICY_FILTER_CRITERIA_NOT_EQUALS:
-                if (attributeValueNode.isArray()) {
+                if (attributeValueNode.isArray()) { // same as not_in operator
                     queryNode.putObject("bool").putObject("must_not").putObject("terms").set(attributeName, attributeValueNode);
                 } else {
                     queryNode.putObject("bool").putObject("must_not").putObject("term").put(attributeName, attributeValue);
@@ -147,6 +154,211 @@ public class JsonToElasticsearchQuery {
         return queryNode;
     }
 
+    // Repeating some code for tag key-value pairs query creation to avoid complexity in the main query creation logic
+    // This method can potentially be merged with createAttributeQuery if needed
+    public static JsonNode createQueryWithOperatorForTag(String operator, String attributeName, JsonNode attributeValueNode) {
+        ObjectNode queryNode = mapper.createObjectNode();
+        
+        if (!isTagKeyValueFormat(attributeValueNode)) {
+            return null;
+        }
+
+        switch (operator) {
+            case POLICY_FILTER_CRITERIA_EQUALS:
+                if (attributeValueNode.isArray()) {
+                    ArrayNode filterArray = queryNode.putObject("bool").putArray("filter");
+                    for (JsonNode valueNode : attributeValueNode) {
+                        filterArray.add(createDSLForTagKeyValue(attributeName, valueNode));
+                    }
+                } else {
+                    return createDSLForTagKeyValue(attributeName, attributeValueNode);
+                }
+                break;
+
+            case POLICY_FILTER_CRITERIA_NOT_EQUALS:
+                ObjectNode mustNotNode = queryNode.putObject("bool").putObject("must_not");
+                if (attributeValueNode.isArray()) {
+                    ArrayNode shouldArray = mustNotNode.putArray("should");
+                    for (JsonNode valueNode : attributeValueNode) {
+                        shouldArray.add(createDSLForTagKeyValue(attributeName, valueNode));
+                    }
+                } else {
+                    mustNotNode.setAll((ObjectNode) createDSLForTagKeyValue(attributeName, attributeValueNode));
+                }
+                break;
+
+            case POLICY_FILTER_CRITERIA_IN:
+                ArrayNode shouldArray = queryNode.putObject("bool").putArray("should");
+                if (attributeValueNode.isArray()) {
+                    for (JsonNode valueNode : attributeValueNode) {
+                        shouldArray.add(createDSLForTagKeyValue(attributeName, valueNode));
+                    }
+                } else {
+                    shouldArray.add(createDSLForTagKeyValue(attributeName, attributeValueNode));
+                }
+                break;
+
+            case POLICY_FILTER_CRITERIA_NOT_IN:
+                ObjectNode notInMustNot = queryNode.putObject("bool").putObject("must_not");
+                ArrayNode notInShouldArray = notInMustNot.putArray("should");
+                if (attributeValueNode.isArray()) {
+                    for (JsonNode valueNode : attributeValueNode) {
+                        notInShouldArray.add(createDSLForTagKeyValue(attributeName, valueNode));
+                    }
+                } else {
+                    notInShouldArray.add(createDSLForTagKeyValue(attributeName, attributeValueNode));
+                }
+                break;
+
+            default: LOG.warn("Found unknown operator {}", operator);
+        }
+        return queryNode;
+    }
+
+    /*
+        For single value, this should produce something like:
+        {
+            "bool": {
+                "filter": [
+                    {
+                        "term": {"__traitNames": "tag"}
+                    },
+                    {
+                        "span_near": {
+                            "clauses": [
+                                {"span_term": {"__classificationsText.text": "tagAttachmentValue"}},
+                                {"span_term": {"__classificationsText.text": "value1"}},
+                                {"span_term": {"__classificationsText.text": "tagAttachmentKey"}}
+                            ],
+                            "in_order": true,
+                            "slop": 0
+                        }
+                    }
+                ]
+            }
+        }
+        
+        For multiple values, this should produce something like:
+        {
+            "bool": {
+                "filter": [
+                    {
+                        "term": {"__traitNames": "tag"}
+                    },
+                    {
+                        "bool": {
+                            "should": [
+                                {
+                                    "span_near": {
+                                        "clauses": [
+                                            {"span_term": {"__classificationsText.text": "tagAttachmentValue"}},
+                                            {"span_term": {"__classificationsText.text": "value1"}},
+                                            {"span_term": {"__classificationsText.text": "tagAttachmentKey"}}
+                                        ],
+                                        "in_order": true,
+                                        "slop": 0
+                                    }
+                                },
+                                {
+                                    "span_near": {
+                                        "clauses": [
+                                            {"span_term": {"__classificationsText.text": "tagAttachmentValue"}},
+                                            {"span_term": {"__classificationsText.text": "value2"}},
+                                            {"span_term": {"__classificationsText.text": "tagAttachmentKey"}}
+                                        ],
+                                        "in_order": true,
+                                        "slop": 0
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+     */
+    public static JsonNode createDSLForTagKeyValue(String attributeName, JsonNode tagKeyValueNode) {
+        ObjectNode queryNode = mapper.createObjectNode();
+
+        // handle simple tag string i.e. without key value object format
+        if (!isTagKeyValueFormat(tagKeyValueNode)) {
+            ArrayNode filter = queryNode.putObject("bool").putArray("filter");
+            filter.addObject().putObject("term").put(attributeName, tagKeyValueNode.asText());
+            return queryNode;
+        }
+
+        String tag = tagKeyValueNode.get("name").asText();
+
+        ArrayNode filterArray = queryNode.putObject("bool").putArray("filter");
+        // Add term query for tag name match
+        ObjectNode tagTermQuery = mapper.createObjectNode();
+        tagTermQuery.putObject("term").put(attributeName, tag);
+        filterArray.add(tagTermQuery);
+
+        ArrayNode tagKeyValues = (ArrayNode) tagKeyValueNode.get("tagValues");
+        if (tagKeyValues == null || !tagKeyValues.isArray()) {
+            return queryNode;
+        }
+
+        ArrayNode valuesQuery = filterArray;
+        if (tagKeyValues.size() > 1) {
+            ObjectNode boolQuery = mapper.createObjectNode();
+            valuesQuery = boolQuery.putObject("bool").putArray("should");
+            filterArray.add(boolQuery);
+        }
+
+        // add span_near clauses
+        for (JsonNode tagKeyValue : tagKeyValues) {
+            String key = tagKeyValue.get("key") == null ? null : tagKeyValue.get("key").asText();
+            JsonNode value = tagKeyValue.get("consolidatedValue");
+            if (value == null) {
+                continue;
+            }
+            valuesQuery.add(createSpanNearQuery(value));
+        }
+        
+        return queryNode;
+    }
+
+    private static ObjectNode createSpanNearQuery(JsonNode value) {
+        // Add span_near query for key-value pair
+        ArrayNode clausesArray = mapper.createArrayNode();
+
+        // Create span_term for left side of the tag
+        ObjectNode tagClause = mapper.createObjectNode();
+        ObjectNode tagSpanTerm = mapper.createObjectNode();
+        tagSpanTerm.put("__classificationsText.text", "tagAttachmentValue");
+        tagClause.set("span_term", tagSpanTerm);
+        clausesArray.add(tagClause);
+
+        // Create span_term for value
+        if (StringUtils.isNotEmpty(value.asText())) {
+            ObjectNode keyClause = mapper.createObjectNode();
+            ObjectNode keySpanTerm = mapper.createObjectNode();
+            keySpanTerm.put("__classificationsText.text", value.asText());
+            keyClause.set("span_term", keySpanTerm);
+            clausesArray.add(keyClause);
+        }
+
+        // Create span_term for right side of the tag
+        ObjectNode valueClause = mapper.createObjectNode();
+        ObjectNode valueSpanTerm = mapper.createObjectNode();
+        valueSpanTerm.put("__classificationsText.text", "tagAttachmentKey");
+        valueClause.set("span_term", valueSpanTerm);
+        clausesArray.add(valueClause);
+
+        // Skipping clause for key to keep the DSL consistent with the FE query
+
+        ObjectNode spanNearNode = mapper.createObjectNode();
+        spanNearNode.set("clauses", clausesArray);
+        spanNearNode.put("in_order", true);
+        spanNearNode.put("slop", 0);
+
+        ObjectNode spanNearQuery = mapper.createObjectNode();
+        spanNearQuery.set("span_near", spanNearNode);
+        
+        return spanNearQuery;
+    }
 
     public static JsonNode parseFilterJSON(String policyFilterCriteria, String rootKey) {
         JsonNode filterCriteriaNode = null;

--- a/repository/src/main/java/org/apache/atlas/authorizer/JsonToElasticsearchQuery.java
+++ b/repository/src/main/java/org/apache/atlas/authorizer/JsonToElasticsearchQuery.java
@@ -58,7 +58,7 @@ public class JsonToElasticsearchQuery {
         }
 
         switch (operator) {
-            case POLICY_FILTER_CRITERIA_EQUALS:
+            case POLICY_FILTER_CRITERIA_EQUALS -> {
                 if (attributeValueNode.isArray()) {
                     ArrayNode filterArray = queryNode.putObject("bool").putArray("filter");
                     for (JsonNode valueNode : attributeValueNode) {
@@ -67,17 +67,15 @@ public class JsonToElasticsearchQuery {
                 } else {
                     queryNode.putObject("term").put(attributeName, attributeValue);
                 }
-                break;
-
-            case POLICY_FILTER_CRITERIA_NOT_EQUALS:
+            }
+            case POLICY_FILTER_CRITERIA_NOT_EQUALS -> {
                 if (attributeValueNode.isArray()) { // same as not_in operator
                     queryNode.putObject("bool").putObject("must_not").putObject("terms").set(attributeName, attributeValueNode);
                 } else {
                     queryNode.putObject("bool").putObject("must_not").putObject("term").put(attributeName, attributeValue);
                 }
-                break;
-
-            case POLICY_FILTER_CRITERIA_STARTS_WITH:
+            }
+            case POLICY_FILTER_CRITERIA_STARTS_WITH -> {
                 if (attributeValueNode.isArray()) {
                     ArrayNode shouldArray = queryNode.putObject("bool").putArray("should");
                     for (JsonNode valueNode : attributeValueNode) {
@@ -86,9 +84,8 @@ public class JsonToElasticsearchQuery {
                 } else {
                     queryNode.putObject("prefix").put(attributeName, attributeValue);
                 }
-                break;
-
-            case POLICY_FILTER_CRITERIA_ENDS_WITH:
+            }
+            case POLICY_FILTER_CRITERIA_ENDS_WITH -> {
                 if (attributeValueNode.isArray() && attributeValueNode.size() > 0) {
                     List<String> escapedValues = new ArrayList<>();
                     for (JsonNode valueNode : attributeValueNode) {
@@ -99,17 +96,10 @@ public class JsonToElasticsearchQuery {
                 } else {
                     queryNode.putObject("wildcard").put(attributeName, "*" + attributeValue);
                 }
-                break;
-
-            case POLICY_FILTER_CRITERIA_IN:
-                queryNode.putObject("terms").set(attributeName, attributeValueNode);
-                break;
-
-            case POLICY_FILTER_CRITERIA_NOT_IN:
-                queryNode.putObject("bool").putObject("must_not").putObject("terms").set(attributeName, attributeValueNode);
-                break;
-
-            default: LOG.warn("Found unknown operator {}", operator);
+            }
+            case POLICY_FILTER_CRITERIA_IN -> queryNode.putObject("terms").set(attributeName, attributeValueNode);
+            case POLICY_FILTER_CRITERIA_NOT_IN -> queryNode.putObject("bool").putObject("must_not").putObject("terms").set(attributeName, attributeValueNode);
+            default -> LOG.warn("Found unknown operator {}", operator);
         }
         return queryNode;
     }
@@ -204,7 +194,7 @@ public class JsonToElasticsearchQuery {
         ObjectNode queryNode = mapper.createObjectNode();
 
         switch (operator) {
-            case POLICY_FILTER_CRITERIA_EQUALS:
+            case POLICY_FILTER_CRITERIA_EQUALS -> {
                 if (attributeValueNode.isArray()) {
                     ArrayNode filterArray = queryNode.putObject("bool").putArray("filter");
                     for (JsonNode valueNode : attributeValueNode) {
@@ -213,9 +203,8 @@ public class JsonToElasticsearchQuery {
                 } else {
                     return createDSLForTagKeyValue(attributeName, attributeValueNode);
                 }
-                break;
-
-            case POLICY_FILTER_CRITERIA_NOT_EQUALS:
+            }
+            case POLICY_FILTER_CRITERIA_NOT_EQUALS -> {
                 ObjectNode mustNotNode = queryNode.putObject("bool").putObject("must_not");
                 if (attributeValueNode.isArray()) {
                     ArrayNode shouldArray = mustNotNode.putArray("should");
@@ -225,9 +214,8 @@ public class JsonToElasticsearchQuery {
                 } else {
                     mustNotNode.setAll((ObjectNode) createDSLForTagKeyValue(attributeName, attributeValueNode));
                 }
-                break;
-
-            case POLICY_FILTER_CRITERIA_IN:
+            }
+            case POLICY_FILTER_CRITERIA_IN -> {
                 ArrayNode shouldArray = queryNode.putObject("bool").putArray("should");
                 if (attributeValueNode.isArray()) {
                     for (JsonNode valueNode : attributeValueNode) {
@@ -236,9 +224,8 @@ public class JsonToElasticsearchQuery {
                 } else {
                     shouldArray.add(createDSLForTagKeyValue(attributeName, attributeValueNode));
                 }
-                break;
-
-            case POLICY_FILTER_CRITERIA_NOT_IN:
+            }
+            case POLICY_FILTER_CRITERIA_NOT_IN -> {
                 ObjectNode notInMustNot = queryNode.putObject("bool").putObject("must_not");
                 ArrayNode notInShouldArray = notInMustNot.putArray("should");
                 if (attributeValueNode.isArray()) {
@@ -248,9 +235,8 @@ public class JsonToElasticsearchQuery {
                 } else {
                     notInShouldArray.add(createDSLForTagKeyValue(attributeName, attributeValueNode));
                 }
-                break;
-
-            default: LOG.warn("Found unknown operator {}", operator);
+            }
+            default -> LOG.warn("Found unknown operator {}", operator);
         }
         return queryNode;
     }

--- a/repository/src/main/java/org/apache/atlas/authorizer/authorizers/AuthorizerCommonUtil.java
+++ b/repository/src/main/java/org/apache/atlas/authorizer/authorizers/AuthorizerCommonUtil.java
@@ -1,5 +1,6 @@
 package org.apache.atlas.authorizer.authorizers;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.instance.AtlasEntityHeader;
 import org.apache.atlas.repository.graphdb.AtlasGraph;
@@ -142,5 +143,28 @@ public class AuthorizerCommonUtil {
             return assetTags.stream().anyMatch(assetTag -> policyValues.stream().anyMatch(policyAssetType -> assetTag.matches(policyAssetType.replace("*", ".*"))));
         }
         return true;
+    }
+
+    // tag.key=value
+    public static String tagKeyValueRepr(String tag, String key, String value) {
+        key = key == null ? "" : key;
+        value = value == null ? "" : value;
+        return tag + "." + key + "=" + value;
+    }
+
+    /* Format required for tag with key value:
+            {
+                "name": "tagTypeName",
+                "tagValues": [
+                    {"consolidatedValue": "value1", "key": "key1"},
+                    {"consolidatedValue": "value2", "key": "key2"}
+                ]
+            }
+     */
+    public static boolean isTagKeyValueFormat(JsonNode attributeValueNode) {
+        JsonNode firstElement = attributeValueNode.isArray() && !attributeValueNode.isEmpty()
+            ? attributeValueNode.get(0)
+            : attributeValueNode;
+        return firstElement.has("name") && firstElement.has("tagValues") && firstElement.get("tagValues").isArray();
     }
 }

--- a/repository/src/main/java/org/apache/atlas/authorizer/authorizers/EntityAuthorizer.java
+++ b/repository/src/main/java/org/apache/atlas/authorizer/authorizers/EntityAuthorizer.java
@@ -6,6 +6,7 @@ import org.apache.atlas.authorize.AtlasAccessResult;
 import org.apache.atlas.authorizer.store.PoliciesStore;
 import org.apache.atlas.model.instance.AtlasClassification;
 import org.apache.atlas.model.instance.AtlasEntityHeader;
+import org.apache.atlas.model.instance.AtlasStruct;
 import org.apache.atlas.plugin.model.RangerPolicy;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
 import org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2;
@@ -18,12 +19,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
-import java.util.Set;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.apache.atlas.authorizer.ABACAuthorizerUtils.POLICY_TYPE_ALLOW;
 import static org.apache.atlas.authorizer.ABACAuthorizerUtils.POLICY_TYPE_DENY;
+import static org.apache.atlas.repository.util.AccessControlUtils.ATTR_TAGS;
 import static org.apache.atlas.repository.util.AccessControlUtils.POLICY_FILTER_CRITERIA_EQUALS;
 import static org.apache.atlas.repository.util.AccessControlUtils.POLICY_FILTER_CRITERIA_ENDS_WITH;
 import static org.apache.atlas.repository.util.AccessControlUtils.POLICY_FILTER_CRITERIA_NOT_EQUALS;
@@ -146,20 +149,23 @@ public class EntityAuthorizer {
         }
 
         List<String> entityAttributeValues = getAttributeValue(entity, attributeName, vertex);
+        entityAttributeValues.addAll(handleSpecialAttributes(entity, attributeName));
         if (entityAttributeValues.isEmpty()) {
-            entityAttributeValues = handleSpecialAttributes(entity, attributeName);
+            LOG.warn("Value for attribute {} not found for {}:{}", attributeName, entity.getTypeName(), entity.getAttribute(ATTR_QUALIFIED_NAME));
         }
 
         JsonNode attributeValueNode = crit.get("attributeValue");
-        String attributeValue = attributeValueNode.asText();
         String operator = crit.get("operator").asText();
 
-        // incase attributeValue is an array
+        if (ATTR_TAGS.contains(attributeName)) { // handling tag values separately to incorporate multiple values requirement
+            return evaluateTagFilterCriteria(attributeName, attributeValueNode, operator, entityAttributeValues);
+        }
+
         List<String> attributeValues = new ArrayList<>();
         if (attributeValueNode.isArray()) {
             attributeValueNode.elements().forEachRemaining(node -> attributeValues.add(node.asText()));
         } else {
-            attributeValues.add(attributeValue);
+            attributeValues.add(attributeValueNode.asText());
         }
 
         switch (operator) {
@@ -173,11 +179,7 @@ public class EntityAuthorizer {
                     }
                 }
                 break;
-            // case "LIKE":
-            //     if (AuthorizerCommonUtil.listMatchesWith(attributeValue, entityAttributeValues)) {
-            //         return true;
-            //     }
-            //     break;
+
             case POLICY_FILTER_CRITERIA_ENDS_WITH:
                 for (String value : attributeValues) {
                     if (AuthorizerCommonUtil.listEndsWith(value, entityAttributeValues)) {
@@ -218,6 +220,7 @@ public class EntityAuthorizer {
                     for (AtlasClassification tag : tags) {
                         if (StringUtils.isEmpty(tag.getEntityGuid()) || tag.getEntityGuid().equals(entity.getGuid())) {
                             entityAttributeValues.add(tag.getTypeName());
+                            entityAttributeValues.addAll(extractTagAttachmentValues(tag));
                         }
                     }
                 }
@@ -229,6 +232,7 @@ public class EntityAuthorizer {
                     for (AtlasClassification tag : tags) {
                         if (StringUtils.isNotEmpty(tag.getEntityGuid()) && !tag.getEntityGuid().equals(entity.getGuid())) {
                             entityAttributeValues.add(tag.getTypeName());
+                            entityAttributeValues.addAll(extractTagAttachmentValues(tag));
                         }
                     }
                 }
@@ -239,12 +243,53 @@ public class EntityAuthorizer {
                 Set<String> allValidTypes = AuthorizerCommonUtil.getTypeAndSupertypesList(typeName);
                 entityAttributeValues.addAll(allValidTypes);
                 break;
-
-            default:
-                LOG.warn("Value for attribute {} not found for {}:{}", attributeName, entity.getTypeName(), entity.getAttribute(ATTR_QUALIFIED_NAME));
         }
 
         return entityAttributeValues;
+    }
+
+    private static List<String> extractTagAttachmentValues(AtlasClassification tag) {
+        String tagTypeName = tag.getTypeName();
+        List<String> tagAttachmentValues = new ArrayList<>();
+
+        if (tag.getAttributes() == null || tag.getAttributes().isEmpty()) {
+            LOG.warn("ABAC_AUTH: Tag attributes are null or empty, tag={}", tagTypeName);
+            return tagAttachmentValues;
+        }
+
+        for (String attrName : tag.getAttributes().keySet()) {
+            try {
+                Collection<AtlasStruct> attrValues = (Collection<AtlasStruct>) tag.getAttribute(attrName);
+                for (AtlasStruct attrValue : attrValues) {
+                    Map<String, Object> attrValueAttributes = attrValue.getAttributes();
+                    if (attrValueAttributes == null || attrValueAttributes.isEmpty()) {
+                        LOG.warn("ABAC_AUTH: Tag attribute value is null, tag={}, attribute={}", tagTypeName, attrName);
+                        continue;
+                    }
+                    
+                    List<AtlasStruct> sourceTagValue = (List<AtlasStruct>) attrValueAttributes.get("sourceTagValue");
+                    if (sourceTagValue == null || sourceTagValue.isEmpty()) {
+                        LOG.warn("ABAC_AUTH: Tag attribute's sourceTagValue attribute is empty, tag={}, attribute={}.sourceTagValue", tagTypeName, attrName);
+                        continue;
+                    }
+
+                    for (AtlasStruct item : sourceTagValue) {
+                        String key = item.getAttribute("tagAttachmentKey") == null ? "" : item.getAttribute("tagAttachmentKey").toString();
+                        String value = item.getAttribute("tagAttachmentValue") == null ? "" : item.getAttribute("tagAttachmentValue").toString();
+                        tagAttachmentValues.add(AuthorizerCommonUtil.tagKeyValueRepr(tagTypeName, key, value));
+                    }
+                }
+            } catch (ClassCastException | NullPointerException e) {
+                LOG.warn("ABAC_AUTH: Unexpected exception in tag attribute processing, tag={}, attribute={}, error={}", tagTypeName, attrName, e.getMessage());
+            }
+        }
+
+        if (tagAttachmentValues.isEmpty()) {
+            tagAttachmentValues.add(tagTypeName + ".="); // to support tag with no attachment values
+        }
+        LOG.info("ABAC_AUTH: Tag attachment values for tag={} value={}", tagTypeName, tagAttachmentValues);
+
+        return tagAttachmentValues;
     }
 
     private static List<String> getAttributeValue(AtlasEntityHeader entity, String attributeName, AtlasVertex vertex) {
@@ -285,5 +330,73 @@ public class EntityAuthorizer {
         }
 
         return relatedAttributes;
+    }
+
+    private static List<String> getRequiredTagValues(JsonNode tagValueNode) {
+        List<String> requiredTagValues = new ArrayList<>();
+        if (AuthorizerCommonUtil.isTagKeyValueFormat(tagValueNode)) {
+            String tagName = tagValueNode.get("name").asText();
+
+            JsonNode valuesNode = tagValueNode.get("tagValues");
+            if (valuesNode != null && valuesNode.isArray()) {
+                for (JsonNode valueNode : valuesNode) {
+                    String key = valueNode.get("key") == null ? null : valueNode.get("key").asText();
+                    String value = valueNode.get("consolidatedValue") == null ? null : valueNode.get("consolidatedValue").asText();
+                    requiredTagValues.add(AuthorizerCommonUtil.tagKeyValueRepr(tagName, key, value));
+                }
+            } else {
+                LOG.warn("Invalid tag values format for tag: {}", tagName);
+            }
+
+            if (requiredTagValues.isEmpty()) {
+                requiredTagValues.add(tagName);
+            }
+        } else {
+            requiredTagValues.add(tagValueNode.asText());
+        }
+        return requiredTagValues;
+    }
+
+    private static boolean evaluateTagFilterCriteria(String attributeName, JsonNode attributeValueNode, String operator, List<String> entityAttributeValues) {
+        List<List<String>> attributeValues = new ArrayList<>();
+        if (attributeValueNode.isArray()) {
+            for (JsonNode node : attributeValueNode) {
+                attributeValues.add(getRequiredTagValues(node));
+            }
+        } else {
+            attributeValues.add(getRequiredTagValues(attributeValueNode));
+        }
+
+        // no support required for starts_with and ends_with for tags
+        boolean result = false;
+        switch(operator) {
+            case POLICY_FILTER_CRITERIA_EQUALS:
+                for (List<String> tagValues : attributeValues) {
+                    if (!AuthorizerCommonUtil.arrayListContains(entityAttributeValues, tagValues)) {
+                        return false;
+                    }
+                }
+                result = true;
+                break;
+
+            case POLICY_FILTER_CRITERIA_NOT_EQUALS:
+            case POLICY_FILTER_CRITERIA_NOT_IN:
+                for (List<String> tagValues : attributeValues) {
+                    if (AuthorizerCommonUtil.arrayListContains(entityAttributeValues, tagValues)) {
+                        return false;
+                    }
+                }
+                result = true;
+                break;
+
+            case POLICY_FILTER_CRITERIA_IN:
+                for (List<String> tagValues : attributeValues) {
+                    if (AuthorizerCommonUtil.arrayListContains(entityAttributeValues, tagValues)) {
+                        return true;
+                    }
+                }
+                break;
+        }
+        return result;
     }
 }

--- a/repository/src/main/java/org/apache/atlas/authorizer/authorizers/EntityAuthorizer.java
+++ b/repository/src/main/java/org/apache/atlas/authorizer/authorizers/EntityAuthorizer.java
@@ -169,41 +169,37 @@ public class EntityAuthorizer {
         }
 
         switch (operator) {
-            case POLICY_FILTER_CRITERIA_EQUALS:
+            case POLICY_FILTER_CRITERIA_EQUALS -> {
                 return new HashSet<>(entityAttributeValues).containsAll(attributeValues);
-
-            case POLICY_FILTER_CRITERIA_STARTS_WITH:
+            }
+            case POLICY_FILTER_CRITERIA_STARTS_WITH -> {
                 for (String value : attributeValues) {
                     if (AuthorizerCommonUtil.listStartsWith(value, entityAttributeValues)) {
                         return true;
                     }
                 }
-                break;
-
-            case POLICY_FILTER_CRITERIA_ENDS_WITH:
+            }
+            case POLICY_FILTER_CRITERIA_ENDS_WITH -> {
                 for (String value : attributeValues) {
                     if (AuthorizerCommonUtil.listEndsWith(value, entityAttributeValues)) {
                         return true;
                     }
                 }
-                break;
-
-            case POLICY_FILTER_CRITERIA_NOT_EQUALS:
+            }
+            case POLICY_FILTER_CRITERIA_NOT_EQUALS -> {
                 return Collections.disjoint(entityAttributeValues, attributeValues);
-
-            case POLICY_FILTER_CRITERIA_IN:
+            }
+            case POLICY_FILTER_CRITERIA_IN -> {
                 if (AuthorizerCommonUtil.arrayListContains(attributeValues, entityAttributeValues)) {
                     return true;
                 }
-                break;
-
-            case POLICY_FILTER_CRITERIA_NOT_IN:
+            }
+            case POLICY_FILTER_CRITERIA_NOT_IN -> {
                 if (!AuthorizerCommonUtil.arrayListContains(attributeValues, entityAttributeValues)) {
                     return true;
                 }
-                break;
-
-            default: LOG.warn("Found unknown operator {}", operator);
+            }
+            default -> LOG.warn("Found unknown operator {}", operator);
         }
 
         RequestContext.get().endMetricRecord(recorder);
@@ -214,7 +210,7 @@ public class EntityAuthorizer {
         List<String> entityAttributeValues = new ArrayList<>();
 
         switch (attributeName) {
-            case "__traitNames":
+            case "__traitNames" -> {
                 List<AtlasClassification> tags = entity.getClassifications();
                 if (tags != null) {
                     for (AtlasClassification tag : tags) {
@@ -224,10 +220,9 @@ public class EntityAuthorizer {
                         }
                     }
                 }
-                break;
-
-            case "__propagatedTraitNames":
-                tags = entity.getClassifications();
+            }
+            case "__propagatedTraitNames" -> {
+                List<AtlasClassification> tags = entity.getClassifications();
                 if (tags != null) {
                     for (AtlasClassification tag : tags) {
                         if (StringUtils.isNotEmpty(tag.getEntityGuid()) && !tag.getEntityGuid().equals(entity.getGuid())) {
@@ -236,13 +231,12 @@ public class EntityAuthorizer {
                         }
                     }
                 }
-                break;
-
-            case "__typeName":
+            }
+            case "__typeName" -> {
                 String typeName = entity.getTypeName();
                 Set<String> allValidTypes = AuthorizerCommonUtil.getTypeAndSupertypesList(typeName);
                 entityAttributeValues.addAll(allValidTypes);
-                break;
+            }
         }
 
         return entityAttributeValues;
@@ -370,32 +364,29 @@ public class EntityAuthorizer {
         // no support required for starts_with and ends_with for tags
         boolean result = false;
         switch(operator) {
-            case POLICY_FILTER_CRITERIA_EQUALS:
+            case POLICY_FILTER_CRITERIA_EQUALS -> {
                 for (List<String> tagValues : attributeValues) {
                     if (!AuthorizerCommonUtil.arrayListContains(entityAttributeValues, tagValues)) {
                         return false;
                     }
                 }
                 result = true;
-                break;
-
-            case POLICY_FILTER_CRITERIA_NOT_EQUALS:
-            case POLICY_FILTER_CRITERIA_NOT_IN:
+            }
+            case POLICY_FILTER_CRITERIA_NOT_EQUALS, POLICY_FILTER_CRITERIA_NOT_IN -> {
                 for (List<String> tagValues : attributeValues) {
                     if (AuthorizerCommonUtil.arrayListContains(entityAttributeValues, tagValues)) {
                         return false;
                     }
                 }
                 result = true;
-                break;
-
-            case POLICY_FILTER_CRITERIA_IN:
+            }
+            case POLICY_FILTER_CRITERIA_IN -> {
                 for (List<String> tagValues : attributeValues) {
                     if (AuthorizerCommonUtil.arrayListContains(entityAttributeValues, tagValues)) {
                         return true;
                     }
                 }
-                break;
+            }
         }
         return result;
     }

--- a/repository/src/main/java/org/apache/atlas/repository/util/AccessControlUtils.java
+++ b/repository/src/main/java/org/apache/atlas/repository/util/AccessControlUtils.java
@@ -151,6 +151,10 @@ public final class AccessControlUtils {
     public static final String POLICY_FILTER_CRITERIA_STARTS_WITH = "STARTS_WITH";
     public static final String POLICY_FILTER_CRITERIA_ENDS_WITH = "ENDS_WITH";
 
+    public static final String ATTR_TAG = "__traitNames";
+    public static final String ATTR_PROPAGATED_TAG = "__propagatedTraitNames";
+    public static final List<String> ATTR_TAGS = List.of(ATTR_TAG, ATTR_PROPAGATED_TAG);
+    
     public static final Set<String> POLICY_FILTER_CRITERIA_VALID_OPS = Set.of(POLICY_FILTER_CRITERIA_EQUALS,
             POLICY_FILTER_CRITERIA_NOT_EQUALS, POLICY_FILTER_CRITERIA_IN, POLICY_FILTER_CRITERIA_NOT_IN,
             POLICY_FILTER_CRITERIA_STARTS_WITH, POLICY_FILTER_CRITERIA_ENDS_WITH);
@@ -419,7 +423,7 @@ public final class AccessControlUtils {
     }
 
     private static boolean hasMatchingVertex(AtlasGraph graph, List<String> newTags,
-                                             IndexSearchParams indexSearchParams) throws AtlasBaseException {
+                                               IndexSearchParams indexSearchParams) throws AtlasBaseException {
         String vertexIndexName = getESIndex();
         AtlasIndexQuery indexQuery = graph.elasticsearchQuery(vertexIndexName);
 


### PR DESCRIPTION
## Change description
Add support for tag key value in abac conditions. Tag values are stored as text in `__classificationText.text` field. FE already uses an ES query (`span_within`) that matches this classification text for tag values when filter is applied. This PR uses the same approach and just replaces `span_within` to `span_near` as later is relatively faster match.

For context, this is how tag values are selected in UI
<img width="640" height="490" alt="image" src="https://github.com/user-attachments/assets/7ec6a464-6c4e-42a1-af0f-7081f2f0cf70" />


## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

https://atlanhq.atlassian.net/browse/PLTS-426

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
