### PR TITLE
feat: Add Raw ES Search and Count Endpoints

### DIFF
--- a/.cursor/rules/feature-flags.mdc
+++ b/.cursor/rules/feature-flags.mdc
@@ -1,0 +1,31 @@
+---
+description: Guidance for the LaunchDarkly feature flag implementation done in this conversation
+---
+### Feature flag implementation (LaunchDarkly)
+
+- Single-class design: all logic in [FeatureFlagStoreLaunchDarklyImpl.java](mdc:intg/src/main/java/org/apache/atlas/featureflag/FeatureFlagStoreLaunchDarklyImpl.java)
+  - Spring bean annotated `@Service` and `@Lazy(false)` ensured earlier; class exposes static `evaluate(...)` helpers.
+  - A single `LDClient` is constructed once in the constructor using env `USER_LAUNCH_DARKLY_SDK_KEY`.
+  - `@PostConstruct preloadOrFail()` waits for client readiness, preloads declared flags, and fails fast on error.
+
+- Evaluation API (boolean-only):
+  - `public static boolean evaluate(String flagKey, String attributeKey, boolean attributeValue)`
+  - `public static boolean evaluate(String flagKey, String attributeKey, String attributeValue)`
+  - These static methods delegate to the initialized bean; they throw if called before init.
+
+- Caching strategy:
+  - TTL cache 30s for current values: Caffeine `expireAfterWrite(ttlMs)`.
+  - LKG cache (no expiry) stores last-known-good values for resilience.
+  - Key format: `flagKey|attributeKey=normalizedValue` and a global key `flagKey|__global__`.
+  - On success: update both caches; on error: serve LKG for specific key, else global, else `false`.
+
+- Preload flags:
+  - Add new flags to `PRELOAD_FLAGS` set in the same class; startup fails if preload fails.
+
+- Constraints and tips:
+  - Keep it single-class; do not introduce new classes for this feature unless explicitly requested.
+  - Only boolean flags are supported (enabled/disabled).
+  - Do not instantiate this class manually; rely on Spring initialization and static `evaluate(...)` entry points.
+
+- Usage example:
+  - `FeatureFlagStoreLaunchDarklyImpl.evaluate("atlas-enable-tag-v2", "tenant", tenantId)`

--- a/.cursor/rules/search-apis.mdc
+++ b/.cursor/rules/search-apis.mdc
@@ -1,0 +1,62 @@
+---
+alwaysApply: false
+description: search-apis
+---
+# Search APIs and ES Integration
+
+This rule documents the search API implementations and ES integration to help navigation and consistent usage across the repo.
+
+## Endpoints
+
+- POST `/search/indexsearch` → Atlas-shaped search using DSL. See [DiscoveryREST.java](mdc:webapp/src/main/java/org/apache/atlas/web/rest/DiscoveryREST.java)
+- POST `/search/es` → Raw ES search response passthrough, trimmed to the `hits` object if present. See [DiscoveryREST.java](mdc:webapp/src/main/java/org/apache/atlas/web/rest/DiscoveryREST.java)
+- POST `/search/count` → ES `_count` API; returns `{ "count": <long> }`. See [DiscoveryREST.java](mdc:webapp/src/main/java/org/apache/atlas/web/rest/DiscoveryREST.java)
+- POST `/search/relationship/indexsearch` → Edge index search. See [DiscoveryREST.java](mdc:webapp/src/main/java/org/apache/atlas/web/rest/DiscoveryREST.java)
+
+## Service Flow
+
+Service implementation: [EntityDiscoveryService.java](mdc:repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java)
+
+- `directIndexSearch(params, useVertexEdgeBulkFetching)` → standard Atlas result shaping
+- `directEsIndexSearch(params)` → returns raw ES map from index query
+- `directCountIndexSearch(params)` → returns `Long` count
+
+Common behavior (all three):
+- Index selection via `getIndexName(IndexSearchParams)`; supports persona/purpose and access control exclusive DSL
+- Optional pre-filtering when `enableFullRestriction` is true via `addPreFiltersToSearchQuery`
+- Optional DSL optimization when feature flag is enabled and request originates from product client (see below)
+- Error handling: propagate exceptions; upstream layers map network/ES errors to appropriate codes
+
+### DSL Optimization
+
+Reusable helper: `optimizeQueryIfApplicable(SearchParams, clientOrigin)` in [EntityDiscoveryService.java](mdc:repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java)
+
+- Controlled by feature flag key `discovery_use_dsl_optimisation`
+- Only applied when `RequestContext.clientOrigin == product_webapp`
+- Uses `ElasticsearchDslOptimizer.optimizeQueryWithValidation(...)`
+- On validation failure: logs a warning and continues
+- On optimizer error: logs and proceeds with original query
+
+## ES Layer
+
+Implementation: [AtlasElasticsearchQuery.java](mdc:graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchQuery.java)
+
+- `vertices(SearchParams)` → executes query via low-level client, returns `DirectIndexQueryResult`
+- `directIndexQuery(String)` → returns parsed ES response with `total`, `data`, optional `aggregations`
+- `directEsIndexQuery(String)` → returns raw ES response as `Map<String,Object>` (unmodified)
+- `countIndexQuery(String)` → calls `/_count`, parses and returns `Long`
+- Request isolation: selects ES client based on `RequestContext.clientOrigin`; `product_webapp` → UI cluster; others → Non-UI cluster; fallback to default client
+- Network errors: mapped to `SERVICE_UNAVAILABLE` or gateway timeout codes
+
+Note: The Janus in-memory index implementation ([AtlasJanusIndexQuery.java](mdc:graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusIndexQuery.java)) does not implement `directEsIndexQuery`/`countIndexQuery` (throws `NotImplementedException`).
+
+## REST Response Shaping
+
+- `/search/es` returns only the `hits` object when present; otherwise returns the full ES response map
+- `/search/count` wraps the `Long` in `{ "count": <long> }`
+
+## Limits and Logging
+
+- Query size limits enforced when `ATLAS_INDEXSEARCH_ENABLE_API_LIMIT` is true; see `ATLAS_INDEXSEARCH_QUERY_SIZE_MAX_LIMIT` and `ATLAS_INDEXSEARCH_LIMIT_UTM_TAGS`
+- Optional search logging; some utmTag patterns skip logging; see `shouldSkipSearchLog` in [DiscoveryREST.java](mdc:webapp/src/main/java/org/apache/atlas/web/rest/DiscoveryREST.java)
+

