### PR TITLE
MESH-645 : Repair API for daapOutputPortGuids

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/AtlasRepairAttributeService.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/AtlasRepairAttributeService.java
@@ -1,0 +1,70 @@
+package org.apache.atlas.repository.store.graph.v2.repair;
+
+import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.AtlasErrorCode;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import java.util.Set;
+
+@Component
+public class AtlasRepairAttributeService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AtlasRepairAttributeService.class);
+
+    private final RepairAttributeFactory repairAttributeFactory;
+
+    @Inject
+    public AtlasRepairAttributeService(RepairAttributeFactory repairAttributeFactory) {
+        this.repairAttributeFactory = repairAttributeFactory;
+    }
+
+    public void repairAttributes(String attributeName, String repairType, Set<String> entityGuids)
+            throws AtlasBaseException {
+
+        validateRequest(attributeName, repairType, entityGuids);
+
+        LOG.info("Starting attribute repair - Type: {}, Attribute: {}, Entities: {}",
+                repairType, attributeName, entityGuids.size());
+
+        try {
+            AtlasRepairAttributeStrategy strategy = repairAttributeFactory.getStrategy(repairType, entityGuids);
+
+            strategy.validate(entityGuids, attributeName);
+            strategy.repair(entityGuids, attributeName);
+
+            LOG.info("Successfully completed attribute repair - Type: {}, Attribute: {}, Entities: {}",
+                    repairType, attributeName, entityGuids.size());
+
+        } catch (Exception e) {
+            LOG.error("Error during attribute repair - Type: {}, Attribute: {}, Entities: {}",
+                    repairType, attributeName, entityGuids.size(), e);
+            throw e;
+        }
+    }
+
+    private void validateRequest(String attributeName, String repairType, Set<String> entityGuids)
+            throws AtlasBaseException {
+
+        if (StringUtils.isEmpty(attributeName)) {
+            throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST, "Attribute name cannot be empty");
+        }
+
+        if (StringUtils.isEmpty(repairType)) {
+            throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST, "Repair type cannot be empty");
+        }
+
+        if (CollectionUtils.isEmpty(entityGuids)) {
+            throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST, "Entity GUIDs cannot be empty");
+        }
+
+        if (entityGuids.size() > 1000) {
+            throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST,
+                    "Too many entities. Maximum allowed: 1000, provided: " + entityGuids.size());
+        }
+    }
+}

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/AtlasRepairAttributeStrategy.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/AtlasRepairAttributeStrategy.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.atlas.repository.store.graph.v2.repair;
+
+
+import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.model.instance.BusinessLineageRequest;
+import org.apache.atlas.repository.RepositoryException;
+
+import java.util.Set;
+
+public interface AtlasRepairAttributeStrategy {
+
+    String getRepairType();
+    void repair(Set<String> entityGuids, String attributeName) throws AtlasBaseException;
+    void validate (Set<String> entityGuids, String attributeName) throws AtlasBaseException;
+
+}
+
+

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/AtlasRepairAttributeStrategy.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/AtlasRepairAttributeStrategy.java
@@ -20,8 +20,6 @@ package org.apache.atlas.repository.store.graph.v2.repair;
 
 
 import org.apache.atlas.exception.AtlasBaseException;
-import org.apache.atlas.model.instance.BusinessLineageRequest;
-import org.apache.atlas.repository.RepositoryException;
 
 import java.util.Set;
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/RemoveInvalidGuidsRepairStrategy.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/RemoveInvalidGuidsRepairStrategy.java
@@ -6,7 +6,6 @@ import org.apache.atlas.repository.graphdb.AtlasVertex;
 import org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2;
 import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
 import org.apache.atlas.repository.store.graph.v2.TransactionInterceptHelper;
-import org.apache.commons.collections.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,15 +20,13 @@ public class RemoveInvalidGuidsRepairStrategy implements AtlasRepairAttributeStr
     private final EntityGraphRetriever entityRetriever;
 
 
-    private Set<String> entityGuids;
     private final TransactionInterceptHelper transactionInterceptHelper;
 
     private static final String REPAIR_TYPE = "REMOVE_INVALID_GUIDS";
 
