### PR TITLE
Sync beta

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/AtlasRepairAttributeService.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/AtlasRepairAttributeService.java
@@ -1,0 +1,70 @@
+package org.apache.atlas.repository.store.graph.v2.repair;
+
+import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.AtlasErrorCode;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import java.util.Set;
+
+@Component
+public class AtlasRepairAttributeService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AtlasRepairAttributeService.class);
+
+    private final RepairAttributeFactory repairAttributeFactory;
+
+    @Inject
+    public AtlasRepairAttributeService(RepairAttributeFactory repairAttributeFactory) {
+        this.repairAttributeFactory = repairAttributeFactory;
+    }
+
+    public void repairAttributes(String attributeName, String repairType, Set<String> entityGuids)
+            throws AtlasBaseException {
+
+        validateRequest(attributeName, repairType, entityGuids);
+
+        LOG.info("Starting attribute repair - Type: {}, Attribute: {}, Entities: {}",
+                repairType, attributeName, entityGuids.size());
+
+        try {
+            AtlasRepairAttributeStrategy strategy = repairAttributeFactory.getStrategy(repairType, entityGuids);
+
+            strategy.validate(entityGuids, attributeName);
+            strategy.repair(entityGuids, attributeName);
+
+            LOG.info("Successfully completed attribute repair - Type: {}, Attribute: {}, Entities: {}",
+                    repairType, attributeName, entityGuids.size());
+
+        } catch (Exception e) {
+            LOG.error("Error during attribute repair - Type: {}, Attribute: {}, Entities: {}",
+                    repairType, attributeName, entityGuids.size(), e);
+            throw e;
+        }
+    }
+
+    private void validateRequest(String attributeName, String repairType, Set<String> entityGuids)
+            throws AtlasBaseException {
+
+        if (StringUtils.isEmpty(attributeName)) {
+            throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST, "Attribute name cannot be empty");
+        }
+
+        if (StringUtils.isEmpty(repairType)) {
+            throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST, "Repair type cannot be empty");
+        }
+
+        if (CollectionUtils.isEmpty(entityGuids)) {
+            throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST, "Entity GUIDs cannot be empty");
+        }
+
+        if (entityGuids.size() > 1000) {
+            throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST,
+                    "Too many entities. Maximum allowed: 1000, provided: " + entityGuids.size());
+        }
+    }
+}

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/AtlasRepairAttributeStrategy.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/AtlasRepairAttributeStrategy.java
@@ -1,0 +1,16 @@
+package org.apache.atlas.repository.store.graph.v2.repair;
+
+
+import org.apache.atlas.exception.AtlasBaseException;
+
+import java.util.Set;
+
+public interface AtlasRepairAttributeStrategy {
+
+    String getRepairType();
+    void repair(Set<String> entityGuids, String attributeName) throws AtlasBaseException;
+    void validate (Set<String> entityGuids, String attributeName) throws AtlasBaseException;
+
+}
+
+

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/RemoveInvalidGuidsRepairStrategy.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/RemoveInvalidGuidsRepairStrategy.java
@@ -1,0 +1,153 @@
+package org.apache.atlas.repository.store.graph.v2.repair;
+
+import org.apache.atlas.AtlasErrorCode;
+import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.repository.graphdb.AtlasGraph;
+import org.apache.atlas.repository.graphdb.AtlasVertex;
+import org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2;
+import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
+import org.apache.atlas.repository.store.graph.v2.TransactionInterceptHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+import static org.apache.atlas.repository.store.graph.v2.preprocessor.PreProcessorUtils.OUTPUT_PORT_GUIDS_ATTR;
+
+public class RemoveInvalidGuidsRepairStrategy implements AtlasRepairAttributeStrategy {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RemoveInvalidGuidsRepairStrategy.class);
+
+    private final EntityGraphRetriever entityRetriever;
+
+
+    private final TransactionInterceptHelper transactionInterceptHelper;
+
+
+    private static final String REPAIR_TYPE = "REMOVE_INVALID_OUTPUT_PORT_GUIDS";
+    private AtlasGraph graph;
+
+    public RemoveInvalidGuidsRepairStrategy(EntityGraphRetriever entityRetriever, TransactionInterceptHelper transactionInterceptHelper, AtlasGraph graph) {
+        this.entityRetriever = entityRetriever;
+        this.transactionInterceptHelper = transactionInterceptHelper;
+        this.graph = graph;
+    }
+
+    @Override
+    public String getRepairType() {
+        return REPAIR_TYPE;
+    }
+
+    @Override
+    public void validate(Set<String> entityGuids, String attributeName) throws AtlasBaseException {
+        for (String entityGuid : entityGuids) {
+            AtlasVertex entityVertex = entityRetriever.getEntityVertex(entityGuid);
+
+            if (entityVertex == null) {
+                throw new AtlasBaseException(AtlasErrorCode.INSTANCE_GUID_NOT_FOUND, "Entity vertex not found for guid: " + entityGuid);
+            }
+        }
+    }
+
+    @Override
+    public void repair(Set<String> entityGuids, String attributeName) throws AtlasBaseException {
+        try {
+            int count = 0;
+            int totalUpdatedCount = 0;
+
+            for (String entityGuid : entityGuids) {
+                AtlasVertex entityVertex = entityRetriever.getEntityVertex(entityGuid);
+
+                if (entityVertex == null) {
+                    LOG.error("Entity vertex not found for guid: {}", entityGuid);
+                    continue;
+                }
+
+                if (!entityVertex.getPropertyKeys().contains(attributeName)) {
+                    LOG.info("Attribute: {} not found for entity: {}. Skipping repair for this entity.", attributeName, entityGuid);
+                    continue;
+                }
+
+                if (OUTPUT_PORT_GUIDS_ATTR.equals(attributeName)) {
+                    boolean isCommitRequired = repairAttr(entityVertex);
+                    if (isCommitRequired){
+                        count++;
+                        totalUpdatedCount++;
+                    } else {
+                        LOG.info("No changes to commit for entity: {}", entityGuid);
+                    }
+
+                    if (count == 50) {
+                        LOG.info("Committing batch of 50 entities...");
+                        commitChanges();
+                        count = 0;
+                    }
+                }
+            }
+
+            if (count > 0) {
+                LOG.info("Committing remaining {} entities...", count);
+                commitChanges();
+            }
+
+            LOG.info("Total Vertex updated: {}", totalUpdatedCount);
+
+        } catch(Exception e){
+            LOG.error("Error while performing repair: {}", entityGuids, e);
+            throw e;
+        }
+    }
+
+    private boolean repairAttr(AtlasVertex vertex) throws AtlasBaseException {
+        try{
+            boolean isCommitRequired = false;
+
+            List<String> outputPortGuids = vertex.getMultiValuedProperty(OUTPUT_PORT_GUIDS_ATTR, String.class);
+            if (outputPortGuids == null || outputPortGuids.isEmpty()) {
+                LOG.info("No guids found in attribute: {} for entity: {}. Skipping repair for this entity.", OUTPUT_PORT_GUIDS_ATTR, vertex.getProperty("guid", String.class));
+                return false;
+            }
+
+            List<String> validGuids = new ArrayList<>();
+            List<String> invalidGuids = new ArrayList<>();
+
+            for (String guid : outputPortGuids) {
+                AtlasVertex portVertex = AtlasGraphUtilsV2.findByGuid(this.graph, guid);
+                if (portVertex != null) {
+                    validGuids.add(guid);
+                } else {
+                    invalidGuids.add(guid);
+                }
+            }
+
+            if (!invalidGuids.isEmpty()) {
+                LOG.info("Removing invalid guids: {} from attribute: {} for entity: {}", invalidGuids, OUTPUT_PORT_GUIDS_ATTR, vertex.getProperty("guid", String.class));
+
+                vertex.removeProperty(OUTPUT_PORT_GUIDS_ATTR);
+
+                for (String validGuid : validGuids) {
+                    AtlasGraphUtilsV2.addEncodedProperty(vertex, OUTPUT_PORT_GUIDS_ATTR, validGuid);
+                }
+
+                isCommitRequired = true;
+            } else {
+                LOG.info("All guids in attribute: {} for entity: {} are valid. No repair needed.", OUTPUT_PORT_GUIDS_ATTR, vertex.getProperty("guid", String.class));
+            }
+
+            return isCommitRequired;
+        } catch (Exception e) {
+            LOG.error("Failed to repair attribute for entity: ", e);
+            throw e;
+        }
+    }
+
+    public void commitChanges() throws AtlasBaseException {
+        try {
+            transactionInterceptHelper.intercept();
+            LOG.info("Committed a entity to the graph");
+        } catch (Exception e){
+            LOG.error("Failed to commit asset: ", e);
+            throw e;
+        }
+    }
+}

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/RepairAttributeFactory.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/repair/RepairAttributeFactory.java
@@ -1,0 +1,41 @@
+package org.apache.atlas.repository.store.graph.v2.repair;
+
+import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.AtlasErrorCode;
+import org.apache.atlas.repository.graphdb.AtlasGraph;
+import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
+import org.apache.atlas.repository.store.graph.v2.TransactionInterceptHelper;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import java.util.Set;
+
+@Component
+public class RepairAttributeFactory {
+
+    private final EntityGraphRetriever entityRetriever;
+    private final TransactionInterceptHelper transactionInterceptHelper;
+    private final AtlasGraph graph;
+
+    @Inject
+    public RepairAttributeFactory(EntityGraphRetriever entityRetriever,
+                                  TransactionInterceptHelper transactionInterceptHelper, AtlasGraph graph) {
+        this.entityRetriever = entityRetriever;
+        this.transactionInterceptHelper = transactionInterceptHelper;
+        this.graph = graph;
+    }
+
+    public AtlasRepairAttributeStrategy getStrategy(String repairType, Set<String> entityGuids) throws AtlasBaseException {
+        switch (repairType) {
+            case "REMOVE_INVALID_OUTPUT_PORT_GUIDS":
+                return new RemoveInvalidGuidsRepairStrategy(entityRetriever, transactionInterceptHelper, graph);
+            default:
+                throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST,
+                        "Unsupported repair type: " + repairType + ". Supported types: [REMOVE_INVALID_OUTPUT_PORT_GUIDS]");
+        }
+    }
+
+    public boolean isValidRepairType(String repairType) {
+        return "REMOVE_INVALID_OUTPUT_PORT_GUIDS".equals(repairType);
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Auto-enables Tags V2 when no classification types exist, adds 'enforcer' to audit logs, hardens policy delta generation, makes soft-reference check case-insensitive, and updates CI workflow branch filters.
> 
> - **Services**:
>   - **Tags V2 Auto-Enable**: New `repository/src/main/java/org/apache/atlas/services/TagsV2AutoEnabler.java` to enable Tags V2 by default when no classification types are found.
> - **Auditing**:
>   - **Log Context**: In `auth-audits/.../Log4JAuditDestination.java`, add `enforcer` (from `getAclEnforcer()`) to MDC and clear it after logging.
> - **Policy Delta Generation**:
>   - In `CachePolicyTransformerImpl`, skip null-mapped audit events and guard delete handling when `deltaChangeType` is null; add warning logs for unmapped actions.
> - **Model**:
>   - In `AtlasStructDef.AtlasAttributeDef#isSoftReferenced`, make soft-reference option check case-insensitive and NPE-safe.
> - **CI/CD**:
>   - Update workflow branch filters: add `atlas_ci_cd_updates` to `.github/workflows/chart-release-dispatcher.yaml`; adjust `.github/workflows/maven.yml` branches (add `fix-pg-prod-cm-soft-ref`, remove `revert-custom-metadata-changes`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 970c6588ef22b0ae72f0084bd4a85878a25037bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->