### PR TITLE
Allow updating daapLineageStatus on DataProducts

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
@@ -119,14 +119,14 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
         String state = vertex.getProperty(STATE_PROPERTY_KEY, String.class);
 
         if (DELETED.name().equals(state)) {
-            //  To allow product restoration but block all other updates if the product is archived
+            //  To allow product restoration and update on daapLineageStatus but block all other updates if the product is archived
             boolean isBeingRestored = false;
 
             if (context != null && context.getEntitiesToRestore() != null) {
                 isBeingRestored = context.getEntitiesToRestore().contains(vertex);
             }
 
-            if (!isBeingRestored) {
+            if (!isBeingRestored && !entity.hasAttribute(DAAP_LINEAGE_STATUS_ATTR)) {
                 throw new AtlasBaseException(OPERATION_NOT_SUPPORTED, "Cannot update DataProduct that is Archived!");
             }
         }


### PR DESCRIPTION
## Change description

> When a DataProduct is archived the `daapLineageStatus` of the product is marked as `Pending`.  After we have delinked assets from the product the `daapLineageStatus` has to be marked as `Completed` but this step fails because we have blocked updates on Data Product after it is archived. We are not specifically checking for other attributes while marking the attribute as Completed because this attribute can only be updated using `Argo token` and our existing scripts only update this attribute and not other attributes/realtions of the product.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable

### Screenshots

## After product is archived
<img width="1512" height="982" alt="Screenshot 2025-10-08 at 22 05 13" src="https://github.com/user-attachments/assets/d8c76ff9-bbb5-4f54-ad5a-22536b94604b" />
<img width="1512" height="982" alt="Screenshot 2025-10-08 at 22 05 23" src="https://github.com/user-attachments/assets/bda96da0-95f9-4885-a385-99481038f98a" />

## After delinking 
<img width="1512" height="982" alt="Screenshot 2025-10-08 at 22 06 45" src="https://github.com/user-attachments/assets/aa93d7b1-80d6-4bc8-8804-ba7e41796c72" />
<img width="1512" height="982" alt="Screenshot 2025-10-08 at 22 06 52" src="https://github.com/user-attachments/assets/b32e7bcd-102d-421c-a411-40c2238b56d8" />