--- a/graphdb/api/src/main/java/org/apache/atlas/repository/graphdb/AtlasIndexQuery.java
+++ b/graphdb/api/src/main/java/org/apache/atlas/repository/graphdb/AtlasIndexQuery.java
@@ -51,6 +51,17 @@ public interface AtlasIndexQuery<V, E> {
     Map<String, Object> directIndexQuery(String query) throws AtlasBaseException;
 
     /**
+     * Executes a raw Elasticsearch search query and returns the direct ES response as a map
+     * without Atlas-specific transformations.
+     */
+    Map<String, Object> directEsIndexQuery(String query) throws AtlasBaseException;
+
+    /**
+     * Executes an Elasticsearch _count query and returns the count value.
+     */
+    Long countIndexQuery(String query) throws AtlasBaseException;
+
+    /**
      * Gets the query results.
      *
      * @return

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchQuery.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasElasticsearchQuery.java
@@ -218,6 +218,44 @@ public class AtlasElasticsearchQuery implements AtlasIndexQuery<AtlasJanusVertex
         }
     }
 
+    private Map<String, Object> runRawQueryWithLowLevelClient(String query) throws AtlasBaseException {
+        try {
+            String responseString = performDirectIndexQuery(query, true);
+            Map<String, Object> responseMap = AtlasType.fromJson(responseString, Map.class);
+            return responseMap;
+        } catch (IOException e) {
+            LOG.error("Failed to execute raw direct query on ES {}", e.getMessage());
+
+            handleNetworkErrors(e);
+
+            throw new AtlasBaseException(AtlasErrorCode.INDEX_SEARCH_FAILED, e.getMessage());
+        }
+    }
+
+    private Long runCountWithLowLevelClient(String query) throws AtlasBaseException {
+        try {
+            String responseString = performDirectCountQuery(query);
+            Map<String, Object> responseMap = AtlasType.fromJson(responseString, Map.class);
+            Object countObj = responseMap.get("count");
+            if (countObj == null) {
+                return 0L;
+            }
+            long countVal;
+            if (countObj instanceof Number) {
+                countVal = ((Number) countObj).longValue();
+            } else {
+                countVal = Long.parseLong(String.valueOf(countObj));
+            }
+            return countVal;
+        } catch (IOException e) {
+            LOG.error("Failed to execute _count query on ES {}", e.getMessage());
+
+            handleNetworkErrors(e);
+
+            throw new AtlasBaseException(AtlasErrorCode.INDEX_SEARCH_FAILED, e.getMessage());
+        }
+    }
+
     private Map<String, LinkedHashMap> runUpdateByQueryWithLowLevelClient(String query) throws AtlasBaseException {
         try {
             String responseString = performDirectUpdateByQuery(query);
@@ -542,6 +580,28 @@ public class AtlasElasticsearchQuery implements AtlasIndexQuery<AtlasJanusVertex
         return EntityUtils.toString(response.getEntity());
     }
 
+    private String performDirectCountQuery(String query) throws AtlasBaseException, IOException {
+        HttpEntity entity = new NStringEntity(query, ContentType.APPLICATION_JSON);
+        String endPoint = index + "/_count";
+
+        Request request = new Request("GET", endPoint);
+        request.setEntity(entity);
+
+        Response response;
+        try {
+            response = getESClient().performRequest(request);
+        } catch (ResponseException rex) {
+            if (rex.getResponse().getStatusLine().getStatusCode() == 404) {
+                LOG.warn(String.format("ES index with name %s not found", index));
+                throw new AtlasBaseException(INDEX_NOT_FOUND, index);
+            } else {
+                throw new AtlasBaseException(String.format("Error in executing elastic count query: %s", EntityUtils.toString(entity)), rex);
+            }
+        }
+
+        return EntityUtils.toString(response.getEntity());
+    }
+
     private String performDirectUpdateByQuery(String query) throws AtlasBaseException, IOException {
         HttpEntity entity = new NStringEntity(query, ContentType.APPLICATION_JSON);
         String endPoint;
@@ -615,6 +675,16 @@ public class AtlasElasticsearchQuery implements AtlasIndexQuery<AtlasJanusVertex
     @Override
     public Map<String, Object> directIndexQuery(String query) throws AtlasBaseException {
         return runQueryWithLowLevelClient(query);
+    }
+
+    @Override
+    public Map<String, Object> directEsIndexQuery(String query) throws AtlasBaseException {
+        return runRawQueryWithLowLevelClient(query);
+    }
+
+    @Override
+    public Long countIndexQuery(String query) throws AtlasBaseException {
+        return runCountWithLowLevelClient(query);
     }
 
     public Map<String, LinkedHashMap> directUpdateByQuery(String query) throws AtlasBaseException {

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusIndexQuery.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusIndexQuery.java
@@ -24,6 +24,7 @@ import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.discovery.SearchParams;
 import org.apache.atlas.repository.graphdb.AtlasIndexQuery;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
+import org.apache.commons.lang.NotImplementedException;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Iterators;
@@ -52,6 +53,16 @@ public class AtlasJanusIndexQuery implements AtlasIndexQuery<AtlasJanusVertex, A
     @Override
     public Map<String, Object> directIndexQuery(String query) throws AtlasBaseException {
         return null;
+    }
+
+    @Override
+    public Map<String, Object> directEsIndexQuery(String query) throws AtlasBaseException {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public Long countIndexQuery(String query) throws AtlasBaseException {
+        throw new NotImplementedException();
     }
 
     @Override

--- a/repository/src/main/java/org/apache/atlas/discovery/AtlasDiscoveryService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/AtlasDiscoveryService.java
@@ -31,6 +31,7 @@ import org.apache.atlas.model.searchlog.SearchLogSearchParams;
 import org.apache.atlas.model.searchlog.SearchLogSearchResult;
 
 import java.util.List;
+import java.util.Map;
 
 public interface AtlasDiscoveryService {
     /**
@@ -58,5 +59,15 @@ public interface AtlasDiscoveryService {
      * @throws AtlasBaseException
      */
     SearchLogSearchResult searchLogs(SearchLogSearchParams searchParams) throws AtlasBaseException;
+
+    /**
+     * Raw Elasticsearch search. Returns direct ES response as-is.
+     */
+    Map<String, Object> directEsIndexSearch(SearchParams searchParams) throws AtlasBaseException;
+
+    /**
+     * Elasticsearch count API. Returns document count for the query.
+     */
+    Long directCountIndexSearch(SearchParams searchParams) throws AtlasBaseException;
 
 }

