### PR TITLE
MESH-645 | Add entity notification while unarchiving Data Products

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -354,6 +354,20 @@ public class EntityGraphMapper {
         if (CollectionUtils.isNotEmpty(context.getEntitiesToRestore())) {
             restoreHandlerV1.restoreEntities(context.getEntitiesToRestore());
             for (AtlasEntityHeader restoredEntity : reqContext.getRestoredEntities()) {
+                if (TYPE_PRODUCT.equals(restoredEntity.getTypeName())) {
+                    AtlasEntity diffEntity;
+                    if (reqContext.getDifferentialEntity(restoredEntity.getGuid()) != null){
+                        diffEntity = reqContext.getDifferentialEntity(restoredEntity.getGuid());
+                    } else {
+                        diffEntity = new AtlasEntity(restoredEntity.getTypeName());
+                    }
+                    diffEntity.setGuid(restoredEntity.getGuid());
+                    diffEntity.setUpdatedBy(RequestContext.get().getUser());
+                    diffEntity.setUpdateTime(new Date(RequestContext.get().getRequestTime()));
+                    diffEntity.setAttribute(STATE_PROPERTY_KEY, ACTIVE.name());
+                    diffEntity.setAttribute(DAAP_STATUS_ATTR, DAAP_ACTIVE_STATUS);
+                    reqContext.cacheDifferentialEntity(diffEntity);
+                }
                 resp.addEntity(UPDATE, restoredEntity);
             }
         }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/PreProcessorUtils.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/PreProcessorUtils.java
@@ -70,6 +70,7 @@ public class PreProcessorUtils {
     public static final String INPUT_PORT_GUIDS_ATTR = "daapInputPortGuids";
     public static final String DAAP_STATUS_ATTR = "daapStatus";
     public static final String DAAP_ARCHIVED_STATUS = "Archived";
+    public static final String DAAP_ACTIVE_STATUS = "Active";
     public static final String DAAP_ASSET_DSL_ATTR = "dataProductAssetsDSL";
     public static final String DAAP_LINEAGE_STATUS_ATTR = "daapLineageStatus";
     public static final String DAAP_LINEAGE_STATUS_IN_PROGRESS = "InProgress";


### PR DESCRIPTION
## Change description

> We want to capture Kafka events triggered during data product restoration so that we can update the denormalized attributes of the linked assets that were previously delinked when the product was deleted.

JIRA: [MESH-645](https://atlanhq.atlassian.net/browse/MESH-645) - Ticket has 2 separate issues, we are concerned about the first issue mentioned in the ticket.


## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
