### PR TITLE
MLH-940 Check for duplicate Refresh task when hard deleting edges

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tags/TagDAOCassandraImpl.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tags/TagDAOCassandraImpl.java
@@ -778,7 +778,12 @@ public class TagDAOCassandraImpl implements TagDAO, AutoCloseable {
     }
 
     public static AtlasClassification toAtlasClassification(Map<String, Object> tagMetaJsonMap) {
-        return objectMapper.convertValue(tagMetaJsonMap, AtlasClassification.class);
+        AtlasPerfMetrics.MetricRecorder recorder = RequestContext.get().startMetricRecord("dao.toAtlasClassification");
+        try {
+            return objectMapper.convertValue(tagMetaJsonMap, AtlasClassification.class);
+        } finally {
+            RequestContext.get().endMetricRecord(recorder);
+        }
     }
 
     /**


### PR DESCRIPTION
## Change description

Avoid duplicate Refresh tasks creation when hard deleting edges

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> https://atlanhq.atlassian.net/browse/MLH-940

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
