### PR TITLE
MLH-1054 fix correct updatedTime and updatedBy for mutatedDetails

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/businesslineage/BusinessLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/repository/businesslineage/BusinessLineageService.java
@@ -328,7 +328,7 @@ public class BusinessLineageService implements AtlasBusinessLineageService {
         }
 
         diffEntity.setGuid(ev.getProperty(GUID_PROPERTY_KEY, String.class));
-        diffEntity.setUpdatedBy(ev.getProperty(MODIFIED_BY_KEY, String.class));
+        diffEntity.setUpdatedBy(requestContext.getUser());
         diffEntity.setUpdateTime(new Date(RequestContext.get().getRequestTime()));
         diffEntity.setAttribute(assetDenormAttribute, existingValues);
 

--- a/repository/src/main/java/org/apache/atlas/repository/businesslineage/BusinessLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/repository/businesslineage/BusinessLineageService.java
@@ -328,7 +328,7 @@ public class BusinessLineageService implements AtlasBusinessLineageService {
         }
 
         diffEntity.setGuid(ev.getProperty(GUID_PROPERTY_KEY, String.class));
-        diffEntity.setUpdatedBy(requestContext.getUser());
+        diffEntity.setUpdatedBy(ev.getProperty(MODIFIED_BY_KEY, String.class));
         diffEntity.setUpdateTime(new Date(RequestContext.get().getRequestTime()));
         diffEntity.setAttribute(assetDenormAttribute, existingValues);
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -6319,7 +6319,7 @@ public class EntityGraphMapper {
     private void setEntityCommonAttributes(AtlasVertex ev, AtlasEntity diffEntity) {
         diffEntity.setGuid(ev.getProperty(GUID_PROPERTY_KEY, String.class));
         diffEntity.setUpdatedBy(ev.getProperty(MODIFIED_BY_KEY, String.class));
-        diffEntity.setUpdateTime(new Date(RequestContext.get().getRequestTime()));
+        diffEntity.setUpdateTime(new Date(ev.getProperty(MODIFICATION_TIMESTAMP_PROPERTY_KEY, Long.class)));
     }
 
     private void isAuthorizedToLink(AtlasVertex vertex) throws AtlasBaseException {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -609,16 +609,16 @@ public class EntityGraphMapper {
     private void setSystemAttributesToEntity(AtlasVertex entityVertex, AtlasEntity createdEntity) {
 
         createdEntity.setCreatedBy(GraphHelper.getCreatedByAsString(entityVertex));
-        createdEntity.setUpdatedBy(GraphHelper.getModifiedByAsString(entityVertex));
+        createdEntity.setUpdatedBy(RequestContext.get().getUser());
         createdEntity.setCreateTime(new Date(GraphHelper.getCreatedTime(entityVertex)));
-        createdEntity.setUpdateTime(new Date(GraphHelper.getModifiedTime(entityVertex)));
+        createdEntity.setUpdateTime(new Date(RequestContext.get().getRequestTime()));
 
 
         if (DIFFERENTIAL_AUDITS) {
             AtlasEntity diffEntity = RequestContext.get().getDifferentialEntity(createdEntity.getGuid());
             if (diffEntity != null) {
-                diffEntity.setUpdateTime(createdEntity.getUpdateTime());
-                diffEntity.setUpdatedBy(createdEntity.getUpdatedBy());
+                diffEntity.setUpdateTime(new Date(RequestContext.get().getRequestTime()));
+                diffEntity.setUpdatedBy(RequestContext.get().getUser());
             }
         }
     }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -6319,7 +6319,7 @@ public class EntityGraphMapper {
     private void setEntityCommonAttributes(AtlasVertex ev, AtlasEntity diffEntity) {
         diffEntity.setGuid(ev.getProperty(GUID_PROPERTY_KEY, String.class));
         diffEntity.setUpdatedBy(ev.getProperty(MODIFIED_BY_KEY, String.class));
-        diffEntity.setUpdateTime(new Date(ev.getProperty(MODIFICATION_TIMESTAMP_PROPERTY_KEY, Long.class)));
+        diffEntity.setUpdateTime(new Date(RequestContext.get().getRequestTime()));
     }
 
     private void isAuthorizedToLink(AtlasVertex vertex) throws AtlasBaseException {


### PR DESCRIPTION
## Change description

> mutatedDetails should always have updatedBy and updatedTime
It is fine to send updatedBy always even if it didn't change

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues
https://atlanhq.atlassian.net/browse/MLH-1054
> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