--- a/repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java
@@ -171,20 +171,10 @@ public class EntityDiscoveryService implements AtlasDiscoveryService {
             }
 
             AtlasPerfMetrics.MetricRecorder elasticSearchQueryMetric = RequestContext.get().startMetricRecord("elasticSearchQuery");
-            if (FeatureFlagStore.evaluate(USE_DSL_OPTIMISATION, "true") &&
-                    CLIENT_ORIGIN_PRODUCT.equals(clientOrigin)) {
-                ElasticsearchDslOptimizer.OptimizationResult result = dslOptimizer.optimizeQueryWithValidation(searchParams.getQuery());
-                String dslOptimised = result.getOptimizedQuery();
-                searchParams.setQuery(dslOptimised);
-
-                // Log validation status for monitoring
-                if (!result.isValidationPassed()) {
-                    LOG.warn("DSL optimization validation failed: {} - falling back to original query",
-                             result.getValidationFailureReason());
-                }
-
+            optimizeQueryIfApplicable(searchParams, clientOrigin);
+            if (FeatureFlagStore.evaluate(USE_DSL_OPTIMISATION, "true") && CLIENT_ORIGIN_PRODUCT.equals(clientOrigin)) {
                 if (AtlasPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
-                    perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "EntityDiscoveryService.directIndexSearch(" + dslOptimised + ")");
+                    perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "EntityDiscoveryService.directIndexSearch(" + searchParams.getQuery() + ")");
                 }
             }
 
