### PR TITLE
ADMIN-358 | Fix not_in operator tags in abac

### DIFF
--- a/repository/src/main/java/org/apache/atlas/authorizer/JsonToElasticsearchQuery.java
+++ b/repository/src/main/java/org/apache/atlas/authorizer/JsonToElasticsearchQuery.java
@@ -176,10 +176,10 @@ public class JsonToElasticsearchQuery {
                     return createDSLForTagKeyValue(attributeName, attributeValueNode);
                 }
             }
-            case POLICY_FILTER_CRITERIA_NOT_EQUALS -> {
+            case POLICY_FILTER_CRITERIA_NOT_EQUALS, POLICY_FILTER_CRITERIA_NOT_IN -> {
                 ObjectNode mustNotNode = queryNode.putObject("bool").putObject("must_not");
                 if (attributeValueNode.isArray()) {
-                    ArrayNode shouldArray = mustNotNode.putArray("should");
+                    ArrayNode shouldArray = mustNotNode.putObject("bool").putArray("should");
                     for (JsonNode valueNode : attributeValueNode) {
                         shouldArray.add(createDSLForTagKeyValue(attributeName, valueNode));
                     }
@@ -195,17 +195,6 @@ public class JsonToElasticsearchQuery {
                     }
                 } else {
                     shouldArray.add(createDSLForTagKeyValue(attributeName, attributeValueNode));
-                }
-            }
-            case POLICY_FILTER_CRITERIA_NOT_IN -> {
-                ObjectNode notInMustNot = queryNode.putObject("bool").putObject("must_not");
-                ArrayNode notInShouldArray = notInMustNot.putArray("should");
-                if (attributeValueNode.isArray()) {
-                    for (JsonNode valueNode : attributeValueNode) {
-                        notInShouldArray.add(createDSLForTagKeyValue(attributeName, valueNode));
-                    }
-                } else {
-                    notInShouldArray.add(createDSLForTagKeyValue(attributeName, attributeValueNode));
                 }
             }
             default -> LOG.warn("Found unknown operator {}", operator);


### PR DESCRIPTION
## Change description

ES query for NOT_IN operator is incorrect as it attaches `should` clause directly to a `must_not`. Also, NOT_EQUALS and NOT_IN operators are exactly same so they can be combined.

Test cases:
- Created policy with NOT_IN operator for tags
- Created policy with NOT_EQUALS operator for tags and verified the access.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
