### PR TITLE
sync beta

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -31,7 +31,7 @@ on:
       - tagscanarymerge
       - fixlabels
       - interceptapis
-      - revert-custom-metadata-changes
+      - fix-pg-prod-cm-soft-ref
 
 jobs:
   build:

--- a/intg/src/main/java/org/apache/atlas/model/typedef/AtlasStructDef.java
+++ b/intg/src/main/java/org/apache/atlas/model/typedef/AtlasStructDef.java
@@ -557,7 +557,7 @@ public class AtlasStructDef extends AtlasBaseTypeDef implements Serializable {
         public boolean isSoftReferenced() {
             return this.options != null &&
                     getOptions().containsKey(AtlasAttributeDef.ATTRDEF_OPTION_SOFT_REFERENCE) &&
-                    getOptions().get(AtlasAttributeDef.ATTRDEF_OPTION_SOFT_REFERENCE).equals(STRING_TRUE);
+                    STRING_TRUE.equalsIgnoreCase(getOptions().get(AtlasAttributeDef.ATTRDEF_OPTION_SOFT_REFERENCE));
         }
 
         @JsonIgnore

--- a/intg/src/main/java/org/apache/atlas/type/AtlasBuiltInTypes.java
+++ b/intg/src/main/java/org/apache/atlas/type/AtlasBuiltInTypes.java
@@ -701,12 +701,11 @@ public class AtlasBuiltInTypes {
 
         @Override
         public boolean isValidValue(Object obj) {
-            return obj == null || obj instanceof String;
+            return true;
         }
 
         @Override
         public String getNormalizedValue(Object obj) {
-            //keeping this as-is since it is invoked in many places
             if (obj != null) {
                 return obj.toString();
             }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -5831,17 +5831,7 @@ public class EntityGraphMapper {
                 String    fieldName = entityType.getTypeName() + "." + bmName + "." + attrName;
 
                 if (attrValue != null) {
-                    if ("string".equalsIgnoreCase(attrType.getTypeName())) {
-                        Object existingValue = AtlasGraphUtilsV2.getEncodedProperty(entityVertex, bmAttribute.getVertexPropertyName(), Object.class);
-                        if (existingValue instanceof String) { //do correct validation if existing value is valid type. otherwise ignore validation
-                            attrType.validateValue(attrValue, fieldName, messages);
-                        } else {
-                            LOG.warn("Existing business attribute value is not of type string for attribute {} of entity {}", fieldName, entityVertex.getIdForDisplay());
-                        }
-                    } else {
-                        attrType.validateValue(attrValue, fieldName, messages);
-                    }
-
+                    attrType.validateValue(attrValue, fieldName, messages);
                     boolean isValidLength = bmAttribute.isValidLength(attrValue);
                     if (!isValidLength) {
                         messages.add(fieldName + ":  Business attribute-value exceeds maximum length limit");


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Makes soft-reference option case-insensitive, permits any input for string type validation, enforces unconditional business-metadata attribute validation, and updates Maven CI branch filters.
> 
> - **Core validation logic**:
>   - **String type (`AtlasBuiltInTypes.AtlasStringType`)**: `isValidValue` now accepts any object; normalization still uses `toString()`.
>   - **Soft-reference option (`AtlasStructDef.AtlasAttributeDef.isSoftReferenced`)**: now case-insensitive and null-safe check.
>   - **Business-metadata validation (`EntityGraphMapper.validateBusinessAttributes`)**: always calls `attrType.validateValue(...)` (removed string-only conditional), retaining length and ES keyword checks.
> - **CI/CD**:
>   - **Workflow branches**: update `on.push.branches` in `.github/workflows/maven.yml` (remove `revert-custom-metadata-changes`, add `fix-pg-prod-cm-soft-ref`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1cee4f9c7bf58aad643ea03330472df864f5400e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->