### PR TITLE
MLH-1336 Sets tags FF true for all new tenants by default

### DIFF
--- a/repository/src/main/java/org/apache/atlas/services/TagsV2AutoEnabler.java
+++ b/repository/src/main/java/org/apache/atlas/services/TagsV2AutoEnabler.java
@@ -1,0 +1,84 @@
+package org.apache.atlas.services;
+
+import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.model.SearchFilter;
+import org.apache.atlas.model.typedef.AtlasTypesDef;
+import org.apache.atlas.service.FeatureFlag;
+import org.apache.atlas.service.FeatureFlagStore;
+import org.apache.atlas.store.AtlasTypeDefStore;
+import org.apache.commons.collections.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import java.util.List;
+
+/**
+ * Automatically enables Tag V2 for new Atlas instances
+ * where no classification types are present. This ensures new customer tenants get the
+ * latest tag propagation version by default.
+ */
+@Component
+public class TagsV2AutoEnabler {
+    private static final Logger LOG = LoggerFactory.getLogger(TagsV2AutoEnabler.class);
+
+    private static final String CLASSIFICATION_TYPE = "classification";
+    private static final String ENABLE_JANUS_OPTIMISATION_KEY = FeatureFlag.ENABLE_JANUS_OPTIMISATION.getKey();
+
+    private final AtlasTypeDefStore typeDefStore;
+
+    @Inject
+    public TagsV2AutoEnabler(AtlasTypeDefStore typeDefStore) {
+        this.typeDefStore = typeDefStore;
+    }
+
+    @PostConstruct
+    public void checkAndEnableJanusOptimisation() throws AtlasBaseException {
+        try {
+            LOG.info("Starting auto-enable check for Janus optimization...");
+
+            boolean isTagV2Enabled = FeatureFlagStore.isTagV2Enabled();
+            if (isTagV2Enabled) {
+                LOG.info("Tags v2 optimization is already enabled, skipping auto-enable check");
+                return;
+            }
+
+            // Check if there are any classification types present
+            boolean hasClassificationTypes = hasClassificationTypes();
+
+            if (!hasClassificationTypes) {
+                LOG.info("No classification types found - enabling Janus optimization for new tenant");
+                FeatureFlagStore.setFlag(ENABLE_JANUS_OPTIMISATION_KEY, "true");
+                LOG.info("Successfully enabled Janus optimization feature flag");
+            } else {
+                LOG.info("Classification types found - keeping existing configuration (Janus optimization disabled)");
+            }
+
+        } catch (Exception e) {
+            LOG.error("Error during auto-enable check for Tags v2 optimization", e);
+            throw e;
+        }
+    }
+
+    /**
+     * Checks if there are any classification types present in the system
+     * @return true if classification types exist, false otherwise
+     */
+    private boolean hasClassificationTypes() throws AtlasBaseException {
+        try {
+            SearchFilter searchFilter = new SearchFilter();
+            searchFilter.setParam(SearchFilter.PARAM_TYPE, List.of(CLASSIFICATION_TYPE));
+            AtlasTypesDef typesDef = typeDefStore.searchTypesDef(searchFilter);
+
+            boolean hasClassifications = typesDef != null && !CollectionUtils.isEmpty(typesDef.getClassificationDefs());
+
+            LOG.info("Found {} classification types", hasClassifications ? typesDef.getClassificationDefs().size() : 0);
+            return hasClassifications;
+        } catch (AtlasBaseException e) {
+            LOG.error("Error checking for classification types", e);
+            throw e;
+        }
+    }
+}


### PR DESCRIPTION
This change sets Tags FF to true for all newly onboarded tenants or tenants where no tag type defs are present.
Goal is to avoid migration for any newly onboarded tenants.
Jira: https://atlanhq.atlassian.net/browse/MLH-1336

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Spring component that enables the Tags V2 feature flag on startup if no classification type defs are present.
> 
> - **Backend/Services**:
>   - **New `TagsV2AutoEnabler`** (`org/apache/atlas/services/TagsV2AutoEnabler.java`):
>     - Runs on startup to check `FeatureFlagStore.isTagV2Enabled()` and search classification defs via `AtlasTypeDefStore`.
>     - If none found, sets `FeatureFlag.ENABLE_JANUS_OPTIMISATION` to `true`.
>     - Adds info/error logging around the enablement check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2fb06fa5a7e4b3753b4c6dc6050a607df59c4801. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->