### PR TITLE
MLH-1226 Get all attrs to Kafka for ES Isolation

### DIFF
--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusElement.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusElement.java
@@ -352,7 +352,7 @@ public class AtlasJanusElement<T extends Element> implements AtlasElement {
         }
     }
 
-    protected void recordInternalAttributeIncrementalAdd(String propertyName, Object value, Class cardinality) {
+    protected void recordInternalAttributeIncrementalAdd(String propertyName, Class cardinality) {
         if (propertyName.startsWith(INTERNAL_PROPERTY_KEY_PREFIX)) {
             String entityGuid = this.getProperty(GUID_PROPERTY_KEY, String.class);
 

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusElement.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusElement.java
@@ -19,12 +19,14 @@ package org.apache.atlas.repository.graphdb.janus;
 
 import java.util.*;
 
+import org.apache.atlas.RequestContext;
 import org.apache.atlas.repository.graphdb.AtlasEdge;
 import org.apache.atlas.repository.graphdb.AtlasElement;
 import org.apache.atlas.repository.graphdb.AtlasSchemaViolationException;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
 import org.apache.atlas.repository.graphdb.janus.graphson.AtlasGraphSONMode;
 import org.apache.atlas.repository.graphdb.janus.graphson.AtlasGraphSONUtility;
+import org.apache.commons.lang.StringUtils;
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Property;
 import org.codehaus.jettison.json.JSONException;
@@ -34,6 +36,9 @@ import com.google.common.base.Function;
 import com.google.common.collect.Lists;
 import org.janusgraph.core.SchemaViolationException;
 import org.janusgraph.core.JanusGraphElement;
+
+import static org.apache.atlas.type.Constants.GUID_PROPERTY_KEY;
+import static org.apache.atlas.type.Constants.INTERNAL_PROPERTY_KEY_PREFIX;
 
 /**
  * Janus implementation of AtlasElement.
@@ -109,27 +114,36 @@ public class AtlasJanusElement<T extends Element> implements AtlasElement {
         while(it.hasNext()) {
             Property<String> property = it.next();
             property.remove();
+            recordInternalAttribute(propertyName, null);
         }
     }
 
     @Override
     public void removePropertyValue(String propertyName, Object propertyValue) {
         Iterator<? extends Property<Object>> it = getWrappedElement().properties(propertyName);
+        List<Object> finalValues = new ArrayList<>();
+        boolean removedFirst = false;
 
         while (it.hasNext()) {
             Property currentProperty      = it.next();
             Object   currentPropertyValue = currentProperty.value();
 
-            if (Objects.equals(currentPropertyValue, propertyValue)) {
+            if (!removedFirst && Objects.equals(currentPropertyValue, propertyValue)) {
                 currentProperty.remove();
-                break;
+                removedFirst = true;
+            } else {
+                finalValues.add(currentPropertyValue);
             }
         }
+
+        recordInternalAttribute(propertyName, finalValues);
     }
 
     @Override
     public void removeAllPropertyValue(String propertyName, Object propertyValue) {
         Iterator<? extends Property<Object>> it = getWrappedElement().properties(propertyName);
+        List<Object> finalValues = new ArrayList<>();
+
 
         while (it.hasNext()) {
             Property currentProperty      = it.next();
@@ -137,8 +151,12 @@ public class AtlasJanusElement<T extends Element> implements AtlasElement {
 
             if (Objects.equals(currentPropertyValue, propertyValue)) {
                 currentProperty.remove();
+            } else {
+                finalValues.add(currentPropertyValue);
             }
         }
+
+        recordInternalAttribute(propertyName, finalValues);
     }
 
     @Override
@@ -151,6 +169,7 @@ public class AtlasJanusElement<T extends Element> implements AtlasElement {
                 }
             } else {
                 getWrappedElement().property(propertyName, value);
+                recordInternalAttribute(propertyName, value);
             }
         } catch(SchemaViolationException e) {
             throw new AtlasSchemaViolationException(e);
@@ -308,7 +327,6 @@ public class AtlasJanusElement<T extends Element> implements AtlasElement {
     @Override
     public void setPropertyFromElementId(String propertyName, AtlasElement value) {
         setProperty(propertyName, value.getId().toString());
-
     }
 
 
@@ -317,4 +335,51 @@ public class AtlasJanusElement<T extends Element> implements AtlasElement {
         return true;
     }
 
+    protected void recordInternalAttribute(String propertyName, Object finalValue) {
+        if (propertyName.startsWith(INTERNAL_PROPERTY_KEY_PREFIX)) {
+            RequestContext context = RequestContext.get();
+            String entityGuid = this.getProperty(GUID_PROPERTY_KEY, String.class);
+
+            if (StringUtils.isNotEmpty(entityGuid)) {
+                if (context.getAllInternalAttributesMap().get(entityGuid) != null) {
+                    context.getAllInternalAttributesMap().get(entityGuid).put(propertyName, finalValue);
+                } else {
+                    Map<String, Object> map = new HashMap<>();
+                    map.put(propertyName, finalValue);
+                    context.getAllInternalAttributesMap().put(entityGuid, map);
+                }
+            }
+        }
+    }
+
+    protected void recordInternalAttributeIncrementalAdd(String propertyName, Object value, Class cardinality) {
+        if (propertyName.startsWith(INTERNAL_PROPERTY_KEY_PREFIX)) {
+            String entityGuid = this.getProperty(GUID_PROPERTY_KEY, String.class);
+
+            if (StringUtils.isNotEmpty(entityGuid)) {
+                Collection<Object> currentValues = null;
+
+                if (cardinality == List.class) {
+                    currentValues = getMultiValuedProperty(propertyName, Object.class);
+                } else {
+                    currentValues = getMultiValuedSetProperty(propertyName, Object.class);
+                }
+
+                // Assumption: This method is being called after setting the property on element,
+                // hence assuming currentValues is the final expected state and not adding `value` to `currentValues`
+
+                if (StringUtils.isNotEmpty(entityGuid)) {
+                    RequestContext context = RequestContext.get();
+
+                    if (context.getAllInternalAttributesMap().get(entityGuid) != null) {
+                        context.getAllInternalAttributesMap().get(entityGuid).put(propertyName, currentValues);
+                    } else {
+                        Map<String, Object> map = new HashMap<>();
+                        map.put(propertyName, currentValues);
+                        context.getAllInternalAttributesMap().put(entityGuid, map);
+                    }
+                }
+            }
+        }
+    }
 }

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusVertex.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusVertex.java
@@ -20,6 +20,7 @@ package org.apache.atlas.repository.graphdb.janus;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.StreamSupport;
 
@@ -55,6 +56,7 @@ public class AtlasJanusVertex extends AtlasJanusElement<Vertex> implements Atlas
     public <T> void addProperty(String propertyName, T value) {
         try {
             getWrappedElement().property(VertexProperty.Cardinality.set, propertyName, value);
+            recordInternalAttributeIncrementalAdd(propertyName, value, Set.class);
         } catch(SchemaViolationException e) {
             throw new AtlasSchemaViolationException(e);
         }
@@ -64,6 +66,7 @@ public class AtlasJanusVertex extends AtlasJanusElement<Vertex> implements Atlas
     public <T> void addListProperty(String propertyName, T value) {
         try {
             getWrappedElement().property(VertexProperty.Cardinality.list, propertyName, value);
+            recordInternalAttributeIncrementalAdd(propertyName, value, List.class);
         } catch(SchemaViolationException e) {
             throw new AtlasSchemaViolationException(e);
         }

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusVertex.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusVertex.java
@@ -56,7 +56,7 @@ public class AtlasJanusVertex extends AtlasJanusElement<Vertex> implements Atlas
     public <T> void addProperty(String propertyName, T value) {
         try {
             getWrappedElement().property(VertexProperty.Cardinality.set, propertyName, value);
-            recordInternalAttributeIncrementalAdd(propertyName, value, Set.class);
+            recordInternalAttributeIncrementalAdd(propertyName, Set.class);
         } catch(SchemaViolationException e) {
             throw new AtlasSchemaViolationException(e);
         }
@@ -66,7 +66,7 @@ public class AtlasJanusVertex extends AtlasJanusElement<Vertex> implements Atlas
     public <T> void addListProperty(String propertyName, T value) {
         try {
             getWrappedElement().property(VertexProperty.Cardinality.list, propertyName, value);
-            recordInternalAttributeIncrementalAdd(propertyName, value, List.class);
+            recordInternalAttributeIncrementalAdd(propertyName, List.class);
         } catch(SchemaViolationException e) {
             throw new AtlasSchemaViolationException(e);
         }

--- a/intg/src/main/java/org/apache/atlas/model/instance/AtlasEntity.java
+++ b/intg/src/main/java/org/apache/atlas/model/instance/AtlasEntity.java
@@ -35,14 +35,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
@@ -71,6 +64,8 @@ public class AtlasEntity extends AtlasStruct implements Serializable {
     public static final String KEY_CREATE_TIME     = "createTime";
     public static final String KEY_UPDATE_TIME     = "updateTime";
     public static final String KEY_VERSION         = "version";
+    public static final String KEY_DOC_ID          = "docId";
+    public static final String KEY_SUPER_TYPES     = "superTypeNames";
 
     /**
      * Status of the entity - can be active or deleted. Deleted entities are not removed from Atlas store.
@@ -90,6 +85,9 @@ public class AtlasEntity extends AtlasStruct implements Serializable {
     private Date    updateTime     = null;
     private Long    version        = 0L;
     private Boolean starred       = null;
+
+    private Set<String>                     superTypeNames      = new HashSet<>();
+    private String                          docId               = null;
 
     private Map<String, Object>              relationshipAttributes;
     private Map<String, Object>              appendRelationshipAttributes;
@@ -241,6 +239,22 @@ public class AtlasEntity extends AtlasStruct implements Serializable {
             setAddedRelationshipAttributes(other.getAddedRelationshipAttributes());
             setRemovedRelationshipAttributes(other.getRemovedRelationshipAttributes());
         }
+    }
+
+    public Set<String> getSuperTypeNames() {
+        return superTypeNames;
+    }
+
+    public void setSuperTypeNames(Set<String> superTypeNames) {
+        this.superTypeNames = superTypeNames;
+    }
+
+    public String getDocId() {
+        return docId;
+    }
+
+    public void setDocId(String docId) {
+        this.docId = docId;
     }
 
     public String getGuid() {

--- a/intg/src/main/java/org/apache/atlas/model/instance/AtlasEntityHeader.java
+++ b/intg/src/main/java/org/apache/atlas/model/instance/AtlasEntityHeader.java
@@ -34,12 +34,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.Date;
+import java.util.*;
 
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.PUBLIC_ONLY;
@@ -56,6 +51,9 @@ import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.PUBLIC_
 public class AtlasEntityHeader extends AtlasStruct implements Serializable {
     private static final long serialVersionUID = 1L;
 
+    private Set<String>                     superTypeNames      = new HashSet<>();
+    private String                          vertexId            = null;
+    private String                          docId               = null;
     private String                          guid                = null;
     private AtlasEntity.Status              status              = AtlasEntity.Status.ACTIVE;
     private String                          displayText         = null;
@@ -101,6 +99,30 @@ public class AtlasEntityHeader extends AtlasStruct implements Serializable {
         setClassificationNames(null);
         setClassifications(null);
         setLabels(null);
+    }
+
+    public Set<String> getSuperTypeNames() {
+        return superTypeNames;
+    }
+
+    public void setSuperTypeNames(Set<String> superTypeNames) {
+        this.superTypeNames = superTypeNames;
+    }
+
+    public String getVertexId() {
+        return vertexId;
+    }
+
+    public void setVertexId(String vertexId) {
+        this.vertexId = vertexId;
+    }
+
+    public String getDocId() {
+        return docId;
+    }
+
+    public void setDocId(String docId) {
+        this.docId = docId;
     }
 
     public List<AtlasClassification> getAddOrUpdateClassifications() {

--- a/intg/src/main/java/org/apache/atlas/model/instance/AtlasEntityHeaderWithRelations.java
+++ b/intg/src/main/java/org/apache/atlas/model/instance/AtlasEntityHeaderWithRelations.java
@@ -26,6 +26,7 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -45,6 +46,7 @@ public class AtlasEntityHeaderWithRelations extends AtlasEntityHeader implements
     private static final long serialVersionUID = 1L;
 
     private Map<String, Object> relationshipAttributes = null;
+    private Map<String, Object> internalAttributes = null;
 
     public AtlasEntityHeaderWithRelations(String typeName, String guid, Map<String, Object> attributes) {
         super(typeName, attributes);
@@ -62,24 +64,34 @@ public class AtlasEntityHeaderWithRelations extends AtlasEntityHeader implements
         this.relationshipAttributes = relationshipAttributes;
     }
 
+    public Map<String, Object> getInternalAttributes() {
+        return internalAttributes;
+    }
+
+    public void setInternalAttributes(Map<String, Object> internalAttributes) {
+        this.internalAttributes = internalAttributes;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         if (!super.equals(o)) return false;
         AtlasEntityHeaderWithRelations that = (AtlasEntityHeaderWithRelations) o;
-        return Objects.equals(relationshipAttributes, that.relationshipAttributes);
+        return Objects.equals(relationshipAttributes, that.relationshipAttributes) &&
+                Objects.equals(internalAttributes, that.internalAttributes);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), relationshipAttributes);
+        return Objects.hash(super.hashCode(), relationshipAttributes, internalAttributes);
     }
 
     @Override
     public String toString() {
         return "AtlasEntityHeaderWithRelations{" +
                 "relationshipAttributes=" + relationshipAttributes +
+                "internalAttributes=" + internalAttributes +
                 "AtlasEntityHeader=" + super.toString() +
                 '}';
     }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -284,7 +284,7 @@ public abstract class DeleteHandlerV1 {
             }
             entity.setVertexId(vertex.getIdForDisplay());
             entity.setDocId(LongEncoding.encode(Long.parseLong(vertex.getIdForDisplay())));
-            entity.setSuperTypeNames(entityType.getSuperTypes());
+            entity.setSuperTypeNames(entityType.getAllSuperTypes());
             vertexInfoMap.put(guid, new GraphHelper.VertexInfo(entity, vertex));
 
             for (AtlasStructType.AtlasAttribute attributeInfo : entityType.getOwnedRefAttributes()) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -66,6 +66,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSo
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.janusgraph.util.encoding.LongEncoding;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -281,7 +282,9 @@ public abstract class DeleteHandlerV1 {
             if (entityType == null) {
                 throw new AtlasBaseException(AtlasErrorCode.TYPE_NAME_INVALID, TypeCategory.ENTITY.name(), typeName);
             }
-
+            entity.setVertexId(vertex.getIdForDisplay());
+            entity.setDocId(LongEncoding.encode(Long.parseLong(vertex.getIdForDisplay())));
+            entity.setSuperTypeNames(entityType.getSuperTypes());
             vertexInfoMap.put(guid, new GraphHelper.VertexInfo(entity, vertex));
 
             for (AtlasStructType.AtlasAttribute attributeInfo : entityType.getOwnedRefAttributes()) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityChangeNotifier.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityChangeNotifier.java
@@ -780,6 +780,9 @@ public class AtlasEntityChangeNotifier implements IAtlasEntityChangeNotifier {
                 }
 
                 if (entity != null) {
+                    // For ES Isolation
+                    entity.setDocId(entityHeader.getDocId());
+                    entity.setSuperTypeNames(entityHeader.getSuperTypeNames());
                     ret.add(entity);
                 }
             }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -83,6 +83,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.structure.*;
 import org.janusgraph.core.Cardinality;
 import org.janusgraph.graphdb.relations.CacheVertexProperty;
+import org.janusgraph.util.encoding.LongEncoding;
 import org.javatuples.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1453,6 +1454,9 @@ public class EntityGraphRetriever {
 
             mapSystemAttributes(entityVertex, entity);
 
+            entity.setDocId(LongEncoding.encode(Long.parseLong(entityVertex.getIdForDisplay())));
+            entity.setSuperTypeNames(typeRegistry.getEntityTypeByName(entity.getTypeName()).getAllSuperTypes());
+
             mapBusinessAttributes(entityVertex, entity);
 
             mapAttributes(entityVertex, entity, entityExtInfo, isMinExtInfo, includeReferences);
@@ -1732,6 +1736,9 @@ public class EntityGraphRetriever {
             }
             AtlasEntityType entityType = typeRegistry.getEntityTypeByName(typeName);
 
+            ret.setDocId(LongEncoding.encode(Long.parseLong(entityVertex.getIdForDisplay())));
+            ret.setSuperTypeNames(entityType.getAllSuperTypes());
+
             if (entityType != null) {
                 for (AtlasAttribute headerAttribute : entityType.getHeaderAttributes().values()) {
                     Object attrValue = getVertexAttribute(entityVertex, headerAttribute, vertexEdgePropertiesCache);
@@ -1837,6 +1844,9 @@ public class EntityGraphRetriever {
             }
             AtlasEntityType entityType = typeRegistry.getEntityTypeByName(typeName);
 
+            ret.setDocId(LongEncoding.encode(Long.parseLong(entityVertex.getIdForDisplay())));
+            ret.setSuperTypeNames(entityType.getAllSuperTypes());
+
             if (entityType != null) {
                 for (AtlasAttribute headerAttribute : entityType.getHeaderAttributes().values()) {
                     Object attrValue = getVertexAttribute(entityVertex, headerAttribute);
@@ -1909,6 +1919,9 @@ public class EntityGraphRetriever {
 
             ret.setTypeName(typeName);
             ret.setGuid(guid);
+
+            ret.setDocId(LongEncoding.encode(Long.parseLong(entityVertex.getIdForDisplay())));
+            ret.setSuperTypeNames(entityType.getAllSuperTypes());
 
             String state = (String)properties.get(Constants.STATE_PROPERTY_KEY);
             Id.EntityState entityState = state == null ? null : Id.EntityState.valueOf(state);

--- a/server-api/src/main/java/org/apache/atlas/RequestContext.java
+++ b/server-api/src/main/java/org/apache/atlas/RequestContext.java
@@ -50,6 +50,7 @@ public class RequestContext {
     private final Map<String, AtlasEntityHeader>         updatedEntities      = new HashMap<>();
     private final Map<String, AtlasEntityHeader>         deletedEntities      = new HashMap<>();
     private final Map<String, AtlasEntityHeader>         restoreEntities      = new HashMap<>();
+    private final Map<String, Map<String, Object>> allInternalAttributesMap     = new HashMap<>();
 
 
     private       Map<String, String>                    lexoRankCache        = null;
@@ -193,6 +194,7 @@ public class RequestContext {
         addedClassificationAndVertices.clear();
         esDeferredOperations.clear();
         this.cassandraTagOperations.clear();
+        this.allInternalAttributesMap.clear();
 
         if (metrics != null && !metrics.isEmpty()) {
             METRICS.debug(metrics.toString());
@@ -837,6 +839,10 @@ public class RequestContext {
 
     public boolean isInvokedByLineage() {
         return isInvokedByLineage;
+    }
+
+    public Map<String, Map<String, Object>> getAllInternalAttributesMap() {
+        return allInternalAttributesMap;
     }
 
     public class EntityGuidPair {

--- a/webapp/src/main/java/org/apache/atlas/notification/EntityNotificationListenerV2.java
+++ b/webapp/src/main/java/org/apache/atlas/notification/EntityNotificationListenerV2.java
@@ -281,6 +281,9 @@ public class EntityNotificationListenerV2 implements EntityChangeListenerV2 {
         ret.setCreateTime(entity.getCreateTime());
         ret.setUpdateTime(entity.getUpdateTime());
         ret.setDeleteHandler(entity.getDeleteHandler());
+        // For ES Isolation
+        ret.setDocId(entity.getDocId());
+        ret.setSuperTypeNames(entity.getSuperTypeNames());
 
         setAttribute(ret, NAME, name);
         setAttribute(ret, DESCRIPTION, entity.getAttribute(DESCRIPTION));
@@ -302,6 +305,13 @@ public class EntityNotificationListenerV2 implements EntityChangeListenerV2 {
                         ret.setAttribute(attribute.getName(), attrValue);
                     }
                 }
+            }
+
+            // fill the internal properties like __glossary, __meanings etc. (ES Isolation)
+            RequestContext context = RequestContext.get();
+            Map<String, Object> allInternalAttributesMap = context.getAllInternalAttributesMap().get(entity.getGuid());
+            if (MapUtils.isNotEmpty(allInternalAttributesMap)) {
+                ret.setInternalAttributes(allInternalAttributesMap);
             }
 
             //Add relationship attributes which has isOptional as false


### PR DESCRIPTION


## Change description

> all change to get docId, superTypenames and internal attrs to kafka for ES isolation
Based on 2 PRs
https://github.com/atlanhq/atlas-metastore/pull/5260/files#diff-ff4d498f1bdd9b723a44f4db7958644591954ee5600a1e104a6b51f3050f9993
https://github.com/atlanhq/atlas-metastore/pull/5392/files#diff-fe4c76c59fd5b78500ffa51d1f771668268401135fbd352728db37d270cf4d8d

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues
https://atlanhq.atlassian.net/browse/MLH-978
> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
