### PR TITLE
MLH-1022 | add edges whiles querying

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,7 +32,6 @@ on:
       - fixlabels
       - interceptapis
       - mlh-965
-      - mlh1022
 
 jobs:
   build:


### PR DESCRIPTION
# Issue

Previously, we were not passing `edgeLabels` to JanusGraph queries. As a result, the queries were fetching all edges and then filtering them locally based on attributes. This was highly inefficient and often resulted in timeouts, especially when assets had multiple associated edges.
Results:
300 terms-> timing out
200 terms-> 8 mins +

## Fix

We now pass `edgeLabels` directly in the JanusGraph query. This ensures that only the required edges (with relevant attributes) are retrieved, reducing the query size and improving performance significantly.

<img width="1076" height="434" alt="image" src="https://github.com/user-attachments/assets/01d8366d-5a6a-4cf9-ade8-6fc51390e958" />


## Testing

 **Support-Internal & Metastore Playground**

* Validated that relationships are fetched correctly with the updated query.
* Confirmed that results are consistent with expectations.

**Shelter Environment**

* Updated the image and verified that the affected query return assets as expected.
* Observed notable improvement in response time, with no timeouts.