### PR TITLE
PLTS-511 | Skip unknown policy change event

### DIFF
--- a/auth-agents-common/src/main/java/org/apache/atlas/policytransformer/CachePolicyTransformerImpl.java
+++ b/auth-agents-common/src/main/java/org/apache/atlas/policytransformer/CachePolicyTransformerImpl.java
@@ -375,6 +375,10 @@ public class CachePolicyTransformerImpl {
 
         for (RangerPolicy policy : rangerPolicies) {
             Integer changeType = auditEventToDeltaChangeType.get(policyChanges.get(policy.getAtlasGuid()));
+            if (changeType == null) {
+                LOG.warn("PolicyDelta: {}: No change type found for policy guid={} audit_event={}", serviceName, policy.getAtlasGuid(), policyChanges.get(policy.getAtlasGuid()));
+                continue;
+            }
             RangerPolicyDelta delta = new RangerPolicyDelta(policy.getId(), changeType, policy.getVersion(), policy);
             policyDeltas.add(delta);
         }
@@ -383,9 +387,7 @@ public class CachePolicyTransformerImpl {
         List<RangerPolicyDelta> deletedPolicyDeltas = new ArrayList<>();
         for (String policyGuid : policyGuids) {
             Integer deltaChangeType = auditEventToDeltaChangeType.get(policyChanges.get(policyGuid));
-            if (deltaChangeType == null) {
-                LOG.warn("PolicyDelta: {}: No change type found for policy audit guid={} audit_event={}", serviceName, policyGuid, policyChanges.get(policyGuid));
-            } else if (deltaChangeType == RangerPolicyDelta.CHANGE_TYPE_POLICY_DELETE) {
+            if (deltaChangeType == RangerPolicyDelta.CHANGE_TYPE_POLICY_DELETE) {
                 RangerPolicy deletedPolicy = new RangerPolicy();
                 deletedPolicy.setGuid(policyGuid);
                 deletedPolicy.setService(serviceName);


### PR DESCRIPTION
## Change description

When a persona is disabled, there are two audit events logged for each policy - `BUSINESS_ATTRIBUTE_UPDATE` and `ENTITY_UPDATE`. We only need to create a delta for update event and other can be safely ignored. Currently, it's causing exception while applying the policy delta because this event is not mapped to any delta type.

Test cases:
- Update a policy and see if changes are reflected 🟢 
- Disable the persona and see if policies are getting refreshed 🟢 
- Enable the persona and see if policies are getting refreshed 🟢 

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

https://atlanhq.atlassian.net/browse/PLTS-511

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
