### PR TITLE
MLH-1022 | add edges whiles querying

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -133,6 +133,7 @@ import static org.apache.atlas.type.AtlasStructType.AtlasAttribute.AtlasRelation
 import static org.apache.atlas.type.AtlasStructType.AtlasAttribute.AtlasRelationshipEdgeDirection.OUT;
 import static org.apache.atlas.type.AtlasStructType.AtlasAttribute.encodePropertyKey;
 import static org.apache.atlas.type.Constants.PENDING_TASKS_PROPERTY_KEY;
+import org.apache.tinkerpop.gremlin.process.traversal.P;
 
 @Component
 public class EntityGraphRetriever {
@@ -1245,7 +1246,14 @@ public class EntityGraphRetriever {
 
             GraphTraversal<Edge, Map<String, Object>> edgeTraversal =
                     ((AtlasJanusGraph) graph).V(vertexIds)
-                            .bothE()
+                            .bothE();
+
+            // Filter by edge labels if provided
+            if (!CollectionUtils.isEmpty(edgeLabels)) {
+                edgeTraversal = edgeTraversal.hasLabel(P.within(edgeLabels));
+            }
+
+            edgeTraversal = edgeTraversal
                             .has(STATE_PROPERTY_KEY, ACTIVE.name())
                             .has(RELATIONSHIP_GUID_PROPERTY_KEY)
                             .project( "id", "valueMap","label", "inVertexId", "outVertexId")


### PR DESCRIPTION
# Issue

Previously, we were not passing `edgeLabels` to JanusGraph queries. As a result, the queries were fetching all edges and then filtering them locally based on attributes. This was highly inefficient and often resulted in timeouts, especially when assets had multiple associated edges.
Results:
300 terms-> timing out
200 terms-> 8 mins +

## Fix

We now pass `edgeLabels` directly in the JanusGraph query. This ensures that only the required edges (with relevant attributes) are retrieved, reducing the query size and improving performance significantly.

<img width="1076" height="434" alt="image" src="https://github.com/user-attachments/assets/01d8366d-5a6a-4cf9-ade8-6fc51390e958" />


## Testing

**Support-Internal & Metastore Playground**

* Validated that relationships are fetched correctly with the updated query.
* Confirmed that results are consistent with expectations.

**Shelter Environment**

* Updated the image and verified that the affected query return assets as expected.
* Observed notable improvement in response time, with no timeouts.