-    public RemoveInvalidGuidsRepairStrategy(EntityGraphRetriever entityRetriever, Set<String> entityGuids, TransactionInterceptHelper transactionInterceptHelper) {
+    public RemoveInvalidGuidsRepairStrategy(EntityGraphRetriever entityRetriever, TransactionInterceptHelper transactionInterceptHelper) {
         this.entityRetriever = entityRetriever;
         this.transactionInterceptHelper = transactionInterceptHelper;
-        this.entityGuids = entityGuids;
     }
 
     @Override

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/RemoveInvalidGuidsRepairStrategy.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/RemoveInvalidGuidsRepairStrategy.java
@@ -1,0 +1,138 @@
+package org.apache.atlas.repository.store.graph.v2.repair;
+
+import org.apache.atlas.AtlasErrorCode;
+import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.repository.graphdb.AtlasVertex;
+import org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2;
+import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
+import org.apache.atlas.repository.store.graph.v2.TransactionInterceptHelper;
+import org.apache.commons.collections.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+import static org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessorUtils.OUTPUT_PORT_GUIDS_ATTR;
+
+public class RemoveInvalidGuidsRepairStrategy implements AtlasRepairAttributeStrategy {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RemoveInvalidGuidsRepairStrategy.class);
+
+    private final EntityGraphRetriever entityRetriever;
+
+
+    private Set<String> entityGuids;
+    private final TransactionInterceptHelper transactionInterceptHelper;
+
+    private static final String REPAIR_TYPE = "REMOVE_INVALID_GUIDS";
+
+    public RemoveInvalidGuidsRepairStrategy(EntityGraphRetriever entityRetriever, Set<String> entityGuids, TransactionInterceptHelper transactionInterceptHelper) {
+        this.entityRetriever = entityRetriever;
+        this.transactionInterceptHelper = transactionInterceptHelper;
+        this.entityGuids = entityGuids;
+    }
+
+    @Override
+    public String getRepairType() {
+        return REPAIR_TYPE;
+    }
+
+    @Override
+    public void validate(Set<String> entityGuids, String attributeName) throws AtlasBaseException {
+        for (String entityGuid : entityGuids) {
+            AtlasVertex entityVertex = entityRetriever.getEntityVertex(entityGuid);
+
+            if (entityVertex == null) {
+                throw new AtlasBaseException(AtlasErrorCode.INSTANCE_GUID_NOT_FOUND, "Entity vertex not found for guid: " + entityGuid);
+            }
+        }
+    }
+
+    @Override
+    public void repair(Set<String> entityGuids, String attributeName) throws AtlasBaseException {
+        try {
+            int count = 0;
+            int totalUpdatedCount = 0;
+
+            for (String entityGuid : entityGuids) {
+                AtlasVertex entityVertex = entityRetriever.getEntityVertex(entityGuid);
+
+                if (entityVertex == null) {
+                    LOG.error("Entity vertex not found for guid: {}", entityGuid);
+                    continue;
+                }
+
+                if (!entityVertex.getPropertyKeys().contains(attributeName)) {
+                    LOG.info("Attribute: {} not found for entity: {}. Skipping repair for this entity.", attributeName, entityGuid);
+                    continue;
+                }
+
+                if (OUTPUT_PORT_GUIDS_ATTR.equals(attributeName)) {
+                    boolean isCommitRequired = repairAttr(entityVertex);
+                    if (isCommitRequired){
+                        count++;
+                        totalUpdatedCount++;
+                    } else {
+                        LOG.info("No changes to commit for entity: {}", entityGuid);
+                    }
+
+                    if (count == 50) {
+                        LOG.info("Committing batch of 50 entities...");
+                        commitChanges();
+                        count = 0;
+                    }
+                }
+            }
+
+            if (count > 0) {
+                LOG.info("Committing remaining {} entities...", count);
+                commitChanges();
+            }
+
+            LOG.info("Total Vertex updated: {}", totalUpdatedCount);
+
+        } catch(Exception e){
+            LOG.error("Error while performing repair: {}", entityGuids, e);
+            throw e;
+        }
+    }
+
+    private boolean repairAttr(AtlasVertex vertex) throws AtlasBaseException {
+        try{
+            boolean isCommitRequired = false;
+
+            List<String> outputPortGuids = vertex.getMultiValuedProperty(OUTPUT_PORT_GUIDS_ATTR, String.class);
+            if (outputPortGuids == null || outputPortGuids.isEmpty()) {
+                LOG.info("No guids found in attribute: {} for entity: {}. Skipping repair for this entity.", OUTPUT_PORT_GUIDS_ATTR, vertex.getProperty("guid", String.class));
+                return false;
+            }
+
+            vertex.removeProperty(OUTPUT_PORT_GUIDS_ATTR);
+
+            for (String guid : outputPortGuids) {
+                AtlasVertex portVertex = entityRetriever.getEntityVertex(guid);
+                if (portVertex != null) {
+                    AtlasGraphUtilsV2.addEncodedProperty(vertex, OUTPUT_PORT_GUIDS_ATTR , guid);
+                    isCommitRequired = true;
+                } else {
+                    LOG.info("Removing invalid or hard deleted guid: {}", guid);
+                }
+            }
+
+            return isCommitRequired;
+        } catch (Exception e) {
+            LOG.error("Failed to migrate unique qualifiedName attribute for entity: ", e);
+            throw e;
+        }
+    }
+
+    public void commitChanges() throws AtlasBaseException {
+        try {
+            transactionInterceptHelper.intercept();
+            LOG.info("Committed a entity to the graph");
+        } catch (Exception e){
+            LOG.error("Failed to commit asset: ", e);
+            throw e;
+        }
+    }
+}

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/RepairAttributeFactory.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/RepairAttributeFactory.java
@@ -25,7 +25,7 @@ public class RepairAttributeFactory {
     public AtlasRepairAttributeStrategy getStrategy(String repairType, Set<String> entityGuids) throws AtlasBaseException {
         switch (repairType) {
             case "REMOVE_INVALID_GUIDS":
-                return new RemoveInvalidGuidsRepairStrategy(entityRetriever, entityGuids, transactionInterceptHelper);
+                return new RemoveInvalidGuidsRepairStrategy(entityRetriever, transactionInterceptHelper);
             default:
                 throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST,
                         "Unsupported repair type: " + repairType + ". Supported types: [REMOVE_INVALID_GUIDS]");

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/RepairAttributeFactory.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/RepairAttributeFactory.java
@@ -1,0 +1,38 @@
+package org.apache.atlas.repository.store.graph.v2.repair;
+
+import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.AtlasErrorCode;
+import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
+import org.apache.atlas.repository.store.graph.v2.TransactionInterceptHelper;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import java.util.Set;
+
+@Component
+public class RepairAttributeFactory {
+
+    private final EntityGraphRetriever entityRetriever;
+    private final TransactionInterceptHelper transactionInterceptHelper;
+
+    @Inject
+    public RepairAttributeFactory(EntityGraphRetriever entityRetriever,
+                                  TransactionInterceptHelper transactionInterceptHelper) {
+        this.entityRetriever = entityRetriever;
+        this.transactionInterceptHelper = transactionInterceptHelper;
+    }
+
+    public AtlasRepairAttributeStrategy getStrategy(String repairType, Set<String> entityGuids) throws AtlasBaseException {
+        switch (repairType) {
+            case "REMOVE_INVALID_GUIDS":
+                return new RemoveInvalidGuidsRepairStrategy(entityRetriever, entityGuids, transactionInterceptHelper);
+            default:
+                throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST,
+                        "Unsupported repair type: " + repairType + ". Supported types: [REMOVE_INVALID_GUIDS]");
+        }
+    }
+
+    public boolean isValidRepairType(String repairType) {
+        return "REMOVE_INVALID_GUIDS".equals(repairType);
+    }
+}

--- a/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
@@ -43,6 +43,7 @@ import org.apache.atlas.repository.audit.ESBasedAuditRepository;
 import org.apache.atlas.repository.converters.AtlasInstanceConverter;
 import org.apache.atlas.repository.store.graph.AtlasEntityStore;
 import org.apache.atlas.repository.store.graph.v2.*;
+import org.apache.atlas.repository.store.graph.v2.repair.AtlasRepairAttributeService;
 import org.apache.atlas.service.FeatureFlagStore;
 import org.apache.atlas.type.AtlasClassificationType;
 import org.apache.atlas.type.AtlasEntityType;
@@ -109,14 +110,16 @@ public class EntityREST {
     private final ESBasedAuditRepository  esBasedAuditRepository;
     private final EntityGraphRetriever entityGraphRetriever;
     private final EntityMutationService entityMutationService;
+    private final AtlasRepairAttributeService repairAttributeService;
 
     @Inject
-    public EntityREST(AtlasTypeRegistry typeRegistry, AtlasEntityStore entitiesStore, ESBasedAuditRepository  esBasedAuditRepository, EntityGraphRetriever retriever, EntityMutationService entityMutationService) {
+    public EntityREST(AtlasTypeRegistry typeRegistry, AtlasEntityStore entitiesStore, ESBasedAuditRepository  esBasedAuditRepository, EntityGraphRetriever retriever, EntityMutationService entityMutationService, AtlasRepairAttributeService repairAttributeService) {
         this.typeRegistry      = typeRegistry;
         this.entitiesStore     = entitiesStore;
         this.esBasedAuditRepository = esBasedAuditRepository;
         this.entityGraphRetriever = retriever;
         this.entityMutationService = entityMutationService;
+        this.repairAttributeService = repairAttributeService;
     }
 
     /**
@@ -1850,6 +1853,38 @@ public class EntityREST {
             repairIndex.restoreByIds(guids);
         } catch (Exception e) {
             LOG.error("Exception while repairEntityIndexBulk ", e);
+            throw new AtlasBaseException(e);
+        } finally {
+            AtlasPerfTracer.log(perf);
+        }
+    }
+
+    /**
+     * Repair attributes for the entity GUID.
+     * @param guids
+     * @throws AtlasBaseException
+     */
+
+    @POST
+    @Path("/guid/bulk/repairattributes")
+    public void repairEntityAttributesBulk(Set<String> guids, @QueryParam("repairType") String repairType, @QueryParam("repairAttributeName") String repairAttributeName) throws AtlasBaseException {
+
+        Servlets.validateQueryParamLength("repairType", repairType);
+        Servlets.validateQueryParamLength("repairAttribute", repairAttributeName);
+
+        AtlasAuthorizationUtils.verifyAccess(new AtlasAdminAccessRequest(AtlasPrivilege.ADMIN_REPAIR_INDEX), "Admin Repair Attributes");
+
+        AtlasPerfTracer perf = null;
+
+        try {
+            if (AtlasPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
+                perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "EntityREST.repairEntityAttributesBulk(" + guids.size() + ")");
+            }
+
+            repairAttributeService.repairAttributes(repairAttributeName, repairType, guids);
+
+        } catch (Exception e) {
+            LOG.error("Exception while repairEntityAttributesBulk ", e);
             throw new AtlasBaseException(e);
         } finally {
             AtlasPerfTracer.log(perf);

--- a/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
@@ -1870,7 +1870,7 @@ public class EntityREST {
     public void repairEntityAttributesBulk(Set<String> guids, @QueryParam("repairType") String repairType, @QueryParam("repairAttributeName") String repairAttributeName) throws AtlasBaseException {
 
         Servlets.validateQueryParamLength("repairType", repairType);
-        Servlets.validateQueryParamLength("repairAttribute", repairAttributeName);
+        Servlets.validateQueryParamLength("repairAttributeName", repairAttributeName);
 
         AtlasAuthorizationUtils.verifyAccess(new AtlasAdminAccessRequest(AtlasPrivilege.ADMIN_REPAIR_INDEX), "Admin Repair Attributes");
 


### PR DESCRIPTION
## Change description

> Description here

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a pluggable attribute-repair framework and a new bulk REST API to clean invalid GUIDs in entity attributes.
> 
> - **Backend**:
>   - **Repair framework**:
>     - Introduces `AtlasRepairAttributeStrategy` interface and `RepairAttributeFactory` (validates type; supports `REMOVE_INVALID_GUIDS`).
>     - Implements `RemoveInvalidGuidsRepairStrategy` to purge non-existent GUIDs from `OUTPUT_PORT_GUIDS_ATTR`, batching commits and using `TransactionInterceptHelper`.
>     - Adds `AtlasRepairAttributeService` to validate requests and orchestrate strategy execution with logging.
> - **REST API**:
>   - In `EntityREST`:
>     - Injects `AtlasRepairAttributeService`.
>     - Adds `POST /v2/entity/guid/bulk/repairattributes` with `repairType` and `repairAttributeName` query params; admin check, perf tracing, delegates to service.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06c77418c465ab28f3e0347b4f6959aeb3e8f223. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->