### PR TITLE
MLH-1131 : add retry logic for update and delete

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -33,6 +33,7 @@ on:
       - interceptapis
       - mlh-965
       - mlh-498-use-spec-store-master
+      - mlh1131
 
 
 jobs:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -33,7 +33,6 @@ on:
       - interceptapis
       - mlh-965
       - mlh-498-use-spec-store-master
-      - mlh1131
 
 
 jobs:

--- a/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
@@ -784,7 +784,7 @@ public class TypesREST {
         this.redisService.releaseDistributedLock(typeDefLock);
     }
 
-    public AtlasTypesDef createTypeDefsWithRetry(AtlasTypesDef typesDef, String clientOrigin) throws AtlasBaseException {
+    private AtlasTypesDef createTypeDefsWithRetry(AtlasTypesDef typesDef, String clientOrigin) throws AtlasBaseException {
         AtlasBaseException lastException = null;
 
         for (int attempt = 1; attempt <= MAX_RETRIES; attempt++) {
@@ -829,7 +829,7 @@ public class TypesREST {
         throw lastException; // Should never reach here, but for completeness
     }
 
-    public AtlasTypesDef updateTypeDefsWithRetry(AtlasTypesDef typesDef, String clientOrigin) throws AtlasBaseException {
+    private AtlasTypesDef updateTypeDefsWithRetry(AtlasTypesDef typesDef, String clientOrigin) throws AtlasBaseException {
         AtlasBaseException lastException = null;
         boolean originalPatchingState = RequestContext.get().isInTypePatching();
 
@@ -876,7 +876,7 @@ public class TypesREST {
         throw lastException; // Should never reach here, but for completeness
     }
 
-    public void deleteTypeDefsWithRetry(AtlasTypesDef typesDef, String clientOrigin) throws AtlasBaseException {
+    private void deleteTypeDefsWithRetry(AtlasTypesDef typesDef, String clientOrigin) throws AtlasBaseException {
         AtlasBaseException lastException = null;
 
         for (int attempt = 1; attempt <= MAX_RETRIES; attempt++) {
@@ -915,7 +915,7 @@ public class TypesREST {
         throw lastException; // Should never reach here, but for completeness
     }
 
-    public void deleteTypeByNameWithRetry(String typeName) throws AtlasBaseException {
+    private void deleteTypeByNameWithRetry(String typeName) throws AtlasBaseException {
         AtlasBaseException lastException = null;
 
         for (int attempt = 1; attempt <= MAX_RETRIES; attempt++) {

--- a/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
@@ -831,6 +831,7 @@ public class TypesREST {
 
     public AtlasTypesDef updateTypeDefsWithRetry(AtlasTypesDef typesDef, String clientOrigin) throws AtlasBaseException {
         AtlasBaseException lastException = null;
+        boolean originalPatchingState = RequestContext.get().isInTypePatching();
 
         for (int attempt = 1; attempt <= MAX_RETRIES; attempt++) {
             try {
@@ -866,6 +867,9 @@ public class TypesREST {
                     LOG.error("Non-retryable error occurred", e);
                     throw e;
                 }
+            } finally {
+                // Always restore original patching state
+                RequestContext.get().setInTypePatching(originalPatchingState);
             }
         }
 

--- a/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
@@ -908,7 +908,7 @@ public class TypesREST {
             try {
                 // Perform the deletion
                 typeDefStore.deleteTypeByName(typeName);
-                typeCacheRefresher.refreshAllHostCache();
+                refreshAllHostCache(RequestContext.get().getTraceId(), null);
                 LOG.info("Successfully deleted typedef '{}' on attempt {}", typeName, attempt);
                 return;
 


### PR DESCRIPTION
## Change description

 **Issue:** 
Race condition in distributed Atlas deployments where typedef deletions don't sync across all pods, causing ATTRIBUTE_DELETION_NOT_SUPPORTED errors during recreation.

**Fix:** 
Added ATTRIBUTE_DELETION_NOT_SUPPORTED to retryable errors and implemented consistent retry logic (3 attempts, 1000ms delay) for all typedef CRUD operations.
PATCH added in update during retry and also for create irrespective of user input

**Scope:** 
Enhanced CREATE, UPDATE, DELETE bulk, and DELETE by name operations with identical retry patterns and unified cache refresh handling

## Type of change
- [X] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1](https://atlanhq.atlassian.net/browse/MLH-1131) 
