### PR TITLE
MLH-1240 revert all optimisations and keep current cinv based full refresh

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -31,7 +31,7 @@ on:
       - tagscanarymerge
       - fixlabels
       - interceptapis
-      - 1277-master
+      - revert-custom-metadata-changes
 
 jobs:
   build:

--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -538,13 +538,6 @@ public final class Constants {
         add(STAKEHOLDER_TITLE_ENTITY_TYPE);
     }};
 
-    public static final String TYPEDEF_ENUM_CACHE_LATEST_VERSION = "typdef.enum.cache.version";
-    public static final String TYPEDEF_BUSINESS_METADATA_CACHE_LATEST_VERSION = "typdef.bm.cache.version";
-    public static final String TYPEDEF_CLASSIFICATION_METADATA_CACHE_LATEST_VERSION = "typdef.cls.cache.version";
-    public static final String TYPEDEF_STRUCT_CACHE_LATEST_VERSION = "typdef.struct.cache.version";
-    public static final String TYPEDEF_ENTITY_CACHE_LATEST_VERSION = "typdef.entity.cache.version";
-    public static final String TYPEDEF_RELATIONSHIP_CACHE_LATEST_VERSION = "typdef.relationship.cache.version";
-
     private Constants() {
     }
 

--- a/common/src/main/java/org/apache/atlas/service/redis/AbstractRedisService.java
+++ b/common/src/main/java/org/apache/atlas/service/redis/AbstractRedisService.java
@@ -5,7 +5,6 @@ import org.apache.atlas.AtlasException;
 import org.apache.atlas.service.metrics.MetricUtils;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.lang.ArrayUtils;
