### PR TITLE
MLH-927 | Merge all attributes for ENTITY_UPDATE

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,6 +32,7 @@ on:
       - fixlabels
       - interceptapis
       - mlh-965
+      - mlh927
 
 jobs:
   build:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,7 +32,6 @@ on:
       - fixlabels
       - interceptapis
       - mlh-965
-      - mlh927
 
 jobs:
   build:


### PR DESCRIPTION
## Change description

Previously, we unconditionally replaced entity.attributes with entityHeader.attributes
For relationship-driven updates, the header often has null/sparse attributes, causing attribute loss in notifications. Now we safely merge header attribute with existing entity attributes.

### Test Case: Move term from one category to another
Before Fix
[before-fix-category1.json](https://github.com/user-attachments/files/21857138/before-fix-category1.json)
[before-fix-category2.json](https://github.com/user-attachments/files/21857139/before-fix-category2.json)
[before-fix-term.json](https://github.com/user-attachments/files/21857140/before-fix-term.json)

After Fix
[after-fix-category1.json](https://github.com/user-attachments/files/21857149/after-fix-category1.json)
[after-fix-category2.json](https://github.com/user-attachments/files/21857150/after-fix-category2.json)
[after-fix-term.json](https://github.com/user-attachments/files/21857151/after-fix-term.json)



## Type of change
- [X] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1](https://atlanhq.atlassian.net/browse/MLH-928) 

