### PR TITLE
MLH-1013 Optimised duplicate task fetch code

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -1769,15 +1769,6 @@ public abstract class DeleteHandlerV1 {
                 return false;
             }
 
-            List<AtlasTask> pendingRefreshPropagationTasks = pendingTasks.stream()
-                    .filter(task -> CLASSIFICATION_REFRESH_PROPAGATION.equals(task.getType()))
-                    .collect(Collectors.toList());
-
-            // Ideally there should be only refresh propagation task
-            if (pendingRefreshPropagationTasks.size() > 1) {
-                LOG.warn("More than one {} task found for tag:entity pair {}:{}", CLASSIFICATION_REFRESH_PROPAGATION, tagTypeName, entityGuid);
-            }
-
             // If the list is not empty, a duplicate exists. No further filtering is needed.
             if (CollectionUtils.isNotEmpty(pendingTasks)) {
                 if (pendingTasks.stream().anyMatch(task -> CLASSIFICATION_REFRESH_PROPAGATION.equals(task.getType()))) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -1763,7 +1763,7 @@ public abstract class DeleteHandlerV1 {
             if (hasDuplicateTask(tasksInRequestContext, entityGuid, tagTypeName))
                 return true;
 
-            List<AtlasTask> pendingTasks = taskUtil.getAllTasksByCondition(PENDING_TASK_QUERY_SIZE_PAGE_SIZE, entityGuid, tagTypeName, taskTypesToSkip);
+            List<AtlasTask> pendingTasks = taskUtil.findFirstPageOfPendingTasks(PENDING_TASK_QUERY_SIZE_PAGE_SIZE, entityGuid, tagTypeName, taskTypesToSkip);
 
             if(CollectionUtils.isEmpty(pendingTasks)) {
                 return false;

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -1778,11 +1778,12 @@ public abstract class DeleteHandlerV1 {
                 LOG.warn("More than one {} task found for tag:entity pair {}:{}", CLASSIFICATION_REFRESH_PROPAGATION, tagTypeName, entityGuid);
             }
 
-            // if any task have status as PENDING, then skip task creation
-            if (hasDuplicateTask(pendingTasks, entityGuid, tagTypeName)) {
+            // If the list is not empty, a duplicate exists. No further filtering is needed.
+            if (CollectionUtils.isNotEmpty(pendingTasks)) {
+                if (pendingTasks.stream().anyMatch(task -> CLASSIFICATION_REFRESH_PROPAGATION.equals(task.getType()))) {
+                    LOG.warn("More than one {} task found for tag:entity pair {}:{}", CLASSIFICATION_REFRESH_PROPAGATION, tagTypeName, entityGuid);
+                }
                 return true;
-            } else {
-                LOG.warn("There is inconsistency in task queue, there are no pending tasks for tag:entity pair {}:{} but there are tasks in queue", tagTypeName, entityGuid);
             }
         } catch (AtlasBaseException e) {
             LOG.error("Error while checking if classification task creation is required for tag:entity pair {}:{}", tagTypeName, entityGuid, e);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tasks/TaskUtil.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tasks/TaskUtil.java
@@ -56,17 +56,17 @@ public class TaskUtil {
 
     /**
      *
-     * Finds the first page of pending tasks that match the specified criteria.
-     * This avoids fetching all tasks and is more performant for existence checks.
+     * Finds a single page of pending tasks that match the specified criteria, starting from a given offset.
      *
+     * @param from        The starting offset for pagination.
      * @param size        The page size.
      * @param entityGuid  The GUID of the entity.
      * @param tagTypeName The type name of the classification/tag.
      * @param types       A list of task types to search for.
-     * @return A list of tasks from the first page of results.
+     * @return A list of tasks from the specified page of results.
      * @throws AtlasBaseException
      */
-    public List<AtlasTask> findFirstPageOfPendingTasks(int size, String entityGuid, String tagTypeName, List<String> types) throws AtlasBaseException {
+    public List<AtlasTask> findAPageOfPendingTasks(int from, int size, String entityGuid, String tagTypeName, List<String> types) throws AtlasBaseException {
         List<Map<String,Object>> mustConditions = new ArrayList<>();
 
         if (StringUtils.isNotEmpty(entityGuid))
@@ -79,11 +79,11 @@ public class TaskUtil {
             mustConditions.add(getMap("terms", getMap(TASK_TYPE, types)));
         }
 
+        // The ES query is filtered by PENDING status, though results must be validated due to potential sync issues/delays.
         mustConditions.add(getMap("term", getMap(TASK_STATUS + ".keyword", TASK_STATUS_PENDING)));
 
-        return taskService.getFirstPageOfTasksByCondition(size, mustConditions);
+        return taskService.getTasksByCondition(from, size, mustConditions);
     }
-
 
     private Map<String, Object> getMap(String key, Object value) {
         Map<String, Object> map = new HashMap<>();

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tasks/TaskUtil.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tasks/TaskUtil.java
@@ -72,6 +72,36 @@ public class TaskUtil {
         return taskService.getAllTasksByCondition(size, mustConditions);
     }
 
+    /**
+     *
+     * Finds the first page of pending tasks that match the specified criteria.
+     * This avoids fetching all tasks and is more performant for existence checks.
+     *
+     * @param size        The page size.
+     * @param entityGuid  The GUID of the entity.
+     * @param tagTypeName The type name of the classification/tag.
+     * @param types       A list of task types to search for.
+     * @return A list of tasks from the first page of results.
+     * @throws AtlasBaseException
+     */
+    public List<AtlasTask> findFirstPageOfPendingTasks(int size, String entityGuid, String tagTypeName, List<String> types) throws AtlasBaseException {
+        List<Map<String,Object>> mustConditions = new ArrayList<>();
+
+        if (StringUtils.isNotEmpty(entityGuid))
+            mustConditions.add(getMap("term", getMap(TASK_ENTITY_GUID, entityGuid)));
+
+        if (StringUtils.isNotEmpty(tagTypeName))
+            mustConditions.add(getMap("term", getMap(TASK_CLASSIFICATION_TYPENAME, tagTypeName)));
+
+        if (CollectionUtils.isNotEmpty(types)) {
+            mustConditions.add(getMap("terms", getMap(TASK_TYPE, types)));
+        }
+
+        mustConditions.add(getMap("term", getMap(TASK_STATUS + ".keyword", TASK_STATUS_PENDING)));
+
+        return taskService.getFirstPageOfTasksByCondition(size, mustConditions);
+    }
+
 
     private Map<String, Object> getMap(String key, Object value) {
         Map<String, Object> map = new HashMap<>();

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tasks/TaskUtil.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tasks/TaskUtil.java
@@ -54,24 +54,6 @@ public class TaskUtil {
 
     }
 
-    public List<AtlasTask> getAllTasksByCondition(int size, String entityGuid, String tagTypeName, List<String> types) throws AtlasBaseException {
-        List<Map<String,Object>> mustConditions = new ArrayList<>();
-
-        if (StringUtils.isNotEmpty(entityGuid))
-            mustConditions.add(getMap("term", getMap(TASK_ENTITY_GUID, entityGuid)));
-
-        if (StringUtils.isNotEmpty(tagTypeName))
-            mustConditions.add(getMap("term", getMap(TASK_CLASSIFICATION_TYPENAME, tagTypeName)));
-
-        if (CollectionUtils.isNotEmpty(types)) {
-            mustConditions.add(getMap("terms", getMap(TASK_TYPE, types)));
-        }
-
-        mustConditions.add(getMap("term", getMap(TASK_STATUS + ".keyword", TASK_STATUS_PENDING)));
-
-        return taskService.getAllTasksByCondition(size, mustConditions);
-    }
-
     /**
      *
      * Finds the first page of pending tasks that match the specified criteria.

--- a/repository/src/main/java/org/apache/atlas/tasks/AtlasTaskService.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/AtlasTaskService.java
@@ -125,7 +125,6 @@ public class AtlasTaskService implements TaskService {
         Map<String, Object> dsl = mapOf("size", size);
         dsl.put("from", from);
         dsl.put("query", mapOf("bool", mapOf("must", mustConditions)));
-
         TaskSearchParams taskSearchParams = new TaskSearchParams();
         taskSearchParams.setDsl(dsl);
 
@@ -139,7 +138,6 @@ public class AtlasTaskService implements TaskService {
 
         return Collections.emptyList();
     }
-
 
     private Map<String, Object> getMap(String key, Object value) {
         Map<String, Object> map = new HashMap<>();

--- a/repository/src/main/java/org/apache/atlas/tasks/AtlasTaskService.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/AtlasTaskService.java
@@ -110,20 +110,20 @@ public class AtlasTaskService implements TaskService {
 
     /**
      *
-     * Retrieves a single page of tasks matching a given set of 'must' conditions.
-     * Unlike getAllTasksByCondition, this method does not paginate through all results.
+     * Fetches a single page of tasks based on a given set of 'must' conditions, from a specific offset.
+     * This is used for controlled pagination.
      *
-     * @param batchSize      The maximum number of tasks to return.
-     * @param mustConditions A list of 'must' conditions for the search query.
-     * @return A list of tasks for the first page of results.
+     * @param from           The starting offset for the results.
+     * @param size           The number of tasks to retrieve (page size).
+     * @param mustConditions A list of 'must' conditions for the Elasticsearch query.
+     * @return A list of tasks for the specified page.
      * @throws AtlasBaseException
      */
-    @Override
-    public List<AtlasTask> getFirstPageOfTasksByCondition(int batchSize, List<Map<String, Object>> mustConditions) throws AtlasBaseException {
-        AtlasPerfMetrics.MetricRecorder recorder = RequestContext.get().startMetricRecord("getFirstPageOfTasksByCondition");
+    public List<AtlasTask> getTasksByCondition(int from, int size, List<Map<String, Object>> mustConditions) throws AtlasBaseException {
+        AtlasPerfMetrics.MetricRecorder recorder = RequestContext.get().startMetricRecord("getTasksByCondition_singlePage");
 
-        Map<String, Object> dsl = mapOf("size", batchSize);
-        dsl.put("from", 0);
+        Map<String, Object> dsl = mapOf("size", size);
+        dsl.put("from", from);
         dsl.put("query", mapOf("bool", mapOf("must", mustConditions)));
 
         TaskSearchParams taskSearchParams = new TaskSearchParams();
@@ -139,6 +139,7 @@ public class AtlasTaskService implements TaskService {
 
         return Collections.emptyList();
     }
+
 
     private Map<String, Object> getMap(String key, Object value) {
         Map<String, Object> map = new HashMap<>();

--- a/repository/src/main/java/org/apache/atlas/tasks/AtlasTaskService.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/AtlasTaskService.java
@@ -95,13 +95,15 @@ public class AtlasTaskService implements TaskService {
                                                 List<Map<String,Object>> mustNotConditions) throws AtlasBaseException {
         Map<String, Object> dsl = getMap("from", from);
         dsl.put("size", size);
+
         Map<String, Map<String, Object>> boolCondition = Collections.singletonMap("bool", new HashMap<>());
+
         Map<String, Object> shouldQuery = getMap("bool", getMap("should", shouldConditions));
         mustConditions.add(shouldQuery);
+
         boolCondition.get("bool").put("must", mustConditions);
         boolCondition.get("bool").put("must_not", mustNotConditions);
 
-        dsl.put("query", boolCondition);
         TaskSearchParams taskSearchParams = new TaskSearchParams();
         taskSearchParams.setDsl(dsl);
         TaskSearchResult tasks = getTasks(taskSearchParams);
@@ -126,6 +128,11 @@ public class AtlasTaskService implements TaskService {
         Map<String, Object> dsl = mapOf("size", size);
         dsl.put("from", from);
         dsl.put("query", mapOf("bool", mapOf("must", mustConditions)));
+
+        Map<String, Object> sortOrder = mapOf("order", "asc");
+        Map<String, Object> sortField = mapOf(Constants.TASK_CREATED_TIME, sortOrder);
+        dsl.put("sort", Collections.singletonList(sortField));
+
         TaskSearchParams taskSearchParams = new TaskSearchParams();
         taskSearchParams.setDsl(dsl);
 

--- a/repository/src/main/java/org/apache/atlas/tasks/AtlasTaskService.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/AtlasTaskService.java
@@ -108,44 +108,6 @@ public class AtlasTaskService implements TaskService {
         return tasks;
     }
 
-    @Override
-    public List<AtlasTask> getAllTasksByCondition(int batchSize, List<Map<String,Object>> mustConditions) throws AtlasBaseException {
-        AtlasPerfMetrics.MetricRecorder recorder = RequestContext.get().startMetricRecord("findDuplicatePendingTasksV2");
-
-        List<AtlasTask> tasks = new ArrayList<>(0);
-        long from = 0;
-
-        Map<String, Object> dsl = mapOf("size", batchSize);
-        dsl.put("from", from);
-
-        dsl.put("query", mapOf("bool", mapOf("must", mustConditions)));
-        TaskSearchParams taskSearchParams = new TaskSearchParams();
-        taskSearchParams.setDsl(dsl);
-
-        boolean hasNext = true;
-
-        while (hasNext) {
-            TaskSearchResult page = getTasks(taskSearchParams);
-            if (page == null || CollectionUtils.isEmpty(page.getTasks())) {
-                hasNext = false;
-            } else {
-                tasks.addAll(page.getTasks());
-
-                if (page.getTasks().size() < batchSize) {
-                    hasNext = false;
-                } else {
-                    from += batchSize;
-                    dsl.put("from", from);
-                    taskSearchParams.setDsl(dsl);
-                }
-            }
-        }
-
-        RequestContext.get().endMetricRecord(recorder);
-
-        return tasks;
-    }
-
     /**
      *
      * Retrieves a single page of tasks matching a given set of 'must' conditions.

--- a/repository/src/main/java/org/apache/atlas/tasks/AtlasTaskService.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/AtlasTaskService.java
@@ -119,6 +119,7 @@ public class AtlasTaskService implements TaskService {
      * @return A list of tasks for the specified page.
      * @throws AtlasBaseException
      */
+    @Override
     public List<AtlasTask> getTasksByCondition(int from, int size, List<Map<String, Object>> mustConditions) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder recorder = RequestContext.get().startMetricRecord("getTasksByCondition_singlePage");
 

--- a/repository/src/main/java/org/apache/atlas/tasks/AtlasTaskService.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/AtlasTaskService.java
@@ -146,6 +146,38 @@ public class AtlasTaskService implements TaskService {
         return tasks;
     }
 
+    /**
+     *
+     * Retrieves a single page of tasks matching a given set of 'must' conditions.
+     * Unlike getAllTasksByCondition, this method does not paginate through all results.
+     *
+     * @param batchSize      The maximum number of tasks to return.
+     * @param mustConditions A list of 'must' conditions for the search query.
+     * @return A list of tasks for the first page of results.
+     * @throws AtlasBaseException
+     */
+    @Override
+    public List<AtlasTask> getFirstPageOfTasksByCondition(int batchSize, List<Map<String, Object>> mustConditions) throws AtlasBaseException {
+        AtlasPerfMetrics.MetricRecorder recorder = RequestContext.get().startMetricRecord("getFirstPageOfTasksByCondition");
+
+        Map<String, Object> dsl = mapOf("size", batchSize);
+        dsl.put("from", 0);
+        dsl.put("query", mapOf("bool", mapOf("must", mustConditions)));
+
+        TaskSearchParams taskSearchParams = new TaskSearchParams();
+        taskSearchParams.setDsl(dsl);
+
+        TaskSearchResult page = getTasks(taskSearchParams);
+
+        RequestContext.get().endMetricRecord(recorder);
+
+        if (page != null && CollectionUtils.isNotEmpty(page.getTasks())) {
+            return page.getTasks();
+        }
+
+        return Collections.emptyList();
+    }
+
     private Map<String, Object> getMap(String key, Object value) {
         Map<String, Object> map = new HashMap<>();
         map.put(key, value);

--- a/repository/src/main/java/org/apache/atlas/tasks/TaskService.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/TaskService.java
@@ -51,11 +51,6 @@ public interface TaskService {
     TaskSearchResult getTasksByCondition(int from, int size, List<Map<String,Object>> mustConditions, List<Map<String,Object>> shouldConditions,
                                          List<Map<String,Object>> mustNotConditions) throws AtlasBaseException;
 
-    /*
-    * Returns all tasks mathing the criteria with paginated requests
-    * */
-    List<AtlasTask> getAllTasksByCondition(int batchSize, List<Map<String,Object>> mustConditions) throws AtlasBaseException;
-
 
     List<AtlasTask> getFirstPageOfTasksByCondition(int batchSize, List<Map<String, Object>> mustConditions) throws AtlasBaseException;
 

--- a/repository/src/main/java/org/apache/atlas/tasks/TaskService.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/TaskService.java
@@ -57,6 +57,8 @@ public interface TaskService {
     List<AtlasTask> getAllTasksByCondition(int batchSize, List<Map<String,Object>> mustConditions) throws AtlasBaseException;
 
 
+    List<AtlasTask> getFirstPageOfTasksByCondition(int batchSize, List<Map<String, Object>> mustConditions) throws AtlasBaseException;
+
     /**
      * Retry the task by changing its status to PENDING and increment attempt count
      * @param taskGuid Guid of the task

--- a/repository/src/main/java/org/apache/atlas/tasks/TaskService.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/TaskService.java
@@ -52,7 +52,7 @@ public interface TaskService {
                                          List<Map<String,Object>> mustNotConditions) throws AtlasBaseException;
 
 
-    List<AtlasTask> getFirstPageOfTasksByCondition(int batchSize, List<Map<String, Object>> mustConditions) throws AtlasBaseException;
+
 
     /**
      * Retry the task by changing its status to PENDING and increment attempt count

--- a/repository/src/main/java/org/apache/atlas/tasks/TaskService.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/TaskService.java
@@ -52,6 +52,7 @@ public interface TaskService {
                                          List<Map<String,Object>> mustNotConditions) throws AtlasBaseException;
 
 
+    List<AtlasTask> getTasksByCondition(int from, int size, List<Map<String, Object>> mustConditions) throws AtlasBaseException;
 
     /**
      * Retry the task by changing its status to PENDING and increment attempt count

--- a/repository/src/main/java/org/apache/atlas/tasks/TaskService.java
+++ b/repository/src/main/java/org/apache/atlas/tasks/TaskService.java
@@ -53,7 +53,6 @@ public interface TaskService {
 
 
 
-
     /**
      * Retry the task by changing its status to PENDING and increment attempt count
      * @param taskGuid Guid of the task


### PR DESCRIPTION
JIRA: https://atlanhq.atlassian.net/browse/MLH-1013

**Problem**
The DeleteHandlerV1.skipClassificationTaskCreationV2 method is designed to prevent the creation of duplicate CLASSIFICATION_REFRESH_PROPAGATION or CLASSIFICATION_PROPAGATION_DELETE tasks.

However, the current implementation checks for duplicates by calling taskUtil.getAllTasksByCondition(), which paginates through and fetches all matching tasks from the database. In environments with millions of tasks, this operation is extremely inefficient and causes a significant performance bottleneck, as it retrieves large amounts of data and then performs the check.

**Solution**
This PR implements a hybrid pagination and validation approach to safely optimize the duplicate task check.
1. Paginate and Validate: Instead of fetching all tasks, the code now fetches one page of potential duplicates at a time from Elasticsearch. It then performs an in-memory validation (hasDuplicateTask) on that page to check the true status of each task against the graph data.
2. Early Exit for Performance: The key performance gain is preserved. The pagination loop stops immediately the moment a single, true PENDING task is found on any page, avoiding the need to process all subsequent results.