### PR TITLE
MLH-498 update typedef registry without locks

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,6 +32,7 @@ on:
       - fixlabels
       - interceptapis
       - mlh-965
+      - mlh-498-use-spec-store-master
 
 
 jobs:

--- a/intg/src/main/java/org/apache/atlas/type/AtlasTypeRegistry.java
+++ b/intg/src/main/java/org/apache/atlas/type/AtlasTypeRegistry.java
@@ -293,6 +293,97 @@ public class AtlasTypeRegistry {
         }
     }
 
+    public void addTypes(AtlasTypesDef typesDef) throws AtlasBaseException {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("==> AtlasTypeRegistry.addTypes({})", typesDef);
+        }
+
+        if (typesDef != null) {
+            addTypesWithNoRefResolve(typesDef.getEnumDefs());
+            addTypesWithNoRefResolve(typesDef.getStructDefs());
+            addTypesWithNoRefResolve(typesDef.getClassificationDefs());
+            addTypesWithNoRefResolve(typesDef.getEntityDefs());
+            addTypesWithNoRefResolve(typesDef.getRelationshipDefs());
+            addTypesWithNoRefResolve(typesDef.getBusinessMetadataDefs());
+        }
+
+        resolveReferences();
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("<== AtlasTypeRegistry.addTypes({})", typesDef);
+        }
+    }
+
+    private void addTypesWithNoRefResolve(Collection<? extends AtlasBaseTypeDef> typeDefs) throws AtlasBaseException {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("==> AtlasTypeRegistry.addTypesWithNoRefResolve(length={})",
+                    (typeDefs == null ? 0 : typeDefs.size()));
+        }
+
+        if (CollectionUtils.isNotEmpty(typeDefs)) {
+            for (AtlasBaseTypeDef typeDef : typeDefs) {
+                addTypeWithNoRefResolve(typeDef);
+            }
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("<== AtlasTypeRegistry.addTypesWithNoRefResolve(length={})",
+                    (typeDefs == null ? 0 : typeDefs.size()));
+        }
+    }
+
+    private void resolveReferences() throws AtlasBaseException {
+        for (AtlasType type : registryData.allTypes.getAllTypes()) {
+            type.resolveReferences(this);
+        }
+
+        for (AtlasType type : registryData.allTypes.getAllTypes()) {
+            type.resolveReferencesPhase2(this);
+        }
+
+        for (AtlasType type : registryData.allTypes.getAllTypes()) {
+            type.resolveReferencesPhase3(this);
+        }
+    }
+
+    private void addTypeWithNoRefResolve(AtlasBaseTypeDef typeDef) throws AtlasBaseException{
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("==> AtlasTypeRegistry.addTypeWithNoRefResolve({})", typeDef);
+        }
+
+        if (typeDef != null) {
+            if (typeDef.getClass().equals(AtlasEnumDef.class)) {
+                AtlasEnumDef enumDef = (AtlasEnumDef) typeDef;
+
+                registryData.enumDefs.addType(enumDef, new AtlasEnumType(enumDef));
+            } else if (typeDef.getClass().equals(AtlasStructDef.class)) {
+                AtlasStructDef structDef = (AtlasStructDef) typeDef;
+
+                registryData.structDefs.addType(structDef, new AtlasStructType(structDef));
+            } else if (typeDef.getClass().equals(AtlasClassificationDef.class)) {
+                AtlasClassificationDef classificationDef = (AtlasClassificationDef) typeDef;
+
+                registryData.classificationDefs.addType(classificationDef,
+                        new AtlasClassificationType(classificationDef));
+            } else if (typeDef.getClass().equals(AtlasEntityDef.class)) {
+                AtlasEntityDef entityDef = (AtlasEntityDef) typeDef;
+
+                registryData.entityDefs.addType(entityDef, new AtlasEntityType(entityDef));
+            } else if (typeDef.getClass().equals(AtlasRelationshipDef.class)) {
+                AtlasRelationshipDef relationshipDef = (AtlasRelationshipDef) typeDef;
+
+                registryData.relationshipDefs.addType(relationshipDef, new AtlasRelationshipType(relationshipDef));
+            } else if (typeDef.getClass().equals(AtlasBusinessMetadataDef.class)) {
+                AtlasBusinessMetadataDef businessMetadataDef = (AtlasBusinessMetadataDef) typeDef;
+                registryData.businessMetadataDefs.addType(businessMetadataDef, new AtlasBusinessMetadataType(businessMetadataDef));
+            }
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("<== AtlasTypeRegistry.addTypeWithNoRefResolve({})", typeDef);
+        }
+    }
+
     private void resolveIndexFieldNamesForRootTypes() {
         for (AtlasStructType structType : Arrays.asList(AtlasEntityType.ENTITY_ROOT, AtlasClassificationType.CLASSIFICATION_ROOT)) {
             for (AtlasAttribute attribute : structType.getAllAttributes().values()) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasTypeDefGraphStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasTypeDefGraphStore.java
@@ -123,6 +123,20 @@ public abstract class AtlasTypeDefGraphStore implements AtlasTypeDefStore {
     }
 
     @Override
+    public void initWithoutLock() throws AtlasBaseException {
+        // need even better approach than this
+        AtlasTypesDef typesDef = new AtlasTypesDef(getEnumDefStore(typeRegistry).getAll(),
+                getStructDefStore(typeRegistry).getAll(),
+                getClassificationDefStore(typeRegistry).getAll(),
+                getEntityDefStore(typeRegistry).getAll(),
+                getRelationshipDefStore(typeRegistry).getAll(),
+                getBusinessMetadataDefStore(typeRegistry).getAll());
+
+        rectifyTypeErrorsIfAny(typesDef);
+        typeRegistry.addTypes(typesDef);
+    }
+
+    @Override
     public AtlasEnumDef getEnumDefByName(String name) throws AtlasBaseException {
         AtlasEnumDef ret = typeRegistry.getEnumDefByName(name);
         if (ret == null) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasTypeDefGraphStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasTypeDefGraphStoreV2.java
@@ -122,6 +122,16 @@ public class AtlasTypeDefGraphStoreV2 extends AtlasTypeDefGraphStore {
         LOG.info("<== AtlasTypeDefGraphStoreV1.init()");
     }
 
+    @Override
+    @GraphTransaction
+    public void initWithoutLock() throws AtlasBaseException {
+        LOG.info("==> AtlasTypeDefGraphStoreV1.initWithoutLock()");
+
+        super.initWithoutLock();
+
+        LOG.info("<== AtlasTypeDefGraphStoreV1.initWithoutLock()");
+    }
+
     AtlasGraph getAtlasGraph() { return atlasGraph; }
 
     @VisibleForTesting

--- a/repository/src/main/java/org/apache/atlas/store/AtlasTypeDefStore.java
+++ b/repository/src/main/java/org/apache/atlas/store/AtlasTypeDefStore.java
@@ -35,6 +35,8 @@ import org.apache.atlas.model.typedef.AtlasTypesDef;
 public interface AtlasTypeDefStore {
     void init() throws AtlasBaseException;
 
+    void initWithoutLock() throws AtlasBaseException;
+
     /* EnumDef operations */
 
     AtlasEnumDef getEnumDefByName(String name) throws AtlasBaseException;

--- a/webapp/src/main/java/org/apache/atlas/web/rest/TypeCacheRefreshREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/TypeCacheRefreshREST.java
@@ -67,7 +67,7 @@ public class TypeCacheRefreshREST {
         }
     }
 
-    private void refreshTypeDef(int expectedFieldKeys,final String traceId) throws RepositoryException, InterruptedException, AtlasBaseException {
+    private synchronized void refreshTypeDef(int expectedFieldKeys,final String traceId) throws RepositoryException, InterruptedException, AtlasBaseException {
         LOG.info("Initiating type-def cache refresh with expectedFieldKeys = {} :: traceId {}", expectedFieldKeys,traceId);
         int currentSize = provider.get().getManagementSystem().getGraphIndex(VERTEX_INDEX).getFieldKeys().size();
         LOG.info("Size of field keys before refresh = {} :: traceId {}", currentSize,traceId);
@@ -91,7 +91,7 @@ public class TypeCacheRefreshREST {
             LOG.info("Found desired size of fieldKeys in iteration {} :: traceId {}", counter, traceId);
         }
         //Reload in-memory cache of type-registry
-        typeDefStore.init();
+        typeDefStore.initWithoutLock();
 
         LOG.info("Size of field keys after refresh = {}", provider.get().getManagementSystem().getGraphIndex(VERTEX_INDEX).getFieldKeys().size());
         LOG.info("Completed type-def cache refresh :: traceId {}", traceId);

--- a/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
@@ -680,7 +680,7 @@ public class TypesREST {
             validateTypeNames(typesDef);
         } catch (AtlasBaseException e) {
             if(AtlasErrorCode.TYPE_NAME_NOT_FOUND.equals(e.getAtlasErrorCode())) {
-                typeDefStore.init();
+                typeDefStore.initWithoutLock();
                 validateTypeNames(typesDef);
             }
         }


### PR DESCRIPTION
## Change description

> Introduce a method to init typedef registry without expensive locks
Use this initWithoutLock on refresh interface when cinv calls
Update typedef registry without locks
Call this only on PUT /typedef

What async did - https://atlanhq.atlassian.net/browse/AIGOV-91?focusedCommentId=450573
Current issue after making it async - https://atlanhq.atlassian.net/browse/AIGOV-91?focusedCommentId=451859

Video proof of testing in development environment
https://www.loom.com/share/027bd273c8894093846a7ae42cde727c

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues
https://atlanhq.atlassian.net/browse/AIGOV-91
https://atlanhq.atlassian.net/browse/MLH-498
> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
