### PR TITLE
Staging helper

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,7 +25,6 @@ on:
       - beta
       - master
       - staging
-      - mlh-1226-denorm-attrs-push-kafka
 
 jobs:
   build:

--- a/intg/src/main/java/org/apache/atlas/model/typedef/AtlasStructDef.java
+++ b/intg/src/main/java/org/apache/atlas/model/typedef/AtlasStructDef.java
@@ -557,7 +557,7 @@ public class AtlasStructDef extends AtlasBaseTypeDef implements Serializable {
         public boolean isSoftReferenced() {
             return this.options != null &&
                     getOptions().containsKey(AtlasAttributeDef.ATTRDEF_OPTION_SOFT_REFERENCE) &&
-                    getOptions().get(AtlasAttributeDef.ATTRDEF_OPTION_SOFT_REFERENCE).equals(STRING_TRUE);
+                    STRING_TRUE.equalsIgnoreCase(getOptions().get(AtlasAttributeDef.ATTRDEF_OPTION_SOFT_REFERENCE));
         }
 
         @JsonIgnore

--- a/intg/src/main/java/org/apache/atlas/type/AtlasBuiltInTypes.java
+++ b/intg/src/main/java/org/apache/atlas/type/AtlasBuiltInTypes.java
@@ -701,12 +701,11 @@ public class AtlasBuiltInTypes {
 
         @Override
         public boolean isValidValue(Object obj) {
-            return obj == null || obj instanceof String;
+            return true;
         }
 
         @Override
         public String getNormalizedValue(Object obj) {
-            //keeping this as-is since it is invoked in many places
             if (obj != null) {
                 return obj.toString();
             }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -5831,17 +5831,7 @@ public class EntityGraphMapper {
                 String    fieldName = entityType.getTypeName() + "." + bmName + "." + attrName;
 
                 if (attrValue != null) {
-                    if ("string".equalsIgnoreCase(attrType.getTypeName())) {
-                        Object existingValue = AtlasGraphUtilsV2.getEncodedProperty(entityVertex, bmAttribute.getVertexPropertyName(), Object.class);
-                        if (existingValue instanceof String) { //do correct validation if existing value is valid type. otherwise ignore validation
-                            attrType.validateValue(attrValue, fieldName, messages);
-                        } else {
-                            LOG.warn("Existing business attribute value is not of type string for attribute {} of entity {}", fieldName, entityVertex.getIdForDisplay());
-                        }
-                    } else {
-                        attrType.validateValue(attrValue, fieldName, messages);
-                    }
-
+                    attrType.validateValue(attrValue, fieldName, messages);
                     boolean isValidLength = bmAttribute.isValidLength(attrValue);
                     if (!isValidLength) {
                         messages.add(fieldName + ":  Business attribute-value exceeds maximum length limit");


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Case-insensitive soft-ref option check, `string` type now accepts any value, business-attr values always validated, and CI push branches pruned.
> 
> - **Types/Model**:
>   - `AtlasStructDef.AtlasAttributeDef.isSoftReferenced()`: make soft-reference option comparison case-insensitive and null-safe.
>   - `AtlasBuiltInTypes.AtlasStringType.isValidValue()`: return `true` for any input (no type check), keeping normalization as `toString()`.
> - **Validation**:
>   - `EntityGraphMapper.validateBusinessAttributes(...)`: always call `attrType.validateValue(...)` for provided values (remove special-casing for existing `string` values).
> - **CI**:
>   - `.github/workflows/maven.yml`: remove `mlh-1226-denorm-attrs-push-kafka` from `push` branches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8783bb0465bfc7328360b322bfb3d6890e0c97a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->