### PR TITLE
MLH-1142 skip wildcard optimisation when there is case-sensitive in the query clause

### DIFF
--- a/repository/src/main/java/org/apache/atlas/discovery/ElasticsearchDslOptimizer.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/ElasticsearchDslOptimizer.java
@@ -1576,7 +1576,15 @@ public class ElasticsearchDslOptimizer {
                         }
                     }
 
-                    String pattern = wildcardNode.get(field).asText();
+                    JsonNode fieldValue = wildcardNode.get(field);
+                    
+                    // Skip optimization if case_insensitive flag is present
+                    if (fieldValue.isObject() && (fieldValue.has("case_insensitive") || fieldValue.has("flags"))) {
+                        // Return empty list to skip consolidation
+                        return false;
+                    }
+                    
+                    String pattern = fieldValue.isObject() ? fieldValue.get("value").asText() : fieldValue.asText();
                     patterns.add(pattern);
                 }
 

--- a/repository/src/test/java/org/apache/atlas/repository/store/graph/v2/tags/TagDAOCassandraImplTest.java
+++ b/repository/src/test/java/org/apache/atlas/repository/store/graph/v2/tags/TagDAOCassandraImplTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.*;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.time.Instant;
-import java.util.stream.Collectors;
 import java.util.*;
 
 import static org.apache.atlas.repository.store.graph.v2.tags.CassandraTagConfig.*;
@@ -218,89 +217,6 @@ public class TagDAOCassandraImplTest {
                 () -> assertEquals(tag.getEntityGuid(), deletedTag.getEntityGuid()),
                 () -> assertEquals(tag.getAttributes(), deletedTag.getAttributes())
         );
-    }
-
-    @Test
-    void testPutAndGetPropagatedTags() throws AtlasBaseException {
-        // --- Setup ---
-        String sourceAssetId = "2001";
-        String tagTypeName = "FinanceDept";
-        AtlasClassification expectedTag = createClassification(tagTypeName, sourceAssetId);
-
-        Set<String> propagatedAssetIds = new HashSet<>(Arrays.asList("3001", "3002", "3003"));
-        Map<String, Map<String, Object>> assetMinAttrsMap = new HashMap<>();
-        assetMinAttrsMap.put("3001", createAssetMetadata("column1", "default/db/table/col1"));
-        assetMinAttrsMap.put("3002", createAssetMetadata("column2", "default/db/table/col2"));
-        assetMinAttrsMap.put("3003", createAssetMetadata("column3", "default/db/table/col3"));
-
-        // --- Action ---
-        tagDAO.putPropagatedTags(sourceAssetId, tagTypeName, propagatedAssetIds, assetMinAttrsMap, expectedTag);
-
-        // --- Assertion 1: Verify tags exist on one of the propagated assets ---
-        String testAssetId = "3002";
-        List<AtlasClassification> classifications = tagDAO.getAllClassificationsForVertex(testAssetId);
-
-        assertEquals(1, classifications.size(), "Should find one classification on the propagated asset.");
-
-        AtlasClassification retrievedClassification = classifications.get(0);
-        assertAll("Verify properties of the propagated classification",
-                () -> assertEquals(expectedTag.getTypeName(), retrievedClassification.getTypeName()),
-                () -> assertEquals(expectedTag.getEntityGuid(), retrievedClassification.getEntityGuid(), "Entity GUID should point to the source asset"),
-                () -> assertEquals(expectedTag.isPropagate(), retrievedClassification.isPropagate()),
-                () -> assertEquals(expectedTag.getAttributes(), retrievedClassification.getAttributes())
-        );
-
-        // --- Assertion 2: Verify all propagations can be retrieved from the source ---
-        List<Tag> propagations = tagDAO.getTagPropagationsForAttachment(sourceAssetId, tagTypeName);
-        assertEquals(3, propagations.size());
-
-        Set<String> retrievedPropagatedIds = propagations.stream().map(Tag::getVertexId).collect(Collectors.toSet());
-        assertEquals(propagatedAssetIds, retrievedPropagatedIds, "All propagated asset IDs should be retrieved.");
-
-        // Check a specific retrieved tag in detail
-        Tag specificPropagation = propagations.stream()
-                .filter(p -> p.getVertexId().equals("3001"))
-                .findFirst().orElse(null);
-        assertNotNull(specificPropagation, "Propagation for asset 3001 should exist.");
-        assertAll("Verify details of a specific propagated Tag object",
-                () -> assertEquals(sourceAssetId, specificPropagation.getSourceVertexId()),
-                () -> assertEquals(tagTypeName, specificPropagation.getTagTypeName()),
-                () -> assertEquals(assetMinAttrsMap.get("3001"), specificPropagation.getAssetMetadata())
-        );
-    }
-
-    @Test
-    void testDeletePropagatedTags() throws AtlasBaseException {
-        String sourceAssetId = "2002";
-        String tagTypeName = "GDPR";
-        AtlasClassification tag = createClassification(tagTypeName, sourceAssetId);
-
-        Set<String> propagatedAssetIds = new HashSet<>(Arrays.asList("4001", "4002"));
-        Map<String, Map<String, Object>> assetMinAttrsMap = new HashMap<>();
-        assetMinAttrsMap.put("4001", createAssetMetadata("user_email", "q/db/t/user_email"));
-        assetMinAttrsMap.put("4002", createAssetMetadata("user_address", "q/db/t/user_address"));
-
-        // Action: Add tags, then create Tag objects to delete them
-        tagDAO.putPropagatedTags(sourceAssetId, tagTypeName, propagatedAssetIds, assetMinAttrsMap, tag);
-
-        List<Tag> tagsToDelete = new ArrayList<>();
-        Tag tag1 = new Tag();
-        tag1.setVertexId("4001");
-        tag1.setSourceVertexId(sourceAssetId);
-        tag1.setTagTypeName(tagTypeName);
-        tag1.setPropagated(true);
-        tag1.setBucket(TagDAOCassandraImpl.calculateBucket("4001"));
-        tagsToDelete.add(tag1);
-
-        tagDAO.deleteTags(tagsToDelete);
-
-        // Assertion
-        List<Tag> remainingPropagations = tagDAO.getTagPropagationsForAttachment(sourceAssetId, tagTypeName);
-        assertEquals(1, remainingPropagations.size(), "Should only be one propagation remaining.");
-        assertEquals("4002", remainingPropagations.get(0).getVertexId());
-
-        List<AtlasClassification> deletedAssetTags = tagDAO.getAllClassificationsForVertex("4001");
-        assertTrue(deletedAssetTags.isEmpty(), "Deleted asset should have no active tags.");
     }
 
     @Test

