### PR TITLE
MLH-1096 | Add batching in edge retrieval

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,6 +32,7 @@ on:
       - fixlabels
       - interceptapis
       - mlh-965
+      - mlh1096
 
 
 jobs:

--- a/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
@@ -136,8 +136,8 @@ public enum AtlasConfiguration {
     ATLAS_INDEXSEARCH_ENABLE_JANUS_OPTIMISATION_FOR_LINEAGE("atlas.indexsearch.enable.janus.optimization.for.lineage", false),
     ATLAS_LINEAGE_ENABLE_CONNECTION_LINEAGE("atlas.lineage.enable.connection.lineage", false),
     ATLAS_INDEXSEARCH_ENABLE_JANUS_OPTIMISATION_EXTENDED("atlas.indexsearch.enable.janus.optimization.extended", false),
-    ATLAS_INDEXSEARCH_ENABLE_BULK_FETCHING("atlas.indexsearch.bulk.fetching.enable", false),
-    ATLAS_INDEXSEARCH_BULK_FETCHING_SIZE("atlas.indexsearch.bulk.fetching.size", 100),
+    ATLAS_INDEXSEARCH_EDGE_BULK_FETCH_ENABLE("atlas.indexsearch.edge.bulk.fetch.enable", false),
+    ATLAS_INDEXSEARCH_EDGE_BULK_FETCH_BATCH_SIZE ("atlas.indexsearch.edge.bulk.fetch.batch.size", 10),
     ATLAS_MAINTENANCE_MODE("atlas.maintenance.mode", false),
     DELTA_BASED_REFRESH_ENABLED("atlas.authorizer.enable.delta_based_refresh", false),
 

--- a/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
@@ -136,6 +136,8 @@ public enum AtlasConfiguration {
     ATLAS_INDEXSEARCH_ENABLE_JANUS_OPTIMISATION_FOR_LINEAGE("atlas.indexsearch.enable.janus.optimization.for.lineage", false),
     ATLAS_LINEAGE_ENABLE_CONNECTION_LINEAGE("atlas.lineage.enable.connection.lineage", false),
     ATLAS_INDEXSEARCH_ENABLE_JANUS_OPTIMISATION_EXTENDED("atlas.indexsearch.enable.janus.optimization.extended", false),
+    ATLAS_INDEXSEARCH_ENABLE_BULK_FETCHING("atlas.indexsearch.bulk.fetching.enable", false),
+    ATLAS_INDEXSEARCH_BULK_FETCHING_SIZE("atlas.indexsearch.bulk.fetching.size", 100),
     ATLAS_MAINTENANCE_MODE("atlas.maintenance.mode", false),
     DELTA_BASED_REFRESH_ENABLED("atlas.authorizer.enable.delta_based_refresh", false),
 
@@ -143,6 +145,7 @@ public enum AtlasConfiguration {
 
     // Slow query logging threshold for search endpoints (ms)
     SEARCH_SLOW_QUERY_THRESHOLD_MS("atlas.search.slow.query.threshold.ms", 1000),
+
 
     /***
      * OTEL Configuration

--- a/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
@@ -136,7 +136,7 @@ public enum AtlasConfiguration {
     ATLAS_INDEXSEARCH_ENABLE_JANUS_OPTIMISATION_FOR_LINEAGE("atlas.indexsearch.enable.janus.optimization.for.lineage", false),
     ATLAS_LINEAGE_ENABLE_CONNECTION_LINEAGE("atlas.lineage.enable.connection.lineage", false),
     ATLAS_INDEXSEARCH_ENABLE_JANUS_OPTIMISATION_EXTENDED("atlas.indexsearch.enable.janus.optimization.extended", false),
-    ATLAS_INDEXSEARCH_EDGE_BULK_FETCH_ENABLE("atlas.indexsearch.edge.bulk.fetch.enable", false),
+    ATLAS_INDEXSEARCH_EDGE_BULK_FETCH_ENABLE("atlas.indexsearch.edge.bulk.fetch.enable", true),
     ATLAS_INDEXSEARCH_EDGE_BULK_FETCH_BATCH_SIZE ("atlas.indexsearch.edge.bulk.fetch.batch.size", 10),
     ATLAS_MAINTENANCE_MODE("atlas.maintenance.mode", false),
     DELTA_BASED_REFRESH_ENABLED("atlas.authorizer.enable.delta_based_refresh", false),

--- a/repository/src/main/java/org/apache/atlas/discovery/ElasticsearchDslOptimizer.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/ElasticsearchDslOptimizer.java
@@ -544,7 +544,7 @@ public class ElasticsearchDslOptimizer {
                 MDC.put("validation.failure_reason", "validation_check_failed");
                 MDC.put("fallback.used", "true");
 
-                log.error("Query optimization failed validation - using original query as fallback");
+                log.warn("Query optimization failed validation - using original query as fallback");
 
                 return fallbackResult;
             }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -1283,7 +1283,7 @@ public class EntityGraphRetriever {
 
             for (int i = 0; i < vertexIdList.size(); i += vertexBatchSize) {
                 int end = Math.min(i + vertexBatchSize, vertexIdList.size());
-                Set<String> vertexBatch = new HashSet<>(vertexIdList.subList(i, end));
+                List<String> vertexBatch = vertexIdList.subList(i, end);
 
                 GraphTraversal<Edge, Map<String, Object>> edgeTraversal =
                         ((AtlasJanusGraph) graph).V(vertexBatch)
@@ -1296,6 +1296,7 @@ public class EntityGraphRetriever {
                 List<Map<String, Object>> batchResults = edgeTraversal
                         .has(STATE_PROPERTY_KEY, ACTIVE.name())
                         .has(RELATIONSHIP_GUID_PROPERTY_KEY)
+                        .dedup()
                         .project("id", "valueMap", "label", "inVertexId", "outVertexId")
                         .by(__.id())
                         .by(__.valueMap(true))

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -1279,7 +1279,7 @@ public class EntityGraphRetriever {
 
             List<Map<String, Object>> allResults = new ArrayList<>();
             List<String> vertexIdList = new ArrayList<>(vertexIds);
-            int vertexBatchSize = AtlasConfiguration.ATLAS_INDEXSEARCH_BULK_FETCHING_SIZE.getInt(); // Process 100 vertices at a time
+            int vertexBatchSize = AtlasConfiguration.ATLAS_INDEXSEARCH_EDGE_BULK_FETCH_BATCH_SIZE.getInt(); // Process 100 vertices at a time
 
             for (int i = 0; i < vertexIdList.size(); i += vertexBatchSize) {
                 int end = Math.min(i + vertexBatchSize, vertexIdList.size());
@@ -1353,7 +1353,7 @@ public class EntityGraphRetriever {
            Set<String> vertexIdsToProcess = new HashSet<>();
            if (!CollectionUtils.isEmpty(edgeLabelsToProcess)) {
                List<Map<String, Object>> relationEdges;
-               if (AtlasConfiguration.ATLAS_INDEXSEARCH_ENABLE_BULK_FETCHING.getBoolean()) {
+               if (AtlasConfiguration.ATLAS_INDEXSEARCH_EDGE_BULK_FETCH_ENABLE.getBoolean()) {
                    relationEdges = getConnectedRelationEdgesVertexBatching(vertexIds, edgeLabelsToProcess, relationAttrsSize);
                } else {
                    relationEdges = getConnectedRelationEdges(vertexIds, edgeLabelsToProcess, relationAttrsSize);


### PR DESCRIPTION
## Change description

> Description here

Title: Fix Backend Timeouts by Batching Related Asset Property Fetching

Problem Statement
The current implementation causes backend timeouts when fetching relationship edges for assets. While vertex properties are efficiently fetched in batches of 100, the related asset edges are fetched all at once, creating a performance bottleneck.
Root Cause Analysis

Current Behavior:

Vertex properties: Fetched in controlled batches of 100 ✅
Related asset edges: Fetched for ALL vertices simultaneously ❌
When vertices have thousands of relationships, attempting to fetch all edges with valueMap(true) causes backend timeouts

Solution Implemented
Batch Processing for Related Assets: Apply the batching strategy to relationship edge fetching.

Key Changes

- Partition vertex IDs into manageable batches (same size as vertex property batch: 100)
- Fetch relationship edges for each vertex batch independently
- Aggregate results from all batches into final response
- Consistent batching strategy across both vertex properties and relationship edges

Also utilise following flags for bulk-fetching
- For heavy relationship queries with many properties
atlas.graph.query.batch.enabled=true
atlas.graph.query.batch.limited=true
atlas.graph.query.batch.limited-size=5000  # Reduce from 10000
atlas.graph.query.batch.property-prefetch=false  # Use lazy loading with valueMap(true)


JIRA : https://atlanhq.atlassian.net/browse/MLH-1096

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues
- add bat

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
