### PR TITLE
MLH-984 : Handling doc conflicts for task mismatch fixes

### DIFF
--- a/repository/src/main/java/org/apache/atlas/tasks/TaskRegistry.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/TaskRegistry.java
@@ -78,6 +78,7 @@ import static org.apache.atlas.repository.Constants.ATLAN_HEADER_PREFIX_PATTERN;
 import static org.apache.atlas.repository.Constants.TASK_GUID;
 import static org.apache.atlas.repository.Constants.TASK_STATUS;
 import static org.apache.atlas.repository.audit.ESBasedAuditRepository.getHttpHosts;
+import static org.apache.atlas.repository.graphdb.janus.AtlasElasticsearchDatabase.getClient;
 import static org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2.setEncodedProperty;
 
 @Component
@@ -103,9 +104,7 @@ public class TaskRegistry {
         this.taskService = taskService;
         queueSize = AtlasConfiguration.TASKS_QUEUE_SIZE.getInt();
         useGraphQuery = AtlasConfiguration.TASKS_REQUEUE_GRAPH_QUERY.getBoolean();
-        RestClientBuilder lowLevelClient = null;
-        lowLevelClient = initializeClient();
-        this.hlClient = new RestHighLevelClient(lowLevelClient);
+        this.hlClient = getClient();
     }
 
 


### PR DESCRIPTION
## Description
Adds robust retry logic for task-mismatch repair in Elasticsearch.

Uses Elasticsearch’s internal retry_on_conflict (10 retries) plus 6 external retries from Metastore with backoff, giving up to 60 total attempts before failing.

Ensures updates succeed under heavy concurrency, reducing chances of tasks being left in incorrect states.

Improved logging for visibility into retries and failures.

References

Slack: [discussion](https://atlanhq.slack.com/archives/C08KM349090/p1755587234137249)

Jira: [MLH-984](https://atlanhq.atlassian.net/browse/MLH-984?atlOrigin=eyJpIjoiYzY3MDYxNjMxOTUwNGQwZTllZjk4ZjlkYzFjYTU5NTUiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

[MLH-984]: https://atlanhq.atlassian.net/browse/MLH-984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