### PR TITLE
PLTS-580 | Change policycache file location to non-root to write

### DIFF
--- a/atlas-hub/pre-conf/atlas-auth/atlas-atlas-security.xml
+++ b/atlas-hub/pre-conf/atlas-auth/atlas-atlas-security.xml
@@ -59,7 +59,7 @@
 
 	<property>
 		<name>atlas.plugin.atlas.policy.cache.dir</name>
-		<value>/etc/atlas/atlasdev/policycache</value>
+		<value>/tmp/atlasdev/policycache</value>
 		<description>
 			Directory where Ranger policies are cached after successful retrieval from the source
 		</description>


### PR DESCRIPTION
## Change description

Update the policy store path to use the /tmp folder, similar to how it's used in heka. This change is necessary due to the recent change in security which blocked the root access on the server leading to failing of file creation on currently configured location.
Context: https://atlanhq.slack.com/archives/C05NR8V0RE3/p1759900787847519\?thread_ts\=1759835130.107179\&cid\=C05NR8V0RE3

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

https://atlanhq.atlassian.net/browse/PLTS-580

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
