### PR TITLE
MLH-1163 return when edge or its typeName is empty

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -31,8 +31,7 @@ on:
       - tagscanarymerge
       - fixlabels
       - interceptapis
-      - mlh-965
-      - mlh-498-use-spec-store-master
+      - mlh-1163-master
 
 
 jobs:

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/SoftDeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/SoftDeleteHandlerV1.java
@@ -42,8 +42,7 @@ import static org.apache.atlas.model.instance.AtlasEntity.Status.DELETED;
 import static org.apache.atlas.repository.Constants.MODIFICATION_TIMESTAMP_PROPERTY_KEY;
 import static org.apache.atlas.repository.Constants.MODIFIED_BY_KEY;
 import static org.apache.atlas.repository.Constants.STATE_PROPERTY_KEY;
-import static org.apache.atlas.repository.graph.GraphHelper.getPropagatableClassifications;
-import static org.apache.atlas.repository.graph.GraphHelper.getPropagatableClassificationsV2;
+import static org.apache.atlas.repository.graph.GraphHelper.*;
 
 public class SoftDeleteHandlerV1 extends DeleteHandlerV1 {
 
@@ -78,8 +77,8 @@ public class SoftDeleteHandlerV1 extends DeleteHandlerV1 {
                 LOG.debug("==> SoftDeleteHandlerV1.deleteEdge({}, {})", GraphHelper.string(edge), force);
             }
 
-            if (edge == null) {
-                LOG.warn("Edge is null. Nothing to delete");
+            if (edge == null || getTypeName(edge) == null) {
+                LOG.warn("Edge is null or its typeName is empty. Nothing to delete");
                 return;
             }
 


### PR DESCRIPTION
## Change description

> return when edge or its typeName is empty

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues
https://atlanhq.atlassian.net/browse/MLH-1163
> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
