### PR TITLE
MLH-969 Fix code to avoid creation of duplicate ADD prop tasks

### DIFF
--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -388,6 +388,8 @@ public final class Constants {
     public static final String TASK_PARENT_ENTITY_GUID             = encodePropertyKey(TASK_PREFIX + "parentEntityGuid");
     public static final String TASK_CLASSIFICATION_TYPENAME = encodePropertyKey(TASK_PREFIX + "classificationTypeName");
     public static final String ACTIVE_STATE_VALUE           = "ACTIVE";
+
+    public static final String ATLAN_HEADER_PREFIX_PATTERN  = "x-atlan-";
     public static final String TASK_HEADER_ATLAN_AGENT      = "x-atlan-agent";
     public static final String TASK_HEADER_ATLAN_AGENT_ID   = "x-atlan-agent-id";
     public static final String TASK_HEADER_ATLAN_PKG_NAME   = "x-atlan-package-name";

--- a/intg/src/main/java/org/apache/atlas/model/Tag.java
+++ b/intg/src/main/java/org/apache/atlas/model/Tag.java
@@ -144,6 +144,14 @@ public class Tag {
         return objectMapper.convertValue(tagMetaJson, AtlasClassification.class);
     }
 
+    public boolean isPropagatable() {
+        // Return True if
+        // 1. tag itself is propagated
+        // OR
+        // 2. tag is a direct attachment with propagate option as true
+        return this.isPropagated() || this.isPropagationEnabled();
+    }
+
     @Override
     public String toString() {
         return "Tag{" +

--- a/intg/src/main/java/org/apache/atlas/model/tasks/AtlasTask.java
+++ b/intg/src/main/java/org/apache/atlas/model/tasks/AtlasTask.java
@@ -104,7 +104,8 @@ public class AtlasTask {
     private Status              status;
     private String              classificationId;
     private String              entityGuid;
-    private String tagTypeName;
+    private String              tagTypeName;
+    private Map<String, Object> headers;
 
     public AtlasTask() {
     }
@@ -122,7 +123,7 @@ public class AtlasTask {
         this.attemptCount       = 0;
         this.classificationId   = classificationId;
         this.entityGuid         = entityGuid;
-        this.tagTypeName = tagTypeName;
+        this.tagTypeName        = tagTypeName;
     }
 
     public String getGuid() {
@@ -163,6 +164,14 @@ public class AtlasTask {
 
     public void setParameters(Map<String, Object> val) {
         this.parameters = val;
+    }
+
+    public Map<String, Object> getHeaders() {
+        return headers;
+    }
+
+    public void setHeaders(Map<String, Object> headers) {
+        this.headers = headers;
     }
 
     public void setType(String val) {

--- a/repository/src/main/java/org/apache/atlas/tasks/TaskRegistry.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/TaskRegistry.java
@@ -60,6 +60,7 @@ import java.util.LinkedHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import static org.apache.atlas.repository.Constants.ATLAN_HEADER_PREFIX_PATTERN;
 import static org.apache.atlas.repository.Constants.TASK_GUID;
 import static org.apache.atlas.repository.Constants.TASK_STATUS;
 import static org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2.setEncodedProperty;
@@ -659,6 +660,18 @@ public class TaskRegistry {
         String warningMessage = v.getProperty(Constants.TASK_WARNING_MESSAGE, String.class);
         if (warningMessage != null) {
             ret.setWarningMessage(warningMessage);
+        }
+
+        List<String> headerKeys = v.getPropertyKeys().stream().filter(key -> key.toLowerCase().startsWith(ATLAN_HEADER_PREFIX_PATTERN)).collect(Collectors.toUnmodifiableList());
+        if (CollectionUtils.isNotEmpty(headerKeys)) {
+            Map<String, Object> headers = new HashMap<>(headerKeys.size());
+            for (String headerKey : headerKeys) {
+                Object headerValue = v.getProperty(headerKey, Object.class);
+                if (headerValue != null) {
+                    headers.put(headerKey, headerValue);
+                }
+            }
+            ret.setHeaders(headers);
         }
 
         return ret;


### PR DESCRIPTION
## Change description

Redundant Add propagation tasks are getting created even if asset doesn't have any tag attahced.
Handle this to avoid creating many redundant tasks to relieve the pending tasks queue & task executor thread

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix https://atlanhq.atlassian.net/browse/MLH-969

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
