### PR TITLE
Tags v2 default for new onboardings

### DIFF
--- a/repository/src/main/java/org/apache/atlas/services/TagsV2AutoEnabler.java
+++ b/repository/src/main/java/org/apache/atlas/services/TagsV2AutoEnabler.java
@@ -8,7 +8,6 @@ import org.apache.atlas.repository.graphdb.AtlasVertex;
 import org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2;
 import org.apache.atlas.service.FeatureFlag;
 import org.apache.atlas.service.FeatureFlagStore;
-import org.apache.atlas.store.AtlasTypeDefStore;
 import org.apache.atlas.typesystem.types.DataTypes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,7 +27,6 @@ import java.util.Iterator;
 public class TagsV2AutoEnabler {
     private static final Logger LOG = LoggerFactory.getLogger(TagsV2AutoEnabler.class);
 
-    private static final String CLASSIFICATION_TYPE = "classification";
     private static final String ENABLE_JANUS_OPTIMISATION_KEY = FeatureFlag.ENABLE_JANUS_OPTIMISATION.getKey();
     
     // Property keys for type system vertices
@@ -36,12 +34,10 @@ public class TagsV2AutoEnabler {
     private static final String TYPE_CATEGORY_PROPERTY_KEY = Constants.TYPE_CATEGORY_PROPERTY_KEY;
     private static final String VERTEX_TYPE = AtlasGraphUtilsV2.VERTEX_TYPE; // "typeSystem"
 
-    private final AtlasTypeDefStore typeDefStore;
     private final AtlasGraph graph;
 
     @Inject
-    public TagsV2AutoEnabler(AtlasTypeDefStore typeDefStore, AtlasGraph graph) {
-        this.typeDefStore = typeDefStore;
+    public TagsV2AutoEnabler(AtlasGraph graph) {
         this.graph = graph;
     }
 

--- a/repository/src/main/java/org/apache/atlas/services/TagsV2AutoEnabler.java
+++ b/repository/src/main/java/org/apache/atlas/services/TagsV2AutoEnabler.java
@@ -1,0 +1,84 @@
+package org.apache.atlas.services;
+
+import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.model.SearchFilter;
+import org.apache.atlas.model.typedef.AtlasTypesDef;
+import org.apache.atlas.service.FeatureFlag;
+import org.apache.atlas.service.FeatureFlagStore;
+import org.apache.atlas.store.AtlasTypeDefStore;
+import org.apache.commons.collections.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import java.util.List;
+
+/**
+ * Automatically enables Tag V2 for new Atlas instances
+ * where no classification types are present. This ensures new customer tenants get the
+ * latest tag propagation version by default.
+ */
+@Component
+public class TagsV2AutoEnabler {
+    private static final Logger LOG = LoggerFactory.getLogger(TagsV2AutoEnabler.class);
+
+    private static final String CLASSIFICATION_TYPE = "classification";
+    private static final String ENABLE_JANUS_OPTIMISATION_KEY = FeatureFlag.ENABLE_JANUS_OPTIMISATION.getKey();
+
+    private final AtlasTypeDefStore typeDefStore;
+
+    @Inject
+    public TagsV2AutoEnabler(AtlasTypeDefStore typeDefStore) {
+        this.typeDefStore = typeDefStore;
+    }
+
+    @PostConstruct
+    public void checkAndEnableJanusOptimisation() throws AtlasBaseException {
+        try {
+            LOG.info("Starting auto-enable check for Janus optimization...");
+
+            boolean isTagV2Enabled = FeatureFlagStore.isTagV2Enabled();
+            if (isTagV2Enabled) {
+                LOG.info("Tags v2 optimization is already enabled, skipping auto-enable check");
+                return;
+            }
+
+            // Check if there are any classification types present
+            boolean hasClassificationTypes = hasClassificationTypes();
+
+            if (!hasClassificationTypes) {
+                LOG.info("No classification types found - enabling Janus optimization for new tenant");
+                FeatureFlagStore.setFlag(ENABLE_JANUS_OPTIMISATION_KEY, "true");
+                LOG.info("Successfully enabled Janus optimization feature flag");
+            } else {
+                LOG.info("Classification types found - keeping existing configuration (Janus optimization disabled)");
+            }
+
+        } catch (Exception e) {
+            LOG.error("Error during auto-enable check for Tags v2 optimization", e);
+            throw e;
+        }
+    }
+
+    /**
+     * Checks if there are any classification types present in the system
+     * @return true if classification types exist, false otherwise
+     */
+    private boolean hasClassificationTypes() throws AtlasBaseException {
+        try {
+            SearchFilter searchFilter = new SearchFilter();
+            searchFilter.setParam(SearchFilter.PARAM_TYPE, List.of(CLASSIFICATION_TYPE));
+            AtlasTypesDef typesDef = typeDefStore.searchTypesDef(searchFilter);
+
+            boolean hasClassifications = typesDef != null && !CollectionUtils.isEmpty(typesDef.getClassificationDefs());
+
+            LOG.info("Found {} classification types", hasClassifications ? typesDef.getClassificationDefs().size() : 0);
+            return hasClassifications;
+        } catch (AtlasBaseException e) {
+            LOG.error("Error checking for classification types", e);
+            throw e;
+        }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a Spring component that auto-enables Tags V2 by checking for absence of classification types via an optimized graph query.
> 
> - **Services**:
>   - **New `TagsV2AutoEnabler`** (`org/apache/atlas/services/TagsV2AutoEnabler.java`):
>     - On startup (`@PostConstruct`), checks `FeatureFlagStore.isTagV2Enabled()` and queries the graph for any `typeSystem` vertices with `TRAIT` category.
>     - If none found, sets feature flag `ENABLE_JANUS_OPTIMISATION` to `true` to enable Tags V2.
>     - Uses `AtlasGraph` direct query for an optimized existence check and logs outcomes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9074a5422463e06e0d268893a979a8bf74f90d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->