### PR TITLE
feat: in case of other attributes fetch using default

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -1720,10 +1720,6 @@ public final class GraphHelper {
             }
             return (List) instanceVertex.getMultiValuedProperty(propertyName, elementType.getClass());
         } else {
-            if (vertexEdgePropertiesCache != null) {
-                List values =  vertexEdgePropertiesCache.getMultiValuedProperties(instanceVertex.getIdForDisplay(), propertyName);
-                return values;
-            }
             return (List) instanceVertex.getListProperty(propertyName);
         }
     }


### PR DESCRIPTION
## Change description

> In case the array type is other than primitive, enum, relation we will not fetch it from cache
<img width="1385" height="533" alt="image" src="https://github.com/user-attachments/assets/9f732c94-e313-4047-a7aa-e7ef6e374079" />
Comparison with existing code so nothing will change in case it is of other type we will not process it using new method instead it will be processed using existing method.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

