### PR TITLE
PLTS-487 | Log unknown audit event while fetching policy delta

### DIFF
--- a/auth-agents-common/src/main/java/org/apache/atlas/policytransformer/CachePolicyTransformerImpl.java
+++ b/auth-agents-common/src/main/java/org/apache/atlas/policytransformer/CachePolicyTransformerImpl.java
@@ -239,7 +239,7 @@ public class CachePolicyTransformerImpl {
             }
 
         } catch (Exception e) {
-            LOG.error("PolicyDelta: {}: ABAC_AUTH: ERROR in getPoliciesDelta {}: {}", serviceName, e.getMessage(), e);
+            LOG.error("PolicyDelta: {}: ABAC_AUTH: ERROR in getPoliciesDelta: {}", serviceName, e.getMessage(), e);
             return null;
         }
 
@@ -382,8 +382,10 @@ public class CachePolicyTransformerImpl {
         // handle delete changes separately as they won't be present in atlas policies
         List<RangerPolicyDelta> deletedPolicyDeltas = new ArrayList<>();
         for (String policyGuid : policyGuids) {
-            int deltaChangeType = auditEventToDeltaChangeType.get(policyChanges.get(policyGuid));
-            if (deltaChangeType == RangerPolicyDelta.CHANGE_TYPE_POLICY_DELETE) {
+            Integer deltaChangeType = auditEventToDeltaChangeType.get(policyChanges.get(policyGuid));
+            if (deltaChangeType == null) {
+                LOG.warn("PolicyDelta: {}: No change type found for policy audit guid={} audit_event={}", serviceName, policyGuid, policyChanges.get(policyGuid));
+            } else if (deltaChangeType == RangerPolicyDelta.CHANGE_TYPE_POLICY_DELETE) {
                 RangerPolicy deletedPolicy = new RangerPolicy();
                 deletedPolicy.setGuid(policyGuid);
                 deletedPolicy.setService(serviceName);


### PR DESCRIPTION
## Change description
Noticed these error log in one of the tenant during policy delta fetching and seems like there might be some cases where policy audit event is not mapped to proper delta type.
<img width="763" height="151" alt="image" src="https://github.com/user-attachments/assets/7c2727d3-3a4f-4a6e-bce1-6a96a342587d" />

Log link – https://observability.atlan.com/goto/ETPtpE_NR?orgId=1

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

https://atlanhq.atlassian.net/browse/PLTS-487

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
