### PR TITLE
Updated commons-lang3 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1476,7 +1476,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.4</version>
+                <version>3.10</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This PR is to help resolve these errors on Atlas:
Caused by: java.lang.NoSuchMethodError: 'java.lang.Throwable org.apache.commons.lang3.exception.ExceptionUtils.throwableOfType(java.lang.Throwable, java.lang.Class)

The throwableOfType(Throwable, Class<T>) method was added in version 3.10 of Apache Commons Lang 3. It appears in the source with a 'since' 3.10 annotation.