@@ -206,6 +196,82 @@ public class EntityDiscoveryService implements AtlasDiscoveryService {
             }
         }
         return ret;
+    }
+
+    @Override
+    public Map<String, Object> directEsIndexSearch(SearchParams searchParams) throws AtlasBaseException {
+        IndexSearchParams params = (IndexSearchParams) searchParams;
+        RequestContext.get().setRelationAttrsForSearch(params.getRelationAttributes());
+        RequestContext.get().setAllowDeletedRelationsIndexsearch(params.isAllowDeletedRelations());
+        RequestContext.get().setIncludeRelationshipAttributes(params.isIncludeRelationshipAttributes());
+        String clientOrigin = RequestContext.get().getClientOrigin();
+
+        try {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Performing raw ES search for the params ({})", searchParams);
+            }
+
+            String indexName = getIndexName(params);
+            AtlasIndexQuery indexQuery = graph.elasticsearchQuery(indexName);
+
+            if (searchParams.getEnableFullRestriction()) {
+                addPreFiltersToSearchQuery(searchParams);
+            }
+
+            optimizeQueryIfApplicable(searchParams, clientOrigin);
+
+            return indexQuery.directEsIndexQuery(searchParams.getQuery());
+        } catch (Exception e) {
+            LOG.error("Error while performing raw index search for the params ({}), {}", searchParams, e.getMessage());
+            throw e;
+        }
+    }
+
+    @Override
+    public Long directCountIndexSearch(SearchParams searchParams) throws AtlasBaseException {
+        IndexSearchParams params = (IndexSearchParams) searchParams;
+        RequestContext.get().setRelationAttrsForSearch(params.getRelationAttributes());
+        RequestContext.get().setAllowDeletedRelationsIndexsearch(params.isAllowDeletedRelations());
+        RequestContext.get().setIncludeRelationshipAttributes(params.isIncludeRelationshipAttributes());
+        String clientOrigin = RequestContext.get().getClientOrigin();
+
+        try {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Performing ES count for the params ({})", searchParams);
+            }
+
+            String indexName = getIndexName(params);
+            AtlasIndexQuery indexQuery = graph.elasticsearchQuery(indexName);
+
+            if (searchParams.getEnableFullRestriction()) {
+                addPreFiltersToSearchQuery(searchParams);
+            }
+
+            optimizeQueryIfApplicable(searchParams, clientOrigin);
+
+            return indexQuery.countIndexQuery(searchParams.getQuery());
+        } catch (Exception e) {
+            LOG.error("Error while performing count index search for the params ({}), {}", searchParams, e.getMessage());
+            throw e;
+        }
+    }
+
+    private void optimizeQueryIfApplicable(SearchParams searchParams, String clientOrigin) {
+        try {
+            if (FeatureFlagStore.evaluate(USE_DSL_OPTIMISATION, "true") && CLIENT_ORIGIN_PRODUCT.equals(clientOrigin)) {
+                ElasticsearchDslOptimizer.OptimizationResult result = dslOptimizer.optimizeQueryWithValidation(searchParams.getQuery());
+                String dslOptimised = result.getOptimizedQuery();
+                searchParams.setQuery(dslOptimised);
+
+                if (!result.isValidationPassed()) {
+                    LOG.warn("DSL optimization validation failed: {} - falling back to original query",
+                            result.getValidationFailureReason());
+                }
+            }
+        } catch (Exception ex) {
+            // Do not fail the request on optimization errors; log and proceed with original query
+            LOG.error("DSL optimization errored; proceeding with original query: {}", ex.getMessage());
+        }
     }
 
     public List<AtlasVertex> directVerticesIndexSearch(SearchParams searchParams) throws AtlasBaseException {


### PR DESCRIPTION
# Add Raw ES Search and Count Endpoints

## Summary
Introduces two new search endpoints that provide direct access to Elasticsearch responses without Atlas-specific transformations.

## New Endpoints

### `POST /search/es`
- Returns raw ES search response (trimmed to `hits` object)
- Automatically injects mandatory source fields (`__guid`, `qualifiedName`, `name`, etc.)
- Merges user-requested attributes with system fields
- Respects existing query size limits and UTM tag filtering

### `POST /search/count` 
- Executes ES `_count` API and returns `{"count": <long>}`
- Uses same validation and pre-filtering as existing search endpoints
