### PR TITLE
ADMIN-374 Fix policy refresh when persona is disabled

### DIFF
--- a/auth-agents-common/src/main/java/org/apache/atlas/policytransformer/CachePolicyTransformerImpl.java
+++ b/auth-agents-common/src/main/java/org/apache/atlas/policytransformer/CachePolicyTransformerImpl.java
@@ -418,6 +418,10 @@ public class CachePolicyTransformerImpl {
         Map<String, EntityAuditActionV2> policyChanges = new HashMap<>();
         for (EntityAuditEventV2 event : events) {
             if (POLICY_ENTITY_TYPE.equals(event.getTypeName()) && !policyChanges.containsKey(event.getEntityId())) {
+                if (auditEventToDeltaChangeType.get(event.getAction()) == null) {
+                    LOG.warn("PolicyDelta: {}: No delta type found for audit_event={} guid={}", serviceName, event.getAction(), event.getEntityId());
+                    continue;
+                }
                 policyChanges.put(event.getEntityId(), event.getAction());
             }
         }

--- a/auth-audits/src/main/java/org/apache/atlas/audit/destination/Log4JAuditDestination.java
+++ b/auth-audits/src/main/java/org/apache/atlas/audit/destination/Log4JAuditDestination.java
@@ -46,6 +46,7 @@ public class Log4JAuditDestination extends AuditDestination {
 	private static final String AUTH_AUDIT_RESOURCE= "resource";
 	private static final String AUTH_AUDIT_CLIENT_IP = "cliIP";
 	private static final String AUTH_AUDIT_AGENT = "agent";
+	private static final String AUTH_AUDIT_ENFORCER = "enforcer";
 
 
 	public Log4JAuditDestination() {
@@ -105,6 +106,7 @@ public class Log4JAuditDestination extends AuditDestination {
 			MDC.put(AUTH_AUDIT_RESULT, String.valueOf(event.getAccessResult()));
 			MDC.put(AUTH_AUDIT_CLIENT_IP, event.getClientIP());
 			MDC.put(AUTH_AUDIT_AGENT, event.getAgentId());
+			MDC.put(AUTH_AUDIT_ENFORCER, event.getAclEnforcer());
 		}
 	}
 
@@ -118,6 +120,7 @@ public class Log4JAuditDestination extends AuditDestination {
 			MDC.remove(AUTH_AUDIT_RESULT);
 			MDC.remove(AUTH_AUDIT_CLIENT_IP);
 			MDC.remove(AUTH_AUDIT_AGENT);
+			MDC.remove(AUTH_AUDIT_ENFORCER);
 		}
 	}
 


### PR DESCRIPTION
## Change description

Fix policy refresh when persona is disabled by ignoring the non-relevant audit events

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

https://atlanhq.atlassian.net/browse/ADMIN-374

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Skips unsupported policy audit actions when building deltas and adds the "enforcer" field to audit log MDC.
> 
> - **Policy Delta Generation**:
>   - Ignores unmapped audit actions in `createPolicyChangeMap()` to avoid generating invalid policy deltas (`CachePolicyTransformerImpl`).
> - **Auditing**:
>   - Adds `enforcer` MDC attribute by recording/removing `event.getAclEnforcer()` in `Log4JAuditDestination`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd4d3545f6c9c8d7c53ca8d89391d30873122986. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->