### PR TITLE
MLH-1140 Revert direct tag attach Kafka notification

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -4320,9 +4320,7 @@ public class EntityGraphMapper {
                 propagatedEntitiesGuids.addAll(chunkedPropagatedEntitiesGuids);
                 offset += CHUNK_SIZE;
                 transactionInterceptHelper.intercept();
-                //Convert entitiesPropagatedTo to Set
-                Set<AtlasVertex> entitiesPropagatedToSet = new HashSet<>(entitiesPropagatedTo);
-                entityChangeNotifier.onClassificationsAddedToEntitiesV2(entitiesPropagatedToSet, Collections.singletonList(classification), false, RequestContext.get());
+                entityChangeNotifier.onClassificationsAddedToEntities(propagatedEntitiesChunked, Collections.singletonList(classification), false);
             } while (offset < impactedVerticesSize);
         } catch (AtlasBaseException exception) {
             LOG.error("Error occurred while adding classification propagation for classification with propagation id {}", classificationVertex.getIdForDisplay());

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -3883,7 +3883,7 @@ public class EntityGraphMapper {
                 } else {
                     List<AtlasEntity> propagatedEntities = updateClassificationText(classification, vertices);
 
-                    entityChangeNotifier.onClassificationsAddedToEntitiesV2(vertices, Collections.singletonList(classification), false, RequestContext.get());
+                    entityChangeNotifier.onClassificationsAddedToEntities(propagatedEntities, Collections.singletonList(classification), false);
                 }
             }
 


### PR DESCRIPTION
## Change description

The CLASSIFICATION_ADD Kafka event is not being sent for propagated assets after adding a tag with V1, while UPDATE and DELETE events are being sent.

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix https://atlanhq.atlassian.net/browse/MLH-1140

