### PR TITLE
Tags v2 default for new on-boardings

### DIFF
--- a/repository/src/main/java/org/apache/atlas/services/TagsV2AutoEnabler.java
+++ b/repository/src/main/java/org/apache/atlas/services/TagsV2AutoEnabler.java
@@ -8,7 +8,6 @@ import org.apache.atlas.repository.graphdb.AtlasVertex;
 import org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2;
 import org.apache.atlas.service.FeatureFlag;
 import org.apache.atlas.service.FeatureFlagStore;
-import org.apache.atlas.store.AtlasTypeDefStore;
 import org.apache.atlas.typesystem.types.DataTypes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,7 +27,6 @@ import java.util.Iterator;
 public class TagsV2AutoEnabler {
     private static final Logger LOG = LoggerFactory.getLogger(TagsV2AutoEnabler.class);
 
-    private static final String CLASSIFICATION_TYPE = "classification";
     private static final String ENABLE_JANUS_OPTIMISATION_KEY = FeatureFlag.ENABLE_JANUS_OPTIMISATION.getKey();
     
     // Property keys for type system vertices
@@ -36,12 +34,10 @@ public class TagsV2AutoEnabler {
     private static final String TYPE_CATEGORY_PROPERTY_KEY = Constants.TYPE_CATEGORY_PROPERTY_KEY;
     private static final String VERTEX_TYPE = AtlasGraphUtilsV2.VERTEX_TYPE; // "typeSystem"
 
-    private final AtlasTypeDefStore typeDefStore;
     private final AtlasGraph graph;
 
     @Inject
-    public TagsV2AutoEnabler(AtlasTypeDefStore typeDefStore, AtlasGraph graph) {
-        this.typeDefStore = typeDefStore;
+    public TagsV2AutoEnabler(AtlasGraph graph) {
         this.graph = graph;
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a startup component that enables Tags V2 by default for new tenants if no classification types are found via a graph query.
> 
> - **Backend/Services**:
>   - **New component** `org.apache.atlas.services.TagsV2AutoEnabler`:
>     - Runs at startup to check for existing classification types via direct `AtlasGraph` query.
>     - If none found and Tags V2 not already enabled, sets feature flag `ENABLE_JANUS_OPTIMISATION` to `true`.
>     - Adds basic logging and error handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9074a5422463e06e0d268893a979a8bf74f90d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->