### PR TITLE
MLH-988 Duplicate key issue for microStrategyColumnId

### DIFF
--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/graphv3/AtlasIndexInfoRetriever.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/graphv3/AtlasIndexInfoRetriever.java
@@ -59,7 +59,7 @@ public class AtlasIndexInfoRetriever extends org.janusgraph.graphdb.database.ind
                     final MixedIndexType extIndex = IndexRecordUtil.getMixedIndex(store, transaction);
                     assert extIndex.getBackingIndexName().equals(index);
                     final ImmutableMap.Builder<String,KeyInformation> b = ImmutableMap.builder();
-                    if ("edge_index".equals(store)) {
+                    if ("edge_index".equals(store) || "vertex_index".equals(store)) {
                         Set<String> processedKeys = new HashSet<>();
                         for (final ParameterIndexField field : extIndex.getFieldKeys()) {
                             String key = key2Field(field);


### PR DESCRIPTION
## Change description

JanusGraph transaction errors have been reported in the LendingClub workflow, specifically during the publishing of top-level assets. The errors include transaction commit failures due to duplicate index field names and multiple entries with the same key. The error details are as follows:

- org.janusgraph.core.JanusGraphException: Could not commit transaction due to exception during persistence
- Duplicate index field names found, likely multiple properties mapped to the same index field
- Multiple entries with same key: microStrategyColumnId

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix https://atlanhq.atlassian.net/browse/MLH-988

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
