### PR TITLE
Removed datastax driver 30s timeout

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tags/TagDAOCassandraImpl.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tags/TagDAOCassandraImpl.java
@@ -58,7 +58,7 @@ public class TagDAOCassandraImpl implements TagDAO, AutoCloseable {
     private static final int BATCH_SIZE_LIMIT = 100;
     private static final int BATCH_SIZE_LIMIT_FOR_DELETION = 1000;
     private static final Duration CONNECTION_TIMEOUT = Duration.ofSeconds(5);
-    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(120);
+    //private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(120);
     private static final Duration HEARTBEAT_INTERVAL = Duration.ofSeconds(30);
     public static final String DEFAULT_HOST = "localhost";
     public static final String DATACENTER = "datacenter1";
@@ -115,7 +115,7 @@ public class TagDAOCassandraImpl implements TagDAO, AutoCloseable {
             Map<String, String> replicationConfig = Map.of("class", "SimpleStrategy", "replication_factor", ApplicationProperties.get().getString(CASSANDRA_REPLICATION_FACTOR_PROPERTY, "3"));
 
             DriverConfigLoader configLoader = DriverConfigLoader.programmaticBuilder()
-                    .withDuration(DefaultDriverOption.REQUEST_TIMEOUT, REQUEST_TIMEOUT)
+                    //.withDuration(DefaultDriverOption.REQUEST_TIMEOUT, REQUEST_TIMEOUT)
                     .withDuration(DefaultDriverOption.CONNECTION_INIT_QUERY_TIMEOUT, CONNECTION_TIMEOUT)
                     .withDuration(DefaultDriverOption.CONNECTION_CONNECT_TIMEOUT, CONNECTION_TIMEOUT)
                     .withDuration(DefaultDriverOption.CONTROL_CONNECTION_TIMEOUT, CONNECTION_TIMEOUT)
@@ -607,8 +607,17 @@ public class TagDAOCassandraImpl implements TagDAO, AutoCloseable {
             do {
                 pageCount++;
                 result = getPropagationsForAttachmentBatchWithPagination(sourceVertexId, tagTypeName, pagingState, 500, cacheKey);
-                int fetchedCount = result.getTags().size();
-                allTags.addAll(result.getTags());
+                List<Tag> currentPageTags = result.getTags();
+                int fetchedCount = currentPageTags.size();
+
+                if (fetchedCount > 0) {
+                    LOG.info("Page {}: First tag: {}", pageCount, currentPageTags.get(0));
+                    if (fetchedCount > 1) {
+                        LOG.info("Page {}: Last tag: {}", pageCount, currentPageTags.get(fetchedCount - 1));
+                    }
+                }
+
+                allTags.addAll(currentPageTags);
                 pagingState = result.getPagingState();
                 LOG.info("sourceVertexId={}, tagTypeName={}: Page {}: Fetched {} propagations. Total fetched: {}. Has next page: {}",
                         sourceVertexId, tagTypeName, pageCount, fetchedCount, allTags.size(), !result.isDone());


### PR DESCRIPTION
## Revert Cassandra driver timeout change
Causing availability problems in prod due to huge tag propagations.
