### PR TITLE
MLH-1019: Add retry mechanism for ES tag operations.

### DIFF
--- a/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
@@ -169,6 +169,8 @@ public enum AtlasConfiguration {
     // ES and Cassandra batch operation configurations
     ES_BULK_BATCH_SIZE("atlas.es.bulk.batch.size", 500),
     CASSANDRA_BATCH_SIZE("atlas.cassandra.batch.size", 100),
+    ES_MAX_RETRIES("atlas.es.max.retries", 5),
+    ES_RETRY_DELAY_MS("atlas.es.retry.delay.ms", 1000),
 
 
     MIN_EDGES_SUPER_VERTEX("atlas.jg.super.vertex.min.edge.count", 100);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityCreateOrUpdateMutationPostProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityCreateOrUpdateMutationPostProcessor.java
@@ -66,7 +66,28 @@ public class EntityCreateOrUpdateMutationPostProcessor implements EntityMutation
                     }
 
                     if (!batchPayload.isEmpty()) {
-                        ESConnector.writeTagProperties(batchPayload, upsert);
+                        int maxRetries = AtlasConfiguration.ES_MAX_RETRIES.getInt();
+                        long retryDelay = AtlasConfiguration.ES_RETRY_DELAY_MS.getLong();
+
+                        for (int retryCount = 0; retryCount < maxRetries; retryCount++) {
+                            try {
+                                ESConnector.writeTagProperties(batchPayload, upsert);
+                                break; // Success
+                            } catch (Exception e) {
+                                LOG.warn("Failed to execute ES operation. Retrying... ({}/{})", retryCount + 1, maxRetries, e);
+                                if (retryCount < maxRetries - 1) {
+                                    try {
+                                        Thread.sleep(retryDelay);
+                                    } catch (InterruptedException interruptedException) {
+                                        Thread.currentThread().interrupt();
+                                        throw new RuntimeException("ES operation interrupted during retry delay", interruptedException);
+                                    }
+                                } else {
+                                    LOG.error("Failed to execute ES operation after {} retries", maxRetries, e);
+                                    throw e; // Rethrow the exception after all retries have failed
+                                }
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Jira: https://atlanhq.atlassian.net/browse/MLH-1019
This pull request introduces a retry mechanism for Elasticsearch bulk update operations to improve resilience against transient failures.

 Changes:
   * Added configurable retry properties: atlas.es.max.retries (default: 5) and atlas.es.retry.delay.ms (default: 1000) to AtlasConfiguration.java.
   * Implemented retry logic in ESConnector.writeTagProperties to automatically retry failed Elasticsearch requests.
   * Added a similar retry wrapper in EntityCreateOrUpdateMutationPostProcessor for an additional layer of robustness during deferred ES operations.

This ensures that temporary connectivity issues with Elasticsearch do not result in failed metadata updates, making the system more reliable.
