### PR TITLE
feat: Change-log-driven tag reconciliation service

### DIFF
--- a/docs/data-consistency/tag-reconciliation-service.md
+++ b/docs/data-consistency/tag-reconciliation-service.md
@@ -1,0 +1,318 @@
+# Tag Reconciliation Service
+
+## Problem
+
+Atlas stores tag (classification) data in two systems that can drift apart:
+
+1. **Cassandra `tags.tags_by_id`** — source of truth for tag ownership (direct and propagated)
+2. **Elasticsearch denormalized fields** — derived view used for search and UI display
+
+Five ES fields are derived from Cassandra tag state:
+
+| ES Field | Source |
+|----------|--------|
+| `__traitNames` | Direct tag type names (list) |
+| `__classificationNames` | Direct tag type names (pipe-delimited string) |
+| `__propagatedTraitNames` | Propagated tag type names (list) |
+| `__propagatedClassificationNames` | Propagated tag type names (pipe-delimited string) |
+| `__classificationsText` | All tag names concatenated for full-text search |
+
+### How drift occurs
+
+| Failure mode | Effect |
+|-------------|--------|
+| ES write fails silently during tag propagation | Asset shows stale tags in search/UI |
+| Propagation cleanup task fails or is lost | Orphaned propagated rows in Cassandra; ES shows tags the source no longer has |
+| Partial ES bulk write | Some assets in a propagation batch get updated, others don't |
+| Race condition between concurrent tag operations | ES reflects an intermediate state |
+| Pod restart during propagation task | Task may be retried but ES state is already partially written |
+
+### Scale of the problem
+
+On a production tenant (newsuk), a dry-run scan of one tag type found:
+- 7,000 assets checked (of 15,309 with the tag)
+- **5,824 assets (83%) had orphaned propagated tags**
+- 20,254 orphaned propagated rows total
+- 572 unique source vertices had lost their direct tag without cleaning up downstream propagations
+
+## Architecture
+
+```
+                        ┌──────────────────────────┐
+                        │  K8s Seed Job (one-time)  │
+                        │  cqlsh COPY TO/FROM       │
+                        └────────────┬─────────────┘
+                                     │ populates
+                                     ▼
+┌─────────────────┐          ┌──────────────────┐          ┌───────────────┐
+│ Tag Write Paths │──INSERT──│ tags.tag_change_  │──READ────│ TagReconcilia │
+│ (EntityGraph    │          │ log              │          │ tionService   │
+│  Mapper)        │          │                  │          │ (@Scheduled)  │
+└─────────────────┘          │ day_bucket (PK)  │          └───────┬───────┘
+                             │ created_at (CK)  │                  │
+                             │ vertex_id  (CK)  │                  │ for each vertex:
+                             │ tag_type_name    │                  │
+                             │ operation        │                  ▼
+                             │ TTL: 7 days      │      ┌──────────────────────┐
+                             └──────────────────┘      │ 1. Read all tags     │
+                                                       │    from C* (truth)   │
+                                                       │ 2. Detect orphaned   │
+                                                       │    propagated tags   │
+                                                       │ 3. Clean orphans     │
+                                                       │    (C* soft-delete)  │
+                                                       │ 4. Compute 5 denorm  │
+                                                       │    fields            │
+                                                       │ 5. Write full ES     │
+                                                       │    snapshot          │
+                                                       └──────────────────────┘
+```
+
+### Three components
+
+**1. `tags.tag_change_log` table** — a Cassandra work queue of vertex IDs that need reconciliation.
+
+```sql
+CREATE TABLE tags.tag_change_log (
+    day_bucket text,        -- partition key, e.g. '2026-03-31'
+    created_at timestamp,   -- clustering key, write time
+    vertex_id text,         -- clustering key, the asset vertex ID
+    tag_type_name text,     -- which tag changed (for debugging)
+    operation text,         -- ADD, DELETE, PROPAGATE_ADD, etc. (for debugging)
+    PRIMARY KEY ((day_bucket), created_at, vertex_id)
+) WITH CLUSTERING ORDER BY (created_at ASC, vertex_id ASC)
+  AND compaction = {'class': 'TimeWindowCompactionStrategy', ...}
+  AND default_time_to_live = 604800;  -- 7 days
+```
+
+**2. Seed Job** — a K8s Job that populates the change log from existing `tags_by_id` using native cqlsh `COPY TO/FROM`. Runs once per tenant.
+
+**3. `TagReconciliationService`** — a Spring `@Scheduled` bean inside Atlas that drains the change log. Runs within a configurable nightly window. Single-pod execution via Redis lock.
+
+## Why a change log (not a full table scan)
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| Full scan of `tags_by_id` every cycle | Simple, no extra table | Slow for large tenants (millions of vertices); re-reads unchanged data; race condition with live writes |
+| Change log | Only processes what changed; no race (reads C* after the write); self-cleaning via TTL | Requires instrumenting tag write paths; extra INSERT per tag operation |
+
+The change log solves the race condition (#10 in the tradeoffs analysis): the log entry is written AFTER the Cassandra tag write. When the reconciler reads the entry and then reads Cassandra, it sees the committed state. If another write happens concurrently, that write adds its own log entry — the reconciler catches it in the next cycle.
+
+## How it works
+
+### Initial backfill (one-time per tenant)
+
+```bash
+# 1. Run the seed job
+kubectl apply -f tools/tag-reconciler-seed-job.yaml -n atlas
+
+# 2. Enable the reconciler
+cqlsh $HOST -e "INSERT INTO config_store.configs
+  (app_name, config_key, config_value, updated_by, last_updated)
+  VALUES ('atlas', 'TAG_RECONCILER_ENABLED', 'true', 'admin', toTimestamp(now()));"
+```
+
+The seed job:
+1. Exports all vertex IDs from `tags.tags_by_id` using `cqlsh COPY TO`
+2. Deduplicates with `sort -u`
+3. Loads into `tag_change_log` using `cqlsh COPY FROM`
+
+For a tenant with 3.2M rows / 1M unique vertices, this takes ~2 minutes.
+
+### Steady-state (after initial backfill)
+
+1. Every 15 minutes, the reconciler checks: enabled? within window? can acquire Redis lock?
+2. If yes, it reads the change log from its last saved position (day_bucket + timestamp + vertex_id)
+3. For each vertex in the page:
+   - Reads all tags from `tags_by_id` (direct and propagated, active only)
+   - For each propagated tag, checks if the source vertex still has an active direct tag
+   - If source has no direct tag: **orphan** — soft-deletes the propagated row from `tags_by_id`, hard-deletes from `propagated_tags_by_source`
+   - Computes the 5 denorm fields from surviving tags
+   - Writes full snapshot to ES via `ESConnector.writeTagProperties()`
+4. Saves cursor position to `config_store.configs`
+5. Stops when the window expires or the log is exhausted
+6. Next night, resumes from saved position
+
+### Forward path (future PR)
+
+Every tag write operation (add, delete, propagate) inserts the affected vertex ID into the change log:
+
+```java
+tagDAO.logTagChange(vertexId, tagTypeName, "ADD");
+```
+
+This is a single Cassandra INSERT — best-effort, non-blocking. If it fails, the change is not logged and will only be caught on the next full backfill (or if the vertex is touched again).
+
+## Orphan detection
+
+A propagated tag is orphaned when the source vertex no longer has an active direct tag of that type. This happens when:
+
+1. Direct tag is removed from source entity
+2. Propagation cleanup task runs but fails partway through
+3. Downstream assets retain stale propagated rows
+
+The reconciler detects orphans by checking each propagated tag's source:
+
+```
+For each tag on vertex V:
+  if tag.sourceVertexId != V (propagated):
+    check: does sourceVertexId have active direct tag of this type?
+    if no: orphan — delete from tags_by_id and propagated_tags_by_source
+    if yes: legitimate propagation — include in denorm
+```
+
+A source cache (`sourceVertexId|tagTypeName -> boolean`) avoids repeated lookups for the same source across vertices in a page.
+
+## Configuration
+
+All configuration is per-tenant via `config_store.configs` or JVM properties.
+
+### Dynamic config (per-tenant, no redeploy)
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `TAG_RECONCILER_ENABLED` | `false` | Master switch. Set to `true` to enable. |
+| `TAG_RECONCILER_STATE` | `null` | JSON cursor state. Managed by the reconciler. Do not edit manually unless resetting. |
+
+### JVM properties (set in Atlas container env or atlas-application.properties)
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `atlas.tag.reconciler.poll.interval` | `900000` (15 min) | How often the scheduler ticks to check if it should run |
+| `atlas.tag.reconciler.window.start.hour` | `0` (midnight UTC) | Window start hour (0-23, UTC) |
+| `atlas.tag.reconciler.window.duration.hours` | `4` | Window duration in hours |
+| `atlas.tag.reconciler.page.size` | `500` | Change log entries per page |
+| `atlas.tag.reconciler.es.batch.size` | `50` | ES bulk write batch size |
+
+### Resetting state
+
+To restart reconciliation from the beginning (e.g., after a re-seed):
+
+```sql
+DELETE FROM config_store.configs
+WHERE app_name = 'atlas' AND config_key = 'TAG_RECONCILER_STATE';
+```
+
+### Disabling
+
+```sql
+UPDATE config_store.configs
+SET config_value = 'false', updated_by = 'admin', last_updated = toTimestamp(now())
+WHERE app_name = 'atlas' AND config_key = 'TAG_RECONCILER_ENABLED';
+```
+
+Takes effect within 15 minutes (next tick).
+
+## Tradeoffs and known limitations
+
+### 1. No CDC/audit/notification for orphan cleanup
+
+The reconciler deletes orphaned tags directly via `tagDAO.deleteTags()` and writes ES directly via `ESConnector.writeTagProperties()`. This bypasses:
+- Entity audit entries
+- Kafka CDC notifications
+- Downstream consumer updates
+
+This is intentional — the reconciler is a **data repair** tool, not a business operation. The orphaned data should never have existed. Adding audit/notification would create false signals.
+
+### 2. Forward path not yet instrumented
+
+Until every tag write path in `EntityGraphMapper` is instrumented with `tagDAO.logTagChange()`, the change log only captures what the seed job populated. Any tag changes after the seed but before instrumentation will be invisible until the next re-seed.
+
+Planned for a follow-up PR. Tag write paths to instrument:
+- `addClassificationsV2` / `deleteClassificationV2` / `updateClassificationsV2`
+- `deleteClassificationPropagationV2`
+- `classificationRefreshPropagationV2_new`
+- `addTagPropagationV2`
+
+### 3. Duplicate processing
+
+The same vertex ID may appear multiple times in the change log (e.g., multiple tag operations in one day). The reconciler deduplicates within a page but not across pages. Processing the same vertex twice is harmless (idempotent ES write) but wastes a Cassandra read.
+
+### 4. N+1 Cassandra reads
+
+For each vertex, the reconciler makes:
+- 1 call to `getAllTagsByVertexId` (all tags for the vertex)
+- 1 call per unique propagated source (orphan check) — cached across vertices in the page
+
+For vertices with many propagated tags from many unique sources, this can be slow. The source cache mitigates this for common sources.
+
+### 5. TTL tombstones
+
+The 7-day TTL on `tag_change_log` creates Cassandra tombstones when entries expire. The `TimeWindowCompactionStrategy` is chosen to compact tombstones efficiently (one SSTable per day window, old windows compact away cleanly).
+
+### 6. Window-based execution
+
+The reconciler only runs during the configured window (default: midnight–4am UTC). Changes during the day are not reconciled until the next window. This is by design — the nightly window minimizes impact on production traffic.
+
+For urgent reconciliation, temporarily change the window:
+```
+-Datlas.tag.reconciler.window.start.hour=10 -Datlas.tag.reconciler.window.duration.hours=24
+```
+
+### 7. Single-threaded, single-pod
+
+Only one pod holds the Redis lock and processes the change log. No parallelism within a cycle. For large backlogs, this means the initial backfill takes multiple nightly windows to complete.
+
+At ~500 vertices/page and ~2 CQL calls/vertex at ~2ms each:
+- 1M vertices ≈ 2 hours (fits in one 4-hour window)
+- 10M vertices ≈ 20 hours (spans ~5 nightly windows)
+
+## Monitoring
+
+### Logs
+
+```bash
+# Follow reconciler activity
+kubectl logs -f atlas-0 -c atlas-main -n atlas | grep TagReconciler
+```
+
+Key log lines:
+- `TagReconciler: acquired lock, starting cycle` — cycle started
+- `TagReconciler: cycle done — entries=X, vertices=Y, orphans=Z, elapsed=Nms` — cycle summary
+- `TagReconciler: cleaned orphan tag X on vertex Y from source Z` — individual orphan cleanup
+- `TagReconciler: change log is empty, nothing to do` — fully caught up
+
+### State inspection
+
+```sql
+-- Current cursor position
+SELECT config_value FROM config_store.configs
+WHERE app_name = 'atlas' AND config_key = 'TAG_RECONCILER_STATE';
+
+-- Change log size per day
+SELECT day_bucket, count(*) FROM tags.tag_change_log GROUP BY day_bucket;
+```
+
+## Deployment runbook
+
+### First-time setup on a tenant
+
+1. **Deploy Atlas** with the reconciler code (creates the `tag_change_log` table on startup)
+
+2. **Run the seed job:**
+   ```bash
+   kubectl apply -f tools/tag-reconciler-seed-job.yaml -n atlas
+   kubectl logs -f job/tag-reconciler-seed -n atlas
+   ```
+
+3. **Enable the reconciler:**
+   ```bash
+   kubectl exec -n atlas atlas-cassandra-0 -c atlas-cassandra -- cqlsh localhost -e \
+     "INSERT INTO config_store.configs (app_name, config_key, config_value, updated_by, last_updated) \
+      VALUES ('atlas', 'TAG_RECONCILER_ENABLED', 'true', 'admin', toTimestamp(now()));"
+   ```
+
+4. **Monitor** the next nightly window for reconciler activity in logs.
+
+5. **Clean up** the seed job:
+   ```bash
+   kubectl delete job tag-reconciler-seed -n atlas
+   ```
+
+### Re-seeding (if needed)
+
+If the forward path is not yet instrumented and you want to catch up on changes since the last seed:
+
+1. Disable the reconciler
+2. Reset state: `DELETE FROM config_store.configs WHERE app_name = 'atlas' AND config_key = 'TAG_RECONCILER_STATE';`
+3. Run the seed job again
+4. Re-enable the reconciler

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tags/TagDAO.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tags/TagDAO.java
@@ -77,5 +77,34 @@ public interface TagDAO {
      * @throws AtlasBaseException If an error occurs during retrieval
      */
     Map<String, List<AtlasClassification>> getAllClassificationsForVertices(Collection<String> vertexIds) throws AtlasBaseException;
+
+    /**
+     * Logs a tag change to the change log table for reconciliation.
+     */
+    void logTagChange(String vertexId, String tagTypeName, String operation) throws AtlasBaseException;
+
+    /**
+     * Reads a page of change log entries for a given day bucket, starting after the given position.
+     */
+    List<TagChangeLogEntry> readChangeLog(String dayBucket, long afterTimestamp, String afterVertexId, int pageSize) throws AtlasBaseException;
+
+    /**
+     * A change log entry.
+     */
+    class TagChangeLogEntry {
+        public final String dayBucket;
+        public final long   createdAt;
+        public final String vertexId;
+        public final String tagTypeName;
+        public final String operation;
+
+        public TagChangeLogEntry(String dayBucket, long createdAt, String vertexId, String tagTypeName, String operation) {
+            this.dayBucket   = dayBucket;
+            this.createdAt   = createdAt;
+            this.vertexId    = vertexId;
+            this.tagTypeName = tagTypeName;
+            this.operation   = operation;
+        }
+    }
 }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tags/TagDAOCassandraImpl.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/tags/TagDAOCassandraImpl.java
@@ -114,6 +114,11 @@ public class TagDAOCassandraImpl implements TagDAO, AutoCloseable {
     // Health check prepared statement
     private final PreparedStatement healthCheckStmt;
 
+    // Change log for reconciliation
+    private static final String CHANGE_LOG_TABLE_NAME = "tag_change_log";
+    private final PreparedStatement insertChangeLogStmt;
+    private final PreparedStatement readChangeLogStmt;
+
 
     private TagDAOCassandraImpl() throws AtlasBaseException {
         try {
@@ -188,6 +193,16 @@ public class TagDAOCassandraImpl implements TagDAO, AutoCloseable {
             // === Health check statement ===
             healthCheckStmt = prepare("SELECT release_version FROM system.local");
 
+            // === Change log statements ===
+            insertChangeLogStmt = prepare(String.format(
+                    "INSERT INTO %s.%s (day_bucket, created_at, vertex_id, tag_type_name, operation) VALUES (?, ?, ?, ?, ?)",
+                    KEYSPACE, CHANGE_LOG_TABLE_NAME));
+
+            readChangeLogStmt = prepare(String.format(
+                    "SELECT day_bucket, created_at, vertex_id, tag_type_name, operation FROM %s.%s " +
+                            "WHERE day_bucket = ? AND (created_at, vertex_id) > (?, ?)",
+                    KEYSPACE, CHANGE_LOG_TABLE_NAME));
+
         } catch (Exception e) {
             LOG.error("Failed to initialize TagDAO", e);
             throw new AtlasBaseException("Failed to initialize TagDAO", e);
@@ -240,6 +255,21 @@ public class TagDAOCassandraImpl implements TagDAO, AutoCloseable {
                 KEYSPACE, PROPAGATED_TAGS_TABLE_NAME);
         executeWithRetry(SimpleStatement.builder(createPropagatedTagsTable).setConsistencyLevel(DefaultConsistencyLevel.ALL).build());
         LOG.info("Ensured table {}.{} exists with SizeTieredCompactionStrategy and hard deletes", KEYSPACE, PROPAGATED_TAGS_TABLE_NAME);
+
+        String createChangeLogTable = String.format(
+                "CREATE TABLE IF NOT EXISTS %s.%s (" +
+                        "day_bucket text, " +
+                        "created_at timestamp, " +
+                        "vertex_id text, " +
+                        "tag_type_name text, " +
+                        "operation text, " +
+                        "PRIMARY KEY ((day_bucket), created_at, vertex_id)" +
+                        ") WITH CLUSTERING ORDER BY (created_at ASC, vertex_id ASC) " +
+                        "AND compaction = {'class': 'TimeWindowCompactionStrategy', 'compaction_window_unit': 'DAYS', 'compaction_window_size': '1'} " +
+                        "AND default_time_to_live = 604800;",
+                KEYSPACE, CHANGE_LOG_TABLE_NAME);
+        executeWithRetry(SimpleStatement.builder(createChangeLogTable).setConsistencyLevel(DefaultConsistencyLevel.ALL).build());
+        LOG.info("Ensured table {}.{} exists with 7-day TTL", KEYSPACE, CHANGE_LOG_TABLE_NAME);
     }
 
     @Override
@@ -914,6 +944,47 @@ public class TagDAOCassandraImpl implements TagDAO, AutoCloseable {
         } catch (Exception e) {
             LOG.warn("Cassandra health check failed due to unexpected error: {}", e.getMessage(), e);
             return false;
+        }
+    }
+
+    @Override
+    public void logTagChange(String vertexId, String tagTypeName, String operation) throws AtlasBaseException {
+        try {
+            String dayBucket = java.time.LocalDate.now(java.time.ZoneOffset.UTC).toString();
+            java.time.Instant now = java.time.Instant.now();
+            BoundStatement bound = insertChangeLogStmt.bind(dayBucket, now, vertexId,
+                    tagTypeName != null ? tagTypeName : "", operation != null ? operation : "");
+            executeWithRetry(bound);
+        } catch (Exception e) {
+            // Log but don't throw — change log is best-effort, must not break tag operations
+            LOG.warn("Failed to log tag change for vertex={}, tag={}, op={}", vertexId, tagTypeName, operation, e);
+        }
+    }
+
+    @Override
+    public List<TagChangeLogEntry> readChangeLog(String dayBucket, long afterTimestamp, String afterVertexId, int pageSize) throws AtlasBaseException {
+        try {
+            java.time.Instant afterInstant = java.time.Instant.ofEpochMilli(afterTimestamp);
+            BoundStatement bound = readChangeLogStmt.bind(dayBucket, afterInstant, afterVertexId != null ? afterVertexId : "")
+                    .setPageSize(pageSize);
+            ResultSet rs = executeWithRetry(bound);
+            List<TagChangeLogEntry> entries = new ArrayList<>();
+            int count = 0;
+            for (Row row : rs) {
+                if (count >= pageSize) break;
+                entries.add(new TagChangeLogEntry(
+                        row.getString("day_bucket"),
+                        row.getInstant("created_at").toEpochMilli(),
+                        row.getString("vertex_id"),
+                        row.getString("tag_type_name"),
+                        row.getString("operation")
+                ));
+                count++;
+            }
+            return entries;
+        } catch (Exception e) {
+            LOG.error("Failed to read change log for dayBucket={}", dayBucket, e);
+            throw new AtlasBaseException("Failed to read change log", e);
         }
     }
 

--- a/repository/src/main/java/org/apache/atlas/service/config/ConfigKey.java
+++ b/repository/src/main/java/org/apache/atlas/service/config/ConfigKey.java
@@ -41,7 +41,11 @@ public enum ConfigKey {
     DELETE_BATCH_ENABLED("atlas.delete.batch.enabled", "false"),
 
     // Async ingestion flag - when enabled, write operations also publish to Kafka for shadow consumer
-    ENABLE_ASYNC_INGESTION("ENABLE_ASYNC_INGESTION", "false");
+    ENABLE_ASYNC_INGESTION("ENABLE_ASYNC_INGESTION", "false"),
+
+    // Tag reconciliation service — syncs Cassandra tags to ES and cleans up orphaned propagations
+    TAG_RECONCILER_ENABLED("TAG_RECONCILER_ENABLED", "false"),
+    TAG_RECONCILER_STATE("TAG_RECONCILER_STATE", null);
 
     private final String key;
     private final String defaultValue;

--- a/repository/src/main/java/org/apache/atlas/services/TagReconciliationService.java
+++ b/repository/src/main/java/org/apache/atlas/services/TagReconciliationService.java
@@ -221,6 +221,7 @@ public class TagReconciliationService {
 
         List<String> directTagNames = new ArrayList<>();
         List<String> propagatedTagNames = new ArrayList<>();
+        List<Tag> orphanTags = new ArrayList<>();
 
         for (Tag tag : allTags) {
             boolean isPropagated = !vertexId.equals(tag.getSourceVertexId());
@@ -241,18 +242,24 @@ public class TagReconciliationService {
                 if (sourceCache.get(cacheKey)) {
                     propagatedTagNames.add(tag.getTagTypeName());
                 } else {
-                    // Orphan — clean up
-                    try {
-                        tagDAO.deleteTags(Collections.singletonList(tag));
-                        result.orphansCleaned++;
-                        LOG.info("TagReconciler: cleaned orphan tag {} on vertex {} from source {}",
-                                tag.getTagTypeName(), vertexId, tag.getSourceVertexId());
-                    } catch (Exception e) {
-                        LOG.warn("TagReconciler: failed to clean orphan on vertex {}", vertexId, e);
-                    }
+                    orphanTags.add(tag);
                 }
             } else {
                 directTagNames.add(tag.getTagTypeName());
+            }
+        }
+
+        // Batch-delete all orphans in one call
+        if (!orphanTags.isEmpty()) {
+            try {
+                tagDAO.deleteTags(orphanTags);
+                result.orphansCleaned = orphanTags.size();
+                for (Tag orphan : orphanTags) {
+                    LOG.info("TagReconciler: cleaned orphan tag {} on vertex {} from source {}",
+                            orphan.getTagTypeName(), vertexId, orphan.getSourceVertexId());
+                }
+            } catch (Exception e) {
+                LOG.warn("TagReconciler: failed to clean {} orphans on vertex {}", orphanTags.size(), vertexId, e);
             }
         }
 
@@ -267,11 +274,11 @@ public class TagReconciliationService {
 
         fields.put(TRAIT_NAMES_PROPERTY_KEY, new ArrayList<>(directNames));
         fields.put(CLASSIFICATION_NAMES_KEY, directNames.isEmpty() ? null
-                : CLASSIFICATION_NAME_DELIMITER + String.join(CLASSIFICATION_NAME_DELIMITER, directNames));
+                : CLASSIFICATION_NAME_DELIMITER + String.join(CLASSIFICATION_NAME_DELIMITER, directNames) + CLASSIFICATION_NAME_DELIMITER);
 
         fields.put(PROPAGATED_TRAIT_NAMES_PROPERTY_KEY, new ArrayList<>(propagatedNames));
         fields.put(PROPAGATED_CLASSIFICATION_NAMES_KEY, propagatedNames.isEmpty() ? null
-                : CLASSIFICATION_NAME_DELIMITER + String.join(CLASSIFICATION_NAME_DELIMITER, propagatedNames));
+                : CLASSIFICATION_NAME_DELIMITER + String.join(CLASSIFICATION_NAME_DELIMITER, propagatedNames) + CLASSIFICATION_NAME_DELIMITER);
 
         Set<String> allNames = new LinkedHashSet<>();
         allNames.addAll(directNames);

--- a/repository/src/main/java/org/apache/atlas/services/TagReconciliationService.java
+++ b/repository/src/main/java/org/apache/atlas/services/TagReconciliationService.java
@@ -1,0 +1,380 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas.services;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.model.Tag;
+import org.apache.atlas.model.instance.AtlasClassification;
+import org.apache.atlas.repository.store.graph.v2.ESConnector;
+import org.apache.atlas.repository.store.graph.v2.tags.TagDAO;
+import org.apache.atlas.repository.store.graph.v2.tags.TagDAOCassandraImpl;
+import org.apache.atlas.service.config.ConfigKey;
+import org.apache.atlas.service.config.DynamicConfigStore;
+import org.apache.atlas.service.redis.RedisService;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.apache.atlas.repository.Constants.*;
+
+/**
+ * Change-log-driven tag reconciliation service.
+ *
+ * Drains the tags.tag_change_log table, and for each vertex:
+ * 1. Reads all tags from Cassandra (source of truth)
+ * 2. Detects and cleans orphaned propagated tags
+ * 3. Computes the 5 denorm fields and writes a full snapshot to ES
+ *
+ * The change log is populated by:
+ * - Initial seed: K8s Job using cqlsh COPY TO/FROM (one-time backfill)
+ * - Forward path: tag write operations INSERT into the change log (added incrementally)
+ *
+ * Disabled by default. Enable per-tenant:
+ *   DynamicConfigStore.setConfig("TAG_RECONCILER_ENABLED", "true", "admin")
+ *
+ * Runs within a configurable nightly window. Resumes from where it left off.
+ * Single-pod execution via Redis distributed lock.
+ */
+@Component
+@DependsOn("dynamicConfigStore")
+public class TagReconciliationService {
+    private static final Logger LOG = LoggerFactory.getLogger(TagReconciliationService.class);
+
+    private static final String LOCK_KEY       = "atlas:tag:reconciler:lock";
+    private static final String CONFIG_ENABLED = ConfigKey.TAG_RECONCILER_ENABLED.getKey();
+    private static final String CONFIG_STATE   = ConfigKey.TAG_RECONCILER_STATE.getKey();
+    private static final String UPDATER        = "tag-reconciler";
+
+    private static final int WINDOW_START_HOUR = Integer.getInteger("atlas.tag.reconciler.window.start.hour", 0);
+    private static final int WINDOW_DURATION_H = Integer.getInteger("atlas.tag.reconciler.window.duration.hours", 4);
+    private static final int PAGE_SIZE         = Integer.getInteger("atlas.tag.reconciler.page.size", 500);
+    private static final int ES_BATCH_SIZE     = Integer.getInteger("atlas.tag.reconciler.es.batch.size", 50);
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final RedisService redisService;
+
+    @Inject
+    public TagReconciliationService(RedisService redisService) {
+        this.redisService = redisService;
+    }
+
+    // ── Scheduled entry point ───────────────────────────────────────────
+
+    @Scheduled(fixedDelayString = "${atlas.tag.reconciler.poll.interval:900000}")
+    public void tick() {
+        if (!isEnabled() || !isWithinWindow()) {
+            return;
+        }
+
+        boolean lockAcquired = false;
+        try {
+            lockAcquired = redisService.acquireDistributedLock(LOCK_KEY);
+            if (!lockAcquired) {
+                return;
+            }
+            LOG.info("TagReconciler: acquired lock, starting cycle");
+            runCycle();
+        } catch (Exception e) {
+            LOG.error("TagReconciler: error during cycle", e);
+        } finally {
+            if (lockAcquired) {
+                try { redisService.releaseDistributedLock(LOCK_KEY); } catch (Exception ignored) {}
+            }
+        }
+    }
+
+    // ── Core loop — drains the change log ───────────────────────────────
+
+    private void runCycle() throws Exception {
+        ReconcileState state = loadState();
+        TagDAOCassandraImpl tagDAO = TagDAOCassandraImpl.getInstance();
+        long windowEnd = computeWindowEndMs();
+        long cycleStart = System.currentTimeMillis();
+
+        int entriesProcessed = 0;
+        int verticesReconciled = 0;
+        int orphansCleaned = 0;
+
+        // Source cache: sourceVertexId|tagTypeName -> has active direct tag
+        Map<String, Boolean> sourceCache = new HashMap<>();
+
+        String currentDayBucket = state.dayBucket != null ? state.dayBucket : oldestDayBucket();
+
+        LOG.info("TagReconciler: starting from dayBucket={}, lastTimestamp={}, lastVertexId={}",
+                currentDayBucket, state.lastTimestamp, state.lastVertexId);
+
+        String today = LocalDate.now(ZoneOffset.UTC).toString();
+
+        while (System.currentTimeMillis() < windowEnd) {
+            if (currentDayBucket == null) {
+                currentDayBucket = oldestDayBucket();
+                if (currentDayBucket == null) {
+                    LOG.info("TagReconciler: change log is empty, nothing to do");
+                    break;
+                }
+            }
+
+            // Don't process future days
+            if (currentDayBucket.compareTo(today) > 0) {
+                LOG.info("TagReconciler: caught up to today, done for this cycle");
+                break;
+            }
+
+            List<TagDAO.TagChangeLogEntry> entries = tagDAO.readChangeLog(
+                    currentDayBucket, state.lastTimestamp, state.lastVertexId, PAGE_SIZE);
+
+            if (entries.isEmpty()) {
+                // This day bucket is exhausted, move to next day
+                currentDayBucket = nextDay(currentDayBucket);
+                state.dayBucket = currentDayBucket;
+                state.lastTimestamp = 0;
+                state.lastVertexId = null;
+                saveState(state);
+
+                if (currentDayBucket.compareTo(today) > 0) {
+                    LOG.info("TagReconciler: finished all day buckets up to today");
+                    break;
+                }
+                continue;
+            }
+
+            // Deduplicate vertex IDs in this page
+            Set<String> vertexIds = entries.stream()
+                    .map(e -> e.vertexId)
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+
+            Map<String, Map<String, Object>> esBatch = new HashMap<>();
+
+            for (String vertexId : vertexIds) {
+                try {
+                    ReconcileResult result = reconcileVertex(tagDAO, vertexId, sourceCache);
+                    verticesReconciled++;
+                    orphansCleaned += result.orphansCleaned;
+
+                    if (result.denormFields != null) {
+                        esBatch.put(vertexId, result.denormFields);
+                    }
+
+                    if (esBatch.size() >= ES_BATCH_SIZE) {
+                        flushToES(esBatch);
+                        esBatch.clear();
+                    }
+                } catch (Exception e) {
+                    LOG.warn("TagReconciler: error processing vertex {}", vertexId, e);
+                }
+            }
+
+            if (!esBatch.isEmpty()) {
+                flushToES(esBatch);
+            }
+
+            // Update cursor to the last entry in this page
+            TagDAO.TagChangeLogEntry lastEntry = entries.get(entries.size() - 1);
+            state.dayBucket = currentDayBucket;
+            state.lastTimestamp = lastEntry.createdAt;
+            state.lastVertexId = lastEntry.vertexId;
+            entriesProcessed += entries.size();
+
+            saveState(state);
+        }
+
+        long elapsed = System.currentTimeMillis() - cycleStart;
+        LOG.info("TagReconciler: cycle done — entries={}, vertices={}, orphans={}, elapsed={}ms",
+                entriesProcessed, verticesReconciled, orphansCleaned, elapsed);
+    }
+
+    // ── Per-vertex reconciliation ───────────────────────────────────────
+
+    private ReconcileResult reconcileVertex(TagDAOCassandraImpl tagDAO, String vertexId,
+                                            Map<String, Boolean> sourceCache) throws AtlasBaseException {
+        ReconcileResult result = new ReconcileResult();
+        List<Tag> allTags = tagDAO.getAllTagsByVertexId(vertexId);
+
+        List<String> directTagNames = new ArrayList<>();
+        List<String> propagatedTagNames = new ArrayList<>();
+
+        for (Tag tag : allTags) {
+            boolean isPropagated = !vertexId.equals(tag.getSourceVertexId());
+
+            if (isPropagated) {
+                String cacheKey = tag.getSourceVertexId() + "|" + tag.getTagTypeName();
+
+                if (!sourceCache.containsKey(cacheKey)) {
+                    try {
+                        AtlasClassification directTag = tagDAO.findDirectTagByVertexIdAndTagTypeName(
+                                tag.getSourceVertexId(), tag.getTagTypeName(), false);
+                        sourceCache.put(cacheKey, directTag != null);
+                    } catch (Exception e) {
+                        sourceCache.put(cacheKey, true); // assume valid on error
+                    }
+                }
+
+                if (sourceCache.get(cacheKey)) {
+                    propagatedTagNames.add(tag.getTagTypeName());
+                } else {
+                    // Orphan — clean up
+                    try {
+                        tagDAO.deleteTags(Collections.singletonList(tag));
+                        result.orphansCleaned++;
+                        LOG.info("TagReconciler: cleaned orphan tag {} on vertex {} from source {}",
+                                tag.getTagTypeName(), vertexId, tag.getSourceVertexId());
+                    } catch (Exception e) {
+                        LOG.warn("TagReconciler: failed to clean orphan on vertex {}", vertexId, e);
+                    }
+                }
+            } else {
+                directTagNames.add(tag.getTagTypeName());
+            }
+        }
+
+        result.denormFields = computeDenormFields(directTagNames, propagatedTagNames);
+        return result;
+    }
+
+    // ── Denorm computation ──────────────────────────────────────────────
+
+    private Map<String, Object> computeDenormFields(List<String> directNames, List<String> propagatedNames) {
+        Map<String, Object> fields = new HashMap<>();
+
+        fields.put(TRAIT_NAMES_PROPERTY_KEY, new ArrayList<>(directNames));
+        fields.put(CLASSIFICATION_NAMES_KEY, directNames.isEmpty() ? null
+                : CLASSIFICATION_NAME_DELIMITER + String.join(CLASSIFICATION_NAME_DELIMITER, directNames));
+
+        fields.put(PROPAGATED_TRAIT_NAMES_PROPERTY_KEY, new ArrayList<>(propagatedNames));
+        fields.put(PROPAGATED_CLASSIFICATION_NAMES_KEY, propagatedNames.isEmpty() ? null
+                : CLASSIFICATION_NAME_DELIMITER + String.join(CLASSIFICATION_NAME_DELIMITER, propagatedNames));
+
+        Set<String> allNames = new LinkedHashSet<>();
+        allNames.addAll(directNames);
+        allNames.addAll(propagatedNames);
+        fields.put(CLASSIFICATION_TEXT_KEY, allNames.isEmpty() ? "" : String.join(" ", allNames));
+
+        return fields;
+    }
+
+    // ── ES flush ────────────────────────────────────────────────────────
+
+    private void flushToES(Map<String, Map<String, Object>> batch) {
+        try {
+            ESConnector.writeTagProperties(batch);
+        } catch (Exception e) {
+            LOG.error("TagReconciler: failed to flush {} vertices to ES", batch.size(), e);
+        }
+    }
+
+    // ── Day bucket helpers ──────────────────────────────────────────────
+
+    private String oldestDayBucket() {
+        // Start from 7 days ago (TTL window)
+        return LocalDate.now(ZoneOffset.UTC).minusDays(7).toString();
+    }
+
+    private String nextDay(String dayBucket) {
+        return LocalDate.parse(dayBucket).plusDays(1).toString();
+    }
+
+    // ── Window check ────────────────────────────────────────────────────
+
+    private boolean isWithinWindow() {
+        int hour = LocalTime.now(ZoneOffset.UTC).getHour();
+        int windowEnd = (WINDOW_START_HOUR + WINDOW_DURATION_H) % 24;
+
+        if (WINDOW_START_HOUR < windowEnd) {
+            return hour >= WINDOW_START_HOUR && hour < windowEnd;
+        } else {
+            return hour >= WINDOW_START_HOUR || hour < windowEnd;
+        }
+    }
+
+    private long computeWindowEndMs() {
+        // Compute actual window end time today
+        int windowEndHour = (WINDOW_START_HOUR + WINDOW_DURATION_H) % 24;
+        LocalDate today = LocalDate.now(ZoneOffset.UTC);
+        long windowEndMs;
+
+        if (WINDOW_START_HOUR < windowEndHour) {
+            windowEndMs = today.atTime(windowEndHour, 0).toInstant(ZoneOffset.UTC).toEpochMilli();
+        } else {
+            // Wraps midnight — end is next day
+            windowEndMs = today.plusDays(1).atTime(windowEndHour, 0).toInstant(ZoneOffset.UTC).toEpochMilli();
+        }
+
+        return windowEndMs;
+    }
+
+    // ── Config ──────────────────────────────────────────────────────────
+
+    private boolean isEnabled() {
+        try {
+            return "true".equalsIgnoreCase(DynamicConfigStore.getConfig(CONFIG_ENABLED));
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    // ── State persistence ───────────────────────────────────────────────
+
+    private ReconcileState loadState() {
+        try {
+            String json = DynamicConfigStore.getConfig(CONFIG_STATE);
+            if (StringUtils.isNotEmpty(json)) {
+                return MAPPER.readValue(json, ReconcileState.class);
+            }
+        } catch (Exception e) {
+            LOG.warn("TagReconciler: failed to load state, starting fresh", e);
+        }
+        return new ReconcileState();
+    }
+
+    private void saveState(ReconcileState state) {
+        try {
+            DynamicConfigStore.setConfig(CONFIG_STATE, MAPPER.writeValueAsString(state), UPDATER);
+        } catch (Exception e) {
+            LOG.error("TagReconciler: failed to save state", e);
+        }
+    }
+
+    // ── Models ──────────────────────────────────────────────────────────
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    static class ReconcileState {
+        public String dayBucket;
+        public long   lastTimestamp;
+        public String lastVertexId;
+    }
+
+    private static class ReconcileResult {
+        int orphansCleaned;
+        Map<String, Object> denormFields;
+    }
+}

--- a/tools/tag-reconciler-seed-job.yaml
+++ b/tools/tag-reconciler-seed-job.yaml
@@ -1,0 +1,96 @@
+# Tag Reconciler Seed Job
+#
+# One-time K8s Job to populate tags.tag_change_log from existing tags.tags_by_id.
+# Run this once per tenant before enabling the reconciler.
+#
+# Usage:
+#   kubectl apply -f tag-reconciler-seed-job.yaml -n atlas
+#
+# Monitor:
+#   kubectl logs -f job/tag-reconciler-seed -n atlas
+#
+# Cleanup:
+#   kubectl delete job tag-reconciler-seed -n atlas
+#
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: tag-reconciler-seed
+  namespace: atlas
+spec:
+  backoffLimit: 2
+  activeDeadlineSeconds: 3600
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: seed
+        image: cassandra:4.1
+        command: ["bash", "-c"]
+        args:
+        - |
+          set -e
+          CQLSH_HOST="${CASSANDRA_HOST:-atlas-cassandra-0.atlas-cassandra.atlas.svc.cluster.local}"
+          echo "=== Tag Reconciler Seed ==="
+          echo "Cassandra host: $CQLSH_HOST"
+          echo ""
+
+          # Step 1: Create the change log table (idempotent)
+          echo "Step 1: Ensuring tag_change_log table exists..."
+          cqlsh "$CQLSH_HOST" -e "
+            CREATE TABLE IF NOT EXISTS tags.tag_change_log (
+              day_bucket text,
+              created_at timestamp,
+              vertex_id text,
+              tag_type_name text,
+              operation text,
+              PRIMARY KEY ((day_bucket), created_at, vertex_id)
+            ) WITH CLUSTERING ORDER BY (created_at ASC, vertex_id ASC)
+              AND compaction = {'class': 'TimeWindowCompactionStrategy', 'compaction_window_unit': 'DAYS', 'compaction_window_size': '1'}
+              AND default_time_to_live = 604800;"
+          echo "Done."
+
+          # Step 2: Export vertex IDs from tags_by_id
+          echo ""
+          echo "Step 2: Exporting vertex IDs from tags.tags_by_id..."
+          cqlsh "$CQLSH_HOST" -e "COPY tags.tags_by_id (id) TO '/tmp/raw_ids.csv';"
+          RAW_COUNT=$(wc -l < /tmp/raw_ids.csv)
+          echo "Exported $RAW_COUNT rows."
+
+          # Step 3: Deduplicate and prepare for load
+          echo ""
+          echo "Step 3: Deduplicating vertex IDs..."
+          sort -u /tmp/raw_ids.csv > /tmp/unique_ids.csv
+          UNIQUE_COUNT=$(wc -l < /tmp/unique_ids.csv)
+          echo "Unique vertex IDs: $UNIQUE_COUNT"
+
+          # Step 4: Generate change log CSV with today's date and current epoch ms
+          echo ""
+          echo "Step 4: Generating change log CSV..."
+          DAY_BUCKET=$(date -u +%Y-%m-%d)
+          EPOCH_MS=$(date -u +%s)000
+
+          awk -v d="$DAY_BUCKET" -v ts="$EPOCH_MS" '{print d "," ts "," $1 ",,SEED"}' /tmp/unique_ids.csv > /tmp/change_log.csv
+          echo "Generated $(wc -l < /tmp/change_log.csv) change log entries."
+
+          # Step 5: Load into tag_change_log
+          echo ""
+          echo "Step 5: Loading into tags.tag_change_log..."
+          cqlsh "$CQLSH_HOST" -e "COPY tags.tag_change_log (day_bucket, created_at, vertex_id, tag_type_name, operation) FROM '/tmp/change_log.csv';"
+
+          echo ""
+          echo "=== Seed complete ==="
+          echo "Day bucket: $DAY_BUCKET"
+          echo "Vertices seeded: $UNIQUE_COUNT"
+          echo ""
+          echo "Next steps:"
+          echo "  1. Enable the reconciler:"
+          echo "     cqlsh $CQLSH_HOST -e \"INSERT INTO config_store.configs (app_name, config_key, config_value, updated_by, last_updated) VALUES ('atlas', 'TAG_RECONCILER_ENABLED', 'true', 'admin', toTimestamp(now()));\""
+          echo "  2. Monitor progress in atlas logs: grep 'TagReconciler' atlas.log"
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "250m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"


### PR DESCRIPTION
## Summary

Adds a self-contained tag reconciliation service that syncs Cassandra tag state to ES and cleans up orphaned propagated tags. Disabled by default, enabled per-tenant.

### Components

1. **`tags.tag_change_log`** Cassandra table — work queue of vertex IDs needing reconciliation. Day-partitioned, 7-day TTL, auto-created on startup.
2. **`TagReconciliationService`** — Spring `@Scheduled` bean. Drains the change log within a configurable nightly window. For each vertex: reads all tags from Cassandra, detects orphaned propagated tags, computes 5 denorm fields, writes full snapshot to ES.
3. **Seed K8s Job** — populates change log from existing `tags_by_id` using native cqlsh `COPY TO/FROM`. Run once per tenant.

### Why a change log

- Full table scan of `tags_by_id` is too slow for large tenants (millions of vertices, weeks of nightly windows)
- Change log only processes what changed — after initial seed, steady state is near-zero work
- Solves the race condition: log entry written AFTER Cassandra write, so reconciler always reads committed state

### Files changed

- `ConfigKey.java` — TAG_RECONCILER_ENABLED, TAG_RECONCILER_STATE config keys
- `TagDAO.java` — `logTagChange()`, `readChangeLog()`, `TagChangeLogEntry`
- `TagDAOCassandraImpl.java` — table creation, prepared statements, implementations
- `TagReconciliationService.java` — the reconciler (new)
- `tools/tag-reconciler-seed-job.yaml` — K8s Job for initial backfill (new)
- `docs/data-consistency/tag-reconciliation-service.md` — full architecture doc (new)

### Deployment

1. Deploy Atlas (creates table on startup)
2. Run seed job: `kubectl apply -f tools/tag-reconciler-seed-job.yaml -n atlas`
3. Enable: `INSERT INTO config_store.configs ... VALUES ('atlas', 'TAG_RECONCILER_ENABLED', 'true', ...)`

### Configuration

| Config | Default | Description |
|--------|---------|-------------|
| `TAG_RECONCILER_ENABLED` | `false` | Master switch (dynamic, per-tenant) |
| `atlas.tag.reconciler.window.start.hour` | `0` | Window start (UTC) |
| `atlas.tag.reconciler.window.duration.hours` | `4` | Window duration |
| `atlas.tag.reconciler.page.size` | `500` | Entries per page |
| `atlas.tag.reconciler.es.batch.size` | `50` | ES bulk batch size |

See `docs/data-consistency/tag-reconciliation-service.md` for full architecture, tradeoffs, and runbook.

## Test plan
- [ ] Deploy to staging, run seed job, verify `tag_change_log` table populated
- [ ] Enable reconciler, set window to current hour, verify it processes entries
- [ ] Verify orphaned propagated tags are cleaned from Cassandra
- [ ] Verify ES denorm fields match Cassandra state after reconciliation
- [ ] Verify reconciler resumes from saved state after pod restart
- [ ] Verify only one pod runs (Redis lock) in multi-replica setup
- [ ] Verify reconciler stops at window boundary

Relates to [MS-907](https://linear.app/atlan-epd/issue/MS-907/playbook-fails-to-remove-tags-from-linked-assets)

Generated with [Claude Code](https://claude.com/claude-code)