### PR TITLE
MESH-645 : Repair API for daapOutputPortGuids

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/AtlasRepairAttributeStrategy.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/AtlasRepairAttributeStrategy.java
@@ -1,21 +1,3 @@
-/**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.apache.atlas.repository.store.graph.v2.repair;
 
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/RemoveInvalidGuidsRepairStrategy.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/RemoveInvalidGuidsRepairStrategy.java
@@ -22,7 +22,7 @@ public class RemoveInvalidGuidsRepairStrategy implements AtlasRepairAttributeStr
 
     private final TransactionInterceptHelper transactionInterceptHelper;
 
-    private static final String REPAIR_TYPE = "REMOVE_INVALID_GUIDS";
+    private static final String REPAIR_TYPE = "REMOVE_INVALID_OUTPUT_PORT_GUIDS";
 
     public RemoveInvalidGuidsRepairStrategy(EntityGraphRetriever entityRetriever, TransactionInterceptHelper transactionInterceptHelper) {
         this.entityRetriever = entityRetriever;

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/RemoveInvalidGuidsRepairStrategy.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/RemoveInvalidGuidsRepairStrategy.java
@@ -2,6 +2,7 @@ package org.apache.atlas.repository.store.graph.v2.repair;
 
 import org.apache.atlas.AtlasErrorCode;
 import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.repository.graphdb.AtlasGraph;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
 import org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2;
 import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
@@ -22,11 +23,14 @@ public class RemoveInvalidGuidsRepairStrategy implements AtlasRepairAttributeStr
 
     private final TransactionInterceptHelper transactionInterceptHelper;
 
-    private static final String REPAIR_TYPE = "REMOVE_INVALID_OUTPUT_PORT_GUIDS";
 
-    public RemoveInvalidGuidsRepairStrategy(EntityGraphRetriever entityRetriever, TransactionInterceptHelper transactionInterceptHelper) {
+    private static final String REPAIR_TYPE = "REMOVE_INVALID_OUTPUT_PORT_GUIDS";
+    private AtlasGraph graph;
+
+    public RemoveInvalidGuidsRepairStrategy(EntityGraphRetriever entityRetriever, TransactionInterceptHelper transactionInterceptHelper, AtlasGraph graph) {
         this.entityRetriever = entityRetriever;
         this.transactionInterceptHelper = transactionInterceptHelper;
+        this.graph = graph;
     }
 
     @Override
@@ -108,7 +112,7 @@ public class RemoveInvalidGuidsRepairStrategy implements AtlasRepairAttributeStr
             List<String> invalidGuids = new ArrayList<>();
 
             for (String guid : outputPortGuids) {
-                AtlasVertex portVertex = entityRetriever.getEntityVertex(guid);
+                AtlasVertex portVertex = AtlasGraphUtilsV2.findByGuid(this.graph, guid);
                 if (portVertex != null) {
                     validGuids.add(guid);
                 } else {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/RepairAttributeFactory.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/RepairAttributeFactory.java
@@ -2,6 +2,7 @@ package org.apache.atlas.repository.store.graph.v2.repair;
 
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.AtlasErrorCode;
+import org.apache.atlas.repository.graphdb.AtlasGraph;
 import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
 import org.apache.atlas.repository.store.graph.v2.TransactionInterceptHelper;
 import org.springframework.stereotype.Component;
@@ -14,18 +15,20 @@ public class RepairAttributeFactory {
 
     private final EntityGraphRetriever entityRetriever;
     private final TransactionInterceptHelper transactionInterceptHelper;
+    private final AtlasGraph graph;
 
     @Inject
     public RepairAttributeFactory(EntityGraphRetriever entityRetriever,
-                                  TransactionInterceptHelper transactionInterceptHelper) {
+                                  TransactionInterceptHelper transactionInterceptHelper, AtlasGraph graph) {
         this.entityRetriever = entityRetriever;
         this.transactionInterceptHelper = transactionInterceptHelper;
+        this.graph = graph;
     }
 
     public AtlasRepairAttributeStrategy getStrategy(String repairType, Set<String> entityGuids) throws AtlasBaseException {
         switch (repairType) {
             case "REMOVE_INVALID_OUTPUT_PORT_GUIDS":
-                return new RemoveInvalidGuidsRepairStrategy(entityRetriever, transactionInterceptHelper);
+                return new RemoveInvalidGuidsRepairStrategy(entityRetriever, transactionInterceptHelper, graph);
             default:
                 throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST,
                         "Unsupported repair type: " + repairType + ". Supported types: [REMOVE_INVALID_OUTPUT_PORT_GUIDS]");

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/RepairAttributeFactory.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/RepairAttributeFactory.java
@@ -24,15 +24,15 @@ public class RepairAttributeFactory {
 
     public AtlasRepairAttributeStrategy getStrategy(String repairType, Set<String> entityGuids) throws AtlasBaseException {
         switch (repairType) {
-            case "REMOVE_INVALID_GUIDS":
+            case "REMOVE_INVALID_OUTPUT_PORT_GUIDS":
                 return new RemoveInvalidGuidsRepairStrategy(entityRetriever, transactionInterceptHelper);
             default:
                 throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST,
-                        "Unsupported repair type: " + repairType + ". Supported types: [REMOVE_INVALID_GUIDS]");
+                        "Unsupported repair type: " + repairType + ". Supported types: [REMOVE_INVALID_OUTPUT_PORT_GUIDS]");
         }
     }
 
     public boolean isValidRepairType(String repairType) {
-        return "REMOVE_INVALID_GUIDS".equals(repairType);
+        return "REMOVE_INVALID_OUTPUT_PORT_GUIDS".equals(repairType);
     }
 }


### PR DESCRIPTION
## Change description

> Description here

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames the repair type and updates the strategy to validate output port GUIDs using AtlasGraph, rewriting the attribute only when invalid GUIDs exist, and wires the factory accordingly.
> 
> - **Repair Strategy (`RemoveInvalidGuidsRepairStrategy`)**:
>   - Change `REPAIR_TYPE` to `REMOVE_INVALID_OUTPUT_PORT_GUIDS` and constructor to accept `AtlasGraph`.
>   - Validate GUIDs via `AtlasGraphUtilsV2.findByGuid(graph)` instead of `EntityGraphRetriever`.
>   - Repair logic: collect valid/invalid GUIDs; rewrite `OUTPUT_PORT_GUIDS_ATTR` only if invalids are found; improved logging and error message.
> - **Factory (`RepairAttributeFactory`)**:
>   - Inject/store `AtlasGraph`; update supported type to `REMOVE_INVALID_OUTPUT_PORT_GUIDS`.
>   - Pass `AtlasGraph` to strategy; update `isValidRepairType` and error text.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a75a926b3591bc953ff5cf4b97cbf904094ed59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->