### PR TITLE
MLH-1158 add correct value type validation for atlas built in type

### DIFF
--- a/intg/src/main/java/org/apache/atlas/type/AtlasBuiltInTypes.java
+++ b/intg/src/main/java/org/apache/atlas/type/AtlasBuiltInTypes.java
@@ -701,7 +701,7 @@ public class AtlasBuiltInTypes {
 
         @Override
         public boolean isValidValue(Object obj) {
-            return true;
+            return obj == null || obj instanceof String;
         }
 
         @Override

--- a/intg/src/main/java/org/apache/atlas/type/AtlasBuiltInTypes.java
+++ b/intg/src/main/java/org/apache/atlas/type/AtlasBuiltInTypes.java
@@ -706,6 +706,7 @@ public class AtlasBuiltInTypes {
 
         @Override
         public String getNormalizedValue(Object obj) {
+            //keeping this as-is since it is invoked in many places
             if (obj != null) {
                 return obj.toString();
             }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -5797,7 +5797,17 @@ public class EntityGraphMapper {
                 String    fieldName = entityType.getTypeName() + "." + bmName + "." + attrName;
 
                 if (attrValue != null) {
-                    attrType.validateValue(attrValue, fieldName, messages);
+                    if ("string".equalsIgnoreCase(attrType.getTypeName())) {
+                        Object existingValue = AtlasGraphUtilsV2.getEncodedProperty(entityVertex, bmAttribute.getVertexPropertyName(), Object.class);
+                        if (existingValue instanceof String) { //do correct validation if existing value is valid type. otherwise ignore validation
+                            attrType.validateValue(attrValue, fieldName, messages);
+                        } else {
+                            LOG.warn("Existing business attribute value is not of type string for attribute {} of entity {}", fieldName, entityVertex.getIdForDisplay());
+                        }
+                    } else {
+                        attrType.validateValue(attrValue, fieldName, messages);
+                    }
+
                     boolean isValidLength = bmAttribute.isValidLength(attrValue);
                     if (!isValidLength) {
                         messages.add(fieldName + ":  Business attribute-value exceeds maximum length limit");


### PR DESCRIPTION
add correct value type validation for atlas built in type (string)

## Change description

> add correct value type validation for atlas built in type (string)
Throw below error otherwise
```
{
    "errorCode": "ATLAS-404-00-007",
    "errorMessage": "Invalid instance creation/updation parameters passed : Table.hNphv1wBrjQeD0pVgKPtbp.oanydbpTqKdz8RhoxNN7mI={check=true}: invalid value for type string"
}
```

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues
https://atlanhq.atlassian.net/browse/MLH-1158
> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces correct `string` type validation and conditionally validates string business attributes based on existing stored value, adding warnings when types mismatch.
> 
> - **Types**:
>   - Update `AtlasBuiltInTypes.AtlasStringType.isValidValue()` to accept only `null` or `String`.
>   - Keep `getNormalizedValue()` behavior (note added comment).
> - **Entity Validation**:
>   - In `repository/store/graph/v2/EntityGraphMapper.validateBusinessAttributes()`, for `string` attributes, validate new values only if the existing stored value is a `String`; otherwise log a warning and skip validation. Continue length checks as before.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3bc30ab13f63537f52f861961caa1e77afc89217. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->