### PR TITLE
ADMIN-347 | Add logs to term linking flow

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -2953,7 +2953,7 @@ public class EntityGraphMapper {
                         AtlasAuthorizationUtils.verifyAccess(new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_UPDATE, targetAssetHeader),
                                 "update on entity: " + targetEntityHeader.getDisplayText());
                     } catch(AtlasBaseException e) {
-                        throw new AtlasBaseException(AtlasErrorCode.UNAUTHORIZED_ACCESS, "User does not have permission to update entity: " + targetEntityHeader.getDisplayText(), ATTR_MEANINGS);
+                        throw new AtlasBaseException(AtlasErrorCode.UNAUTHORIZED_ACCESS, "User does not have permission to update entity: " + targetAssetHeader.getDisplayText(), ATTR_MEANINGS);
                     }
                 } else {
                     AtlasVertex termVertex = edge.getOutVertex();
@@ -2969,7 +2969,7 @@ public class EntityGraphMapper {
                         AtlasAuthorizationUtils.verifyAccess(new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_UPDATE, termEntityHeader),
                                 "update on entity: " + targetEntityHeader.getDisplayText());
                     } catch(AtlasBaseException e) {
-                        throw new AtlasBaseException(AtlasErrorCode.UNAUTHORIZED_ACCESS, "User does not have permission to update entity: " + targetEntityHeader.getDisplayText(), ATTR_MEANINGS);
+                        throw new AtlasBaseException(AtlasErrorCode.UNAUTHORIZED_ACCESS, "User does not have permission to update entity: " + termEntityHeader.getDisplayText(), ATTR_MEANINGS);
                     }
                 }
             }
@@ -2991,7 +2991,7 @@ public class EntityGraphMapper {
                         AtlasAuthorizationUtils.verifyAccess(new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_UPDATE, targetAssetHeader),
                                 "update on entity: " + targetEntityHeader.getDisplayText());
                     } catch(AtlasBaseException e) {
-                        throw new AtlasBaseException(AtlasErrorCode.UNAUTHORIZED_ACCESS, "User does not have permission to update entity: " + targetEntityHeader.getDisplayText(), ATTR_MEANINGS);
+                        throw new AtlasBaseException(AtlasErrorCode.UNAUTHORIZED_ACCESS, "User does not have permission to update entity: " + targetAssetHeader.getDisplayText(), ATTR_MEANINGS);
                     }
                 } else {
                     AtlasVertex termVertex = edge.getOutVertex();
@@ -3007,7 +3007,7 @@ public class EntityGraphMapper {
                         AtlasAuthorizationUtils.verifyAccess(new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_UPDATE, termEntityHeader),
                                 "update on entity: " + targetEntityHeader.getDisplayText());
                     } catch(AtlasBaseException e) {
-                        throw new AtlasBaseException(AtlasErrorCode.UNAUTHORIZED_ACCESS, "User does not have permission to update entity: " + targetEntityHeader.getDisplayText(), ATTR_MEANINGS);
+                        throw new AtlasBaseException(AtlasErrorCode.UNAUTHORIZED_ACCESS, "User does not have permission to update entity: " + termEntityHeader.getDisplayText(), ATTR_MEANINGS);
                     }
                 }
             }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -2835,7 +2835,11 @@ public class EntityGraphMapper {
 
     private void addMeaningsToEntity(AttributeMutationContext ctx, List<Object> createdElements, List<AtlasEdge> deletedElements, boolean isAppend) throws AtlasBaseException {
         if (ctx.getReferringVertex().getProperty(ENTITY_TYPE_PROPERTY_KEY, String.class).equals(ATLAS_GLOSSARY_TERM_ENTITY_TYPE) && isAppend) {
-            addMeaningsToEntityRelations(ctx, createdElements, deletedElements);
+            try {
+                addMeaningsToEntityRelations(ctx, createdElements, deletedElements);
+            } catch (AtlasBaseException e) {
+                throw e;
+            }
         } else {
             try {
                 addMeaningsToEntityV1(ctx, createdElements, deletedElements, isAppend);


### PR DESCRIPTION
## Change description

> This PR adds detailed logging to the term linking flow to help debug an issue reported by **CMA CGM (tenant: arkane.atlan.com)**, where a user with the member role and persona-based full access to both products and glossaries is unable to link a term to a product. Despite the correct policies being picked up and the user having update access on both entities, the action consistently fails with a `403 (ATLAS-403-00-001: not authorized to perform {1})`. The issue, which started occurring last Thursday after previously working as expected, suggests the failure is not in policy evaluation but in a deeper part of the flow; the added logs will allow us to pinpoint exactly where the operation is breaking.

JIRA: [ADMIN-347](https://atlanhq.atlassian.net/browse/ADMIN-347)

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
