### PR TITLE
MS-692: Smart classification prefetch — skip CQL for tagless vertices

### DIFF
--- a/repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java
@@ -584,18 +584,41 @@ public class EntityDiscoveryService implements AtlasDiscoveryService {
                 vertexEdgePropertiesCache = null;
             }
 
-            // Batch-prefetch classifications for all result vertices (TagV2 only, with per-vertex fallback)
+            // Batch-prefetch classifications only for vertices that actually have tags.
+            // Pre-filter using vertex properties (__classificationsText, __classificationNames,
+            // __propagatedClassificationNames) to skip CQL queries to tags_by_id for tagless
+            // vertices. Vertices with no tags get an empty list in the cache to prevent the
+            // per-vertex sync fallback in mapVertexToAtlasEntityHeader.
             Map<String, List<AtlasClassification>> classificationCache = null;
             if (useVertexEdgeBulkFetching && vertexEdgePropertiesCache != null
                     && RequestContext.get().includeClassifications()) {
-                List<AtlasVertex> resultVertices = new ArrayList<>(vertexIds.size());
+                List<AtlasVertex> verticesWithClassifications = new ArrayList<>();
+                classificationCache = new HashMap<>();
+
                 for (String vid : vertexIds) {
                     AtlasVertex v = vertexEdgePropertiesCache.getVertexById(vid);
-                    if (v != null) {
-                        resultVertices.add(v);
+                    if (v == null) {
+                        continue;
+                    }
+
+                    String clsText = vertexEdgePropertiesCache.getPropertyValue(vid, CLASSIFICATION_TEXT_KEY, String.class);
+                    String clsNames = vertexEdgePropertiesCache.getPropertyValue(vid, CLASSIFICATION_NAMES_KEY, String.class);
+                    String propClsNames = vertexEdgePropertiesCache.getPropertyValue(vid, PROPAGATED_CLASSIFICATION_NAMES_KEY, String.class);
+
+                    if (StringUtils.isNotEmpty(clsText) || StringUtils.isNotEmpty(clsNames) || StringUtils.isNotEmpty(propClsNames)) {
+                        verticesWithClassifications.add(v);
+                    } else {
+                        classificationCache.put(vid, Collections.emptyList());
                     }
                 }
-                classificationCache = entityRetriever.prefetchClassifications(resultVertices);
+
+                if (!verticesWithClassifications.isEmpty()) {
+                    Map<String, List<AtlasClassification>> fetched =
+                            entityRetriever.prefetchClassifications(verticesWithClassifications);
+                    if (fetched != null) {
+                        classificationCache.putAll(fetched);
+                    }
+                }
             }
 
             for(Result result : results) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -1483,66 +1483,6 @@ public class EntityGraphRetriever {
         return allResults;
     }
 
-    /**
-     * Fetches ALL edges for the given vertices using bulk partition reads (2 CQL per vertex:
-     * one for edges_out, one for edges_in), then filters by the requested edge labels in memory.
-     *
-     * This is significantly more efficient than per-label CQL queries for indexsearch because
-     * it trades a few extra rows fetched for dramatically fewer network round-trips:
-     *   - Per-label approach: N vertices × L labels × directions = ~1,500 CQL for 100 results
-     *   - Full-scan approach: N vertices × 2 = 200 CQL for 100 results
-     *
-     * The limitPerLabel constraint is NOT enforced here — it is enforced downstream by
-     * {@link VertexEdgePropertiesCache#addEdgeLabelToVertexIds} which caps edges per (vertex, label).
-     */
-    @SuppressWarnings("unchecked")
-    private List<Map<String, Object>> fetchEdgesViaFullScan(Set<String> vertexIds, Set<String> edgeLabels) {
-        AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("fetchEdgesViaFullScan");
-        try {
-            Map<String, List<AtlasEdge>> allEdgesMap = (Map) graph.getEdgesForVertices(vertexIds);
-
-            List<Map<String, Object>> results = new ArrayList<>();
-            Set<String> seenEdgeIds = new HashSet<>();
-
-            for (String vertexId : vertexIds) {
-                List<AtlasEdge> edges = allEdgesMap.getOrDefault(vertexId, Collections.emptyList());
-
-                for (AtlasEdge edge : edges) {
-                    String edgeId = edge.getIdForDisplay();
-                    if (!seenEdgeIds.add(edgeId)) continue;
-
-                    String label = edge.getLabel();
-                    if (!edgeLabels.contains(label)) continue;
-
-                    String state = edge.getProperty(STATE_PROPERTY_KEY, String.class);
-                    if (!ACTIVE.name().equals(state)) continue;
-
-                    String relGuid = edge.getProperty(RELATIONSHIP_GUID_PROPERTY_KEY, String.class);
-                    if (relGuid == null) continue;
-
-                    Map<String, Object> edgeInfo = new HashMap<>();
-                    edgeInfo.put("id", edge.getId());
-
-                    LinkedHashMap<String, Object> valueMap = new LinkedHashMap<>();
-                    for (String key : edge.getPropertyKeys()) {
-                        valueMap.put(key, edge.getProperty(key, Object.class));
-                    }
-                    edgeInfo.put("valueMap", valueMap);
-                    edgeInfo.put("label", label);
-                    edgeInfo.put("inVertexId", edge.getInVertex().getId());
-                    edgeInfo.put("outVertexId", edge.getOutVertex().getId());
-                    results.add(edgeInfo);
-                }
-            }
-
-            LOG.debug("fetchEdgesViaFullScan: {} vertices, {} labels, {} edges found",
-                      vertexIds.size(), edgeLabels.size(), results.size());
-
-            return results;
-        } finally {
-            RequestContext.get().endMetricRecord(metricRecorder);
-        }
-    }
 
     public VertexEdgePropertiesCache enrichVertexPropertiesByVertexIds(Set<String> vertexIds, Set<String> attributes) {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("enrichVertexPropertiesByVertexIds");
@@ -1580,20 +1520,10 @@ public class EntityGraphRetriever {
            Set<String> vertexIdsToProcess = new HashSet<>();
            if (!CollectionUtils.isEmpty(edgeLabelsToProcess)) {
                List<Map<String, Object>> relationEdges;
-
-               if (graph instanceof CassandraGraph) {
-                   // ZeroGraph: fetch ALL edges per vertex (2 CQL per vertex, async) instead
-                   // of per-label CQL (N×L queries). Filters by requested labels in memory.
-                   // For 100 results × 15 labels: 200 CQL vs 1,500 — 7.5× fewer round-trips.
-                   // The downstream addEdgeLabelToVertexIds enforces limitPerLabel.
-                   relationEdges = fetchEdgesViaFullScan(vertexIds, edgeLabelsToProcess);
+               if (AtlasConfiguration.ATLAS_INDEXSEARCH_EDGE_BULK_FETCH_ENABLE.getBoolean()) {
+                   relationEdges = getConnectedRelationEdgesVertexBatching(vertexIds, edgeLabelDirections, relationAttrsSize);
                } else {
-                   // JanusGraph: existing Gremlin traversal path — direction-aware labels
-                   if (AtlasConfiguration.ATLAS_INDEXSEARCH_EDGE_BULK_FETCH_ENABLE.getBoolean()) {
-                       relationEdges = getConnectedRelationEdgesVertexBatching(vertexIds, edgeLabelDirections, relationAttrsSize);
-                   } else {
-                       relationEdges = getConnectedRelationEdges(vertexIds, edgeLabelDirections, relationAttrsSize);
-                   }
+                   relationEdges = getConnectedRelationEdges(vertexIds, edgeLabelDirections, relationAttrsSize);
                }
 
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -1483,6 +1483,66 @@ public class EntityGraphRetriever {
         return allResults;
     }
 
+    /**
+     * Fetches ALL edges for the given vertices using bulk partition reads (2 CQL per vertex:
+     * one for edges_out, one for edges_in), then filters by the requested edge labels in memory.
+     *
+     * This is significantly more efficient than per-label CQL queries for indexsearch because
+     * it trades a few extra rows fetched for dramatically fewer network round-trips:
+     *   - Per-label approach: N vertices × L labels × directions = ~1,500 CQL for 100 results
+     *   - Full-scan approach: N vertices × 2 = 200 CQL for 100 results
+     *
+     * The limitPerLabel constraint is NOT enforced here — it is enforced downstream by
+     * {@link VertexEdgePropertiesCache#addEdgeLabelToVertexIds} which caps edges per (vertex, label).
+     */
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> fetchEdgesViaFullScan(Set<String> vertexIds, Set<String> edgeLabels) {
+        AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("fetchEdgesViaFullScan");
+        try {
+            Map<String, List<AtlasEdge>> allEdgesMap = (Map) graph.getEdgesForVertices(vertexIds);
+
+            List<Map<String, Object>> results = new ArrayList<>();
+            Set<String> seenEdgeIds = new HashSet<>();
+
+            for (String vertexId : vertexIds) {
+                List<AtlasEdge> edges = allEdgesMap.getOrDefault(vertexId, Collections.emptyList());
+
+                for (AtlasEdge edge : edges) {
+                    String edgeId = edge.getIdForDisplay();
+                    if (!seenEdgeIds.add(edgeId)) continue;
+
+                    String label = edge.getLabel();
+                    if (!edgeLabels.contains(label)) continue;
+
+                    String state = edge.getProperty(STATE_PROPERTY_KEY, String.class);
+                    if (!ACTIVE.name().equals(state)) continue;
+
+                    String relGuid = edge.getProperty(RELATIONSHIP_GUID_PROPERTY_KEY, String.class);
+                    if (relGuid == null) continue;
+
+                    Map<String, Object> edgeInfo = new HashMap<>();
+                    edgeInfo.put("id", edge.getId());
+
+                    LinkedHashMap<String, Object> valueMap = new LinkedHashMap<>();
+                    for (String key : edge.getPropertyKeys()) {
+                        valueMap.put(key, edge.getProperty(key, Object.class));
+                    }
+                    edgeInfo.put("valueMap", valueMap);
+                    edgeInfo.put("label", label);
+                    edgeInfo.put("inVertexId", edge.getInVertex().getId());
+                    edgeInfo.put("outVertexId", edge.getOutVertex().getId());
+                    results.add(edgeInfo);
+                }
+            }
+
+            LOG.debug("fetchEdgesViaFullScan: {} vertices, {} labels, {} edges found",
+                      vertexIds.size(), edgeLabels.size(), results.size());
+
+            return results;
+        } finally {
+            RequestContext.get().endMetricRecord(metricRecorder);
+        }
+    }
 
     public VertexEdgePropertiesCache enrichVertexPropertiesByVertexIds(Set<String> vertexIds, Set<String> attributes) {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("enrichVertexPropertiesByVertexIds");
@@ -1520,10 +1580,20 @@ public class EntityGraphRetriever {
            Set<String> vertexIdsToProcess = new HashSet<>();
            if (!CollectionUtils.isEmpty(edgeLabelsToProcess)) {
                List<Map<String, Object>> relationEdges;
-               if (AtlasConfiguration.ATLAS_INDEXSEARCH_EDGE_BULK_FETCH_ENABLE.getBoolean()) {
-                   relationEdges = getConnectedRelationEdgesVertexBatching(vertexIds, edgeLabelDirections, relationAttrsSize);
+
+               if (graph instanceof CassandraGraph) {
+                   // ZeroGraph: fetch ALL edges per vertex (2 CQL per vertex, async) instead
+                   // of per-label CQL (N×L queries). Filters by requested labels in memory.
+                   // For 100 results × 15 labels: 200 CQL vs 1,500 — 7.5× fewer round-trips.
+                   // The downstream addEdgeLabelToVertexIds enforces limitPerLabel.
+                   relationEdges = fetchEdgesViaFullScan(vertexIds, edgeLabelsToProcess);
                } else {
-                   relationEdges = getConnectedRelationEdges(vertexIds, edgeLabelDirections, relationAttrsSize);
+                   // JanusGraph: existing Gremlin traversal path — direction-aware labels
+                   if (AtlasConfiguration.ATLAS_INDEXSEARCH_EDGE_BULK_FETCH_ENABLE.getBoolean()) {
+                       relationEdges = getConnectedRelationEdgesVertexBatching(vertexIds, edgeLabelDirections, relationAttrsSize);
+                   } else {
+                       relationEdges = getConnectedRelationEdges(vertexIds, edgeLabelDirections, relationAttrsSize);
+                   }
                }
 
 


### PR DESCRIPTION
## Change Description

### Problem

During indexsearch, `EntityDiscoveryService.prepareSearchResult()` calls `prefetchClassifications()` for **ALL** result vertices, which fires N async CQL queries to `tags.tags_by_id` — one per vertex. In practice, ~80% of vertices have zero classifications, so most of these queries return empty results.

**Cassandra impact (validated on duair15p01):**
- `tags_by_id` receives **2.13 million reads** across the 3-node cluster — **290x more** than any other indexsearch table
- **259,903 speculative retries** (12.2% retry rate) from the volume
- **17,467 bloom filter false positives** — wasted SSTable scans for non-existent partitions

**From HAR analysis:**
- Call #20 (20 Table/View entities): only 4 of 20 had classifications → 16 queries wasted (80%)
- Call #27 (20 Column entities): 0 of 20 had classifications → 20 queries wasted (100%)
- Call #4 (8 Connection entities): 0 of 8 had classifications → 8 queries wasted (100%)

### Solution

Pre-filter vertices before calling `prefetchClassifications()` using three vertex properties already available in the vertex property cache (loaded in Step B1):

1. `__classificationsText` — set when direct classifications exist
2. `__classificationNames` — set when direct classifications exist
3. `__propagatedClassificationNames` — set when propagated classifications exist

**Logic:**
- If **ANY** of the three properties is non-empty → vertex has tags → include in prefetch batch (query `tags_by_id`)
- If **ALL THREE** are empty/absent → vertex has no tags → put `Collections.emptyList()` in the cache

Putting an empty list in the cache for tagless vertices is critical — it prevents the **sync per-vertex fallback** in `EntityGraphRetriever.mapVertexToAtlasEntityHeader()` (line 1936-1939) which would fire individual CQL queries for any vertex not found in the cache.

### Changes

**Single file: `EntityDiscoveryService.java`** (28 insertions, 5 deletions)

In `prepareSearchResult()`, replaced the unconditional vertex collection:
```java
// Before: queries tags for ALL vertices
List<AtlasVertex> resultVertices = new ArrayList<>();
for (String vid : vertexIds) {
    AtlasVertex v = vertexEdgePropertiesCache.getVertexById(vid);
    if (v != null) resultVertices.add(v);
}
classificationCache = entityRetriever.prefetchClassifications(resultVertices);
```

With pre-filtered collection:
```java
// After: only queries tags for vertices that actually have classifications
for (String vid : vertexIds) {
    AtlasVertex v = vertexEdgePropertiesCache.getVertexById(vid);
    if (v == null) continue;
    
    String clsText = cache.getPropertyValue(vid, CLASSIFICATION_TEXT_KEY, String.class);
    String clsNames = cache.getPropertyValue(vid, CLASSIFICATION_NAMES_KEY, String.class);
    String propClsNames = cache.getPropertyValue(vid, PROPAGATED_CLASSIFICATION_NAMES_KEY, String.class);
    
    if (any non-empty) → verticesWithClassifications.add(v);
    else → classificationCache.put(vid, Collections.emptyList());
}
// Only query tags_by_id for vertices that have tags
prefetchClassifications(verticesWithClassifications);
```

### Safety

- **No data loss:** If ANY of the three classification properties is non-empty, the vertex is included in the prefetch. All three must be empty to skip.
- **Fallback preserved:** Even if a vertex is incorrectly skipped (theoretical — would require a bug in the tag write path), the sync fallback in `mapVertexToAtlasEntityHeader` still works for vertices not in the cache. But we explicitly cache empty lists to avoid this sync fallback.
- **No downstream changes:** `EntityGraphRetriever`, `TagDAOCassandraImpl`, and `CassandraGraph` are unmodified.
- **Property reliability validated on Cassandra:**
  - Vertex with 2 classifications (41996504): `__classificationsText` = `"k9RKs1TjWNc91lGsHI95NJ "` (present)
  - Vertex with 0 classifications (42094840): `__classificationsText` NOT in properties (absent)
  - Vertex with 0 classifications (20664, Connection): `__classificationsText` NOT in properties (absent)

### Impact

**Per-call:** ~80% fewer CQL queries to `tags_by_id` (e.g., 20 → 4 for a 20-result search)

**Cluster-wide (from Cassandra analysis on duair15p01):**

| Metric | Current | After Fix |
|---|---|---|
| tags_by_id reads | ~2.13M | ~530K |
| Speculative retries | ~260K | ~65K |
| Bloom filter FPs | ~17K | ~4K |

### Analysis Documents
- [IndexSearch CQL Amplification Analysis](https://atlanhq.atlassian.net/wiki/spaces/Metastore/pages/1788837894/MS-692+IndexSearch+CQL+Amplification+Analysis+ZeroGraph)
- [Cassandra Hotspot Analysis](https://atlanhq.atlassian.net/wiki/spaces/Metastore/pages/1787396151/MS-692+Cassandra+Hotspot+Analysis+for+IndexSearch+ZeroGraph) — Section 4: Finding C1 (Critical)
- [Functional Correctness Verification](https://atlanhq.atlassian.net/wiki/spaces/Metastore/pages/1825341485/MS-692+Direction-Aware+IndexSearch+Functional+Correctness+Verification)

## Type of change
- [x] New feature (adds functionality)

## Related issues

Fix [MS-692](https://linear.app/atlan/issue/MS-692)

## **Helm Config Changes for Running Tests (Staging PR)**
### Does this PR require Helm config changes for testing?
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_
- [x] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable