### PR TITLE
MLH-1199 replace null with `this` in gauge builder

### DIFF
--- a/common/src/main/java/org/apache/atlas/service/FeatureFlagStore.java
+++ b/common/src/main/java/org/apache/atlas/service/FeatureFlagStore.java
@@ -83,8 +83,8 @@ public class FeatureFlagStore implements ApplicationContextAware {
                 // Add version tracking metric
                 MeterRegistry meterRegistry = org.apache.atlas.service.metrics.MetricUtils.getMeterRegistry();
                 Gauge.builder(METRIC_COMPONENT + "_atlas_version_enabled", 
-                            null, 
-                            unused -> isTagV2Enabled() ? 2.0 : 1.0)
+                            this,
+                            ref -> isTagV2Enabled() ? 2.0 : 1.0)
                     .description("Indicates which Tag propagation version is enabled (2.0 = v2, 1.0 = v1)")
                     .tag("component", "version")
                     .register(meterRegistry);


### PR DESCRIPTION
## Change description

> Replace null with `this` in gauge builder to get list of all v1 / v2 tenants

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues
https://atlanhq.atlassian.net/browse/MLH-1199
> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
