### PR TITLE
ADMIN-120 : (staging)change Atlas Privilege from Read to update to add scrub value

### DIFF
--- a/auth-plugin-atlas/src/main/java/org/apache/atlas/authorization/atlas/authorizer/RangerAtlasAuthorizer.java
+++ b/auth-plugin-atlas/src/main/java/org/apache/atlas/authorization/atlas/authorizer/RangerAtlasAuthorizer.java
@@ -854,7 +854,7 @@ public class RangerAtlasAuthorizer implements AtlasAuthorizer {
 
     private void checkAccessAndScrub(AtlasEntityHeader entity, AtlasSearchResultScrubRequest request, boolean isScrubAuditEnabled) throws AtlasAuthorizationException {
         if (entity != null && request != null) {
-            final AtlasEntityAccessRequest entityAccessRequest = new AtlasEntityAccessRequest(request.getTypeRegistry(), AtlasPrivilege.ENTITY_READ, entity, request.getUser(), request.getUserGroups());
+            final AtlasEntityAccessRequest entityAccessRequest = new AtlasEntityAccessRequest(request.getTypeRegistry(), AtlasPrivilege.ENTITY_UPDATE, entity, request.getUser(), request.getUserGroups());
 
             entityAccessRequest.setClientIPAddress(request.getClientIPAddress());
             entityAccessRequest.setForwardedAddresses(request.getForwardedAddresses());


### PR DESCRIPTION
## Change description
Change the Atlas privilege from Read to Update in order to verify access for adding a scrub value.
> 
For users with Guest roles who are added as connection admins, the lock icon does not appear because the scrubbed value is missing in the IndexSearch result.

This happens because scrubbed values are only applied when a user does not have READ access. Since in this case the Guest user is a connection admin, the connection admin policy grants them READ permission on the entity. As a result, the search result is not scrubbed, and the lock icon is not shown in the UI.

Fix: Update the logic to check for UPDATE privilege instead of READ privilege when determining whether to scrub the result and display the lock icon.

After Fix :

https://github.com/user-attachments/assets/364f2409-97e2-4446-913d-409afaf6ed47


## Type of change
- [x] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> Fix [ADMIN-120](https://atlanhq.atlassian.net/browse/ADMIN-120) 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable


[ADMIN-120]: https://atlanhq.atlassian.net/browse/ADMIN-120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