### PR TITLE
Mesh 645 repair

### DIFF
--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusVertex.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusVertex.java
@@ -20,6 +20,7 @@ package org.apache.atlas.repository.graphdb.janus;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.StreamSupport;
 
@@ -55,6 +56,7 @@ public class AtlasJanusVertex extends AtlasJanusElement<Vertex> implements Atlas
     public <T> void addProperty(String propertyName, T value) {
         try {
             getWrappedElement().property(VertexProperty.Cardinality.set, propertyName, value);
+            recordInternalAttributeIncrementalAdd(propertyName, Set.class);
         } catch(SchemaViolationException e) {
             throw new AtlasSchemaViolationException(e);
         }
@@ -64,6 +66,7 @@ public class AtlasJanusVertex extends AtlasJanusElement<Vertex> implements Atlas
     public <T> void addListProperty(String propertyName, T value) {
         try {
             getWrappedElement().property(VertexProperty.Cardinality.list, propertyName, value);
+            recordInternalAttributeIncrementalAdd(propertyName, List.class);
         } catch(SchemaViolationException e) {
             throw new AtlasSchemaViolationException(e);
         }

--- a/intg/src/main/java/org/apache/atlas/model/instance/AtlasEntity.java
+++ b/intg/src/main/java/org/apache/atlas/model/instance/AtlasEntity.java
@@ -35,14 +35,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
@@ -71,6 +64,8 @@ public class AtlasEntity extends AtlasStruct implements Serializable {
     public static final String KEY_CREATE_TIME     = "createTime";
     public static final String KEY_UPDATE_TIME     = "updateTime";
     public static final String KEY_VERSION         = "version";
+    public static final String KEY_DOC_ID          = "docId";
+    public static final String KEY_SUPER_TYPES     = "superTypeNames";
 
     /**
      * Status of the entity - can be active or deleted. Deleted entities are not removed from Atlas store.
@@ -90,6 +85,9 @@ public class AtlasEntity extends AtlasStruct implements Serializable {
     private Date    updateTime     = null;
     private Long    version        = 0L;
     private Boolean starred       = null;
+
+    private Set<String>                     superTypeNames      = new HashSet<>();
+    private String                          docId               = null;
 
     private Map<String, Object>              relationshipAttributes;
     private Map<String, Object>              appendRelationshipAttributes;
@@ -241,6 +239,22 @@ public class AtlasEntity extends AtlasStruct implements Serializable {
             setAddedRelationshipAttributes(other.getAddedRelationshipAttributes());
             setRemovedRelationshipAttributes(other.getRemovedRelationshipAttributes());
         }
+    }
+
+    public Set<String> getSuperTypeNames() {
+        return superTypeNames;
+    }
+
+    public void setSuperTypeNames(Set<String> superTypeNames) {
+        this.superTypeNames = superTypeNames;
+    }
+
+    public String getDocId() {
+        return docId;
+    }
+
+    public void setDocId(String docId) {
+        this.docId = docId;
     }
 
     public String getGuid() {

--- a/intg/src/main/java/org/apache/atlas/model/instance/AtlasEntityHeader.java
+++ b/intg/src/main/java/org/apache/atlas/model/instance/AtlasEntityHeader.java
@@ -34,12 +34,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.Date;
+import java.util.*;
 
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.PUBLIC_ONLY;
@@ -56,6 +51,9 @@ import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.PUBLIC_
 public class AtlasEntityHeader extends AtlasStruct implements Serializable {
     private static final long serialVersionUID = 1L;
 
+    private Set<String>                     superTypeNames      = new HashSet<>();
+    private String                          vertexId            = null;
+    private String                          docId               = null;
     private String                          guid                = null;
     private AtlasEntity.Status              status              = AtlasEntity.Status.ACTIVE;
     private String                          displayText         = null;
@@ -101,6 +99,30 @@ public class AtlasEntityHeader extends AtlasStruct implements Serializable {
         setClassificationNames(null);
         setClassifications(null);
         setLabels(null);
+    }
+
+    public Set<String> getSuperTypeNames() {
+        return superTypeNames;
+    }
+
+    public void setSuperTypeNames(Set<String> superTypeNames) {
+        this.superTypeNames = superTypeNames;
+    }
+
+    public String getVertexId() {
+        return vertexId;
+    }
+
+    public void setVertexId(String vertexId) {
+        this.vertexId = vertexId;
+    }
+
+    public String getDocId() {
+        return docId;
+    }
+
+    public void setDocId(String docId) {
+        this.docId = docId;
     }
 
     public List<AtlasClassification> getAddOrUpdateClassifications() {

--- a/intg/src/main/java/org/apache/atlas/model/instance/AtlasEntityHeaderWithRelations.java
+++ b/intg/src/main/java/org/apache/atlas/model/instance/AtlasEntityHeaderWithRelations.java
@@ -26,6 +26,7 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -45,6 +46,7 @@ public class AtlasEntityHeaderWithRelations extends AtlasEntityHeader implements
     private static final long serialVersionUID = 1L;
 
     private Map<String, Object> relationshipAttributes = null;
+    private Map<String, Object> internalAttributes = null;
 
     public AtlasEntityHeaderWithRelations(String typeName, String guid, Map<String, Object> attributes) {
         super(typeName, attributes);
@@ -62,24 +64,34 @@ public class AtlasEntityHeaderWithRelations extends AtlasEntityHeader implements
         this.relationshipAttributes = relationshipAttributes;
     }
 
+    public Map<String, Object> getInternalAttributes() {
+        return internalAttributes;
+    }
+
+    public void setInternalAttributes(Map<String, Object> internalAttributes) {
+        this.internalAttributes = internalAttributes;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         if (!super.equals(o)) return false;
         AtlasEntityHeaderWithRelations that = (AtlasEntityHeaderWithRelations) o;
-        return Objects.equals(relationshipAttributes, that.relationshipAttributes);
+        return Objects.equals(relationshipAttributes, that.relationshipAttributes) &&
+                Objects.equals(internalAttributes, that.internalAttributes);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), relationshipAttributes);
+        return Objects.hash(super.hashCode(), relationshipAttributes, internalAttributes);
     }
 
     @Override
     public String toString() {
         return "AtlasEntityHeaderWithRelations{" +
                 "relationshipAttributes=" + relationshipAttributes +
+                "internalAttributes=" + internalAttributes +
                 "AtlasEntityHeader=" + super.toString() +
                 '}';
     }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -66,6 +66,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSo
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.janusgraph.util.encoding.LongEncoding;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -281,7 +282,9 @@ public abstract class DeleteHandlerV1 {
             if (entityType == null) {
                 throw new AtlasBaseException(AtlasErrorCode.TYPE_NAME_INVALID, TypeCategory.ENTITY.name(), typeName);
             }
-
+            entity.setVertexId(vertex.getIdForDisplay());
+            entity.setDocId(LongEncoding.encode(Long.parseLong(vertex.getIdForDisplay())));
+            entity.setSuperTypeNames(entityType.getAllSuperTypes());
             vertexInfoMap.put(guid, new GraphHelper.VertexInfo(entity, vertex));
 
             for (AtlasStructType.AtlasAttribute attributeInfo : entityType.getOwnedRefAttributes()) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityChangeNotifier.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityChangeNotifier.java
@@ -780,6 +780,9 @@ public class AtlasEntityChangeNotifier implements IAtlasEntityChangeNotifier {
                 }
 
                 if (entity != null) {
+                    // For ES Isolation
+                    entity.setDocId(entityHeader.getDocId());
+                    entity.setSuperTypeNames(entityHeader.getSuperTypeNames());
                     ret.add(entity);
                 }
             }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -64,19 +64,10 @@ import org.apache.atlas.repository.store.graph.v2.utils.TagAttributeMapper;
 import org.apache.atlas.repository.util.TagDeNormAttributesUtil;
 import org.apache.atlas.service.FeatureFlagStore;
 import org.apache.atlas.tasks.TaskManagement;
-import org.apache.atlas.type.AtlasArrayType;
-import org.apache.atlas.type.AtlasBuiltInTypes;
+import org.apache.atlas.type.*;
 import org.apache.atlas.type.AtlasBusinessMetadataType.AtlasBusinessAttribute;
-import org.apache.atlas.type.AtlasClassificationType;
-import org.apache.atlas.type.AtlasEntityType;
-import org.apache.atlas.type.AtlasMapType;
-import org.apache.atlas.type.AtlasRelationshipType;
-import org.apache.atlas.type.AtlasStructType;
 import org.apache.atlas.type.AtlasStructType.AtlasAttribute;
 import org.apache.atlas.type.AtlasStructType.AtlasAttribute.AtlasRelationshipEdgeDirection;
-import org.apache.atlas.type.AtlasType;
-import org.apache.atlas.type.AtlasTypeRegistry;
-import org.apache.atlas.type.AtlasTypeUtil;
 import org.apache.atlas.utils.AtlasEntityUtil;
 import org.apache.atlas.utils.AtlasJson;
 import org.apache.atlas.utils.AtlasPerfMetrics;
@@ -173,6 +164,8 @@ public class EntityGraphMapper {
     private static final String ATTR_MEANINGS = "meanings";
     private static final String ATTR_ANCHOR = "anchor";
     private static final String ATTR_CATEGORIES = "categories";
+    private static final int ELASTICSEARCH_KEYWORD_MAX_BYTES = 32766;
+    private static final String UTF8_CHARSET = "UTF-8";
     private static final List<String> ALLOWED_DATATYPES_FOR_DEFAULT_NULL = new ArrayList() {
         {
             add("int");
@@ -2459,6 +2452,47 @@ public class EntityGraphMapper {
             throw new AtlasBaseException(AtlasErrorCode.OPERATION_NOT_SUPPORTED,
                     "Custom relationships size is more than " + UD_REL_THRESHOLD + ", current is " + size + " for " + vertex.getProperty(NAME, String.class));
         }
+    }
+
+    private void validateElasticsearchKeywordSize(AtlasBusinessAttribute bmAttribute, Object attrValue, String fieldName, List<String> messages) {
+        if (!isKeywordMappedAttribute(bmAttribute)) {
+            return;
+        }
+
+        if (attrValue == null) {
+            return;
+        }
+
+        try {
+            String valueAsString = attrValue.toString();
+            byte[] valueBytes = valueAsString.getBytes(UTF8_CHARSET);
+
+            if (valueBytes.length > ELASTICSEARCH_KEYWORD_MAX_BYTES) {
+                messages.add(String.format("%s: Business attribute value exceeds Elasticsearch keyword limit. " +
+                                "Size: %d bytes, Limit: %d bytes (32KB). Consider using a different field type or reducing the value size.",
+                        fieldName, valueBytes.length, ELASTICSEARCH_KEYWORD_MAX_BYTES));
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to validate Elasticsearch keyword size for field: {}", fieldName, e);
+            messages.add(String.format("%s: Failed to validate Elasticsearch keyword size due to an error: %s",
+                    fieldName, e.getMessage()));
+
+        }
+    }
+
+    private boolean isKeywordMappedAttribute(AtlasBusinessAttribute bmAttribute) {
+        AtlasAttributeDef attributeDef = bmAttribute.getAttributeDef();
+        AtlasType attrType = bmAttribute.getAttributeType();
+
+        if (attrType instanceof AtlasBuiltInTypes.AtlasStringType || attrType instanceof AtlasEnumType) {
+            return true;
+        }
+
+        if (AtlasAttributeDef.IndexType.STRING == attributeDef.getIndexType()) {
+            return true;
+        }
+
+        return false;
     }
 
     private void addInternalProductAttr(AttributeMutationContext ctx, List<Object> createdElements, List<AtlasEdge> deletedElements, List<Object> currentElements) throws AtlasBaseException {
@@ -5802,6 +5836,8 @@ public class EntityGraphMapper {
                     if (!isValidLength) {
                         messages.add(fieldName + ":  Business attribute-value exceeds maximum length limit");
                     }
+
+                    validateElasticsearchKeywordSize(bmAttribute, attrValue, fieldName, messages);
 
                 } else if (!bmAttribute.getAttributeDef().getIsOptional()) {
                     final boolean isAttrValuePresent;

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -83,6 +83,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.structure.*;
 import org.janusgraph.core.Cardinality;
 import org.janusgraph.graphdb.relations.CacheVertexProperty;
+import org.janusgraph.util.encoding.LongEncoding;
 import org.javatuples.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1453,6 +1454,9 @@ public class EntityGraphRetriever {
 
             mapSystemAttributes(entityVertex, entity);
 
+            entity.setDocId(LongEncoding.encode(Long.parseLong(entityVertex.getIdForDisplay())));
+            entity.setSuperTypeNames(typeRegistry.getEntityTypeByName(entity.getTypeName()).getAllSuperTypes());
+
             mapBusinessAttributes(entityVertex, entity);
 
             mapAttributes(entityVertex, entity, entityExtInfo, isMinExtInfo, includeReferences);
@@ -1732,6 +1736,9 @@ public class EntityGraphRetriever {
             }
             AtlasEntityType entityType = typeRegistry.getEntityTypeByName(typeName);
 
+            ret.setDocId(LongEncoding.encode(Long.parseLong(entityVertex.getIdForDisplay())));
+            ret.setSuperTypeNames(entityType.getAllSuperTypes());
+
             if (entityType != null) {
                 for (AtlasAttribute headerAttribute : entityType.getHeaderAttributes().values()) {
                     Object attrValue = getVertexAttribute(entityVertex, headerAttribute, vertexEdgePropertiesCache);
@@ -1837,6 +1844,9 @@ public class EntityGraphRetriever {
             }
             AtlasEntityType entityType = typeRegistry.getEntityTypeByName(typeName);
 
+            ret.setDocId(LongEncoding.encode(Long.parseLong(entityVertex.getIdForDisplay())));
+            ret.setSuperTypeNames(entityType.getAllSuperTypes());
+
             if (entityType != null) {
                 for (AtlasAttribute headerAttribute : entityType.getHeaderAttributes().values()) {
                     Object attrValue = getVertexAttribute(entityVertex, headerAttribute);
@@ -1909,6 +1919,9 @@ public class EntityGraphRetriever {
 
             ret.setTypeName(typeName);
             ret.setGuid(guid);
+
+            ret.setDocId(LongEncoding.encode(Long.parseLong(entityVertex.getIdForDisplay())));
+            ret.setSuperTypeNames(entityType.getAllSuperTypes());
 
             String state = (String)properties.get(Constants.STATE_PROPERTY_KEY);
             Id.EntityState entityState = state == null ? null : Id.EntityState.valueOf(state);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/AtlasRepairAttributeService.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/AtlasRepairAttributeService.java
@@ -1,0 +1,70 @@
+package org.apache.atlas.repository.store.graph.v2.repair;
+
+import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.AtlasErrorCode;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import java.util.Set;
+
+@Component
+public class AtlasRepairAttributeService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AtlasRepairAttributeService.class);
+
+    private final RepairAttributeFactory repairAttributeFactory;
+
+    @Inject
+    public AtlasRepairAttributeService(RepairAttributeFactory repairAttributeFactory) {
+        this.repairAttributeFactory = repairAttributeFactory;
+    }
+
+    public void repairAttributes(String attributeName, String repairType, Set<String> entityGuids)
+            throws AtlasBaseException {
+
+        validateRequest(attributeName, repairType, entityGuids);
+
+        LOG.info("Starting attribute repair - Type: {}, Attribute: {}, Entities: {}",
+                repairType, attributeName, entityGuids.size());
+
+        try {
+            AtlasRepairAttributeStrategy strategy = repairAttributeFactory.getStrategy(repairType, entityGuids);
+
+            strategy.validate(entityGuids, attributeName);
+            strategy.repair(entityGuids, attributeName);
+
+            LOG.info("Successfully completed attribute repair - Type: {}, Attribute: {}, Entities: {}",
+                    repairType, attributeName, entityGuids.size());
+
+        } catch (Exception e) {
+            LOG.error("Error during attribute repair - Type: {}, Attribute: {}, Entities: {}",
+                    repairType, attributeName, entityGuids.size(), e);
+            throw e;
+        }
+    }
+
+    private void validateRequest(String attributeName, String repairType, Set<String> entityGuids)
+            throws AtlasBaseException {
+
+        if (StringUtils.isEmpty(attributeName)) {
+            throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST, "Attribute name cannot be empty");
+        }
+
+        if (StringUtils.isEmpty(repairType)) {
+            throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST, "Repair type cannot be empty");
+        }
+
+        if (CollectionUtils.isEmpty(entityGuids)) {
+            throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST, "Entity GUIDs cannot be empty");
+        }
+
+        if (entityGuids.size() > 1000) {
+            throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST,
+                    "Too many entities. Maximum allowed: 1000, provided: " + entityGuids.size());
+        }
+    }
+}

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/AtlasRepairAttributeStrategy.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/AtlasRepairAttributeStrategy.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.atlas.repository.store.graph.v2.repair;
+
+
+import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.model.instance.BusinessLineageRequest;
+import org.apache.atlas.repository.RepositoryException;
+
+import java.util.Set;
+
+public interface AtlasRepairAttributeStrategy {
+
+    String getRepairType();
+    void repair(Set<String> entityGuids, String attributeName) throws AtlasBaseException;
+    void validate (Set<String> entityGuids, String attributeName) throws AtlasBaseException;
+
+}
+
+

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/AtlasRepairAttributeStrategy.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/AtlasRepairAttributeStrategy.java
@@ -20,8 +20,6 @@ package org.apache.atlas.repository.store.graph.v2.repair;
 
 
 import org.apache.atlas.exception.AtlasBaseException;
-import org.apache.atlas.model.instance.BusinessLineageRequest;
-import org.apache.atlas.repository.RepositoryException;
 
 import java.util.Set;
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/AtlasRepairAttributeStrategy.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/AtlasRepairAttributeStrategy.java
@@ -1,21 +1,3 @@
-/**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.apache.atlas.repository.store.graph.v2.repair;
 
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/RemoveInvalidGuidsRepairStrategy.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/RemoveInvalidGuidsRepairStrategy.java
@@ -22,7 +22,7 @@ public class RemoveInvalidGuidsRepairStrategy implements AtlasRepairAttributeStr
 
     private final TransactionInterceptHelper transactionInterceptHelper;
 
-    private static final String REPAIR_TYPE = "REMOVE_INVALID_GUIDS";
+    private static final String REPAIR_TYPE = "REMOVE_INVALID_OUTPUT_PORT_GUIDS";
 
     public RemoveInvalidGuidsRepairStrategy(EntityGraphRetriever entityRetriever, TransactionInterceptHelper transactionInterceptHelper) {
         this.entityRetriever = entityRetriever;

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/RemoveInvalidGuidsRepairStrategy.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/RemoveInvalidGuidsRepairStrategy.java
@@ -6,7 +6,6 @@ import org.apache.atlas.repository.graphdb.AtlasVertex;
 import org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2;
 import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
 import org.apache.atlas.repository.store.graph.v2.TransactionInterceptHelper;
-import org.apache.commons.collections.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,15 +20,13 @@ public class RemoveInvalidGuidsRepairStrategy implements AtlasRepairAttributeStr
     private final EntityGraphRetriever entityRetriever;
 
 
-    private Set<String> entityGuids;
     private final TransactionInterceptHelper transactionInterceptHelper;
 
     private static final String REPAIR_TYPE = "REMOVE_INVALID_GUIDS";
 
-    public RemoveInvalidGuidsRepairStrategy(EntityGraphRetriever entityRetriever, Set<String> entityGuids, TransactionInterceptHelper transactionInterceptHelper) {
+    public RemoveInvalidGuidsRepairStrategy(EntityGraphRetriever entityRetriever, TransactionInterceptHelper transactionInterceptHelper) {
         this.entityRetriever = entityRetriever;
         this.transactionInterceptHelper = transactionInterceptHelper;
-        this.entityGuids = entityGuids;
     }
 
     @Override

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/RemoveInvalidGuidsRepairStrategy.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/RemoveInvalidGuidsRepairStrategy.java
@@ -1,0 +1,138 @@
+package org.apache.atlas.repository.store.graph.v2.repair;
+
+import org.apache.atlas.AtlasErrorCode;
+import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.repository.graphdb.AtlasVertex;
+import org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2;
+import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
+import org.apache.atlas.repository.store.graph.v2.TransactionInterceptHelper;
+import org.apache.commons.collections.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+import static org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessorUtils.OUTPUT_PORT_GUIDS_ATTR;
+
+public class RemoveInvalidGuidsRepairStrategy implements AtlasRepairAttributeStrategy {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RemoveInvalidGuidsRepairStrategy.class);
+
+    private final EntityGraphRetriever entityRetriever;
+
+
+    private Set<String> entityGuids;
+    private final TransactionInterceptHelper transactionInterceptHelper;
+
+    private static final String REPAIR_TYPE = "REMOVE_INVALID_GUIDS";
+
+    public RemoveInvalidGuidsRepairStrategy(EntityGraphRetriever entityRetriever, Set<String> entityGuids, TransactionInterceptHelper transactionInterceptHelper) {
+        this.entityRetriever = entityRetriever;
+        this.transactionInterceptHelper = transactionInterceptHelper;
+        this.entityGuids = entityGuids;
+    }
+
+    @Override
+    public String getRepairType() {
+        return REPAIR_TYPE;
+    }
+
+    @Override
+    public void validate(Set<String> entityGuids, String attributeName) throws AtlasBaseException {
+        for (String entityGuid : entityGuids) {
+            AtlasVertex entityVertex = entityRetriever.getEntityVertex(entityGuid);
+
+            if (entityVertex == null) {
+                throw new AtlasBaseException(AtlasErrorCode.INSTANCE_GUID_NOT_FOUND, "Entity vertex not found for guid: " + entityGuid);
+            }
+        }
+    }
+
+    @Override
+    public void repair(Set<String> entityGuids, String attributeName) throws AtlasBaseException {
+        try {
+            int count = 0;
+            int totalUpdatedCount = 0;
+
+            for (String entityGuid : entityGuids) {
+                AtlasVertex entityVertex = entityRetriever.getEntityVertex(entityGuid);
+
+                if (entityVertex == null) {
+                    LOG.error("Entity vertex not found for guid: {}", entityGuid);
+                    continue;
+                }
+
+                if (!entityVertex.getPropertyKeys().contains(attributeName)) {
+                    LOG.info("Attribute: {} not found for entity: {}. Skipping repair for this entity.", attributeName, entityGuid);
+                    continue;
+                }
+
+                if (OUTPUT_PORT_GUIDS_ATTR.equals(attributeName)) {
+                    boolean isCommitRequired = repairAttr(entityVertex);
+                    if (isCommitRequired){
+                        count++;
+                        totalUpdatedCount++;
+                    } else {
+                        LOG.info("No changes to commit for entity: {}", entityGuid);
+                    }
+
+                    if (count == 50) {
+                        LOG.info("Committing batch of 50 entities...");
+                        commitChanges();
+                        count = 0;
+                    }
+                }
+            }
+
+            if (count > 0) {
+                LOG.info("Committing remaining {} entities...", count);
+                commitChanges();
+            }
+
+            LOG.info("Total Vertex updated: {}", totalUpdatedCount);
+
+        } catch(Exception e){
+            LOG.error("Error while performing repair: {}", entityGuids, e);
+            throw e;
+        }
+    }
+
+    private boolean repairAttr(AtlasVertex vertex) throws AtlasBaseException {
+        try{
+            boolean isCommitRequired = false;
+
+            List<String> outputPortGuids = vertex.getMultiValuedProperty(OUTPUT_PORT_GUIDS_ATTR, String.class);
+            if (outputPortGuids == null || outputPortGuids.isEmpty()) {
+                LOG.info("No guids found in attribute: {} for entity: {}. Skipping repair for this entity.", OUTPUT_PORT_GUIDS_ATTR, vertex.getProperty("guid", String.class));
+                return false;
+            }
+
+            vertex.removeProperty(OUTPUT_PORT_GUIDS_ATTR);
+
+            for (String guid : outputPortGuids) {
+                AtlasVertex portVertex = entityRetriever.getEntityVertex(guid);
+                if (portVertex != null) {
+                    AtlasGraphUtilsV2.addEncodedProperty(vertex, OUTPUT_PORT_GUIDS_ATTR , guid);
+                    isCommitRequired = true;
+                } else {
+                    LOG.info("Removing invalid or hard deleted guid: {}", guid);
+                }
+            }
+
+            return isCommitRequired;
+        } catch (Exception e) {
+            LOG.error("Failed to migrate unique qualifiedName attribute for entity: ", e);
+            throw e;
+        }
+    }
+
+    public void commitChanges() throws AtlasBaseException {
+        try {
+            transactionInterceptHelper.intercept();
+            LOG.info("Committed a entity to the graph");
+        } catch (Exception e){
+            LOG.error("Failed to commit asset: ", e);
+            throw e;
+        }
+    }
+}

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/RemoveInvalidGuidsRepairStrategy.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/RemoveInvalidGuidsRepairStrategy.java
@@ -2,6 +2,7 @@ package org.apache.atlas.repository.store.graph.v2.repair;
 
 import org.apache.atlas.AtlasErrorCode;
 import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.repository.graphdb.AtlasGraph;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
 import org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2;
 import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
@@ -22,11 +23,14 @@ public class RemoveInvalidGuidsRepairStrategy implements AtlasRepairAttributeStr
 
     private final TransactionInterceptHelper transactionInterceptHelper;
 
-    private static final String REPAIR_TYPE = "REMOVE_INVALID_OUTPUT_PORT_GUIDS";
 
-    public RemoveInvalidGuidsRepairStrategy(EntityGraphRetriever entityRetriever, TransactionInterceptHelper transactionInterceptHelper) {
+    private static final String REPAIR_TYPE = "REMOVE_INVALID_OUTPUT_PORT_GUIDS";
+    private AtlasGraph graph;
+
+    public RemoveInvalidGuidsRepairStrategy(EntityGraphRetriever entityRetriever, TransactionInterceptHelper transactionInterceptHelper, AtlasGraph graph) {
         this.entityRetriever = entityRetriever;
         this.transactionInterceptHelper = transactionInterceptHelper;
+        this.graph = graph;
     }
 
     @Override
@@ -108,7 +112,7 @@ public class RemoveInvalidGuidsRepairStrategy implements AtlasRepairAttributeStr
             List<String> invalidGuids = new ArrayList<>();
 
             for (String guid : outputPortGuids) {
-                AtlasVertex portVertex = entityRetriever.getEntityVertex(guid);
+                AtlasVertex portVertex = AtlasGraphUtilsV2.findByGuid(this.graph, guid);
                 if (portVertex != null) {
                     validGuids.add(guid);
                 } else {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/RepairAttributeFactory.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/RepairAttributeFactory.java
@@ -2,6 +2,7 @@ package org.apache.atlas.repository.store.graph.v2.repair;
 
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.AtlasErrorCode;
+import org.apache.atlas.repository.graphdb.AtlasGraph;
 import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
 import org.apache.atlas.repository.store.graph.v2.TransactionInterceptHelper;
 import org.springframework.stereotype.Component;
@@ -14,18 +15,20 @@ public class RepairAttributeFactory {
 
     private final EntityGraphRetriever entityRetriever;
     private final TransactionInterceptHelper transactionInterceptHelper;
+    private final AtlasGraph graph;
 
     @Inject
     public RepairAttributeFactory(EntityGraphRetriever entityRetriever,
-                                  TransactionInterceptHelper transactionInterceptHelper) {
+                                  TransactionInterceptHelper transactionInterceptHelper, AtlasGraph graph) {
         this.entityRetriever = entityRetriever;
         this.transactionInterceptHelper = transactionInterceptHelper;
+        this.graph = graph;
     }
 
     public AtlasRepairAttributeStrategy getStrategy(String repairType, Set<String> entityGuids) throws AtlasBaseException {
         switch (repairType) {
             case "REMOVE_INVALID_OUTPUT_PORT_GUIDS":
-                return new RemoveInvalidGuidsRepairStrategy(entityRetriever, transactionInterceptHelper);
+                return new RemoveInvalidGuidsRepairStrategy(entityRetriever, transactionInterceptHelper, graph);
             default:
                 throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST,
                         "Unsupported repair type: " + repairType + ". Supported types: [REMOVE_INVALID_OUTPUT_PORT_GUIDS]");

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/RepairAttributeFactory.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/RepairAttributeFactory.java
@@ -25,7 +25,7 @@ public class RepairAttributeFactory {
     public AtlasRepairAttributeStrategy getStrategy(String repairType, Set<String> entityGuids) throws AtlasBaseException {
         switch (repairType) {
             case "REMOVE_INVALID_GUIDS":
-                return new RemoveInvalidGuidsRepairStrategy(entityRetriever, entityGuids, transactionInterceptHelper);
+                return new RemoveInvalidGuidsRepairStrategy(entityRetriever, transactionInterceptHelper);
             default:
                 throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST,
                         "Unsupported repair type: " + repairType + ". Supported types: [REMOVE_INVALID_GUIDS]");

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/RepairAttributeFactory.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/RepairAttributeFactory.java
@@ -24,15 +24,15 @@ public class RepairAttributeFactory {
 
     public AtlasRepairAttributeStrategy getStrategy(String repairType, Set<String> entityGuids) throws AtlasBaseException {
         switch (repairType) {
-            case "REMOVE_INVALID_GUIDS":
+            case "REMOVE_INVALID_OUTPUT_PORT_GUIDS":
                 return new RemoveInvalidGuidsRepairStrategy(entityRetriever, transactionInterceptHelper);
             default:
                 throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST,
-                        "Unsupported repair type: " + repairType + ". Supported types: [REMOVE_INVALID_GUIDS]");
+                        "Unsupported repair type: " + repairType + ". Supported types: [REMOVE_INVALID_OUTPUT_PORT_GUIDS]");
         }
     }
 
     public boolean isValidRepairType(String repairType) {
-        return "REMOVE_INVALID_GUIDS".equals(repairType);
+        return "REMOVE_INVALID_OUTPUT_PORT_GUIDS".equals(repairType);
     }
 }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/RepairAttributeFactory.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/RepairAttributeFactory.java
@@ -1,0 +1,38 @@
+package org.apache.atlas.repository.store.graph.v2.repair;
+
+import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.AtlasErrorCode;
+import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
+import org.apache.atlas.repository.store.graph.v2.TransactionInterceptHelper;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import java.util.Set;
+
+@Component
+public class RepairAttributeFactory {
+
+    private final EntityGraphRetriever entityRetriever;
+    private final TransactionInterceptHelper transactionInterceptHelper;
+
+    @Inject
+    public RepairAttributeFactory(EntityGraphRetriever entityRetriever,
+                                  TransactionInterceptHelper transactionInterceptHelper) {
+        this.entityRetriever = entityRetriever;
+        this.transactionInterceptHelper = transactionInterceptHelper;
+    }
+
+    public AtlasRepairAttributeStrategy getStrategy(String repairType, Set<String> entityGuids) throws AtlasBaseException {
+        switch (repairType) {
+            case "REMOVE_INVALID_GUIDS":
+                return new RemoveInvalidGuidsRepairStrategy(entityRetriever, entityGuids, transactionInterceptHelper);
+            default:
+                throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST,
+                        "Unsupported repair type: " + repairType + ". Supported types: [REMOVE_INVALID_GUIDS]");
+        }
+    }
+
+    public boolean isValidRepairType(String repairType) {
+        return "REMOVE_INVALID_GUIDS".equals(repairType);
+    }
+}

--- a/server-api/src/main/java/org/apache/atlas/RequestContext.java
+++ b/server-api/src/main/java/org/apache/atlas/RequestContext.java
@@ -50,6 +50,7 @@ public class RequestContext {
     private final Map<String, AtlasEntityHeader>         updatedEntities      = new HashMap<>();
     private final Map<String, AtlasEntityHeader>         deletedEntities      = new HashMap<>();
     private final Map<String, AtlasEntityHeader>         restoreEntities      = new HashMap<>();
+    private final Map<String, Map<String, Object>> allInternalAttributesMap     = new HashMap<>();
 
 
     private       Map<String, String>                    lexoRankCache        = null;
@@ -193,6 +194,7 @@ public class RequestContext {
         addedClassificationAndVertices.clear();
         esDeferredOperations.clear();
         this.cassandraTagOperations.clear();
+        this.allInternalAttributesMap.clear();
 
         if (metrics != null && !metrics.isEmpty()) {
             METRICS.debug(metrics.toString());
@@ -837,6 +839,10 @@ public class RequestContext {
 
     public boolean isInvokedByLineage() {
         return isInvokedByLineage;
+    }
+
+    public Map<String, Map<String, Object>> getAllInternalAttributesMap() {
+        return allInternalAttributesMap;
     }
 
     public class EntityGuidPair {

--- a/webapp/src/main/java/org/apache/atlas/notification/EntityNotificationListenerV2.java
+++ b/webapp/src/main/java/org/apache/atlas/notification/EntityNotificationListenerV2.java
@@ -281,6 +281,9 @@ public class EntityNotificationListenerV2 implements EntityChangeListenerV2 {
         ret.setCreateTime(entity.getCreateTime());
         ret.setUpdateTime(entity.getUpdateTime());
         ret.setDeleteHandler(entity.getDeleteHandler());
+        // For ES Isolation
+        ret.setDocId(entity.getDocId());
+        ret.setSuperTypeNames(entity.getSuperTypeNames());
 
         setAttribute(ret, NAME, name);
         setAttribute(ret, DESCRIPTION, entity.getAttribute(DESCRIPTION));
@@ -302,6 +305,13 @@ public class EntityNotificationListenerV2 implements EntityChangeListenerV2 {
                         ret.setAttribute(attribute.getName(), attrValue);
                     }
                 }
+            }
+
+            // fill the internal properties like __glossary, __meanings etc. (ES Isolation)
+            RequestContext context = RequestContext.get();
+            Map<String, Object> allInternalAttributesMap = context.getAllInternalAttributesMap().get(entity.getGuid());
+            if (MapUtils.isNotEmpty(allInternalAttributesMap)) {
+                ret.setInternalAttributes(allInternalAttributesMap);
             }
 
             //Add relationship attributes which has isOptional as false

--- a/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
@@ -43,6 +43,7 @@ import org.apache.atlas.repository.audit.ESBasedAuditRepository;
 import org.apache.atlas.repository.converters.AtlasInstanceConverter;
 import org.apache.atlas.repository.store.graph.AtlasEntityStore;
 import org.apache.atlas.repository.store.graph.v2.*;
+import org.apache.atlas.repository.store.graph.v2.repair.AtlasRepairAttributeService;
 import org.apache.atlas.service.FeatureFlagStore;
 import org.apache.atlas.type.AtlasClassificationType;
 import org.apache.atlas.type.AtlasEntityType;
@@ -109,14 +110,16 @@ public class EntityREST {
     private final ESBasedAuditRepository  esBasedAuditRepository;
     private final EntityGraphRetriever entityGraphRetriever;
     private final EntityMutationService entityMutationService;
+    private final AtlasRepairAttributeService repairAttributeService;
 
     @Inject
-    public EntityREST(AtlasTypeRegistry typeRegistry, AtlasEntityStore entitiesStore, ESBasedAuditRepository  esBasedAuditRepository, EntityGraphRetriever retriever, EntityMutationService entityMutationService) {
+    public EntityREST(AtlasTypeRegistry typeRegistry, AtlasEntityStore entitiesStore, ESBasedAuditRepository  esBasedAuditRepository, EntityGraphRetriever retriever, EntityMutationService entityMutationService, AtlasRepairAttributeService repairAttributeService) {
         this.typeRegistry      = typeRegistry;
         this.entitiesStore     = entitiesStore;
         this.esBasedAuditRepository = esBasedAuditRepository;
         this.entityGraphRetriever = retriever;
         this.entityMutationService = entityMutationService;
+        this.repairAttributeService = repairAttributeService;
     }
 
     /**
@@ -1850,6 +1853,38 @@ public class EntityREST {
             repairIndex.restoreByIds(guids);
         } catch (Exception e) {
             LOG.error("Exception while repairEntityIndexBulk ", e);
+            throw new AtlasBaseException(e);
+        } finally {
+            AtlasPerfTracer.log(perf);
+        }
+    }
+
+    /**
+     * Repair attributes for the entity GUID.
+     * @param guids
+     * @throws AtlasBaseException
+     */
+
+    @POST
+    @Path("/guid/bulk/repairattributes")
+    public void repairEntityAttributesBulk(Set<String> guids, @QueryParam("repairType") String repairType, @QueryParam("repairAttributeName") String repairAttributeName) throws AtlasBaseException {
+
+        Servlets.validateQueryParamLength("repairType", repairType);
+        Servlets.validateQueryParamLength("repairAttribute", repairAttributeName);
+
+        AtlasAuthorizationUtils.verifyAccess(new AtlasAdminAccessRequest(AtlasPrivilege.ADMIN_REPAIR_INDEX), "Admin Repair Attributes");
+
+        AtlasPerfTracer perf = null;
+
+        try {
+            if (AtlasPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
+                perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "EntityREST.repairEntityAttributesBulk(" + guids.size() + ")");
+            }
+
+            repairAttributeService.repairAttributes(repairAttributeName, repairType, guids);
+
+        } catch (Exception e) {
+            LOG.error("Exception while repairEntityAttributesBulk ", e);
             throw new AtlasBaseException(e);
         } finally {
             AtlasPerfTracer.log(perf);

--- a/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
@@ -1870,7 +1870,7 @@ public class EntityREST {
     public void repairEntityAttributesBulk(Set<String> guids, @QueryParam("repairType") String repairType, @QueryParam("repairAttributeName") String repairAttributeName) throws AtlasBaseException {
 
         Servlets.validateQueryParamLength("repairType", repairType);
-        Servlets.validateQueryParamLength("repairAttribute", repairAttributeName);
+        Servlets.validateQueryParamLength("repairAttributeName", repairAttributeName);
 
         AtlasAuthorizationUtils.verifyAccess(new AtlasAdminAccessRequest(AtlasPrivilege.ADMIN_REPAIR_INDEX), "Admin Repair Attributes");
 


### PR DESCRIPTION
## Change description

> Description here

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces ES-isolation metadata on entities, replaces Redis-based typedef cache sync with HTTP refresh (with HA health checks and retries), adds a bulk attribute-repair endpoint, and updates DQ types/policies and related logic.
> 
> - **Server/Core**:
>   - **ES Isolation**: Add `docId` and `superTypeNames` to `AtlasEntity`, `AtlasEntityHeader`, and notifications; populate from vertex ID via `LongEncoding`; track and emit internal attributes during Janus property mutations.
>   - **Type Cache Refresh (HA)**: Replace Redis versioning with HTTP endpoints for cache health/check-and-refresh; async refresh with retries; remove typedef "reload" methods and related constants; simplify Redis service (drop `NoRedisServiceImpl`, `getValue` overloads).
>   - **Entity Ops**: Improve meanings (glossary) auth/updates; handle tag edges in soft-delete; enrich delete headers with `vertexId`, `docId`, and supertypes.
> - **API**:
>   - New endpoint: `POST /entity/guid/bulk/repairattributes` using pluggable strategy (`REMOVE_INVALID_OUTPUT_PORT_GUIDS`).
>   - Types REST now validates names, acquires distributed lock (v2), and triggers cross-host cache refresh.
> - **Policies/Templates**:
>   - Replace `alpha_DQRule`/`alpha_DQRuleTemplate` with `DataQualityRule`/`DataQualityTemplate` across policies and tests.
>   - Expand AI Model persona to allow dataset relationship updates and process create/delete for updates.
> - **Tests/Fixtures**:
>   - Update DSL fixtures to new DQ type names.
> - **CI**:
>   - Adjust workflow branch filters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db533777d6304f8eb9d4ce25fbaf8493ce944e0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->