Kafka event for direct attachment with v1
```
{
    "source":
    {},
    "version":
    {
        "version": "1.0.0",
        "versionParts": [1]
    },
    "msgCompressionKind": "NONE",
    "msgSplitIdx": 1,
    "msgSplitCount": 1,
    "msgSourceIP": "10.205.59.107",
    "msgCreatedBy": "",
    "msgCreationTime": 1757085360555,
    "spooled": false,
    "message":
    {
        "type": "ENTITY_NOTIFICATION_V2",
        "entity":
        {
            "typeName": "Table",
            "attributes":
            {
                "popularityScore": 1.17549435E-38,
                "assetMcMonitorNames": [],
                "lastSyncRunAt": 1756563862017,
                "databaseName": "ATLAN",
                "nonCompliantAssetPolicyGUIDs": [],
                "assetPoliciesCount": 0,
                "outputProductGUIDs": [],
                "assetAnomaloLastCheckRunAt": 0,
                "lastSyncRun": "atlan-oracle-1756562701-gqzr6",
                "schemaName": "WWI_DEMO",
                "assetSodaLastSyncRunAt": 0,
                "starredCount": 0,
                "adminUsers": [],
                "assetMcIsMonitored": false,
                "domainGUIDs": ["05630aee-a77c-49b5-8627-172d2f694815"],
                "assetAnomaloFailedCheckCount": 0,
                "partitionCount": 0,
                "isSharded": false,
                "queryUserCount": 0,
                "assetMcIncidentQualifiedNames": [],
                "assetMcIncidentTypes": [],
                "assetSodaLastScanAt": 0,
                "sourceUpdatedAt": 0,
                "assetDbtJobLastRunArtifactsSaved": false,
                "isEditable": true,
                "assetRedirectGUIDs": [],
                "announcementUpdatedAt": 0,
                "lastProfiledAt": 0,
                "isQueryPreview": true,
                "sourceCreatedAt": 0,
                "assetDbtJobLastRunDequedAt": 0,
                "assetDbtTags": [],
                "qualifiedName": "default/oracle/1756562701/ATLAN/WWI_DEMO/ADDRESSES",
                "assetDbtJobLastRunNotificationsSent": false,
                "assetMcIncidentPriorities": [],
                "assetMcMonitorTypes": [],
                "assetSodaCheckCount": 0,
                "assetMcMonitorStatuses": [],
                "starredBy": [],
                "name": "ADDRESSES",
                "certificateUpdatedAt": 1756972358520,
                "assetAnomaloAppliedCheckTypes": [],
                "connectorName": "oracle",
                "subType": "TABLE",
                "assetMcIncidentSeverities": [],
                "assetMcAlertQualifiedNames": [],
                "ownerUsers": ["aarshi.arora","abhilash.hegde"],
                "lastSyncWorkflowName": "test-full-extraction-wf-1-crawler",
                "certificateStatus": "VERIFIED",
                "connectionQualifiedName": "default/oracle/1756562701",
                "hasContract": false,
                "assetDbtJobLastRunHasSourcesGenerated": false,
                "assetMcIncidentSubTypes": [],
                "isAIGenerated": false,
                "isTemporary": false,
                "assetDbtJobLastRunHasDocsGenerated": false,
                "queryCount": 0,
                "isPartitioned": false,
                "assetTags": [],
                "assetPolicyGUIDs": [],
                "assetMcIncidentStates": [],
                "assetDbtJobLastRunUpdatedAt": 0,
                "ownerGroups": [],
                "certificateUpdatedBy": "angad.sethi",
                "assetMcMonitorQualifiedNames": [],
                "assetDbtJobLastRunStartedAt": 0,
                "isPartial": false,
                "assetAnomaloCheckCount": 0,
                "isDiscoverable": true,
                "rowCount": 0,
                "tableRetentionTime": 0,
                "tableObjectCount": 0,
                "schemaQualifiedName": "default/oracle/1756562701/ATLAN/WWI_DEMO",
                "assetMcMonitorScheduleTypes": [],
                "isProfiled": false,
                "viewerUsers": [],
                "assetMcIncidentNames": [],
                "productGUIDs": [],
                "userDescription": "Creating and managing webhooks usually falls under the App admin role, which handles app-specific settings in Jira.\n\nOrganization admins and site admins do not typically perform webhook creation.\n\nCertain webhook configurations scoped to projects might be done by project admins if granted the appropriate permissions.\n\nThus, the App admin role is the primary admin type that can create webhooks in Jira.\n",
                "adminRoles": [],
                "adminGroups": [],
                "assetDbtJobLastRunCreatedAt": 0,
                "databaseQualifiedName": "default/oracle/1756562701/ATLAN",
                "assetAnomaloFailedCheckTypes": [],
                "assetDbtJobNextRun": 0,
                "columnCount": 7,
                "sizeBytes": 0,
                "assetMcLastSyncRunAt": 0,
                "assetInternalPopularityScore": 1.17549435E-38,
                "viewerGroups": [],
                "assetDbtJobLastRun": 0
            },
            "guid": "7669f20a-5f45-49af-b64c-331248032a5f",
            "status": "ACTIVE",
            "displayText": "ADDRESSES",
            "classificationNames": ["kamLyuaiL7Pc3TbMA3zCMz","RjGt1YHpI6mN4UZrCZNW0s","FXbrWG9qYtxpYerrY1wBFw","e3mDsnRyjvSGKeWEt2bkj6"],
            "classifications": [
                {
                    "typeName": "kamLyuaiL7Pc3TbMA3zCMz",
                    "entityGuid": "7669f20a-5f45-49af-b64c-331248032a5f",
                    "entityStatus": "ACTIVE",
                    "propagate": false,
                    "removePropagationsOnEntityDelete": true,
                    "restrictPropagationThroughLineage": true,
                    "restrictPropagationThroughHierarchy": true
                },
                {
                    "typeName": "RjGt1YHpI6mN4UZrCZNW0s",
                    "entityGuid": "7669f20a-5f45-49af-b64c-331248032a5f",
                    "entityStatus": "ACTIVE",
                    "propagate": false,
                    "removePropagationsOnEntityDelete": true,
                    "restrictPropagationThroughLineage": true,
                    "restrictPropagationThroughHierarchy": true
                },
                {
                    "typeName": "FXbrWG9qYtxpYerrY1wBFw",
                    "entityGuid": "7669f20a-5f45-49af-b64c-331248032a5f",
                    "entityStatus": "ACTIVE",
                    "propagate": false,
                    "removePropagationsOnEntityDelete": true,
                    "restrictPropagationThroughLineage": true,
                    "restrictPropagationThroughHierarchy": true
                },
                {
                    "typeName": "e3mDsnRyjvSGKeWEt2bkj6",
                    "entityGuid": "7669f20a-5f45-49af-b64c-331248032a5f",
                    "entityStatus": "ACTIVE",
                    "propagate": true,
                    "removePropagationsOnEntityDelete": true,
                    "restrictPropagationThroughLineage": false,
                    "restrictPropagationThroughHierarchy": false
                }
            ],
            "isIncomplete": false,
            "createdBy": "praveen.kumar",
            "updatedBy": "nikhil.bonte",
            "createTime": 1756564117159,
            "updateTime": 1757085358843
        },
        "operationType": "CLASSIFICATION_ADD",
        "eventTime": 1757085358843,
        "mutatedDetails": [
            {
                "typeName": "e3mDsnRyjvSGKeWEt2bkj6",
                "attributes":
                {},
                "entityGuid": "7669f20a-5f45-49af-b64c-331248032a5f",
                "entityStatus": "ACTIVE",
                "propagate": true,
                "removePropagationsOnEntityDelete": true,
                "restrictPropagationThroughLineage": false,
                "restrictPropagationThroughHierarchy": false
            }
        ],
        "headers":
        {
            "Origin": "https://preprod.atlan.com",
            "x-atlan-request-id": "e36877c3-e09d-4918-20dc-43d4aac9c2f7",
            "Content-Length": "1265",
            "x-atlan-via-ui": "true",
            "x-atlan-client-origin": "product_webapp",
            "X-Amzn-Trace-Id": "Self=1-68bafeae-12658b395487221f0dc81d41;Root=e36877c3-e09d-4918-20dc-43d4aac9c2f7"
        }
    }
}
```

