### PR TITLE
Remove redundant Cassandra paging cache

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -5179,7 +5179,7 @@ public class EntityGraphMapper {
             int totalDeleted = 0;
             PaginatedTagResult pageToDelete;
 
-            pageToDelete = tagDAO.getPropagationsForAttachmentBatch(vertexIdForPropagations, tagTypeName);
+            pageToDelete = tagDAO.getPropagationsForAttachmentBatch(vertexIdForPropagations, tagTypeName, null);
 
             List<Tag> batchToDelete = pageToDelete.getTags();
             AtlasClassification originalClassification;
@@ -5222,7 +5222,8 @@ public class EntityGraphMapper {
                 if (pageToDelete.isDone()) {
                     break;
                 }
-                pageToDelete = tagDAO.getPropagationsForAttachmentBatch(vertexIdForPropagations, tagTypeName);
+                String pagingState = pageToDelete.getPagingState();
+                pageToDelete = tagDAO.getPropagationsForAttachmentBatch(vertexIdForPropagations, tagTypeName, pagingState);
                 batchToDelete = pageToDelete.getTags();
             }
 
@@ -6231,7 +6232,7 @@ public class EntityGraphMapper {
             int totalUpdated = 0;
 
             // fetch propagated‑tag attachments in batches
-            PaginatedTagResult paginatedResult = tagDAO.getPropagationsForAttachmentBatch(sourceEntityVertex.getIdForDisplay(), tagTypeName);
+            PaginatedTagResult paginatedResult = tagDAO.getPropagationsForAttachmentBatch(sourceEntityVertex.getIdForDisplay(), tagTypeName, null);
             AtlasClassification originalClassification = tagDAO.findDirectTagByVertexIdAndTagTypeName(sourceEntityVertex.getIdForDisplay(), tagTypeName, false);
             if (originalClassification == null) {
                 String warningMessage = String.format("updateClassificationTextPropagationV2(entityGuid=%s, tagTypeName=%s): classification not found, skipping task execution", sourceEntityGuid, tagTypeName);
@@ -6273,7 +6274,8 @@ public class EntityGraphMapper {
                 if (paginatedResult.isDone()) {
                     break;
                 }
-                paginatedResult = tagDAO.getPropagationsForAttachmentBatch(sourceEntityVertex.getIdForDisplay(), tagTypeName);
+                String pagingState = paginatedResult.getPagingState();
+                paginatedResult = tagDAO.getPropagationsForAttachmentBatch(sourceEntityVertex.getIdForDisplay(), tagTypeName, pagingState);
                 batchToUpdate = paginatedResult.getTags();
             }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tags/TagDAO.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tags/TagDAO.java
@@ -20,7 +20,7 @@ public interface TagDAO {
     AtlasClassification findDirectDeletedTagByVertexIdAndTagTypeName(String vertexId, String tagTypeName) throws AtlasBaseException;
 
     Tag findDirectTagByVertexIdAndTagTypeNameWithAssetMetadata(String vertexId, String tagTypeName, boolean includeDeleted) throws AtlasBaseException;
-    PaginatedTagResult getPropagationsForAttachmentBatch(String sourceVertexId, String tagTypeName) throws AtlasBaseException;
+    PaginatedTagResult getPropagationsForAttachmentBatch(String sourceVertexId, String tagTypeName, String storedPagingState) throws AtlasBaseException;
     List<Tag> getTagPropagationsForAttachment(String sourceVertexId, String tagTypeName) throws AtlasBaseException;
 
     List<AtlasClassification> findByVertexIdAndPropagated(String vertexId) throws AtlasBaseException;
@@ -53,6 +53,6 @@ public interface TagDAO {
      * @throws AtlasBaseException If an error occurs during retrieval
      */
     PaginatedTagResult getPropagationsForAttachmentBatchWithPagination(String sourceVertexId, String tagTypeName,
-                                                                       String pagingStateStr, int pageSize, String cacheKey) throws AtlasBaseException;
+                                                                       String pagingStateStr, int pageSize) throws AtlasBaseException;
 }
 

--- a/repository/src/test/java/org/apache/atlas/repository/store/graph/v2/tags/TagDAOCassandraImplTest.java
+++ b/repository/src/test/java/org/apache/atlas/repository/store/graph/v2/tags/TagDAOCassandraImplTest.java
@@ -325,19 +325,19 @@ public class TagDAOCassandraImplTest {
         String cacheKey = "test_pagination_key";
 
         // Page 1
-        PaginatedTagResult page1 = tagDAO.getPropagationsForAttachmentBatchWithPagination(sourceAssetId, tagTypeName, null, pageSize, cacheKey);
+        PaginatedTagResult page1 = tagDAO.getPropagationsForAttachmentBatchWithPagination(sourceAssetId, tagTypeName, null, pageSize);
         assertEquals(pageSize, page1.getTags().size());
         assertNotNull(page1.getPagingState());
         assertFalse(page1.isDone());
 
         // Page 2
-        PaginatedTagResult page2 = tagDAO.getPropagationsForAttachmentBatchWithPagination(sourceAssetId, tagTypeName, page1.getPagingState(), pageSize, cacheKey);
+        PaginatedTagResult page2 = tagDAO.getPropagationsForAttachmentBatchWithPagination(sourceAssetId, tagTypeName, page1.getPagingState(), pageSize);
         assertEquals(pageSize, page2.getTags().size());
         assertNotNull(page2.getPagingState());
         assertFalse(page2.isDone());
 
         // Page 3
-        PaginatedTagResult page3 = tagDAO.getPropagationsForAttachmentBatchWithPagination(sourceAssetId, tagTypeName, page2.getPagingState(), pageSize, cacheKey);
+        PaginatedTagResult page3 = tagDAO.getPropagationsForAttachmentBatchWithPagination(sourceAssetId, tagTypeName, page2.getPagingState(), pageSize);
         assertEquals(1, page3.getTags().size()); // Last page has the remainder
         assertTrue(page3.isDone(), "Paging should be done on the last page.");
     }


### PR DESCRIPTION
## Change description

Remove redundant Cassandra paging cache which might cause memory bloat usage & with dangling cache for keys


## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