-import org.apache.commons.lang.StringUtils;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
@@ -185,22 +184,6 @@ public abstract class AbstractRedisService implements RedisService {
     public String getValue(String key) {
         try {
             return (String) redisCacheClient.getBucket(convertToNamespace(key)).get();
-        } catch (Exception e) {
-            MetricUtils.recordRedisConnectionFailure();
-            getLogger().error("Redis getValue operation failed for key: {}", key, e);
-            throw e;
-        }
-    }
-
-    @Override
-    public String getValue(String key, String defaultValue) {
-        try {
-            String value = getValue(key);
-            if (StringUtils.isEmpty(value)) {
-                return defaultValue;
-            } else {
-                return value;
-            }
         } catch (Exception e) {
             MetricUtils.recordRedisConnectionFailure();
             getLogger().error("Redis getValue operation failed for key: {}", key, e);

--- a/common/src/main/java/org/apache/atlas/service/redis/RedisService.java
+++ b/common/src/main/java/org/apache/atlas/service/redis/RedisService.java
@@ -16,8 +16,6 @@ public interface RedisService {
 
   String getValue(String key);
 
-  String getValue(String key, String defaultValue);
-
   String putValue(String key, String value);
 
   String putValue(String key, String value, int timeout);

--- a/repository/src/main/java/org/apache/atlas/repository/graph/TypeCacheRefresher.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/TypeCacheRefresher.java
@@ -1,201 +1,190 @@
 package org.apache.atlas.repository.graph;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.atlas.ApplicationProperties;
+import org.apache.atlas.AtlasException;
+import org.apache.atlas.RequestContext;
 import org.apache.atlas.exception.AtlasBaseException;
-import org.apache.atlas.model.typedef.*;
-import org.apache.atlas.repository.store.bootstrap.AtlasTypeDefStoreInitializer;
-import org.apache.atlas.service.redis.RedisService;
-import org.apache.atlas.store.AtlasTypeDefStore;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.atlas.ha.HAConfiguration;
+import org.apache.atlas.repository.RepositoryException;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.lang.StringUtils;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.PostConstruct;
 import javax.inject.Inject;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.*;
 
-import static org.apache.atlas.repository.Constants.*;
+import static org.apache.atlas.AtlasErrorCode.CINV_UNHEALTHY;
+import static org.apache.atlas.repository.Constants.VERTEX_INDEX;
 
 @Component
 public class TypeCacheRefresher {
     private static final Logger LOG = LoggerFactory.getLogger(TypeCacheRefresher.class);
-    private final AtlasTypeDefStore typeDefStore;
-
-    // Define type metadata to make code generic
-    private static class TypeDefMetadata {
-        final String redisKey;
-        final String typeName;
-        final Supplier<Long> getCurrentVersion;
-        final Consumer<Long> setCurrentVersion;
-        final Runnable reloadTypeDefs;
-
-        TypeDefMetadata(String redisKey, String typeName, 
-                       Supplier<Long> getCurrentVersion, 
-                       Consumer<Long> setCurrentVersion,
-                       Runnable reloadTypeDefs) {
-            this.redisKey = redisKey;
-            this.typeName = typeName;
-            this.getCurrentVersion = getCurrentVersion;
-            this.setCurrentVersion = setCurrentVersion;
-            this.reloadTypeDefs = reloadTypeDefs;
-        }
-    }
-
-    // Map of all type definitions and their metadata
-    private final Map<Class<?>, TypeDefMetadata> typeDefMetadataMap;
+    private String cacheRefresherEndpoint;
+    private String cacheRefresherHealthEndpoint;
+    private final IAtlasGraphProvider provider;
+    private boolean isActiveActiveHAEnabled;
 
     @Inject
-    public TypeCacheRefresher(final AtlasTypeDefStore typeDefStore) {
-        this.typeDefStore = typeDefStore;
-        this.typeDefMetadataMap = new HashMap<>();
-
-        // Initialize metadata for each type
-        typeDefMetadataMap.put(AtlasBusinessMetadataDef.class, new TypeDefMetadata(
-            TYPEDEF_BUSINESS_METADATA_CACHE_LATEST_VERSION,
-            "BM",
-            AtlasTypeDefStoreInitializer::getCurrentBMTypedefInternalVersion,
-            AtlasTypeDefStoreInitializer::setCurrentBMTypedefInternalVersion,
-            () -> {
-                try {
-                    typeDefStore.reloadBusinessMetadataTypeDefs();
-                } catch (AtlasBaseException e) {
-                    LOG.error("Error reloading BM typedefs", e);
-                }
-            }
-        ));
-
-        typeDefMetadataMap.put(AtlasClassificationDef.class, new TypeDefMetadata(
-            TYPEDEF_CLASSIFICATION_METADATA_CACHE_LATEST_VERSION,
-            "Classification",
-            AtlasTypeDefStoreInitializer::getCurrentClassificationTypedefInternalVersion,
-            AtlasTypeDefStoreInitializer::setCurrentClassificationTypedefInternalVersion,
-            () -> {
-                try {
-                    typeDefStore.reloadClassificationMetadataTypeDefs();
-                } catch (AtlasBaseException e) {
-                    LOG.error("Error reloading Classification typedefs", e);
-                }
-            }
-        ));
-
-        typeDefMetadataMap.put(AtlasEnumDef.class, new TypeDefMetadata(
-            TYPEDEF_ENUM_CACHE_LATEST_VERSION,
-            "Enum",
-            AtlasTypeDefStoreInitializer::getCurrentEnumTypedefInternalVersion,
-            AtlasTypeDefStoreInitializer::setCurrentEnumTypedefInternalVersion,
-            () -> {
-                try {
-                    typeDefStore.reloadEnumTypeDefs();
-                } catch (AtlasBaseException e) {
-                    LOG.error("Error reloading Enum typedefs", e);
-                }
-            }
-        ));
-
-        typeDefMetadataMap.put(AtlasStructDef.class, new TypeDefMetadata(
-            TYPEDEF_STRUCT_CACHE_LATEST_VERSION,
-            "Struct",
-            AtlasTypeDefStoreInitializer::getCurrentStructTypedefInternalVersion,
-            AtlasTypeDefStoreInitializer::setCurrentStructTypedefInternalVersion,
-            () -> {
-                try {
-                    typeDefStore.reloadStructTypeDefs();
-                } catch (AtlasBaseException e) {
-                    LOG.error("Error reloading Struct typedefs", e);
-                }
-            }
-        ));
-
-        typeDefMetadataMap.put(AtlasEntityDef.class, new TypeDefMetadata(
-            TYPEDEF_ENTITY_CACHE_LATEST_VERSION,
-            "Entity",
-            AtlasTypeDefStoreInitializer::getCurrentEntityTypedefInternalVersion,
-            AtlasTypeDefStoreInitializer::setCurrentEntityTypedefInternalVersion,
-            () -> {
-                try {
-                    typeDefStore.reloadEntityTypeDefs();
-                } catch (AtlasBaseException e) {
-                    LOG.error("Error reloading Entity typedefs", e);
-                }
-            }
-        ));
-
-        typeDefMetadataMap.put(AtlasRelationshipDef.class, new TypeDefMetadata(
-            TYPEDEF_RELATIONSHIP_CACHE_LATEST_VERSION,
-            "Relationship",
-            AtlasTypeDefStoreInitializer::getCurrentRelationshipTypedefInternalVersion,
-            AtlasTypeDefStoreInitializer::setCurrentRelationshipTypedefInternalVersion,
-            () -> {
-                try {
-                    typeDefStore.reloadRelationshipTypeDefs();
-                } catch (AtlasBaseException e) {
-                    LOG.error("Error reloading Relationship typedefs", e);
-                }
-            }
-        ));
+    public TypeCacheRefresher(final IAtlasGraphProvider provider) {
+        this.provider = provider;
     }
 
-    public void refreshCacheIfNeeded(RedisService redisService) throws AtlasBaseException {
-        for (TypeDefMetadata metadata : typeDefMetadataMap.values()) {
-            if (isTypeDefCacheRefreshNeeded(redisService, metadata)) {
-                LOG.info("Refreshing {} type-def cache as the version is different from latest", metadata.typeName);
-                metadata.reloadTypeDefs.run();
-                long currentRedisVersion = Long.parseLong(redisService.getValue(metadata.redisKey, "1"));
-                metadata.setCurrentVersion.accept(currentRedisVersion);
-            }
+    @PostConstruct
+    public void init() throws AtlasException {
+        Configuration configuration = ApplicationProperties.get();
+        this.cacheRefresherEndpoint = configuration.getString("atlas.server.type.cache-refresher");
+        this.cacheRefresherHealthEndpoint = configuration.getString("atlas.server.type.cache-refresher-health");
+        this.isActiveActiveHAEnabled = HAConfiguration.isActiveActiveHAEnabled(configuration);
+        LOG.info("Found {} as cache-refresher endpoint", cacheRefresherEndpoint);
+        LOG.info("Found {} as cache-refresher-health endpoint", cacheRefresherHealthEndpoint);
+    }
+
+    public void verifyCacheRefresherHealth() throws AtlasBaseException, IOException {
+        if (StringUtils.isBlank(cacheRefresherHealthEndpoint) || !isActiveActiveHAEnabled) {
+            LOG.info("Skipping type-def cache refresher health checking as URL is {} and isActiveActiveHAEnabled is {}", cacheRefresherHealthEndpoint, isActiveActiveHAEnabled);
+            return;
+        }
+        final String healthResponseBody;
+        try (CloseableHttpClient client = HttpClients.createDefault()) {
+            final HttpGet healthRequest = new HttpGet(cacheRefresherHealthEndpoint);
+            healthResponseBody = executeGet(client, healthRequest);
+        }
+        LOG.debug("Response Body from cache-refresh-health = {}", healthResponseBody);
+        final ObjectMapper mapper = new ObjectMapper();
+        final CacheRefresherHealthResponse jsonResponse = mapper.readValue(healthResponseBody, CacheRefresherHealthResponse.class);
+        if (!"Healthy".equalsIgnoreCase(jsonResponse.getMessage())) {
+            throw new AtlasBaseException(CINV_UNHEALTHY);
         }
     }
 
-    private boolean isTypeDefCacheRefreshNeeded(RedisService redisService, TypeDefMetadata metadata) {
-        long currentRedisVersion = Long.parseLong(redisService.getValue(metadata.redisKey, "1"));
-        long currentInternalVersion = metadata.getCurrentVersion.get();
-        LOG.info("Current Redis {} typedef version: {}, Latest {} typedef version: {}", 
-                metadata.typeName, currentRedisVersion, metadata.typeName, currentInternalVersion);
-        return currentInternalVersion < currentRedisVersion;
-    }
-
-    public void updateVersion(RedisService redisService, AtlasTypesDef atlasTypesDef) {
-        if (atlasTypesDef == null) {
+    public void refreshAllHostCache() throws IOException, URISyntaxException, RepositoryException {
+        final String traceId = RequestContext.get().getTraceId();
+        if(StringUtils.isBlank(cacheRefresherEndpoint) || !isActiveActiveHAEnabled) {
+            LOG.info("Skipping type-def cache refresh :: traceId {}", traceId);
             return;
         }
 
-        updateTypeDefVersions(redisService, atlasTypesDef.getBusinessMetadataDefs(), AtlasBusinessMetadataDef.class);
-        updateTypeDefVersions(redisService, atlasTypesDef.getClassificationDefs(), AtlasClassificationDef.class);
-        updateTypeDefVersions(redisService, atlasTypesDef.getEnumDefs(), AtlasEnumDef.class);
-        updateTypeDefVersions(redisService, atlasTypesDef.getStructDefs(), AtlasStructDef.class);
-        updateTypeDefVersions(redisService, atlasTypesDef.getEntityDefs(), AtlasEntityDef.class);
-        updateTypeDefVersions(redisService, atlasTypesDef.getRelationshipDefs(), AtlasRelationshipDef.class);
+        int totalFieldKeys = provider.get().getManagementSystem().getGraphIndex(VERTEX_INDEX).getFieldKeys().size();
+        LOG.info("Found {} totalFieldKeys to be expected in other nodes :: traceId {}", totalFieldKeys, traceId);
+        refreshCache(totalFieldKeys, traceId);
     }
 
-    private <T extends AtlasBaseTypeDef> void updateTypeDefVersions(RedisService redisService, 
-                                                                   List<T> typeDefs, 
-                                                                   Class<T> typeClass) {
-        if (CollectionUtils.isNotEmpty(typeDefs)) {
-            TypeDefMetadata metadata = typeDefMetadataMap.get(typeClass);
-            if (metadata != null) {
-                long latestVersion = Long.parseLong(redisService.getValue(metadata.redisKey, "1")) + 1;
-                String latestVersionStr = String.valueOf(latestVersion);
-                redisService.putValue(metadata.redisKey, latestVersionStr);
-                metadata.setCurrentVersion.accept(latestVersion);
+    private void refreshCache(final int totalFieldKeys, final String traceId) throws IOException, URISyntaxException {
+        URIBuilder builder = new URIBuilder(cacheRefresherEndpoint);
+        builder.setParameter("expectedFieldKeys", String.valueOf(totalFieldKeys));
+        builder.setParameter("traceId", traceId);
+        final HttpPost httpPost = new HttpPost(builder.build());
+        LOG.info("Invoking cache refresh endpoint {} :: traceId {}", cacheRefresherEndpoint, traceId);
+
+        String responseBody;
+        try (CloseableHttpClient client = HttpClients.createDefault()) {
+            responseBody = executePost(traceId, client, httpPost);
+        }
+        LOG.info("Response Body from cache-refresh = {} :: traceId {}", responseBody, traceId);
+        CacheRefreshResponseEnvelope cacheRefreshResponseEnvelope = convertStringToObject(responseBody);
+
+        for (CacheRefreshResponse responseOfEachNode : cacheRefreshResponseEnvelope.getResponse()) {
+            if (responseOfEachNode.getStatus() != 204) {
+                //Do not throw exception in this case as node must have been in passive state now
+                LOG.error("Error while performing cache refresh on host {} . HTTP code = {} :: traceId {}", responseOfEachNode.getHost(),
+                        responseOfEachNode.getStatus(), traceId);
+            } else {
+                LOG.info("Host {} returns response code {} :: traceId {}", responseOfEachNode.getHost(), responseOfEachNode.getStatus(), traceId);
             }
         }
+        LOG.info("Refreshed cache successfully on all hosts :: traceId {}", traceId);
     }
 
-    public void updateVersion(RedisService redisService, AtlasBaseTypeDef atlasBaseTypeDef) {
-        if (atlasBaseTypeDef == null) {
-            return;
-        }
-
-        TypeDefMetadata metadata = typeDefMetadataMap.get(atlasBaseTypeDef.getClass());
-        if (metadata != null) {
-            long latestVersion = Long.parseLong(redisService.getValue(metadata.redisKey, "1")) + 1;
-            String latestVersionStr = String.valueOf(latestVersion);
-            redisService.putValue(metadata.redisKey, latestVersionStr);
-            metadata.setCurrentVersion.accept(latestVersion);
+    private String executePost(String traceId, CloseableHttpClient client, HttpPost httpPost) throws IOException {
+        try (CloseableHttpResponse response = client.execute(httpPost)) {
+            LOG.info("Received HTTP response code {} from cache refresh endpoint :: traceId {}", response.getStatusLine().getStatusCode(), traceId);
+            if (response.getStatusLine().getStatusCode() != 200) {
+                throw new RuntimeException("Error while calling cache-refresher on host " + cacheRefresherEndpoint + ". HTTP code = " + response.getStatusLine().getStatusCode() + " :: traceId " + traceId);
+            }
+            return EntityUtils.toString(response.getEntity());
         }
     }
 
+    private String executeGet(CloseableHttpClient client, HttpGet getRequest) throws IOException, AtlasBaseException {
+        try (CloseableHttpResponse closeableHttpResponse = client.execute(getRequest)) {
+            LOG.info("Received HTTP response code {} from cache refresh health endpoint", closeableHttpResponse.getStatusLine().getStatusCode());
+            if (closeableHttpResponse.getStatusLine().getStatusCode() != 200) {
+                throw new AtlasBaseException(CINV_UNHEALTHY);
+            }
+            return EntityUtils.toString(closeableHttpResponse.getEntity());
+        }
+    }
+
+    private CacheRefreshResponseEnvelope convertStringToObject(final String responseBody) throws JsonProcessingException {
+        final ObjectMapper mapper = new ObjectMapper();
+        return mapper.readValue(responseBody, CacheRefreshResponseEnvelope.class);
+    }
+}
+
+class CacheRefreshResponseEnvelope {
+    private List<CacheRefreshResponse> response;
+
+    public List<CacheRefreshResponse> getResponse() {
+        return response;
+    }
+
+    public void setResponse(List<CacheRefreshResponse> response) {
+        this.response = response;
+    }
+}
+
+class CacheRefreshResponse {
+    private String host;
+    private int status;
+    private Map<String,String> headers;
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+
+    public void setStatus(int status) {
+        this.status = status;
+    }
+
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
+    public void setHeaders(Map<String, String> headers) {
+        this.headers = headers;
+    }
+}
+
+class CacheRefresherHealthResponse {
+    private String message;
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
 }

--- a/repository/src/main/java/org/apache/atlas/repository/store/bootstrap/AtlasTypeDefStoreInitializer.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/bootstrap/AtlasTypeDefStoreInitializer.java
@@ -50,7 +50,6 @@ import org.apache.atlas.repository.patches.AddMandatoryAttributesPatch;
 import org.apache.atlas.repository.patches.SuperTypesUpdatePatch;
 import org.apache.atlas.repository.patches.AtlasPatchManager;
 import org.apache.atlas.repository.patches.AtlasPatchRegistry;
-import org.apache.atlas.service.redis.RedisService;
 import org.apache.atlas.store.AtlasTypeDefStore;
 import org.apache.atlas.type.AtlasEntityType;
 import org.apache.atlas.type.AtlasStructType.AtlasAttribute;
@@ -102,23 +101,15 @@ public class AtlasTypeDefStoreInitializer implements ActiveStateChangeHandler {
     private final Configuration     conf;
     private final AtlasGraph        graph;
     private final AtlasPatchManager patchManager;
-    private final RedisService redisService;
-    private static long CURRENT_ENUM_TYPEDEF_INTERNAL_VERSION;
-    private static long CURRENT_BUSINESS_METADATA_TYPEDEF_INTERNAL_VERSION;
-    private static long CURRENT_CLASSIFICATION_TYPEDEF_INTERNAL_VERSION;
-    private static long CURRENT_STRUCT_TYPEDEF_INTERNAL_VERSION;
-    private static long CURRENT_ENTITY_TYPEDEF_INTERNAL_VERSION;
-    private static long CURRENT_RELATIONSHIP_TYPEDEF_INTERNAL_VERSION;
 
     @Inject
     public AtlasTypeDefStoreInitializer(AtlasTypeDefStore typeDefStore, AtlasTypeRegistry typeRegistry,
-                                        AtlasGraph graph, Configuration conf, AtlasPatchManager patchManager, RedisService redisService) throws AtlasBaseException {
+                                        AtlasGraph graph, Configuration conf, AtlasPatchManager patchManager) throws AtlasBaseException {
         this.typeDefStore  = typeDefStore;
         this.typeRegistry  = typeRegistry;
         this.conf          = conf;
         this.graph         = graph;
         this.patchManager  = patchManager;
-        this.redisService = redisService;
     }
 
     @PostConstruct
@@ -127,12 +118,6 @@ public class AtlasTypeDefStoreInitializer implements ActiveStateChangeHandler {
 
         if (!HAConfiguration.isHAEnabled(conf)) {
             startInternal();
-            CURRENT_ENUM_TYPEDEF_INTERNAL_VERSION = Long.parseLong(redisService.getValue(Constants.TYPEDEF_ENUM_CACHE_LATEST_VERSION, "1"));
-            CURRENT_BUSINESS_METADATA_TYPEDEF_INTERNAL_VERSION = Long.parseLong(redisService.getValue(Constants.TYPEDEF_BUSINESS_METADATA_CACHE_LATEST_VERSION, "1"));
-            CURRENT_CLASSIFICATION_TYPEDEF_INTERNAL_VERSION = Long.parseLong(redisService.getValue(Constants.TYPEDEF_CLASSIFICATION_METADATA_CACHE_LATEST_VERSION, "1"));
-            CURRENT_STRUCT_TYPEDEF_INTERNAL_VERSION = Long.parseLong(redisService.getValue(Constants.TYPEDEF_STRUCT_CACHE_LATEST_VERSION, "1"));
-            CURRENT_ENTITY_TYPEDEF_INTERNAL_VERSION = Long.parseLong(redisService.getValue(Constants.TYPEDEF_ENTITY_CACHE_LATEST_VERSION, "1"));
-            CURRENT_RELATIONSHIP_TYPEDEF_INTERNAL_VERSION = Long.parseLong(redisService.getValue(Constants.TYPEDEF_RELATIONSHIP_CACHE_LATEST_VERSION, "1"));
         } else {
             LOG.info("AtlasTypeDefStoreInitializer.init(): deferring type loading until instance activation");
         }
@@ -420,54 +405,6 @@ public class AtlasTypeDefStoreInitializer implements ActiveStateChangeHandler {
     @Override
     public int getHandlerOrder() {
         return HandlerOrder.TYPEDEF_STORE_INITIALIZER.getOrder();
-    }
-
-    public static long getCurrentEnumTypedefInternalVersion() {
-        return CURRENT_ENUM_TYPEDEF_INTERNAL_VERSION;
-    }
-
-    public static void setCurrentEnumTypedefInternalVersion(long version) {
-        CURRENT_ENUM_TYPEDEF_INTERNAL_VERSION = version;
-    }
-
-    public static long getCurrentBMTypedefInternalVersion() {
-        return CURRENT_BUSINESS_METADATA_TYPEDEF_INTERNAL_VERSION;
-    }
-
-    public static void setCurrentBMTypedefInternalVersion(long version) {
-        CURRENT_BUSINESS_METADATA_TYPEDEF_INTERNAL_VERSION = version;
-    }
-
-    public static long getCurrentClassificationTypedefInternalVersion() {
-        return CURRENT_CLASSIFICATION_TYPEDEF_INTERNAL_VERSION;
-    }
-
-    public static void setCurrentClassificationTypedefInternalVersion(long version) {
-        CURRENT_CLASSIFICATION_TYPEDEF_INTERNAL_VERSION = version;
-    }
-
-    public static long getCurrentStructTypedefInternalVersion() {
-        return CURRENT_STRUCT_TYPEDEF_INTERNAL_VERSION;
-    }
-
-    public static void setCurrentStructTypedefInternalVersion(long version) {
-        CURRENT_STRUCT_TYPEDEF_INTERNAL_VERSION = version;
-    }
-
-    public static long getCurrentEntityTypedefInternalVersion() {
-        return CURRENT_ENTITY_TYPEDEF_INTERNAL_VERSION;
-    }
-
-    public static void setCurrentEntityTypedefInternalVersion(long version) {
-        CURRENT_ENTITY_TYPEDEF_INTERNAL_VERSION = version;
-    }
-
-    public static long getCurrentRelationshipTypedefInternalVersion() {
-        return CURRENT_RELATIONSHIP_TYPEDEF_INTERNAL_VERSION;
-    }
-
-    public static void setCurrentRelationshipTypedefInternalVersion(long version) {
-        CURRENT_RELATIONSHIP_TYPEDEF_INTERNAL_VERSION = version;
     }
 
     private static boolean updateTypeAttributes(AtlasStructDef oldStructDef, AtlasStructDef newStructDef, boolean checkTypeVersion) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasTypeDefGraphStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasTypeDefGraphStore.java
@@ -123,135 +123,17 @@ public abstract class AtlasTypeDefGraphStore implements AtlasTypeDefStore {
     }
 
     @Override
-    public void reloadEnumTypeDefs() throws AtlasBaseException {
-        LOG.info("==> AtlasTypeDefGraphStore.reloadEnumTypeDefs()");
-        AtlasTransientTypeRegistry ttr           = null;
-        boolean                    commitUpdates = false;
+    public void initWithoutLock() throws AtlasBaseException {
+        // need even better approach than this
+        AtlasTypesDef typesDef = new AtlasTypesDef(getEnumDefStore(typeRegistry).getAll(),
+                getStructDefStore(typeRegistry).getAll(),
+                getClassificationDefStore(typeRegistry).getAll(),
+                getEntityDefStore(typeRegistry).getAll(),
+                getRelationshipDefStore(typeRegistry).getAll(),
+                getBusinessMetadataDefStore(typeRegistry).getAll());
 
-        try {
-            ttr = typeRegistry.lockTypeRegistryForUpdate(5);
-            List<AtlasEnumDef> enumDefs = getEnumDefStore(ttr).getAll();
-            for (AtlasBaseTypeDef atlasBaseTypeDef : ttr.getAllEnumDefs()) {
-                if (atlasBaseTypeDef instanceof AtlasEnumDef) {
-                    ttr.removeTypeByName(atlasBaseTypeDef.getName());
-                }
-            }
-            ttr.addTypes(enumDefs);
-            commitUpdates = true;
-        } finally {
-            typeRegistry.releaseTypeRegistryForUpdate(ttr, commitUpdates);
-            LOG.info("<== AtlasTypeDefGraphStore.reloadEnumTypeDefs()");
-        }
-    }
-
-    @Override
-    public void reloadStructTypeDefs() throws AtlasBaseException {
-        LOG.info("==> AtlasTypeDefGraphStore.reloadStructTypeDefs()");
-        AtlasTransientTypeRegistry ttr = null;
-        boolean commitUpdates = false;
-
-        try {
-            ttr = typeRegistry.lockTypeRegistryForUpdate(5);
-            List<AtlasStructDef> structDefs = getStructDefStore(ttr).getAll();
-            for (AtlasBaseTypeDef atlasBaseTypeDef : ttr.getAllStructDefs()) {
-                if (atlasBaseTypeDef instanceof AtlasStructDef) {
-                    ttr.removeTypeByName(atlasBaseTypeDef.getName());
-                }
-            }
-            ttr.addTypes(structDefs);
-            commitUpdates = true;
-        } finally {
-            typeRegistry.releaseTypeRegistryForUpdate(ttr, commitUpdates);
-            LOG.info("<== AtlasTypeDefGraphStore.reloadStructTypeDefs()");
-        }
-    }
-
-    @Override
-    public void reloadEntityTypeDefs() throws AtlasBaseException {
-        LOG.info("==> AtlasTypeDefGraphStore.reloadEntityTypeDefs()");
-        AtlasTransientTypeRegistry ttr = null;
-        boolean commitUpdates = false;
-
-        try {
-            ttr = typeRegistry.lockTypeRegistryForUpdate(5);
-            List<AtlasEntityDef> entityDefs = getEntityDefStore(ttr).getAll();
-            for (AtlasBaseTypeDef atlasBaseTypeDef : ttr.getAllEntityDefs()) {
-                if (atlasBaseTypeDef instanceof AtlasEntityDef) {
-                    ttr.removeTypeByName(atlasBaseTypeDef.getName());
-                }
-            }
-            ttr.addTypes(entityDefs);
-            commitUpdates = true;
-        } finally {
-            typeRegistry.releaseTypeRegistryForUpdate(ttr, commitUpdates);
-            LOG.info("<== AtlasTypeDefGraphStore.reloadEntityTypeDefs()");
-        }
-    }
-
-    @Override
-    public void reloadRelationshipTypeDefs() throws AtlasBaseException {
-        LOG.info("==> AtlasTypeDefGraphStore.reloadRelationshipTypeDefs()");
-        AtlasTransientTypeRegistry ttr = null;
-        boolean commitUpdates = false;
-
-        try {
-            ttr = typeRegistry.lockTypeRegistryForUpdate(5);
-            List<AtlasRelationshipDef> relationshipDefs = getRelationshipDefStore(ttr).getAll();
-            for (AtlasBaseTypeDef atlasBaseTypeDef : ttr.getAllRelationshipDefs()) {
-                if (atlasBaseTypeDef instanceof AtlasRelationshipDef) {
-                    ttr.removeTypeByName(atlasBaseTypeDef.getName());
-                }
-            }
-            ttr.addTypes(relationshipDefs);
-            commitUpdates = true;
-        } finally {
-            typeRegistry.releaseTypeRegistryForUpdate(ttr, commitUpdates);
-            LOG.info("<== AtlasTypeDefGraphStore.reloadRelationshipTypeDefs()");
-        }
-    }
-
-    @Override
-    public void reloadBusinessMetadataTypeDefs() throws AtlasBaseException {
-        LOG.info("==> AtlasTypeDefGraphStore.reloadBusinessMetadataTypeDefs()");
-        AtlasTransientTypeRegistry ttr           = null;
-        boolean                    commitUpdates = false;
-
-        try {
-            ttr = typeRegistry.lockTypeRegistryForUpdate(5);
-            List<AtlasBusinessMetadataDef> businessMetadataDefs = getBusinessMetadataDefStore(ttr).getAll();
-            for (AtlasBaseTypeDef atlasBaseTypeDef : ttr.getAllBusinessMetadataDefs()) {
-                if (atlasBaseTypeDef instanceof AtlasBusinessMetadataDef) {
-                    ttr.removeTypeByName(atlasBaseTypeDef.getName());
-                }
-            }
-            ttr.addTypes(businessMetadataDefs);
-            commitUpdates = true;
-        } finally {
-            typeRegistry.releaseTypeRegistryForUpdate(ttr, commitUpdates);
-            LOG.info("<== AtlasTypeDefGraphStore.reloadBusinessMetadataTypeDefs()");
-        }
-    }
-
-    @Override
-    public void reloadClassificationMetadataTypeDefs() throws AtlasBaseException {
-        LOG.info("==> AtlasTypeDefGraphStore.reloadClassificationMetadataTypeDefs()");
-        AtlasTransientTypeRegistry ttr           = null;
-        boolean                    commitUpdates = false;
-
-        try {
-            ttr = typeRegistry.lockTypeRegistryForUpdate(5);
-            List<AtlasClassificationDef> classificationDefs = getClassificationDefStore(ttr).getAll();
-            for (AtlasBaseTypeDef atlasBaseTypeDef : ttr.getAllClassificationDefs()) {
-                if (atlasBaseTypeDef instanceof AtlasClassificationDef) {
-                    ttr.removeTypeByName(atlasBaseTypeDef.getName());
-                }
-            }
-            ttr.addTypes(classificationDefs);
-            commitUpdates = true;
-        } finally {
-            typeRegistry.releaseTypeRegistryForUpdate(ttr, commitUpdates);
-            LOG.info("<== AtlasTypeDefGraphStore.reloadClassificationMetadataTypeDefs()");
-        }
+        rectifyTypeErrorsIfAny(typesDef);
+        typeRegistry.addTypes(typesDef);
     }
 
     @Override
@@ -831,7 +713,7 @@ public abstract class AtlasTypeDefGraphStore implements AtlasTypeDefStore {
 
     @Override
     @GraphTransaction
-    public AtlasBaseTypeDef deleteTypeByName(String typeName) throws AtlasBaseException {
+    public void deleteTypeByName(String typeName) throws AtlasBaseException {
         AtlasType atlasType = typeRegistry.getType(typeName);
         if (atlasType == null) {
             throw new AtlasBaseException(AtlasErrorCode.INVALID_PARAMETERS.TYPE_NAME_NOT_FOUND, typeName);
@@ -855,58 +737,52 @@ public abstract class AtlasTypeDefGraphStore implements AtlasTypeDefStore {
         }
 
         deleteTypesDef(typesDef);
-        return baseTypeDef;
     }
 
     @Override
     public AtlasTypesDef searchTypesDef(SearchFilter searchFilter) throws AtlasBaseException {
         final AtlasTypesDef typesDef = new AtlasTypesDef();
         Predicate searchPredicates = FilterUtil.getPredicateFromSearchFilter(searchFilter);
-        AtlasTransientTypeRegistry ttr = null;
-        try {
-            ttr = typeRegistry.lockTypeRegistryForUpdate(5);
-            for (AtlasEnumType enumType : ttr.getAllEnumTypes()) {
-                if (searchPredicates.evaluate(enumType)) {
-                    typesDef.getEnumDefs().add(enumType.getEnumDef());
-                }
+
+        for(AtlasEnumType enumType : typeRegistry.getAllEnumTypes()) {
+            if (searchPredicates.evaluate(enumType)) {
+                typesDef.getEnumDefs().add(enumType.getEnumDef());
             }
-
-            for (AtlasStructType structType : ttr.getAllStructTypes()) {
-                if (searchPredicates.evaluate(structType)) {
-                    typesDef.getStructDefs().add(structType.getStructDef());
-                }
-            }
-
-            for (AtlasClassificationType classificationType : ttr.getAllClassificationTypes()) {
-                if (searchPredicates.evaluate(classificationType)) {
-                    typesDef.getClassificationDefs().add(classificationType.getClassificationDef());
-                }
-            }
-
-            for (AtlasEntityType entityType : ttr.getAllEntityTypes()) {
-                if (searchPredicates.evaluate(entityType)) {
-                    typesDef.getEntityDefs().add(entityType.getEntityDef());
-                }
-            }
-
-            for (AtlasRelationshipType relationshipType : ttr.getAllRelationshipTypes()) {
-                if (searchPredicates.evaluate(relationshipType)) {
-                    typesDef.getRelationshipDefs().add(relationshipType.getRelationshipDef());
-                }
-            }
-
-            for (AtlasBusinessMetadataType businessMetadataType : ttr.getAllBusinessMetadataTypes()) {
-                if (searchPredicates.evaluate(businessMetadataType)) {
-                    typesDef.getBusinessMetadataDefs().add(businessMetadataType.getBusinessMetadataDef());
-                }
-            }
-
-            AtlasAuthorizationUtils.filterTypesDef(new AtlasTypesDefFilterRequest(typesDef));
-
-            return typesDef;
-        } finally {
-                typeRegistry.releaseTypeRegistryForUpdate(ttr, false);
         }
+
+        for(AtlasStructType structType : typeRegistry.getAllStructTypes()) {
+            if (searchPredicates.evaluate(structType)) {
+                typesDef.getStructDefs().add(structType.getStructDef());
+            }
+        }
+
+        for(AtlasClassificationType classificationType : typeRegistry.getAllClassificationTypes()) {
+            if (searchPredicates.evaluate(classificationType)) {
+                typesDef.getClassificationDefs().add(classificationType.getClassificationDef());
+            }
+        }
+
+        for(AtlasEntityType entityType : typeRegistry.getAllEntityTypes()) {
+            if (searchPredicates.evaluate(entityType)) {
+                typesDef.getEntityDefs().add(entityType.getEntityDef());
+            }
+        }
+
+        for(AtlasRelationshipType relationshipType : typeRegistry.getAllRelationshipTypes()) {
+            if (searchPredicates.evaluate(relationshipType)) {
+                typesDef.getRelationshipDefs().add(relationshipType.getRelationshipDef());
+            }
+        }
+
+        for(AtlasBusinessMetadataType businessMetadataType : typeRegistry.getAllBusinessMetadataTypes()) {
+            if (searchPredicates.evaluate(businessMetadataType)) {
+                typesDef.getBusinessMetadataDefs().add(businessMetadataType.getBusinessMetadataDef());
+            }
+        }
+
+        AtlasAuthorizationUtils.filterTypesDef(new AtlasTypesDefFilterRequest(typesDef));
+
+        return typesDef;
     }
 
     @Override

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasTypeDefGraphStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasTypeDefGraphStore.java
@@ -123,20 +123,6 @@ public abstract class AtlasTypeDefGraphStore implements AtlasTypeDefStore {
     }
 
     @Override
-    public void initWithoutLock() throws AtlasBaseException {
-        // need even better approach than this
-        AtlasTypesDef typesDef = new AtlasTypesDef(getEnumDefStore(typeRegistry).getAll(),
-                getStructDefStore(typeRegistry).getAll(),
-                getClassificationDefStore(typeRegistry).getAll(),
-                getEntityDefStore(typeRegistry).getAll(),
-                getRelationshipDefStore(typeRegistry).getAll(),
-                getBusinessMetadataDefStore(typeRegistry).getAll());
-
-        rectifyTypeErrorsIfAny(typesDef);
-        typeRegistry.addTypes(typesDef);
-    }
-
-    @Override
     public AtlasEnumDef getEnumDefByName(String name) throws AtlasBaseException {
         AtlasEnumDef ret = typeRegistry.getEnumDefByName(name);
         if (ret == null) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasTypeDefGraphStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasTypeDefGraphStoreV2.java
@@ -122,16 +122,6 @@ public class AtlasTypeDefGraphStoreV2 extends AtlasTypeDefGraphStore {
         LOG.info("<== AtlasTypeDefGraphStoreV1.init()");
     }
 
-    @Override
-    @GraphTransaction
-    public void initWithoutLock() throws AtlasBaseException {
-        LOG.info("==> AtlasTypeDefGraphStoreV1.initWithoutLock()");
-
-        super.initWithoutLock();
-
-        LOG.info("<== AtlasTypeDefGraphStoreV1.initWithoutLock()");
-    }
-
     AtlasGraph getAtlasGraph() { return atlasGraph; }
 
     @VisibleForTesting

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasTypeDefGraphStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasTypeDefGraphStoreV2.java
@@ -22,12 +22,9 @@ import com.google.common.base.Preconditions;
 import org.apache.atlas.AtlasErrorCode;
 import org.apache.atlas.RequestContext;
 import org.apache.atlas.annotation.GraphTransaction;
-import org.apache.atlas.authorize.AtlasTypesDefFilterRequest;
-import org.apache.atlas.authorizer.AtlasAuthorizationUtils;
 import org.apache.atlas.discovery.EntityDiscoveryService;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.listener.TypeDefChangeListener;
-import org.apache.atlas.model.SearchFilter;
 import org.apache.atlas.model.typedef.*;
 import org.apache.atlas.repository.Constants;
 import org.apache.atlas.repository.graph.GraphHelper;
@@ -37,11 +34,10 @@ import org.apache.atlas.repository.graphdb.AtlasGraph;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
 import org.apache.atlas.repository.store.graph.AtlasDefStore;
 import org.apache.atlas.repository.store.graph.AtlasTypeDefGraphStore;
-import org.apache.atlas.repository.util.FilterUtil;
-import org.apache.atlas.type.*;
+import org.apache.atlas.type.AtlasType;
+import org.apache.atlas.type.AtlasTypeRegistry;
 import org.apache.atlas.typesystem.types.DataTypes.TypeCategory;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.Predicate;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -124,6 +120,16 @@ public class AtlasTypeDefGraphStoreV2 extends AtlasTypeDefGraphStore {
         super.init();
 
         LOG.info("<== AtlasTypeDefGraphStoreV1.init()");
+    }
+
+    @Override
+    @GraphTransaction
+    public void initWithoutLock() throws AtlasBaseException {
+        LOG.info("==> AtlasTypeDefGraphStoreV1.initWithoutLock()");
+
+        super.initWithoutLock();
+
+        LOG.info("<== AtlasTypeDefGraphStoreV1.initWithoutLock()");
     }
 
     AtlasGraph getAtlasGraph() { return atlasGraph; }

--- a/repository/src/main/java/org/apache/atlas/store/AtlasTypeDefStore.java
+++ b/repository/src/main/java/org/apache/atlas/store/AtlasTypeDefStore.java
@@ -35,17 +35,7 @@ import org.apache.atlas.model.typedef.AtlasTypesDef;
 public interface AtlasTypeDefStore {
     void init() throws AtlasBaseException;
 
-    void reloadEnumTypeDefs() throws AtlasBaseException;
-
-    void reloadBusinessMetadataTypeDefs() throws AtlasBaseException;
-
-    void reloadClassificationMetadataTypeDefs() throws AtlasBaseException;
-
-    void reloadStructTypeDefs() throws AtlasBaseException;
-
-    void reloadEntityTypeDefs() throws AtlasBaseException;
-
-    void reloadRelationshipTypeDefs() throws AtlasBaseException;
+    void initWithoutLock() throws AtlasBaseException;
 
     /* EnumDef operations */
 
@@ -122,7 +112,7 @@ public interface AtlasTypeDefStore {
 
     AtlasBaseTypeDef getByGuid(String guid) throws AtlasBaseException;
 
-    AtlasBaseTypeDef deleteTypeByName(String typeName) throws AtlasBaseException;
+    void deleteTypeByName(String typeName) throws AtlasBaseException;
 
     void notifyLoadCompletion();
 }

--- a/repository/src/main/java/org/apache/atlas/store/AtlasTypeDefStore.java
+++ b/repository/src/main/java/org/apache/atlas/store/AtlasTypeDefStore.java
@@ -35,8 +35,6 @@ import org.apache.atlas.model.typedef.AtlasTypesDef;
 public interface AtlasTypeDefStore {
     void init() throws AtlasBaseException;
 
-    void initWithoutLock() throws AtlasBaseException;
-
     /* EnumDef operations */
 
     AtlasEnumDef getEnumDefByName(String name) throws AtlasBaseException;

--- a/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
@@ -681,7 +681,7 @@ public class TypesREST {
             validateTypeNames(typesDef);
         } catch (AtlasBaseException e) {
             if(AtlasErrorCode.TYPE_NAME_NOT_FOUND.equals(e.getAtlasErrorCode())) {
-                typeDefStore.initWithoutLock();
+                typeDefStore.init();
                 validateTypeNames(typesDef);
             }
         }

--- a/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
@@ -25,8 +25,8 @@ import org.apache.atlas.annotation.Timed;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.SearchFilter;
 import org.apache.atlas.model.typedef.*;
+import org.apache.atlas.repository.RepositoryException;
 import org.apache.atlas.repository.graph.TypeCacheRefresher;
-import org.apache.atlas.repository.store.bootstrap.AtlasTypeDefStoreInitializer;
 import org.apache.atlas.repository.util.FilterUtil;
 import org.apache.atlas.service.redis.RedisService;
 import org.apache.atlas.store.AtlasTypeDefStore;
@@ -47,6 +47,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -58,6 +60,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.apache.atlas.AtlasErrorCode.APPLICABLE_ENTITY_TYPES_DELETION_NOT_SUPPORTED;
 import static org.apache.atlas.AtlasErrorCode.ATTRIBUTE_DELETION_NOT_SUPPORTED;
+import static org.apache.atlas.repository.graphdb.janus.AtlasElasticsearchQuery.CLIENT_ORIGIN_PRODUCT;
 import static org.apache.atlas.web.filters.AuditFilter.X_ATLAN_CLIENT_ORIGIN;
 
 /**
@@ -111,7 +114,7 @@ public class TypesREST {
     @Timed
     public AtlasBaseTypeDef getTypeDefByName(@PathParam("name") String name) throws AtlasBaseException {
         Servlets.validateQueryParamLength("name", name);
-        typeCacheRefresher.refreshCacheIfNeeded(redisService);
+
         AtlasBaseTypeDef ret = typeDefStore.getByName(name);
 
         return ret;
@@ -129,7 +132,7 @@ public class TypesREST {
     @Timed
     public AtlasBaseTypeDef getTypeDefByGuid(@PathParam("guid") String guid) throws AtlasBaseException {
         Servlets.validateQueryParamLength("guid", guid);
-        typeCacheRefresher.refreshCacheIfNeeded(redisService);
+
         AtlasBaseTypeDef ret = typeDefStore.getByGuid(guid);
 
         return ret;
@@ -147,7 +150,7 @@ public class TypesREST {
     @Timed
     public List<AtlasTypeDefHeader> getTypeDefHeaders(@Context HttpServletRequest httpServletRequest) throws AtlasBaseException {
         SearchFilter searchFilter = getSearchFilter(httpServletRequest);
-        typeCacheRefresher.refreshCacheIfNeeded(redisService);
+
         AtlasTypesDef searchTypesDef = typeDefStore.searchTypesDef(searchFilter);
 
         return AtlasTypeUtil.toTypeDefHeader(searchTypesDef);
@@ -164,7 +167,7 @@ public class TypesREST {
     @Timed
     public AtlasTypesDef getAllTypeDefs(@Context HttpServletRequest httpServletRequest) throws AtlasBaseException {
         SearchFilter searchFilter = getSearchFilter(httpServletRequest);
-        typeCacheRefresher.refreshCacheIfNeeded(redisService);
+
         AtlasTypesDef typesDef = typeDefStore.searchTypesDef(searchFilter);
 
         return typesDef;
@@ -183,6 +186,7 @@ public class TypesREST {
     @Timed
     public AtlasEnumDef getEnumDefByName(@PathParam("name") String name) throws AtlasBaseException {
         Servlets.validateQueryParamLength("name", name);
+
         AtlasEnumDef ret = typeDefStore.getEnumDefByName(name);
 
         return ret;
@@ -201,6 +205,7 @@ public class TypesREST {
     @Timed
     public AtlasEnumDef getEnumDefByGuid(@PathParam("guid") String guid) throws AtlasBaseException {
         Servlets.validateQueryParamLength("guid", guid);
+
         AtlasEnumDef ret = typeDefStore.getEnumDefByGuid(guid);
 
         return ret;
@@ -220,6 +225,7 @@ public class TypesREST {
     @Timed
     public AtlasStructDef getStructDefByName(@PathParam("name") String name) throws AtlasBaseException {
         Servlets.validateQueryParamLength("name", name);
+
         AtlasStructDef ret = typeDefStore.getStructDefByName(name);
 
         return ret;
@@ -238,6 +244,7 @@ public class TypesREST {
     @Timed
     public AtlasStructDef getStructDefByGuid(@PathParam("guid") String guid) throws AtlasBaseException {
         Servlets.validateQueryParamLength("guid", guid);
+
         AtlasStructDef ret = typeDefStore.getStructDefByGuid(guid);
 
         return ret;
@@ -256,7 +263,7 @@ public class TypesREST {
     @Timed
     public AtlasClassificationDef getClassificationDefByName(@PathParam("name") String name) throws AtlasBaseException {
         Servlets.validateQueryParamLength("name", name);
-        typeCacheRefresher.refreshCacheIfNeeded(redisService);
+
         AtlasClassificationDef ret = typeDefStore.getClassificationDefByName(name);
 
         return ret;
@@ -275,7 +282,7 @@ public class TypesREST {
     @Timed
     public AtlasClassificationDef getClassificationDefByGuid(@PathParam("guid") String guid) throws AtlasBaseException {
         Servlets.validateQueryParamLength("guid", guid);
-        typeCacheRefresher.refreshCacheIfNeeded(redisService);
+
         AtlasClassificationDef ret = typeDefStore.getClassificationDefByGuid(guid);
 
         return ret;
@@ -294,6 +301,7 @@ public class TypesREST {
     @Timed
     public AtlasEntityDef getEntityDefByName(@PathParam("name") String name) throws AtlasBaseException {
         Servlets.validateQueryParamLength("name", name);
+
         AtlasEntityDef ret = typeDefStore.getEntityDefByName(name);
 
         return ret;
@@ -312,6 +320,7 @@ public class TypesREST {
     @Timed
     public AtlasEntityDef getEntityDefByGuid(@PathParam("guid") String guid) throws AtlasBaseException {
         Servlets.validateQueryParamLength("guid", guid);
+
         AtlasEntityDef ret = typeDefStore.getEntityDefByGuid(guid);
 
         return ret;
@@ -329,6 +338,7 @@ public class TypesREST {
     @Timed
     public AtlasRelationshipDef getRelationshipDefByName(@PathParam("name") String name) throws AtlasBaseException {
         Servlets.validateQueryParamLength("name", name);
+
         AtlasRelationshipDef ret = typeDefStore.getRelationshipDefByName(name);
 
         return ret;
@@ -347,6 +357,7 @@ public class TypesREST {
     @Timed
     public AtlasRelationshipDef getRelationshipDefByGuid(@PathParam("guid") String guid) throws AtlasBaseException {
         Servlets.validateQueryParamLength("guid", guid);
+
         AtlasRelationshipDef ret = typeDefStore.getRelationshipDefByGuid(guid);
 
         return ret;
@@ -365,7 +376,7 @@ public class TypesREST {
     @Timed
     public AtlasBusinessMetadataDef getBusinessMetadataDefByGuid(@PathParam("guid") String guid) throws AtlasBaseException {
         Servlets.validateQueryParamLength("guid", guid);
-        typeCacheRefresher.refreshCacheIfNeeded(redisService);
+
         AtlasBusinessMetadataDef ret = typeDefStore.getBusinessMetadataDefByGuid(guid);
 
         return ret;
@@ -384,10 +395,26 @@ public class TypesREST {
     @Timed
     public AtlasBusinessMetadataDef getBusinessMetadataDefByName(@PathParam("name") String name) throws AtlasBaseException {
         Servlets.validateQueryParamLength("name", name);
-        typeCacheRefresher.refreshCacheIfNeeded(redisService);
+
         AtlasBusinessMetadataDef ret = typeDefStore.getBusinessMetadataDefByName(name);
 
         return ret;
+    }
+
+    private void attemptAcquiringLock() throws AtlasBaseException {
+        final String traceId = RequestContext.get().getTraceId();
+        try {
+            if (!redisService.acquireDistributedLock(typeDefLock)) {
+                LOG.info("Lock is already acquired. Returning now :: traceId {}", traceId);
+                throw new AtlasBaseException(AtlasErrorCode.FAILED_TO_OBTAIN_TYPE_UPDATE_LOCK);
+            }
+            LOG.info("successfully acquired lock :: traceId {}", traceId);
+        } catch (AtlasBaseException e) {
+            throw e;
+        } catch (Exception e) {
+            LOG.error("Error while acquiring lock on type-defs :: traceId " + traceId + " ." + e.getMessage(), e);
+            throw new AtlasBaseException("Error while acquiring a lock on type-defs");
+        }
     }
 
     private Lock attemptAcquiringLockV2() throws AtlasBaseException {
@@ -432,9 +459,8 @@ public class TypesREST {
         AtlasPerfTracer perf = null;
         validateBuiltInTypeNames(typesDef);
         RequestContext.get().setTraceId(UUID.randomUUID().toString());
-        AtlasTypesDef atlasTypesDef = null;
         try {
-            typeCacheRefresher.refreshCacheIfNeeded(redisService);
+            typeCacheRefresher.verifyCacheRefresherHealth();
             if (AtlasPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
                 perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "TypesREST.createAtlasTypeDefs(" +
                                                                AtlasTypeUtil.toDebugString(typesDef) + ")");
@@ -444,7 +470,7 @@ public class TypesREST {
             typesDef.getBusinessMetadataDefs().forEach(AtlasBusinessMetadataDef::setRandomNameForEntityAndAttributeDefs);
             typesDef.getClassificationDefs().forEach(AtlasClassificationDef::setRandomNameForEntityAndAttributeDefs);
             String clientOrigin = servletRequest.getHeader(X_ATLAN_CLIENT_ORIGIN);
-            atlasTypesDef = createTypeDefsWithRetry(typesDef, clientOrigin);
+            AtlasTypesDef atlasTypesDef = createTypeDefsWithRetry(typesDef, clientOrigin);
             return atlasTypesDef;
         } catch (AtlasBaseException atlasBaseException) {
             LOG.error("TypesREST.createAtlasTypeDefs:: " + atlasBaseException.getMessage(), atlasBaseException);
@@ -455,7 +481,6 @@ public class TypesREST {
         }
         finally {
             if (lock != null) {
-                typeCacheRefresher.updateVersion(redisService, atlasTypesDef);
                 redisService.releaseDistributedLockV2(lock, typeDefLock);
             }
             AtlasPerfTracer.log(perf);
@@ -478,11 +503,11 @@ public class TypesREST {
                                              @QueryParam("allowDuplicateDisplayName") @DefaultValue("false") boolean allowDuplicateDisplayName) throws AtlasBaseException {
         AtlasPerfTracer perf = null;
         validateBuiltInTypeNames(typesDef);
+        validateTypeNameExists(typesDef);
         RequestContext.get().setTraceId(UUID.randomUUID().toString());
         Lock lock = null;
-        AtlasTypesDef atlasTypesDef = null;
         try {
-            typeCacheRefresher.refreshCacheIfNeeded(redisService);
+            typeCacheRefresher.verifyCacheRefresherHealth();
             if (AtlasPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
                 perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "TypesREST.updateAtlasTypeDefs(" +
                                                                AtlasTypeUtil.toDebugString(typesDef) + ")");
@@ -512,7 +537,7 @@ public class TypesREST {
             RequestContext.get().setAllowDuplicateDisplayName(allowDuplicateDisplayName);
             LOG.info("TypesRest.updateAtlasTypeDefs:: Typedef patch enabled:" + patch);
             String clientOrigin = servletRequest.getHeader(X_ATLAN_CLIENT_ORIGIN);
-            atlasTypesDef = updateTypeDefsWithRetry(typesDef, clientOrigin);
+            AtlasTypesDef atlasTypesDef = updateTypeDefsWithRetry(typesDef, clientOrigin);
             LOG.info("TypesRest.updateAtlasTypeDefs:: Done");
             return atlasTypesDef;
         } catch (AtlasBaseException atlasBaseException) {
@@ -523,7 +548,6 @@ public class TypesREST {
             throw new AtlasBaseException("Error while updating a type definition");
         } finally {
             if (lock != null) {
-                typeCacheRefresher.updateVersion(redisService, atlasTypesDef);
                 redisService.releaseDistributedLockV2(lock, typeDefLock);
             }
             RequestContext.clear();
@@ -547,8 +571,9 @@ public class TypesREST {
         Lock lock = null;
         RequestContext.get().setTraceId(UUID.randomUUID().toString());
         validateBuiltInTypeNames(typesDef);
+        validateTypeNameExists(typesDef);
         try {
-            typeCacheRefresher.refreshCacheIfNeeded(redisService);
+            typeCacheRefresher.verifyCacheRefresherHealth();
             if (AtlasPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
                 perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "TypesREST.deleteAtlasTypeDefs(" +
                                                                AtlasTypeUtil.toDebugString(typesDef) + ")");
@@ -564,7 +589,6 @@ public class TypesREST {
             throw new AtlasBaseException("Error while deleting a type definition");
         } finally {
             if (lock != null) {
-                typeCacheRefresher.updateVersion(redisService, typesDef);
                 redisService.releaseDistributedLockV2(lock, typeDefLock);
             }
             AtlasPerfTracer.log(perf);
@@ -585,14 +609,13 @@ public class TypesREST {
         AtlasPerfTracer perf = null;
         Lock lock = null;
         RequestContext.get().setTraceId(UUID.randomUUID().toString());
-        AtlasBaseTypeDef atlasBaseTypeDef = null;
         try {
-            typeCacheRefresher.refreshCacheIfNeeded(redisService);
+            typeCacheRefresher.verifyCacheRefresherHealth();
             if (AtlasPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
                 perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "TypesREST.deleteAtlasTypeByName(" + typeName + ")");
             }
             lock = attemptAcquiringLockV2();
-            atlasBaseTypeDef = deleteTypeByNameWithRetry(typeName);
+            deleteTypeByNameWithRetry(typeName);
         } catch (AtlasBaseException atlasBaseException) {
             LOG.error("TypesREST.deleteAtlasTypeByName:: " + atlasBaseException.getMessage(), atlasBaseException);
             throw atlasBaseException;
@@ -601,7 +624,6 @@ public class TypesREST {
             throw new AtlasBaseException("Error while deleting a type definition");
         } finally {
             if (lock != null) {
-                typeCacheRefresher.updateVersion(redisService, atlasBaseTypeDef);
                 redisService.releaseDistributedLockV2(lock, typeDefLock);
             }
             AtlasPerfTracer.log(perf);
@@ -623,6 +645,45 @@ public class TypesREST {
             for (AtlasBaseTypeDef typeDef : typesDef.getStructDefs())
                 if (typeDefStore.hasBuiltInTypeName(typeDef))
                     throw new AtlasBaseException(AtlasErrorCode.FORBIDDEN_TYPENAME, typeDef.getName());
+        }
+    }
+
+    private void validateTypeNames(AtlasTypesDef typesDef) throws AtlasBaseException {
+        if (CollectionUtils.isNotEmpty(typesDef.getEnumDefs())) {
+            for (AtlasBaseTypeDef typeDef : typesDef.getEnumDefs()) {
+                typeDefStore.getByName(typeDef.getName());
+            }
+        }
+        if (CollectionUtils.isNotEmpty(typesDef.getEntityDefs())) {
+            for (AtlasBaseTypeDef typeDef : typesDef.getEntityDefs()) {
+                typeDefStore.getByName(typeDef.getName());
+            }
+        }
+        if (CollectionUtils.isNotEmpty(typesDef.getStructDefs())) {
+            for (AtlasBaseTypeDef typeDef : typesDef.getStructDefs()) {
+                typeDefStore.getByName(typeDef.getName());
+            }
+        }
+        if (CollectionUtils.isNotEmpty(typesDef.getClassificationDefs())) {
+            for (AtlasBaseTypeDef typeDef : typesDef.getClassificationDefs()) {
+                typeDefStore.getByName(typeDef.getName());
+            }
+        }
+        if (CollectionUtils.isNotEmpty(typesDef.getBusinessMetadataDefs())) {
+            for (AtlasBaseTypeDef typeDef : typesDef.getBusinessMetadataDefs()) {
+                typeDefStore.getByName(typeDef.getName());
+            }
+        }
+    }
+
+    private void validateTypeNameExists(AtlasTypesDef typesDef) throws AtlasBaseException {
+        try {
+            validateTypeNames(typesDef);
+        } catch (AtlasBaseException e) {
+            if(AtlasErrorCode.TYPE_NAME_NOT_FOUND.equals(e.getAtlasErrorCode())) {
+                typeDefStore.initWithoutLock();
+                validateTypeNames(typesDef);
+            }
         }
     }
 
@@ -656,6 +717,53 @@ public class TypesREST {
         return ret;
     }
 
+    private void refreshAllHostCache(String traceId, String clientOrigin){
+        if (CLIENT_ORIGIN_PRODUCT.equals(clientOrigin) && AtlasConfiguration.ENABLE_ASYNC_TYPE_UPDATE.getBoolean()){
+            cacheRefreshExecutor.submit(() -> {
+                RequestContext.get().setTraceId(traceId);
+                try {
+                    int maxRetries = 5;
+                    int retryCount = 0;
+                    boolean success = false;
+
+                    while (!success && retryCount < maxRetries) {
+                        try {
+                            typeCacheRefresher.refreshAllHostCache();
+                            LOG.info("TypesRest.updateAtlasTypeDefs:: Typedef refreshed successfully on attempt {}", retryCount + 1);
+                            success = true;
+                        } catch (IOException | URISyntaxException | RepositoryException e) {
+                            retryCount++;
+                            if (retryCount >= maxRetries) {
+                                LOG.error("TypesRest.updateAtlasTypeDefs:: Failed to refresh typedef after {} attempts", maxRetries, e);
+                                break;
+                            }
+
+                            // Exponential backoff: wait longer between each retry
+                            long waitTimeMs = 1000 * (long)Math.pow(2, retryCount - 1);
+                            LOG.warn("TypesRest.updateAtlasTypeDefs:: Retry attempt {} after {} ms", retryCount, waitTimeMs);
+
+                            try {
+                                Thread.sleep(waitTimeMs);
+                            } catch (InterruptedException ie) {
+                                Thread.currentThread().interrupt();
+                                LOG.warn("Retry interrupted", ie);
+                                break;
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    LOG.error("Unexpected error in async cache refresh", e);
+                }
+            });
+        } else {
+            try {
+                typeCacheRefresher.refreshAllHostCache();
+            } catch (IOException | URISyntaxException | RepositoryException e) {
+                LOG.error("Error while refreshing all host cache", e);
+            }
+        }
+    }
+
     @PreDestroy
     public void cleanUp() {
         if (cacheRefreshExecutor != null) {
@@ -686,6 +794,7 @@ public class TypesREST {
                 
                 // Perform the creation
                 AtlasTypesDef result = typeDefStore.createTypesDef(typesDef);
+                refreshAllHostCache(RequestContext.get().getTraceId(), clientOrigin);
                 LOG.info("Successfully created typedefs on attempt {}", attempt);
                 return result;
 
@@ -732,6 +841,7 @@ public class TypesREST {
                 }
                 
                 AtlasTypesDef result = typeDefStore.updateTypesDef(typesDef);
+                refreshAllHostCache(RequestContext.get().getTraceId(), clientOrigin);
                 LOG.info("Successfully updated typedefs on attempt {}", attempt);
                 return result;
 
@@ -773,6 +883,7 @@ public class TypesREST {
             try {
                 // Perform the deletion
                 typeDefStore.deleteTypesDef(typesDef);
+                refreshAllHostCache(RequestContext.get().getTraceId(), clientOrigin);
                 LOG.info("Successfully deleted typedefs on attempt {}", attempt);
                 return;
 
@@ -804,15 +915,16 @@ public class TypesREST {
         throw lastException; // Should never reach here, but for completeness
     }
 
-    private AtlasBaseTypeDef deleteTypeByNameWithRetry(String typeName) throws AtlasBaseException {
+    private void deleteTypeByNameWithRetry(String typeName) throws AtlasBaseException {
         AtlasBaseException lastException = null;
 
         for (int attempt = 1; attempt <= MAX_RETRIES; attempt++) {
             try {
                 // Perform the deletion
-                AtlasBaseTypeDef atlasBaseTypeDef = typeDefStore.deleteTypeByName(typeName);
+                typeDefStore.deleteTypeByName(typeName);
+                refreshAllHostCache(RequestContext.get().getTraceId(), null);
                 LOG.info("Successfully deleted typedef '{}' on attempt {}", typeName, attempt);
-                return atlasBaseTypeDef;
+                return;
 
             } catch (AtlasBaseException e) {
                 lastException = e;


### PR DESCRIPTION

## Change description

> revert all optimisations and keep current cinv based full refresh
the redesign of this typedef needs to be thought again

Why revert ?
the reload of custom metadata is not enough with just /typedef endpoint. If a custom metadata like tag is created and immediately operated with asset (without typedef api involved), this operation will always fail. Same for custom metadata which will fail silently.
Enum store reload is not happening due to internal atlas_core enum types

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues
https://atlanhq.atlassian.net/browse/MLH-1240
> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