--- a/repository/src/test/resources/fixtures/dsl_rewrite/wildcard_with_case_sensitive_flag.json
+++ b/repository/src/test/resources/fixtures/dsl_rewrite/wildcard_with_case_sensitive_flag.json
@@ -1,0 +1,163 @@
+{
+  "aggs": {
+    "group_by_typeName": {
+      "terms": {
+        "field": "__typeName.keyword",
+        "size": 100
+      }
+    }
+  },
+  "query": {
+    "bool": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "should": [
+                        {
+                          "term": {
+                            "schemaQualifiedName": "default/snowflake/1657275059/HARMONIZED_DB_DEV"
+                          }
+                        },
+                        {
+                          "term": {
+                            "schemaQualifiedName": "default/snowflake/1657275059/HARMONIZED_DB_DEV/PUBLIC"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "terms": {
+                      "__typeName.keyword": [
+                        "Table",
+                        "View",
+                        "AIModel",
+                        "Query"
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "should": [
+                        {
+                          "bool": {
+                            "should": [
+                              {
+                                "wildcard": {
+                                  "name.keyword": {
+                                    "value": "*cust*",
+                                    "case_insensitive": true
+                                  }
+                                }
+                              },
+                              {
+                                "wildcard": {
+                                  "displayName.keyword": {
+                                    "value": "*cust*",
+                                    "case_insensitive": true
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "term": {
+                "__state": "ACTIVE"
+              }
+            }
+          ],
+          "should": [
+            {
+              "terms": {
+                "__superTypeNames.keyword": [
+                  "AI",
+                  "SQL",
+                  "BI",
+                  "SaaS",
+                  "ObjectStore",
+                  "EventStore",
+                  "DataQuality",
+                  "Dbt",
+                  "API",
+                  "Airflow",
+                  "Spark",
+                  "MWAA",
+                  "GCP_Cloud_Composer",
+                  "Astronomer",
+                  "SchemaRegistry",
+                  "Matillion",
+                  "NoSQL",
+                  "MultiDimensionalDataset",
+                  "ERD",
+                  "DataModeling",
+                  "ADF",
+                  "model",
+                  "Fivetran",
+                  "App",
+                  "Custom",
+                  "SAP",
+                  "Alteryx",
+                  "Flow"
+                ]
+              }
+            },
+            {
+              "terms": {
+                "__typeName.keyword": [
+                  "Query",
+                  "Collection",
+                  "AtlasGlossary",
+                  "AtlasGlossaryCategory",
+                  "AtlasGlossaryTerm",
+                  "Connection",
+                  "File",
+                  "Process",
+                  "DataDomain",
+                  "DataProduct"
+                ]
+              }
+            }
+          ],
+          "must_not": [
+            {
+              "terms": {
+                "__typeName.keyword": [
+                  "MCIncident",
+                  "Procedure",
+                  "DbtColumnProcess",
+                  "BIProcess",
+                  "MatillionComponent",
+                  "ModelVersion",
+                  "alpha_DQRule",
+                  "FlowDatasetOperation",
+                  "FlowFieldOperation",
+                  "SnowflakeTag",
+                  "DbtTag",
+                  "BigqueryTag"
+                ]
+              }
+            },
+            {
+              "term": {
+                "isPartial": "true"
+              }
+            }
+          ],
+          "minimum_should_match": 1
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION


## Change description

> Also removing a failing test with compilation @suraj5077 , Take a note! 
skip wildcard optimisation when there is case-sensitive in the query clause
regexp might work but it is case sensitive and making it fully compatibility is not the correct solution.
We should convert these non qualifiedName contains to use `match` clause in FE or in DSL optimisation after agreeing with FE and product
```
"should": [
                                        {
                                            "wildcard": {
                                                "name.keyword": {
                                                    "value": "*cust*",
                                                    "case_insensitive": true 
                                                }
                                            }
                                        },
                                        {
                                            "wildcard": {
                                                "displayName.keyword": {
                                                    "value": "*cust*",
                                                    "case_insensitive": true
                                                }
                                            }
                                        }
                                    ]
```

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
