### PR TITLE
Sync staging

### DIFF
--- a/addons/static/templates/policy_cache_transformer_persona.json
+++ b/addons/static/templates/policy_cache_transformer_persona.json
@@ -1160,6 +1160,60 @@
         "end-two-entity:*"
       ],
       "actions": ["add-relationship", "update-relationship", "remove-relationship"]
+    },
+    {
+      "policyType": "ACCESS",
+      "policyResourceCategory": "RELATIONSHIP",
+      "description": "Allow to update relation for datasets for this AIModel",
+      "resources": [
+        "relationship-type:*",
+        "end-one-entity-type:AIModel",
+        "end-one-entity-classification:*",
+        "end-one-entity:*",
+        "end-one-entity:{entity}/*",
+
+        "end-two-entity-type:Catalog",
+        "end-two-entity-type:Connection",
+        "end-two-entity-type:Process",
+        "end-two-entity-type:Namespace",
+        "end-two-entity-type:ProcessExecution",
+        "end-two-entity-classification:*",
+        "end-two-entity:*"
+      ],
+      "actions": ["add-relationship", "remove-relationship"]
+    },
+    {
+      "policyType": "ACCESS",
+      "policyResourceCategory": "RELATIONSHIP",
+      "description": "Allow to update relation for datasets for this AIModel",
+      "resources": [
+        "relationship-type:*",
+
+        "end-one-entity-type:Catalog",
+        "end-one-entity-type:Connection",
+        "end-one-entity-type:Process",
+        "end-one-entity-type:Namespace",
+        "end-one-entity-type:ProcessExecution",
+        "end-one-entity-classification:*",
+        "end-one-entity:*",
+
+        "end-two-entity-type:AIModel",
+        "end-two-entity-classification:*",
+        "end-two-entity:*",
+        "end-two-entity:{entity}/*"
+      ],
+      "actions": ["add-relationship", "remove-relationship"]
+    },
+    {
+      "policyResourceCategory": "ENTITY",
+      "policyType": "ACCESS",
+      "description": "Create/delete process to update datasets for this AIModel",
+      "resources": [
+        "entity:*",
+        "entity-type:Process",
+        "entity-classification:*"
+      ],
+      "actions": ["entity-create", "entity-delete"]
     }
   ],
   "persona-ai-model-delete": [

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusVertex.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusVertex.java
@@ -20,6 +20,7 @@ package org.apache.atlas.repository.graphdb.janus;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.StreamSupport;
 
@@ -55,6 +56,7 @@ public class AtlasJanusVertex extends AtlasJanusElement<Vertex> implements Atlas
     public <T> void addProperty(String propertyName, T value) {
         try {
             getWrappedElement().property(VertexProperty.Cardinality.set, propertyName, value);
+            recordInternalAttributeIncrementalAdd(propertyName, Set.class);
         } catch(SchemaViolationException e) {
             throw new AtlasSchemaViolationException(e);
         }
@@ -64,6 +66,7 @@ public class AtlasJanusVertex extends AtlasJanusElement<Vertex> implements Atlas
     public <T> void addListProperty(String propertyName, T value) {
         try {
             getWrappedElement().property(VertexProperty.Cardinality.list, propertyName, value);
+            recordInternalAttributeIncrementalAdd(propertyName, List.class);
         } catch(SchemaViolationException e) {
             throw new AtlasSchemaViolationException(e);
         }

--- a/intg/src/main/java/org/apache/atlas/model/instance/AtlasEntity.java
+++ b/intg/src/main/java/org/apache/atlas/model/instance/AtlasEntity.java
@@ -35,14 +35,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
@@ -71,6 +64,8 @@ public class AtlasEntity extends AtlasStruct implements Serializable {
     public static final String KEY_CREATE_TIME     = "createTime";
     public static final String KEY_UPDATE_TIME     = "updateTime";
     public static final String KEY_VERSION         = "version";
+    public static final String KEY_DOC_ID          = "docId";
+    public static final String KEY_SUPER_TYPES     = "superTypeNames";
 
     /**
      * Status of the entity - can be active or deleted. Deleted entities are not removed from Atlas store.
@@ -90,6 +85,9 @@ public class AtlasEntity extends AtlasStruct implements Serializable {
     private Date    updateTime     = null;
     private Long    version        = 0L;
     private Boolean starred       = null;
+
+    private Set<String>                     superTypeNames      = new HashSet<>();
+    private String                          docId               = null;
 
     private Map<String, Object>              relationshipAttributes;
     private Map<String, Object>              appendRelationshipAttributes;
@@ -241,6 +239,22 @@ public class AtlasEntity extends AtlasStruct implements Serializable {
             setAddedRelationshipAttributes(other.getAddedRelationshipAttributes());
             setRemovedRelationshipAttributes(other.getRemovedRelationshipAttributes());
         }
+    }
+
+    public Set<String> getSuperTypeNames() {
+        return superTypeNames;
+    }
+
+    public void setSuperTypeNames(Set<String> superTypeNames) {
+        this.superTypeNames = superTypeNames;
+    }
+
+    public String getDocId() {
+        return docId;
+    }
+
+    public void setDocId(String docId) {
+        this.docId = docId;
     }
 
     public String getGuid() {

--- a/intg/src/main/java/org/apache/atlas/model/instance/AtlasEntityHeader.java
+++ b/intg/src/main/java/org/apache/atlas/model/instance/AtlasEntityHeader.java
@@ -34,12 +34,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.Date;
+import java.util.*;
 
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.PUBLIC_ONLY;
@@ -56,6 +51,9 @@ import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.PUBLIC_
 public class AtlasEntityHeader extends AtlasStruct implements Serializable {
     private static final long serialVersionUID = 1L;
 
+    private Set<String>                     superTypeNames      = new HashSet<>();
+    private String                          vertexId            = null;
+    private String                          docId               = null;
     private String                          guid                = null;
     private AtlasEntity.Status              status              = AtlasEntity.Status.ACTIVE;
     private String                          displayText         = null;
@@ -101,6 +99,30 @@ public class AtlasEntityHeader extends AtlasStruct implements Serializable {
         setClassificationNames(null);
         setClassifications(null);
         setLabels(null);
+    }
+
+    public Set<String> getSuperTypeNames() {
+        return superTypeNames;
+    }
+
+    public void setSuperTypeNames(Set<String> superTypeNames) {
+        this.superTypeNames = superTypeNames;
+    }
+
+    public String getVertexId() {
+        return vertexId;
+    }
+
+    public void setVertexId(String vertexId) {
+        this.vertexId = vertexId;
+    }
+
+    public String getDocId() {
+        return docId;
+    }
+
+    public void setDocId(String docId) {
+        this.docId = docId;
     }
 
     public List<AtlasClassification> getAddOrUpdateClassifications() {

--- a/intg/src/main/java/org/apache/atlas/model/instance/AtlasEntityHeaderWithRelations.java
+++ b/intg/src/main/java/org/apache/atlas/model/instance/AtlasEntityHeaderWithRelations.java
@@ -26,6 +26,7 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -45,6 +46,7 @@ public class AtlasEntityHeaderWithRelations extends AtlasEntityHeader implements
     private static final long serialVersionUID = 1L;
 
     private Map<String, Object> relationshipAttributes = null;
+    private Map<String, Object> internalAttributes = null;
 
     public AtlasEntityHeaderWithRelations(String typeName, String guid, Map<String, Object> attributes) {
         super(typeName, attributes);
@@ -62,24 +64,34 @@ public class AtlasEntityHeaderWithRelations extends AtlasEntityHeader implements
         this.relationshipAttributes = relationshipAttributes;
     }
 
+    public Map<String, Object> getInternalAttributes() {
+        return internalAttributes;
+    }
+
+    public void setInternalAttributes(Map<String, Object> internalAttributes) {
+        this.internalAttributes = internalAttributes;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         if (!super.equals(o)) return false;
         AtlasEntityHeaderWithRelations that = (AtlasEntityHeaderWithRelations) o;
-        return Objects.equals(relationshipAttributes, that.relationshipAttributes);
+        return Objects.equals(relationshipAttributes, that.relationshipAttributes) &&
+                Objects.equals(internalAttributes, that.internalAttributes);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), relationshipAttributes);
+        return Objects.hash(super.hashCode(), relationshipAttributes, internalAttributes);
     }
 
     @Override
     public String toString() {
         return "AtlasEntityHeaderWithRelations{" +
                 "relationshipAttributes=" + relationshipAttributes +
+                "internalAttributes=" + internalAttributes +
                 "AtlasEntityHeader=" + super.toString() +
                 '}';
     }

--- a/intg/src/main/java/org/apache/atlas/type/AtlasBuiltInTypes.java
+++ b/intg/src/main/java/org/apache/atlas/type/AtlasBuiltInTypes.java
@@ -701,11 +701,12 @@ public class AtlasBuiltInTypes {
 
         @Override
         public boolean isValidValue(Object obj) {
-            return true;
+            return obj == null || obj instanceof String;
         }
 
         @Override
         public String getNormalizedValue(Object obj) {
+            //keeping this as-is since it is invoked in many places
             if (obj != null) {
                 return obj.toString();
             }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -66,6 +66,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSo
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.janusgraph.util.encoding.LongEncoding;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -281,7 +282,9 @@ public abstract class DeleteHandlerV1 {
             if (entityType == null) {
                 throw new AtlasBaseException(AtlasErrorCode.TYPE_NAME_INVALID, TypeCategory.ENTITY.name(), typeName);
             }
-
+            entity.setVertexId(vertex.getIdForDisplay());
+            entity.setDocId(LongEncoding.encode(Long.parseLong(vertex.getIdForDisplay())));
+            entity.setSuperTypeNames(entityType.getAllSuperTypes());
             vertexInfoMap.put(guid, new GraphHelper.VertexInfo(entity, vertex));
 
             for (AtlasStructType.AtlasAttribute attributeInfo : entityType.getOwnedRefAttributes()) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityChangeNotifier.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityChangeNotifier.java
@@ -780,6 +780,9 @@ public class AtlasEntityChangeNotifier implements IAtlasEntityChangeNotifier {
                 }
 
                 if (entity != null) {
+                    // For ES Isolation
+                    entity.setDocId(entityHeader.getDocId());
+                    entity.setSuperTypeNames(entityHeader.getSuperTypeNames());
                     ret.add(entity);
                 }
             }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -5831,7 +5831,17 @@ public class EntityGraphMapper {
                 String    fieldName = entityType.getTypeName() + "." + bmName + "." + attrName;
 
                 if (attrValue != null) {
-                    attrType.validateValue(attrValue, fieldName, messages);
+                    if ("string".equalsIgnoreCase(attrType.getTypeName())) {
+                        Object existingValue = AtlasGraphUtilsV2.getEncodedProperty(entityVertex, bmAttribute.getVertexPropertyName(), Object.class);
+                        if (existingValue instanceof String) { //do correct validation if existing value is valid type. otherwise ignore validation
+                            attrType.validateValue(attrValue, fieldName, messages);
+                        } else {
+                            LOG.warn("Existing business attribute value is not of type string for attribute {} of entity {}", fieldName, entityVertex.getIdForDisplay());
+                        }
+                    } else {
+                        attrType.validateValue(attrValue, fieldName, messages);
+                    }
+
                     boolean isValidLength = bmAttribute.isValidLength(attrValue);
                     if (!isValidLength) {
                         messages.add(fieldName + ":  Business attribute-value exceeds maximum length limit");

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -83,6 +83,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.structure.*;
 import org.janusgraph.core.Cardinality;
 import org.janusgraph.graphdb.relations.CacheVertexProperty;
+import org.janusgraph.util.encoding.LongEncoding;
 import org.javatuples.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1453,6 +1454,9 @@ public class EntityGraphRetriever {
 
             mapSystemAttributes(entityVertex, entity);
 
+            entity.setDocId(LongEncoding.encode(Long.parseLong(entityVertex.getIdForDisplay())));
+            entity.setSuperTypeNames(typeRegistry.getEntityTypeByName(entity.getTypeName()).getAllSuperTypes());
+
             mapBusinessAttributes(entityVertex, entity);
 
             mapAttributes(entityVertex, entity, entityExtInfo, isMinExtInfo, includeReferences);
@@ -1732,6 +1736,9 @@ public class EntityGraphRetriever {
             }
             AtlasEntityType entityType = typeRegistry.getEntityTypeByName(typeName);
 
+            ret.setDocId(LongEncoding.encode(Long.parseLong(entityVertex.getIdForDisplay())));
+            ret.setSuperTypeNames(entityType.getAllSuperTypes());
+
             if (entityType != null) {
                 for (AtlasAttribute headerAttribute : entityType.getHeaderAttributes().values()) {
                     Object attrValue = getVertexAttribute(entityVertex, headerAttribute, vertexEdgePropertiesCache);
@@ -1837,6 +1844,9 @@ public class EntityGraphRetriever {
             }
             AtlasEntityType entityType = typeRegistry.getEntityTypeByName(typeName);
 
+            ret.setDocId(LongEncoding.encode(Long.parseLong(entityVertex.getIdForDisplay())));
+            ret.setSuperTypeNames(entityType.getAllSuperTypes());
+
             if (entityType != null) {
                 for (AtlasAttribute headerAttribute : entityType.getHeaderAttributes().values()) {
                     Object attrValue = getVertexAttribute(entityVertex, headerAttribute);
@@ -1909,6 +1919,9 @@ public class EntityGraphRetriever {
 
             ret.setTypeName(typeName);
             ret.setGuid(guid);
+
+            ret.setDocId(LongEncoding.encode(Long.parseLong(entityVertex.getIdForDisplay())));
+            ret.setSuperTypeNames(entityType.getAllSuperTypes());
 
             String state = (String)properties.get(Constants.STATE_PROPERTY_KEY);
             Id.EntityState entityState = state == null ? null : Id.EntityState.valueOf(state);

--- a/server-api/src/main/java/org/apache/atlas/RequestContext.java
+++ b/server-api/src/main/java/org/apache/atlas/RequestContext.java
@@ -50,6 +50,7 @@ public class RequestContext {
     private final Map<String, AtlasEntityHeader>         updatedEntities      = new HashMap<>();
     private final Map<String, AtlasEntityHeader>         deletedEntities      = new HashMap<>();
     private final Map<String, AtlasEntityHeader>         restoreEntities      = new HashMap<>();
+    private final Map<String, Map<String, Object>> allInternalAttributesMap     = new HashMap<>();
 
 
     private       Map<String, String>                    lexoRankCache        = null;
@@ -193,6 +194,7 @@ public class RequestContext {
         addedClassificationAndVertices.clear();
         esDeferredOperations.clear();
         this.cassandraTagOperations.clear();
+        this.allInternalAttributesMap.clear();
 
         if (metrics != null && !metrics.isEmpty()) {
             METRICS.debug(metrics.toString());
@@ -837,6 +839,10 @@ public class RequestContext {
 
     public boolean isInvokedByLineage() {
         return isInvokedByLineage;
+    }
+
+    public Map<String, Map<String, Object>> getAllInternalAttributesMap() {
+        return allInternalAttributesMap;
     }
 
     public class EntityGuidPair {

--- a/webapp/src/main/java/org/apache/atlas/notification/EntityNotificationListenerV2.java
+++ b/webapp/src/main/java/org/apache/atlas/notification/EntityNotificationListenerV2.java
@@ -281,6 +281,9 @@ public class EntityNotificationListenerV2 implements EntityChangeListenerV2 {
         ret.setCreateTime(entity.getCreateTime());
         ret.setUpdateTime(entity.getUpdateTime());
         ret.setDeleteHandler(entity.getDeleteHandler());
+        // For ES Isolation
+        ret.setDocId(entity.getDocId());
+        ret.setSuperTypeNames(entity.getSuperTypeNames());
 
         setAttribute(ret, NAME, name);
         setAttribute(ret, DESCRIPTION, entity.getAttribute(DESCRIPTION));
@@ -302,6 +305,13 @@ public class EntityNotificationListenerV2 implements EntityChangeListenerV2 {
                         ret.setAttribute(attribute.getName(), attrValue);
                     }
                 }
+            }
+
+            // fill the internal properties like __glossary, __meanings etc. (ES Isolation)
+            RequestContext context = RequestContext.get();
+            Map<String, Object> allInternalAttributesMap = context.getAllInternalAttributesMap().get(entity.getGuid());
+            if (MapUtils.isNotEmpty(allInternalAttributesMap)) {
+                ret.setInternalAttributes(allInternalAttributesMap);
             }
 
             //Add relationship attributes which has isOptional as false


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors type-def cache refresh to an HTTP-based flow (removing Redis versioning), adds ES-isolation metadata (docId, superTypeNames) and internal-attribute tracking to entities/headers, renames alpha DQ types to DataQuality*, and updates policies, REST, graph mappers, and tests accordingly.
> 
> - **Type System & Cache Refresh**:
>   - Replace Redis versioning with HTTP-based cache refresher endpoints in `TypeCacheRefresher`; verify health and refresh all hosts (sync/async with retries) from `TypesREST`.
>   - Remove typedef reload APIs from `AtlasTypeDefStore` and implementations; simplify `searchTypesDef`; `deleteTypeByName` now void.
> - **Redis Service**:
>   - Remove `NoRedisServiceImpl`/local impl and `getValue(key, default)`; streamline `RedisServiceImpl` and `AbstractRedisService`.
>   - `FeatureFlagStore` always validates Redis connectivity.
> - **Entity Model & Notifications (ES isolation)**:
>   - Add `docId` and `superTypeNames` to `AtlasEntity`/`AtlasEntityHeader`; populate via `EntityGraphRetriever`, `DeleteHandlerV1`, `AtlasEntityChangeNotifier`.
>   - Track internal attributes in `RequestContext`; record changes in Janus `AtlasJanusElement/Vertex`; include `internalAttributes` in `EntityNotificationListenerV2`.
> - **Policies/Templates**:
>   - Rename `alpha_DQRule`/`alpha_DQRuleTemplate` to `DataQualityRule`/`DataQualityTemplate` across policies and fixtures; field rename in templates.
>   - Add AIModel relationship update and process create/delete policies.
> - **Search/ES**:
>   - `JsonToElasticsearchQuery`: unify NOT_EQUALS/NOT_IN into `bool.must_not.should`.
>   - `AtlasBuiltInTypes.STRING.isValidValue`: validate only `String` or null.
> - **Graph Store & Mappers**:
>   - Header construction updated; propagate vertex id, `docId`, `superTypeNames`; refine meanings add/remove logic and authorization checks; adjust business-attribute validation for strings.
>   - `SoftDeleteHandlerV1`: safer edge handling (tags without typeName).
> - **CI/Tests**:
>   - Update fixtures to new DQ type names/fields; adjust DSL tests.
>   - Workflow: branch allowlist tweak in `.github/workflows/maven.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca229c5ee05420100c87e6bd61c726ffa3b15351. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->