### PR TITLE
MLH-1260 | Updated error code to handle retries

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
@@ -190,7 +190,7 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
 
                     String responseBody = EntityUtils.toString(response.getEntity());
 
-                    if (statusCode >= 429 && statusCode < 600) {
+                    if ((statusCode >= 500 && statusCode < 600) || statusCode==429) {
                         LOG.warn("Failed to push entity audits to ES due to server error ({}). Retrying... ({}/{}) Response: {}",
                                 statusCode, retryCount + 1, maxRetries, responseBody);
                     } else {


### PR DESCRIPTION
## Change description

Error code 429 is thrown for circuit_breaking_exception on ES.

This can cause ES push to fail.

Retrying with exponential backoff might solve the issue.