Kafka event for propagated attachment with v1
```
{
    "source":
    {},
    "version":
    {
        "version": "1.0.0",
        "versionParts": [1]
    },
    "msgCompressionKind": "NONE",
    "msgSplitIdx": 1,
    "msgSplitCount": 1,
    "msgSourceIP": "10.205.59.107",
    "msgCreatedBy": "",
    "msgCreationTime": 1757085370629,
    "spooled": false,
    "message":
    {
        "type": "ENTITY_NOTIFICATION_V2",
        "entity":
        {
            "typeName": "Column",
            "attributes":
            {
                "popularityScore": 1.17549435E-38,
                "assetMcMonitorNames": [],
                "columnSum": 0.0,
                "databaseName": "ATLAN",
                "columnMissingValuesCountLong": 0,
                "assetPoliciesCount": 0,
                "columnMissingValuesPercentage": 0.0,
                "columnAverageValue": 0.0,
                "assetAnomaloLastCheckRunAt": 0,
                "columnMin": 0.0,
                "lastSyncRun": "atlan-oracle-1756562701-gqzr6",
                "assetSodaLastSyncRunAt": 0,
                "tableName": "ADDRESSES",
                "columnMedian": 0.0,
                "starredCount": 0,
                "domainGUIDs": [],
                "columnMinimumStringLength": 0,
                "assetAnomaloFailedCheckCount": 0,
                "columnMaximumStringLength": 0,
                "assetMcIncidentQualifiedNames": [],
                "assetMcIncidentTypes": [],
                "assetSodaLastScanAt": 0,
                "sourceUpdatedAt": 0,
                "assetDbtJobLastRunArtifactsSaved": false,
                "isPartition": false,
                "lastProfiledAt": 0,
                "columnUniqueValuesCountLong": 0,
                "order": 7,
                "sourceCreatedAt": 0,
                "assetDbtJobLastRunDequedAt": 0,
                "assetDbtTags": [],
                "isIndexed": false,
                "columnIsMeasure": false,
                "assetDbtJobLastRunNotificationsSent": false,
                "nestedColumnCount": 0,
                "assetMcMonitorTypes": [],
                "assetSodaCheckCount": 0,
                "columnMinValue": 0.0,
                "columnMax": 0.0,
                "assetMcIncidentSeverities": [],
                "assetMcAlertQualifiedNames": [],
                "isSort": false,
                "hasContract": false,
                "assetDbtJobLastRunHasSourcesGenerated": false,
                "columnMean": 0.0,
                "isForeign": false,
                "columnMeanValue": 0.0,
                "assetDbtJobLastRunHasDocsGenerated": false,
                "queryCount": 0,
                "assetTags": [],
                "isDist": false,
                "columnAverageLengthValue": 0.0,
                "assetMcMonitorQualifiedNames": [],
                "columnDistinctValuesCount": 0,
                "assetDbtJobLastRunStartedAt": 0,
                "assetAnomaloCheckCount": 0,
                "columnStandardDeviationValue": 0.0,
                "schemaQualifiedName": "default/oracle/1756562701/ATLAN/WWI_DEMO",
                "viewerUsers": [],
                "columnDepthLevel": 0,
                "productGUIDs": ["cdada1dc-baf1-4203-9e41-f806e26f9e9f","d0f50425-f7d6-4543-94f1-a5242ab9ab22"],
                "adminGroups": [],
                "assetDbtJobLastRunCreatedAt": 0,
                "assetAnomaloFailedCheckTypes": [],
                "assetDbtJobNextRun": 0,
                "columnDistinctValuesCountLong": 0,
                "columnMaxs": [],
                "partitionOrder": 0,
                "columnSumValue": 0.0,
                "lastSyncRunAt": 1756563862017,
                "nonCompliantAssetPolicyGUIDs": [],
                "outputProductGUIDs": [],
                "columnUniquenessPercentage": 0.0,
                "precision": 0,
                "schemaName": "WWI_DEMO",
                "adminUsers": [],
                "assetMcIsMonitored": false,
                "columnHierarchy": [],
                "queryUserCount": 0,
                "isEditable": true,
                "assetRedirectGUIDs": [],
                "announcementUpdatedAt": 0,
                "columnDuplicateValuesCountLong": 0,
                "columnDuplicateValuesCount": 0,
                "columnTopValues": [],
                "qualifiedName": "default/oracle/1756562701/ATLAN/WWI_DEMO/ADDRESSES/POSTALCODE",
                "dataType": "VARCHAR2",
                "columnMins": [],
                "assetMcIncidentPriorities": [],
                "isClustered": false,
                "assetMcMonitorStatuses": [],
                "starredBy": [],
                "isNullable": true,
                "name": "POSTALCODE",
                "certificateUpdatedAt": 0,
                "assetAnomaloAppliedCheckTypes": [],
                "connectorName": "oracle",
                "columnAverageLength": 0.0,
                "columnMaxValue": 0.0,
                "columnVarianceValue": 0.0,
                "numericScale": 0.0,
                "maxLength": 20,
                "ownerUsers": [],
                "lastSyncWorkflowName": "test-full-extraction-wf-1-crawler",
                "connectionQualifiedName": "default/oracle/1756562701",
                "assetMcIncidentSubTypes": [],
                "isAIGenerated": false,
                "assetPolicyGUIDs": [],
                "assetMcIncidentStates": [],
                "pinnedAt": 0,
                "assetDbtJobLastRunUpdatedAt": 0,
                "ownerGroups": [],
                "isPrimary": false,
                "isPartial": false,
                "isDiscoverable": true,
                "assetMcMonitorScheduleTypes": [],
                "isProfiled": false,
                "columnAverage": 0.0,
                "assetMcIncidentNames": [],
                "columnMedianValue": 0.0,
                "adminRoles": [],
                "isPinned": false,
                "databaseQualifiedName": "default/oracle/1756562701/ATLAN",
                "columnMissingValuesCount": 0,
                "columnStandardDeviation": 0.0,
                "assetMcLastSyncRunAt": 0,
                "tableQualifiedName": "default/oracle/1756562701/ATLAN/WWI_DEMO/ADDRESSES",
                "assetInternalPopularityScore": 1.17549435E-38,
                "columnUniqueValuesCount": 0,
                "viewerGroups": [],
                "assetDbtJobLastRun": 0,
                "columnVariance": 0.0
            },
            "guid": "d6acb889-747c-463c-946e-4b1530896b99",
            "status": "ACTIVE",
            "displayText": "POSTALCODE",
            "classificationNames": ["e3mDsnRyjvSGKeWEt2bkj6"],
            "classifications": [
                {
                    "typeName": "e3mDsnRyjvSGKeWEt2bkj6",
                    "entityGuid": "7669f20a-5f45-49af-b64c-331248032a5f",
                    "entityStatus": "ACTIVE",
                    "propagate": true,
                    "removePropagationsOnEntityDelete": true,
                    "restrictPropagationThroughLineage": false,
                    "restrictPropagationThroughHierarchy": false
                }
            ],
            "isIncomplete": false,
            "createdBy": "praveen.kumar",
            "updatedBy": "nikhil.bonte",
            "createTime": 1756564303274,
            "updateTime": 1757085298482
        },
        "operationType": "CLASSIFICATION_ADD",
        "eventTime": 1757085369032,
        "mutatedDetails": [
            {
                "typeName": "e3mDsnRyjvSGKeWEt2bkj6",
                "entityGuid": "7669f20a-5f45-49af-b64c-331248032a5f",
                "entityStatus": "ACTIVE",
                "propagate": true,
                "removePropagationsOnEntityDelete": true,
                "restrictPropagationThroughLineage": false,
                "restrictPropagationThroughHierarchy": false
            }
        ],
        "headers":
        {
            "x-atlan-task-guid": "f655a221-44bd-4122-82c5-c1a426dfc391"
        }
    }
}
```


## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
