### PR TITLE
GOVFOUN-349 (POC) | Access Debugger

### DIFF
--- a/auth-plugin-atlas/src/main/java/org/apache/atlas/authorization/atlas/authorizer/RangerAtlasAuthorizerUtil.java
+++ b/auth-plugin-atlas/src/main/java/org/apache/atlas/authorization/atlas/authorizer/RangerAtlasAuthorizerUtil.java
@@ -22,6 +22,7 @@ package org.apache.atlas.authorization.atlas.authorizer;
 import org.apache.atlas.authorize.AtlasAccessorResponse;
 import org.apache.atlas.authorize.AtlasEntityAccessRequest;
 import org.apache.atlas.authorize.AtlasPrivilege;
+import org.apache.atlas.authorizer.trace.AccessDecisionContext;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.atlas.plugin.model.RangerPolicy;
@@ -79,6 +80,15 @@ public class RangerAtlasAuthorizerUtil {
             result.getMatchedItemEvaluators().forEach(x -> {
                 collectSubjects(response, x);
             });
+
+            // Record trace if enabled
+            if (AccessDecisionContext.isTraceEnabled() && result.getPolicyId() != null && !result.getPolicyId().equals("-1")) {
+                AccessDecisionContext.getCurrentTrace().recordRangerMatchFromResult(
+                    result.getPolicyId(),
+                    result.getPolicyPriority(),
+                    result.getIsAllowed()
+                );
+            }
         }
     }
 

--- a/auth-plugin-atlas/src/main/java/org/apache/atlas/authorization/atlas/authorizer/RangerAtlasAuthorizerUtil.java
+++ b/auth-plugin-atlas/src/main/java/org/apache/atlas/authorization/atlas/authorizer/RangerAtlasAuthorizerUtil.java
@@ -78,21 +78,12 @@ public class RangerAtlasAuthorizerUtil {
         if (result != null && CollectionUtils.isNotEmpty(result.getMatchedItemEvaluators())) {
 
             result.getMatchedItemEvaluators().forEach(x -> {
-                collectSubjects(response, x);
+                collectSubjects(response, x, result);
             });
-
-            // Record trace if enabled
-            if (AccessDecisionContext.isTraceEnabled() && result.getPolicyId() != null && !result.getPolicyId().equals("-1")) {
-                AccessDecisionContext.getCurrentTrace().recordRangerMatchFromResult(
-                    result.getPolicyId(),
-                    result.getPolicyPriority(),
-                    result.getIsAllowed()
-                );
-            }
         }
     }
 
-    static private void collectSubjects(AtlasAccessorResponse response, RangerPolicyItemEvaluator evaluator) {
+    static private void collectSubjects(AtlasAccessorResponse response, RangerPolicyItemEvaluator evaluator, RangerAccessResult result) {
 
         RangerPolicy.RangerPolicyItem policyItem = evaluator.getPolicyItem();
 
@@ -105,6 +96,19 @@ public class RangerAtlasAuthorizerUtil {
             response.getDenyUsers().addAll(policyItem.getUsers());
             response.getDenyRoles().addAll(policyItem.getRoles());
             response.getDenyGroups().addAll(policyItem.getGroups());
+        }
+
+        // Record trace if enabled - with principal information
+        if (AccessDecisionContext.isTraceEnabled() && result != null && result.getPolicyId() != null && !result.getPolicyId().equals("-1")) {
+            boolean isAllow = evaluator.getPolicyItemType() == RangerPolicyItemEvaluator.POLICY_ITEM_TYPE_ALLOW;
+            AccessDecisionContext.getCurrentTrace().recordRangerMatchFromResult(
+                result.getPolicyId(),
+                result.getPolicyPriority(),
+                isAllow,
+                policyItem.getUsers(),
+                policyItem.getGroups(),
+                policyItem.getRoles()
+            );
         }
     }
 
@@ -119,11 +123,11 @@ public class RangerAtlasAuthorizerUtil {
 
         // Collect lists of accessors for both results
         resultEnd1.getMatchedItemEvaluators().forEach(x -> {
-            collectSubjects(accessorsEnd1, x);
+            collectSubjects(accessorsEnd1, x, resultEnd1);
         });
 
         resultEnd2.getMatchedItemEvaluators().forEach(x -> {
-            collectSubjects(accessorsEnd2, x);
+            collectSubjects(accessorsEnd2, x, resultEnd2);
         });
 
         // Retain only common accessors

--- a/auth-plugin-atlas/src/main/java/org/apache/atlas/authorization/atlas/authorizer/RangerAtlasAuthorizerUtil.java
+++ b/auth-plugin-atlas/src/main/java/org/apache/atlas/authorization/atlas/authorizer/RangerAtlasAuthorizerUtil.java
@@ -98,17 +98,38 @@ public class RangerAtlasAuthorizerUtil {
             response.getDenyGroups().addAll(policyItem.getGroups());
         }
 
-        // Record trace if enabled - with principal information
-        if (AccessDecisionContext.isTraceEnabled() && result != null && result.getPolicyId() != null && !result.getPolicyId().equals("-1")) {
-            boolean isAllow = evaluator.getPolicyItemType() == RangerPolicyItemEvaluator.POLICY_ITEM_TYPE_ALLOW;
-            AccessDecisionContext.getCurrentTrace().recordRangerMatchFromResult(
-                result.getPolicyId(),
-                result.getPolicyPriority(),
-                isAllow,
-                policyItem.getUsers(),
-                policyItem.getGroups(),
-                policyItem.getRoles()
-            );
+         // Record trace if enabled - with full policy information
+        if (AccessDecisionContext.isTraceEnabled()) {
+            try {
+                // Use reflection to access the protected 'policy' field from RangerAbstractPolicyItemEvaluator
+                java.lang.reflect.Field policyField = evaluator.getClass().getSuperclass().getDeclaredField("policy");
+                policyField.setAccessible(true);
+                RangerPolicy policy = (RangerPolicy) policyField.get(evaluator);
+
+                if (policy != null) {
+                    boolean isAllow = evaluator.getPolicyItemType() == RangerPolicyItemEvaluator.POLICY_ITEM_TYPE_ALLOW;
+                    AccessDecisionContext.getCurrentTrace().recordRangerMatch(
+                        policy,
+                        isAllow,
+                        policyItem.getUsers(),
+                        policyItem.getGroups(),
+                        policyItem.getRoles()
+                    );
+                }
+            } catch (Exception e) {
+                // Fallback to result-based recording if reflection fails
+                if (result != null && result.getPolicyId() != null && !result.getPolicyId().equals("-1")) {
+                    boolean isAllow = evaluator.getPolicyItemType() == RangerPolicyItemEvaluator.POLICY_ITEM_TYPE_ALLOW;
+                    AccessDecisionContext.getCurrentTrace().recordRangerMatchFromResult(
+                        result.getPolicyId(),
+                        result.getPolicyPriority(),
+                        isAllow,
+                        policyItem.getUsers(),
+                        policyItem.getGroups(),
+                        policyItem.getRoles()
+                    );
+                }
+            }
         }
     }
 

--- a/authorization/src/main/java/org/apache/atlas/authorize/AccessDecision.java
+++ b/authorization/src/main/java/org/apache/atlas/authorize/AccessDecision.java
@@ -1,0 +1,23 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas.authorize;
+
+public enum AccessDecision {
+    ALLOW,
+    DENY
+}

--- a/authorization/src/main/java/org/apache/atlas/authorize/AtlasAccessDecision.java
+++ b/authorization/src/main/java/org/apache/atlas/authorize/AtlasAccessDecision.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas.authorize;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AtlasAccessDecision {
+    private String principal;
+    private PrincipalType principalType;
+    private AccessDecision decision;
+    private List<PolicyTrace> policies;
+    private String finalReason;
+
+    public AtlasAccessDecision() {
+    }
+
+    public String getPrincipal() {
+        return principal;
+    }
+
+    public void setPrincipal(String principal) {
+        this.principal = principal;
+    }
+
+    public PrincipalType getPrincipalType() {
+        return principalType;
+    }
+
+    public void setPrincipalType(PrincipalType principalType) {
+        this.principalType = principalType;
+    }
+
+    public AccessDecision getDecision() {
+        return decision;
+    }
+
+    public void setDecision(AccessDecision decision) {
+        this.decision = decision;
+    }
+
+    public List<PolicyTrace> getPolicies() {
+        return policies;
+    }
+
+    public void setPolicies(List<PolicyTrace> policies) {
+        this.policies = policies;
+    }
+
+    public String getFinalReason() {
+        return finalReason;
+    }
+
+    public void setFinalReason(String finalReason) {
+        this.finalReason = finalReason;
+    }
+
+    @Override
+    public String toString() {
+        return "AtlasAccessDecision{" +
+                "principal='" + principal + '\'' +
+                ", principalType=" + principalType +
+                ", decision=" + decision +
+                ", policies=" + policies +
+                ", finalReason='" + finalReason + '\'' +
+                '}';
+    }
+}

--- a/authorization/src/main/java/org/apache/atlas/authorize/AtlasAccessorRequest.java
+++ b/authorization/src/main/java/org/apache/atlas/authorize/AtlasAccessorRequest.java
@@ -57,6 +57,7 @@ public class AtlasAccessorRequest {
     private AtlasEntityHeader entity = null;
 
     private Boolean includeDecisionTrace;
+    private String forUser;
 
     public String getGuid() {
         return guid;
@@ -156,6 +157,14 @@ public class AtlasAccessorRequest {
 
     public void setIncludeDecisionTrace(Boolean includeDecisionTrace) {
         this.includeDecisionTrace = includeDecisionTrace;
+    }
+
+    public String getForUser() {
+        return forUser;
+    }
+
+    public void setForUser(String forUser) {
+        this.forUser = forUser;
     }
 
     @Override

--- a/authorization/src/main/java/org/apache/atlas/authorize/AtlasAccessorRequest.java
+++ b/authorization/src/main/java/org/apache/atlas/authorize/AtlasAccessorRequest.java
@@ -56,6 +56,8 @@ public class AtlasAccessorRequest {
 
     private AtlasEntityHeader entity = null;
 
+    private Boolean includeDecisionTrace;
+
     public String getGuid() {
         return guid;
     }
@@ -146,6 +148,14 @@ public class AtlasAccessorRequest {
 
     public String getEntityTypeEnd2() {
         return entityTypeEnd2;
+    }
+
+    public Boolean getIncludeDecisionTrace() {
+        return includeDecisionTrace;
+    }
+
+    public void setIncludeDecisionTrace(Boolean includeDecisionTrace) {
+        this.includeDecisionTrace = includeDecisionTrace;
     }
 
     @Override

--- a/authorization/src/main/java/org/apache/atlas/authorize/AtlasAccessorResponse.java
+++ b/authorization/src/main/java/org/apache/atlas/authorize/AtlasAccessorResponse.java
@@ -20,6 +20,7 @@ package org.apache.atlas.authorize;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -49,6 +50,9 @@ public class AtlasAccessorResponse {
     private Set<String> denyUsers = new HashSet<>();
     private Set<String> denyGroups = new HashSet<>();
     private Set<String> denyRoles = new HashSet<>();
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private List<AtlasAccessDecision> accessDecisions;
 
     public AtlasAccessorResponse() {
 
@@ -174,6 +178,14 @@ public class AtlasAccessorResponse {
 
     public void setDenyRoles(Set<String> denyRoles) {
         this.denyRoles = denyRoles;
+    }
+
+    public List<AtlasAccessDecision> getAccessDecisions() {
+        return accessDecisions;
+    }
+
+    public void setAccessDecisions(List<AtlasAccessDecision> accessDecisions) {
+        this.accessDecisions = accessDecisions;
     }
 
     @Override

--- a/authorization/src/main/java/org/apache/atlas/authorize/PolicyTrace.java
+++ b/authorization/src/main/java/org/apache/atlas/authorize/PolicyTrace.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas.authorize;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PolicyTrace {
+    private String policyId;
+    private String policyName;
+    private String policyType;      // "ranger", "persona", "purpose"
+    private int policyPriority;     // 0=normal, 100=override
+    private boolean isAllowPolicy;  // true=allow, false=deny
+    private String enforcer;        // "ranger" or "abac"
+
+    public PolicyTrace() {
+    }
+
+    public String getPolicyId() {
+        return policyId;
+    }
+
+    public void setPolicyId(String policyId) {
+        this.policyId = policyId;
+    }
+
+    public String getPolicyName() {
+        return policyName;
+    }
+
+    public void setPolicyName(String policyName) {
+        this.policyName = policyName;
+    }
+
+    public String getPolicyType() {
+        return policyType;
+    }
+
+    public void setPolicyType(String policyType) {
+        this.policyType = policyType;
+    }
+
+    public int getPolicyPriority() {
+        return policyPriority;
+    }
+
+    public void setPolicyPriority(int policyPriority) {
+        this.policyPriority = policyPriority;
+    }
+
+    public boolean isAllowPolicy() {
+        return isAllowPolicy;
+    }
+
+    public void setAllowPolicy(boolean allowPolicy) {
+        isAllowPolicy = allowPolicy;
+    }
+
+    public String getEnforcer() {
+        return enforcer;
+    }
+
+    public void setEnforcer(String enforcer) {
+        this.enforcer = enforcer;
+    }
+
+    @Override
+    public String toString() {
+        return "PolicyTrace{" +
+                "policyId='" + policyId + '\'' +
+                ", policyName='" + policyName + '\'' +
+                ", policyType='" + policyType + '\'' +
+                ", policyPriority=" + policyPriority +
+                ", isAllowPolicy=" + isAllowPolicy +
+                ", enforcer='" + enforcer + '\'' +
+                '}';
+    }
+}

--- a/authorization/src/main/java/org/apache/atlas/authorize/PolicyTrace.java
+++ b/authorization/src/main/java/org/apache/atlas/authorize/PolicyTrace.java
@@ -17,7 +17,11 @@
  */
 package org.apache.atlas.authorize;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.HashSet;
+import java.util.Set;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class PolicyTrace {
@@ -27,6 +31,15 @@ public class PolicyTrace {
     private int policyPriority;     // 0=normal, 100=override
     private boolean isAllowPolicy;  // true=allow, false=deny
     private String enforcer;        // "ranger" or "abac"
+
+    // Internal tracking of which principals this policy applies to
+    // Not serialized to JSON
+    @JsonIgnore
+    private Set<String> applicableUsers = new HashSet<>();
+    @JsonIgnore
+    private Set<String> applicableGroups = new HashSet<>();
+    @JsonIgnore
+    private Set<String> applicableRoles = new HashSet<>();
 
     public PolicyTrace() {
     }
@@ -77,6 +90,60 @@ public class PolicyTrace {
 
     public void setEnforcer(String enforcer) {
         this.enforcer = enforcer;
+    }
+
+    @JsonIgnore
+    public Set<String> getApplicableUsers() {
+        return applicableUsers;
+    }
+
+    @JsonIgnore
+    public void setApplicableUsers(Set<String> applicableUsers) {
+        this.applicableUsers = applicableUsers;
+    }
+
+    @JsonIgnore
+    public Set<String> getApplicableGroups() {
+        return applicableGroups;
+    }
+
+    @JsonIgnore
+    public void setApplicableGroups(Set<String> applicableGroups) {
+        this.applicableGroups = applicableGroups;
+    }
+
+    @JsonIgnore
+    public Set<String> getApplicableRoles() {
+        return applicableRoles;
+    }
+
+    @JsonIgnore
+    public void setApplicableRoles(Set<String> applicableRoles) {
+        this.applicableRoles = applicableRoles;
+    }
+
+    /**
+     * Checks if this policy applies to a specific principal.
+     * @param principal The principal name
+     * @param principalType The principal type (USER, GROUP, ROLE)
+     * @return true if this policy applies to the principal
+     */
+    @JsonIgnore
+    public boolean appliesToPrincipal(String principal, PrincipalType principalType) {
+        if (principal == null || principalType == null) {
+            return false;
+        }
+
+        switch (principalType) {
+            case USER:
+                return applicableUsers.contains(principal);
+            case GROUP:
+                return applicableGroups.contains(principal);
+            case ROLE:
+                return applicableRoles.contains(principal);
+            default:
+                return false;
+        }
     }
 
     @Override

--- a/authorization/src/main/java/org/apache/atlas/authorize/PolicyTrace.java
+++ b/authorization/src/main/java/org/apache/atlas/authorize/PolicyTrace.java
@@ -32,6 +32,14 @@ public class PolicyTrace {
     private boolean isAllowPolicy;  // true=allow, false=deny
     private String enforcer;        // "ranger" or "abac"
 
+    // Atlas policy details (populated for ABAC persona/purpose policies)
+    private String atlasPolicyGuid;        // Original Atlas policy GUID
+    private String atlasPolicyName;        // Human-readable policy name from Atlas
+    private String atlasPolicyCategory;    // "persona", "purpose", "datamesh"
+    private String atlasPolicySubCategory; // "metadata", "data", "glossary", etc.
+    private java.util.List<String> atlasPolicyActions;    // Original Atlas actions
+    private Object atlasPolicyConditions;  // Original Atlas policy conditions
+
     // Internal tracking of which principals this policy applies to
     // Not serialized to JSON
     @JsonIgnore
@@ -120,6 +128,54 @@ public class PolicyTrace {
     @JsonIgnore
     public void setApplicableRoles(Set<String> applicableRoles) {
         this.applicableRoles = applicableRoles;
+    }
+
+    public String getAtlasPolicyGuid() {
+        return atlasPolicyGuid;
+    }
+
+    public void setAtlasPolicyGuid(String atlasPolicyGuid) {
+        this.atlasPolicyGuid = atlasPolicyGuid;
+    }
+
+    public String getAtlasPolicyName() {
+        return atlasPolicyName;
+    }
+
+    public void setAtlasPolicyName(String atlasPolicyName) {
+        this.atlasPolicyName = atlasPolicyName;
+    }
+
+    public String getAtlasPolicyCategory() {
+        return atlasPolicyCategory;
+    }
+
+    public void setAtlasPolicyCategory(String atlasPolicyCategory) {
+        this.atlasPolicyCategory = atlasPolicyCategory;
+    }
+
+    public String getAtlasPolicySubCategory() {
+        return atlasPolicySubCategory;
+    }
+
+    public void setAtlasPolicySubCategory(String atlasPolicySubCategory) {
+        this.atlasPolicySubCategory = atlasPolicySubCategory;
+    }
+
+    public java.util.List<String> getAtlasPolicyActions() {
+        return atlasPolicyActions;
+    }
+
+    public void setAtlasPolicyActions(java.util.List<String> atlasPolicyActions) {
+        this.atlasPolicyActions = atlasPolicyActions;
+    }
+
+    public Object getAtlasPolicyConditions() {
+        return atlasPolicyConditions;
+    }
+
+    public void setAtlasPolicyConditions(Object atlasPolicyConditions) {
+        this.atlasPolicyConditions = atlasPolicyConditions;
     }
 
     /**

--- a/authorization/src/main/java/org/apache/atlas/authorize/PrincipalType.java
+++ b/authorization/src/main/java/org/apache/atlas/authorize/PrincipalType.java
@@ -1,0 +1,24 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas.authorize;
+
+public enum PrincipalType {
+    USER,
+    GROUP,
+    ROLE
+}

--- a/repository/src/main/java/org/apache/atlas/authorizer/AccessorsExtractor.java
+++ b/repository/src/main/java/org/apache/atlas/authorizer/AccessorsExtractor.java
@@ -8,6 +8,7 @@ import org.apache.atlas.authorize.AtlasAccessorResponse;
 import org.apache.atlas.authorize.AtlasEntityAccessRequest;
 import org.apache.atlas.authorize.AtlasRelationshipAccessRequest;
 import org.apache.atlas.authorizer.store.PoliciesStore;
+import org.apache.atlas.authorizer.trace.AccessDecisionContext;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.instance.AtlasEntityHeader;
 import org.apache.atlas.plugin.model.RangerPolicy;
@@ -123,6 +124,12 @@ public class AccessorsExtractor {
                     boolean matched = validateEntityFilterCriteria(entityFilterCriteriaNode, entity, vertex);
                     if (matched) {
                         matchedPolicies.add(policy);
+
+                        // Record trace if enabled
+                        if (AccessDecisionContext.isTraceEnabled()) {
+                            boolean isAllow = CollectionUtils.isNotEmpty(policy.getPolicyItems());
+                            AccessDecisionContext.getCurrentTrace().recordAbacMatch(policy, isAllow);
+                        }
                     }
                 }
             }
@@ -151,6 +158,12 @@ public class AccessorsExtractor {
                 }
                 if (matched) {
                     matchedPolicies.add(policy);
+
+                    // Record trace if enabled
+                    if (AccessDecisionContext.isTraceEnabled()) {
+                        boolean isAllow = CollectionUtils.isNotEmpty(policy.getPolicyItems());
+                        AccessDecisionContext.getCurrentTrace().recordAbacMatch(policy, isAllow);
+                    }
                 }
             }
         }

--- a/repository/src/main/java/org/apache/atlas/authorizer/trace/AccessDecisionContext.java
+++ b/repository/src/main/java/org/apache/atlas/authorizer/trace/AccessDecisionContext.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas.authorizer.trace;
+
+/**
+ * ThreadLocal context manager for decision trace collection.
+ * Provides a way to collect policy match information during authorization
+ * without modifying existing method signatures.
+ */
+public class AccessDecisionContext {
+    private static final ThreadLocal<DecisionTraceCollector> context = new ThreadLocal<>();
+
+    /**
+     * Starts trace collection for the current thread.
+     * Must be paired with endTrace() in a finally block to prevent memory leaks.
+     */
+    public static void startTrace() {
+        context.set(new DecisionTraceCollector());
+    }
+
+    /**
+     * Gets the current trace collector for this thread.
+     * @return the DecisionTraceCollector or null if trace not started
+     */
+    public static DecisionTraceCollector getCurrentTrace() {
+        return context.get();
+    }
+
+    /**
+     * Ends trace collection and cleans up ThreadLocal.
+     * MUST be called in a finally block to prevent memory leaks.
+     */
+    public static void endTrace() {
+        context.remove();
+    }
+
+    /**
+     * Checks if trace collection is enabled for the current thread.
+     * @return true if trace is active, false otherwise
+     */
+    public static boolean isTraceEnabled() {
+        return context.get() != null;
+    }
+}

--- a/repository/src/main/java/org/apache/atlas/authorizer/trace/DecisionTraceBuilder.java
+++ b/repository/src/main/java/org/apache/atlas/authorizer/trace/DecisionTraceBuilder.java
@@ -18,6 +18,11 @@
 package org.apache.atlas.authorizer.trace;
 
 import org.apache.atlas.authorize.*;
+import org.apache.atlas.authorizer.store.UsersStore;
+import org.apache.atlas.plugin.util.RangerUserStore;
+import org.apache.atlas.plugin.util.RangerRoles;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
@@ -26,18 +31,26 @@ import java.util.*;
  * Applies 5-level precedence model to determine final decisions.
  */
 public class DecisionTraceBuilder {
+    private static final Logger LOG = LoggerFactory.getLogger(DecisionTraceBuilder.class);
 
     /**
-     * Builds access decisions for all principals in the response.
+     * Builds access decisions for a specific user showing how they get access.
+     *
+     * SECURITY: This method REQUIRES forUser parameter to prevent unauthorized enumeration
+     * of all principals with access to an asset. Returns empty list if forUser is not provided.
+     *
      * @param response The accessor response with users/groups/roles
      * @param rangerPolicies Map of Ranger policy traces
      * @param abacPolicies Map of ABAC policy traces
-     * @return List of access decisions explaining why each principal has access
+     * @param forUser REQUIRED username to trace access decisions for
+     * @return List of access decisions explaining how the user gets access (direct, via groups, via roles)
+     *         Returns empty list if forUser is null/empty
      */
     public static List<AtlasAccessDecision> buildDecisions(
         AtlasAccessorResponse response,
         Map<String, PolicyTrace> rangerPolicies,
-        Map<String, PolicyTrace> abacPolicies
+        Map<String, PolicyTrace> abacPolicies,
+        String forUser
     ) {
         if (response == null) {
             return Collections.emptyList();
@@ -45,39 +58,124 @@ public class DecisionTraceBuilder {
 
         List<AtlasAccessDecision> decisions = new ArrayList<>();
 
-        // Process each principal type separately to avoid name collisions
-        if (response.getUsers() != null) {
-            for (String user : response.getUsers()) {
-                decisions.add(buildDecisionForPrincipal(user, PrincipalType.USER, false, response, rangerPolicies, abacPolicies));
-            }
+        // This prevents unauthorized users from enumerating all principals with access
+        if (forUser == null || forUser.isEmpty()) {
+            LOG.warn("Decision trace requested without forUser parameter - access denied for security reasons");
+            return Collections.emptyList();
         }
-        if (response.getGroups() != null) {
-            for (String group : response.getGroups()) {
+
+        boolean hasAnyAccess = false;
+
+        // Resolve user's groups and roles
+        ResolvedPrincipals resolved = resolveUserPrincipals(forUser);
+
+        // 1. Check direct user access
+        if (response.getUsers() != null && response.getUsers().contains(forUser)) {
+            decisions.add(buildDecisionForPrincipal(forUser, PrincipalType.USER, false, response, rangerPolicies, abacPolicies));
+            hasAnyAccess = true;
+        } else if (response.getDenyUsers() != null && response.getDenyUsers().contains(forUser)) {
+            decisions.add(buildDecisionForPrincipal(forUser, PrincipalType.USER, true, response, rangerPolicies, abacPolicies));
+            hasAnyAccess = true;
+        }
+
+        // 2. Check group-based access
+        for (String group : resolved.groups) {
+            if (response.getGroups() != null && response.getGroups().contains(group)) {
                 decisions.add(buildDecisionForPrincipal(group, PrincipalType.GROUP, false, response, rangerPolicies, abacPolicies));
-            }
-        }
-        if (response.getRoles() != null) {
-            for (String role : response.getRoles()) {
-                decisions.add(buildDecisionForPrincipal(role, PrincipalType.ROLE, false, response, rangerPolicies, abacPolicies));
-            }
-        }
-        if (response.getDenyUsers() != null) {
-            for (String user : response.getDenyUsers()) {
-                decisions.add(buildDecisionForPrincipal(user, PrincipalType.USER, true, response, rangerPolicies, abacPolicies));
-            }
-        }
-        if (response.getDenyGroups() != null) {
-            for (String group : response.getDenyGroups()) {
+                hasAnyAccess = true;
+            } else if (response.getDenyGroups() != null && response.getDenyGroups().contains(group)) {
                 decisions.add(buildDecisionForPrincipal(group, PrincipalType.GROUP, true, response, rangerPolicies, abacPolicies));
-            }
-        }
-        if (response.getDenyRoles() != null) {
-            for (String role : response.getDenyRoles()) {
-                decisions.add(buildDecisionForPrincipal(role, PrincipalType.ROLE, true, response, rangerPolicies, abacPolicies));
+                hasAnyAccess = true;
             }
         }
 
+        // 3. Check role-based access (includes persona_* and connection_admins_*)
+        for (String role : resolved.roles) {
+            if (response.getRoles() != null && response.getRoles().contains(role)) {
+                decisions.add(buildDecisionForPrincipal(role, PrincipalType.ROLE, false, response, rangerPolicies, abacPolicies));
+                hasAnyAccess = true;
+            } else if (response.getDenyRoles() != null && response.getDenyRoles().contains(role)) {
+                decisions.add(buildDecisionForPrincipal(role, PrincipalType.ROLE, true, response, rangerPolicies, abacPolicies));
+                hasAnyAccess = true;
+            }
+        }
+
+        // 4. If no access found, return implicit deny
+        if (!hasAnyAccess) {
+            decisions.add(buildImplicitDenyDecision(forUser, PrincipalType.USER));
+        }
+
         return decisions;
+    }
+
+    /**
+     * Resolves a user's complete set of groups and roles.
+     * @param username The username to resolve
+     * @return ResolvedPrincipals containing groups and roles
+     */
+    private static ResolvedPrincipals resolveUserPrincipals(String username) {
+        ResolvedPrincipals result = new ResolvedPrincipals();
+
+        try {
+            UsersStore usersStore = UsersStore.getInstance();
+            if (usersStore == null) {
+                LOG.warn("UsersStore not available, cannot resolve groups/roles for user: {}", username);
+                return result;
+            }
+
+            // Get user's groups
+            RangerUserStore userStore = usersStore.getUserStore();
+            List<String> groups = usersStore.getGroupsForUser(username, userStore);
+            result.groups = groups != null ? groups : Collections.emptyList();
+
+            // Get user's roles (direct + from groups)
+            RangerRoles allRoles = usersStore.getAllRoles();
+            List<String> roles = usersStore.getRolesForUser(username, groups, allRoles);
+            if (roles == null) {
+                roles = new ArrayList<>();
+            }
+
+            // Get nested/inherited roles
+            List<String> nestedRoles = usersStore.getNestedRolesForUser(roles, allRoles);
+            if (nestedRoles != null) {
+                roles.addAll(nestedRoles);
+            }
+
+            result.roles = roles;
+
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Resolved principals for user '{}': groups={}, roles={}", username, result.groups, result.roles);
+            }
+
+        } catch (Exception e) {
+            LOG.error("Error resolving principals for user: {}", username, e);
+        }
+
+        return result;
+    }
+
+    /**
+     * Helper class to hold resolved principals for a user.
+     */
+    private static class ResolvedPrincipals {
+        List<String> groups = Collections.emptyList();
+        List<String> roles = Collections.emptyList();
+    }
+
+    /**
+     * Builds an implicit deny decision for a principal not found in access lists.
+     * @param principal The principal name
+     * @param principalType The principal type
+     * @return An access decision with implicit deny
+     */
+    private static AtlasAccessDecision buildImplicitDenyDecision(String principal, PrincipalType principalType) {
+        AtlasAccessDecision decision = new AtlasAccessDecision();
+        decision.setPrincipal(principal);
+        decision.setPrincipalType(principalType);
+        decision.setDecision(AccessDecision.DENY);
+        decision.setPolicies(Collections.emptyList());
+        decision.setFinalReason("Implicit DENY (no matching policies grant access to this principal)");
+        return decision;
     }
 
     /**
@@ -101,27 +199,37 @@ public class DecisionTraceBuilder {
         decision.setPrincipal(principal);
         decision.setPrincipalType(principalType);
 
-        // Collect all policies (both allow and deny)
-        List<PolicyTrace> allPolicies = new ArrayList<>();
+        // Collect only policies that apply to THIS specific principal
+        List<PolicyTrace> applicablePolicies = new ArrayList<>();
+
         if (rangerPolicies != null) {
-            allPolicies.addAll(rangerPolicies.values());
+            for (PolicyTrace policy : rangerPolicies.values()) {
+                if (policy.appliesToPrincipal(principal, principalType)) {
+                    applicablePolicies.add(policy);
+                }
+            }
         }
+
         if (abacPolicies != null) {
-            allPolicies.addAll(abacPolicies.values());
+            for (PolicyTrace policy : abacPolicies.values()) {
+                if (policy.appliesToPrincipal(principal, principalType)) {
+                    applicablePolicies.add(policy);
+                }
+            }
         }
 
         // Sort by precedence: override deny > override allow > explicit deny > allow
-        allPolicies.sort((p1, p2) -> {
+        applicablePolicies.sort((p1, p2) -> {
             int level1 = getPrecedenceLevel(p1);
             int level2 = getPrecedenceLevel(p2);
             return Integer.compare(level1, level2);
         });
 
-        decision.setPolicies(allPolicies);
+        decision.setPolicies(applicablePolicies);
 
         AccessDecision finalDecision = isDenied ? AccessDecision.DENY : AccessDecision.ALLOW;
         decision.setDecision(finalDecision);
-        decision.setFinalReason(explainPrecedenceRule(allPolicies, finalDecision));
+        decision.setFinalReason(explainPrecedenceRule(applicablePolicies, finalDecision));
 
         return decision;
     }

--- a/repository/src/main/java/org/apache/atlas/authorizer/trace/DecisionTraceBuilder.java
+++ b/repository/src/main/java/org/apache/atlas/authorizer/trace/DecisionTraceBuilder.java
@@ -1,0 +1,186 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas.authorizer.trace;
+
+import org.apache.atlas.authorize.*;
+
+import java.util.*;
+
+/**
+ * Builds access decision traces from collected policy information.
+ * Applies 5-level precedence model to determine final decisions.
+ */
+public class DecisionTraceBuilder {
+
+    /**
+     * Builds access decisions for all principals in the response.
+     * @param response The accessor response with users/groups/roles
+     * @param rangerPolicies Map of Ranger policy traces
+     * @param abacPolicies Map of ABAC policy traces
+     * @return List of access decisions explaining why each principal has access
+     */
+    public static List<AtlasAccessDecision> buildDecisions(
+        AtlasAccessorResponse response,
+        Map<String, PolicyTrace> rangerPolicies,
+        Map<String, PolicyTrace> abacPolicies
+    ) {
+        if (response == null) {
+            return Collections.emptyList();
+        }
+
+        Set<String> allPrincipals = collectAllPrincipals(response);
+        List<AtlasAccessDecision> decisions = new ArrayList<>();
+
+        for (String principal : allPrincipals) {
+            decisions.add(buildDecisionForPrincipal(principal, response, rangerPolicies, abacPolicies));
+        }
+
+        return decisions;
+    }
+
+    /**
+     * Collects all unique principals (users, groups, roles) from the response.
+     */
+    private static Set<String> collectAllPrincipals(AtlasAccessorResponse response) {
+        Set<String> principals = new HashSet<>();
+
+        if (response.getUsers() != null) {
+            principals.addAll(response.getUsers());
+        }
+        if (response.getGroups() != null) {
+            principals.addAll(response.getGroups());
+        }
+        if (response.getRoles() != null) {
+            principals.addAll(response.getRoles());
+        }
+        if (response.getDenyUsers() != null) {
+            principals.addAll(response.getDenyUsers());
+        }
+        if (response.getDenyGroups() != null) {
+            principals.addAll(response.getDenyGroups());
+        }
+        if (response.getDenyRoles() != null) {
+            principals.addAll(response.getDenyRoles());
+        }
+
+        return principals;
+    }
+
+    /**
+     * Builds an access decision for a single principal.
+     */
+    private static AtlasAccessDecision buildDecisionForPrincipal(
+        String principal,
+        AtlasAccessorResponse response,
+        Map<String, PolicyTrace> rangerPolicies,
+        Map<String, PolicyTrace> abacPolicies
+    ) {
+        AtlasAccessDecision decision = new AtlasAccessDecision();
+        decision.setPrincipal(principal);
+        decision.setPrincipalType(inferPrincipalType(principal, response));
+
+        // Collect all policies (both allow and deny)
+        List<PolicyTrace> allPolicies = new ArrayList<>();
+        if (rangerPolicies != null) {
+            allPolicies.addAll(rangerPolicies.values());
+        }
+        if (abacPolicies != null) {
+            allPolicies.addAll(abacPolicies.values());
+        }
+
+        // Sort by precedence: override deny > override allow > explicit deny > allow
+        allPolicies.sort((p1, p2) -> {
+            int level1 = getPrecedenceLevel(p1);
+            int level2 = getPrecedenceLevel(p2);
+            return Integer.compare(level1, level2);
+        });
+
+        decision.setPolicies(allPolicies);
+
+        // Determine final decision based on which list the principal is in
+        boolean isDenied = (response.getDenyUsers() != null && response.getDenyUsers().contains(principal)) ||
+                          (response.getDenyGroups() != null && response.getDenyGroups().contains(principal)) ||
+                          (response.getDenyRoles() != null && response.getDenyRoles().contains(principal));
+
+        decision.setDecision(isDenied ? AccessDecision.DENY : AccessDecision.ALLOW);
+        decision.setFinalReason(explainPrecedenceRule(allPolicies, decision.getDecision()));
+
+        return decision;
+    }
+
+    /**
+     * Infers the principal type based on which list it appears in.
+     */
+    private static PrincipalType inferPrincipalType(String principal, AtlasAccessorResponse response) {
+        if ((response.getUsers() != null && response.getUsers().contains(principal)) ||
+            (response.getDenyUsers() != null && response.getDenyUsers().contains(principal))) {
+            return PrincipalType.USER;
+        } else if ((response.getGroups() != null && response.getGroups().contains(principal)) ||
+                   (response.getDenyGroups() != null && response.getDenyGroups().contains(principal))) {
+            return PrincipalType.GROUP;
+        } else {
+            return PrincipalType.ROLE;
+        }
+    }
+
+    /**
+     * Gets the precedence level for a policy.
+     * Lower number = higher precedence.
+     *
+     * Precedence model:
+     * 1. Override DENY (priority=100, deny)
+     * 2. Override ALLOW (priority=100, allow)
+     * 3. Explicit DENY (priority=0, deny)
+     * 4. Normal ALLOW (priority=0, allow)
+     * 5. Implicit DENY (no policies)
+     */
+    private static int getPrecedenceLevel(PolicyTrace policy) {
+        if (policy.getPolicyPriority() == 100 && !policy.isAllowPolicy()) {
+            return 1; // Override DENY
+        } else if (policy.getPolicyPriority() == 100 && policy.isAllowPolicy()) {
+            return 2; // Override ALLOW
+        } else if (policy.getPolicyPriority() == 0 && !policy.isAllowPolicy()) {
+            return 3; // Explicit DENY
+        } else {
+            return 4; // Normal ALLOW
+        }
+    }
+
+    /**
+     * Generates a human-readable explanation of the final decision.
+     */
+    private static String explainPrecedenceRule(List<PolicyTrace> policies, AccessDecision finalDecision) {
+        if (policies == null || policies.isEmpty()) {
+            return "Implicit DENY (no matching policies)";
+        }
+
+        PolicyTrace highestPrecedence = policies.get(0);
+        String policyName = highestPrecedence.getPolicyName() != null ? highestPrecedence.getPolicyName() : "unknown";
+        String enforcer = highestPrecedence.getEnforcer() != null ? highestPrecedence.getEnforcer() : "unknown";
+
+        if (highestPrecedence.getPolicyPriority() == 100 && !highestPrecedence.isAllowPolicy()) {
+            return "Override DENY from " + policyName;
+        } else if (highestPrecedence.getPolicyPriority() == 100 && highestPrecedence.isAllowPolicy()) {
+            return "Override ALLOW from " + policyName;
+        } else if (!highestPrecedence.isAllowPolicy()) {
+            return "Explicit DENY from " + policyName;
+        } else {
+            return "Normal ALLOW from " + enforcer + " " + policyName;
+        }
+    }
+}

--- a/repository/src/main/java/org/apache/atlas/authorizer/trace/DecisionTraceBuilder.java
+++ b/repository/src/main/java/org/apache/atlas/authorizer/trace/DecisionTraceBuilder.java
@@ -43,56 +43,63 @@ public class DecisionTraceBuilder {
             return Collections.emptyList();
         }
 
-        Set<String> allPrincipals = collectAllPrincipals(response);
         List<AtlasAccessDecision> decisions = new ArrayList<>();
 
-        for (String principal : allPrincipals) {
-            decisions.add(buildDecisionForPrincipal(principal, response, rangerPolicies, abacPolicies));
+        // Process each principal type separately to avoid name collisions
+        if (response.getUsers() != null) {
+            for (String user : response.getUsers()) {
+                decisions.add(buildDecisionForPrincipal(user, PrincipalType.USER, false, response, rangerPolicies, abacPolicies));
+            }
+        }
+        if (response.getGroups() != null) {
+            for (String group : response.getGroups()) {
+                decisions.add(buildDecisionForPrincipal(group, PrincipalType.GROUP, false, response, rangerPolicies, abacPolicies));
+            }
+        }
+        if (response.getRoles() != null) {
+            for (String role : response.getRoles()) {
+                decisions.add(buildDecisionForPrincipal(role, PrincipalType.ROLE, false, response, rangerPolicies, abacPolicies));
+            }
+        }
+        if (response.getDenyUsers() != null) {
+            for (String user : response.getDenyUsers()) {
+                decisions.add(buildDecisionForPrincipal(user, PrincipalType.USER, true, response, rangerPolicies, abacPolicies));
+            }
+        }
+        if (response.getDenyGroups() != null) {
+            for (String group : response.getDenyGroups()) {
+                decisions.add(buildDecisionForPrincipal(group, PrincipalType.GROUP, true, response, rangerPolicies, abacPolicies));
+            }
+        }
+        if (response.getDenyRoles() != null) {
+            for (String role : response.getDenyRoles()) {
+                decisions.add(buildDecisionForPrincipal(role, PrincipalType.ROLE, true, response, rangerPolicies, abacPolicies));
+            }
         }
 
         return decisions;
     }
 
     /**
-     * Collects all unique principals (users, groups, roles) from the response.
-     */
-    private static Set<String> collectAllPrincipals(AtlasAccessorResponse response) {
-        Set<String> principals = new HashSet<>();
-
-        if (response.getUsers() != null) {
-            principals.addAll(response.getUsers());
-        }
-        if (response.getGroups() != null) {
-            principals.addAll(response.getGroups());
-        }
-        if (response.getRoles() != null) {
-            principals.addAll(response.getRoles());
-        }
-        if (response.getDenyUsers() != null) {
-            principals.addAll(response.getDenyUsers());
-        }
-        if (response.getDenyGroups() != null) {
-            principals.addAll(response.getDenyGroups());
-        }
-        if (response.getDenyRoles() != null) {
-            principals.addAll(response.getDenyRoles());
-        }
-
-        return principals;
-    }
-
-    /**
-     * Builds an access decision for a single principal.
+     * Builds an access decision for a single principal with known type and decision.
+     * @param principal The principal name
+     * @param principalType The type (USER, GROUP, or ROLE)
+     * @param isDenied True if this principal is denied access
+     * @param response The accessor response
+     * @param rangerPolicies Map of Ranger policy traces
+     * @param abacPolicies Map of ABAC policy traces
      */
     private static AtlasAccessDecision buildDecisionForPrincipal(
         String principal,
+        PrincipalType principalType,
+        boolean isDenied,
         AtlasAccessorResponse response,
         Map<String, PolicyTrace> rangerPolicies,
         Map<String, PolicyTrace> abacPolicies
     ) {
         AtlasAccessDecision decision = new AtlasAccessDecision();
         decision.setPrincipal(principal);
-        decision.setPrincipalType(inferPrincipalType(principal, response));
+        decision.setPrincipalType(principalType);
 
         // Collect all policies (both allow and deny)
         List<PolicyTrace> allPolicies = new ArrayList<>();
@@ -112,30 +119,11 @@ public class DecisionTraceBuilder {
 
         decision.setPolicies(allPolicies);
 
-        // Determine final decision based on which list the principal is in
-        boolean isDenied = (response.getDenyUsers() != null && response.getDenyUsers().contains(principal)) ||
-                          (response.getDenyGroups() != null && response.getDenyGroups().contains(principal)) ||
-                          (response.getDenyRoles() != null && response.getDenyRoles().contains(principal));
-
-        decision.setDecision(isDenied ? AccessDecision.DENY : AccessDecision.ALLOW);
-        decision.setFinalReason(explainPrecedenceRule(allPolicies, decision.getDecision()));
+        AccessDecision finalDecision = isDenied ? AccessDecision.DENY : AccessDecision.ALLOW;
+        decision.setDecision(finalDecision);
+        decision.setFinalReason(explainPrecedenceRule(allPolicies, finalDecision));
 
         return decision;
-    }
-
-    /**
-     * Infers the principal type based on which list it appears in.
-     */
-    private static PrincipalType inferPrincipalType(String principal, AtlasAccessorResponse response) {
-        if ((response.getUsers() != null && response.getUsers().contains(principal)) ||
-            (response.getDenyUsers() != null && response.getDenyUsers().contains(principal))) {
-            return PrincipalType.USER;
-        } else if ((response.getGroups() != null && response.getGroups().contains(principal)) ||
-                   (response.getDenyGroups() != null && response.getDenyGroups().contains(principal))) {
-            return PrincipalType.GROUP;
-        } else {
-            return PrincipalType.ROLE;
-        }
     }
 
     /**
@@ -163,24 +151,45 @@ public class DecisionTraceBuilder {
 
     /**
      * Generates a human-readable explanation of the final decision.
+     * @param policies List of policies sorted by precedence
+     * @param finalDecision The actual final decision (ALLOW or DENY)
      */
     private static String explainPrecedenceRule(List<PolicyTrace> policies, AccessDecision finalDecision) {
         if (policies == null || policies.isEmpty()) {
-            return "Implicit DENY (no matching policies)";
+            if (finalDecision == AccessDecision.DENY) {
+                return "Implicit DENY (no matching policies)";
+            } else {
+                return "ALLOW (no deny policies matched)";
+            }
         }
 
         PolicyTrace highestPrecedence = policies.get(0);
         String policyName = highestPrecedence.getPolicyName() != null ? highestPrecedence.getPolicyName() : "unknown";
         String enforcer = highestPrecedence.getEnforcer() != null ? highestPrecedence.getEnforcer() : "unknown";
 
-        if (highestPrecedence.getPolicyPriority() == 100 && !highestPrecedence.isAllowPolicy()) {
-            return "Override DENY from " + policyName;
-        } else if (highestPrecedence.getPolicyPriority() == 100 && highestPrecedence.isAllowPolicy()) {
-            return "Override ALLOW from " + policyName;
-        } else if (!highestPrecedence.isAllowPolicy()) {
-            return "Explicit DENY from " + policyName;
+        // Use the actual final decision to determine the explanation
+        if (finalDecision == AccessDecision.DENY) {
+            // Find the highest precedence deny policy
+            for (PolicyTrace policy : policies) {
+                if (!policy.isAllowPolicy()) {
+                    String denyPolicyName = policy.getPolicyName() != null ? policy.getPolicyName() : "unknown";
+                    if (policy.getPolicyPriority() == 100) {
+                        return "Override DENY from " + denyPolicyName;
+                    } else {
+                        return "Explicit DENY from " + denyPolicyName;
+                    }
+                }
+            }
+            return "DENY (policy evaluation)";
         } else {
-            return "Normal ALLOW from " + enforcer + " " + policyName;
+            // ALLOW decision
+            if (highestPrecedence.getPolicyPriority() == 100 && highestPrecedence.isAllowPolicy()) {
+                return "Override ALLOW from " + policyName;
+            } else if (highestPrecedence.isAllowPolicy()) {
+                return "Normal ALLOW from " + enforcer + " " + policyName;
+            } else {
+                return "ALLOW (no deny policies matched)";
+            }
         }
     }
 }

--- a/repository/src/main/java/org/apache/atlas/authorizer/trace/DecisionTraceCollector.java
+++ b/repository/src/main/java/org/apache/atlas/authorizer/trace/DecisionTraceCollector.java
@@ -38,15 +38,34 @@ public class DecisionTraceCollector {
      * @param policyId The policy ID
      * @param policyPriority The policy priority
      * @param isAllow True if this is an allow policy, false if deny
+     * @param users List of users this policy applies to
+     * @param groups List of groups this policy applies to
+     * @param roles List of roles this policy applies to
      */
-    public void recordRangerMatchFromResult(String policyId, int policyPriority, boolean isAllow) {
+    public void recordRangerMatchFromResult(String policyId, int policyPriority, boolean isAllow,
+                                           java.util.List<String> users,
+                                           java.util.List<String> groups,
+                                           java.util.List<String> roles) {
         if (policyId == null || policyId.equals("-1")) {
             return;
         }
 
-        // Use cache to avoid duplicate processing
-        if (!rangerPolicyCache.containsKey(policyId)) {
-            rangerPolicyCache.put(policyId, createRangerPolicyTraceFromResult(policyId, policyPriority, isAllow));
+        // Use cache to avoid duplicate processing, but merge principals if already exists
+        PolicyTrace trace = rangerPolicyCache.get(policyId);
+        if (trace == null) {
+            trace = createRangerPolicyTraceFromResult(policyId, policyPriority, isAllow);
+            rangerPolicyCache.put(policyId, trace);
+        }
+
+        // Add principals from this policy item
+        if (users != null) {
+            trace.getApplicableUsers().addAll(users);
+        }
+        if (groups != null) {
+            trace.getApplicableGroups().addAll(groups);
+        }
+        if (roles != null) {
+            trace.getApplicableRoles().addAll(roles);
         }
     }
 
@@ -65,9 +84,27 @@ public class DecisionTraceCollector {
             return;
         }
 
-        // Use cache to avoid duplicate processing
-        if (!abacPolicyCache.containsKey(policyId)) {
-            abacPolicyCache.put(policyId, createAbacPolicyTrace(policy, isAllow));
+        // Use cache to avoid duplicate processing, but merge principals if already exists
+        PolicyTrace trace = abacPolicyCache.get(policyId);
+        if (trace == null) {
+            trace = createAbacPolicyTrace(policy, isAllow);
+            abacPolicyCache.put(policyId, trace);
+        }
+
+        // Extract principals from policy items
+        java.util.List<RangerPolicy.RangerPolicyItem> policyItems = isAllow ? policy.getPolicyItems() : policy.getDenyPolicyItems();
+        if (policyItems != null) {
+            for (RangerPolicy.RangerPolicyItem item : policyItems) {
+                if (item.getUsers() != null) {
+                    trace.getApplicableUsers().addAll(item.getUsers());
+                }
+                if (item.getGroups() != null) {
+                    trace.getApplicableGroups().addAll(item.getGroups());
+                }
+                if (item.getRoles() != null) {
+                    trace.getApplicableRoles().addAll(item.getRoles());
+                }
+            }
         }
     }
 
@@ -111,9 +148,17 @@ public class DecisionTraceCollector {
         trace.setPolicyId(policy.getGuid());
         trace.setPolicyName(policy.getName());
 
-        // Infer policy type from name pattern
+        // Infer policy type from service type or policy name
         String policyName = policy.getName();
-        if (policyName != null) {
+        String serviceType = policy.getServiceType();
+
+        // Try to use service type first (more reliable)
+        if (serviceType != null && serviceType.contains("persona")) {
+            trace.setPolicyType("persona");
+        } else if (serviceType != null && serviceType.contains("purpose")) {
+            trace.setPolicyType("purpose");
+        } else if (policyName != null) {
+            // Fall back to name-based inference
             if (policyName.contains("persona")) {
                 trace.setPolicyType("persona");
             } else if (policyName.contains("purpose")) {

--- a/repository/src/main/java/org/apache/atlas/authorizer/trace/DecisionTraceCollector.java
+++ b/repository/src/main/java/org/apache/atlas/authorizer/trace/DecisionTraceCollector.java
@@ -1,0 +1,134 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas.authorizer.trace;
+
+import org.apache.atlas.authorize.PolicyTrace;
+import org.apache.atlas.plugin.model.RangerPolicy;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Collects policy match information during authorization evaluation.
+ * Uses caching to minimize overhead and ensure <20% performance impact.
+ */
+public class DecisionTraceCollector {
+    // Caches to prevent duplicate policy object creation
+    private final Map<String, PolicyTrace> rangerPolicyCache = new ConcurrentHashMap<>();
+    private final Map<String, PolicyTrace> abacPolicyCache = new ConcurrentHashMap<>();
+
+    /**
+     * Records a Ranger policy match from RangerAccessResult.
+     * Used when we don't have access to the full RangerPolicy object.
+     * @param policyId The policy ID
+     * @param policyPriority The policy priority
+     * @param isAllow True if this is an allow policy, false if deny
+     */
+    public void recordRangerMatchFromResult(String policyId, int policyPriority, boolean isAllow) {
+        if (policyId == null || policyId.equals("-1")) {
+            return;
+        }
+
+        // Use cache to avoid duplicate processing
+        if (!rangerPolicyCache.containsKey(policyId)) {
+            rangerPolicyCache.put(policyId, createRangerPolicyTraceFromResult(policyId, policyPriority, isAllow));
+        }
+    }
+
+    /**
+     * Records an ABAC policy match (persona or purpose).
+     * @param policy The matched ABAC policy
+     * @param isAllow True if this is an allow policy, false if deny
+     */
+    public void recordAbacMatch(RangerPolicy policy, boolean isAllow) {
+        if (policy == null) {
+            return;
+        }
+
+        String policyId = policy.getGuid();
+        if (policyId == null) {
+            return;
+        }
+
+        // Use cache to avoid duplicate processing
+        if (!abacPolicyCache.containsKey(policyId)) {
+            abacPolicyCache.put(policyId, createAbacPolicyTrace(policy, isAllow));
+        }
+    }
+
+    /**
+     * Gets all recorded Ranger policies.
+     * @return Map of policy ID to PolicyTrace
+     */
+    public Map<String, PolicyTrace> getRangerPolicies() {
+        return rangerPolicyCache;
+    }
+
+    /**
+     * Gets all recorded ABAC policies.
+     * @return Map of policy ID to PolicyTrace
+     */
+    public Map<String, PolicyTrace> getAbacPolicies() {
+        return abacPolicyCache;
+    }
+
+    /**
+     * Creates a PolicyTrace from RangerAccessResult information.
+     * Used when we don't have access to the full RangerPolicy object.
+     */
+    private PolicyTrace createRangerPolicyTraceFromResult(String policyId, int policyPriority, boolean isAllow) {
+        PolicyTrace trace = new PolicyTrace();
+        trace.setPolicyId(policyId);
+        trace.setPolicyName("ranger-policy-" + policyId);  // Use ID as name since we don't have the actual name
+        trace.setPolicyType("ranger");
+        trace.setPolicyPriority(policyPriority);
+        trace.setAllowPolicy(isAllow);
+        trace.setEnforcer("ranger");
+
+        return trace;
+    }
+
+    /**
+     * Creates a PolicyTrace from an ABAC policy.
+     */
+    private PolicyTrace createAbacPolicyTrace(RangerPolicy policy, boolean isAllow) {
+        PolicyTrace trace = new PolicyTrace();
+        trace.setPolicyId(policy.getGuid());
+        trace.setPolicyName(policy.getName());
+
+        // Infer policy type from name pattern
+        String policyName = policy.getName();
+        if (policyName != null) {
+            if (policyName.contains("persona")) {
+                trace.setPolicyType("persona");
+            } else if (policyName.contains("purpose")) {
+                trace.setPolicyType("purpose");
+            } else {
+                trace.setPolicyType("abac");
+            }
+        } else {
+            trace.setPolicyType("abac");
+        }
+
+        trace.setPolicyPriority(policy.getPolicyPriority() != null ? policy.getPolicyPriority() : 0);
+        trace.setAllowPolicy(isAllow);
+        trace.setEnforcer("abac");
+
+        return trace;
+    }
+}

--- a/repository/src/main/java/org/apache/atlas/authorizer/trace/DecisionTraceCollector.java
+++ b/repository/src/main/java/org/apache/atlas/authorizer/trace/DecisionTraceCollector.java
@@ -33,7 +33,45 @@ public class DecisionTraceCollector {
     private final Map<String, PolicyTrace> abacPolicyCache = new ConcurrentHashMap<>();
 
     /**
-     * Records a Ranger policy match from RangerAccessResult.
+     * Records a Ranger policy match with full policy object.
+     * This is the preferred method as it has access to the actual policy name and metadata.
+     * @param policy The full Ranger policy object
+     * @param isAllow True if this is an allow policy, false if deny
+     * @param users List of users from the matched policy item
+     * @param groups List of groups from the matched policy item
+     * @param roles List of roles from the matched policy item
+     */
+    public void recordRangerMatch(RangerPolicy policy, boolean isAllow,
+                                   java.util.List<String> users,
+                                   java.util.List<String> groups,
+                                   java.util.List<String> roles) {
+        if (policy == null || policy.getGuid() == null) {
+            return;
+        }
+
+        String policyId = policy.getGuid();
+
+        // Use cache to avoid duplicate processing, but merge principals if already exists
+        PolicyTrace trace = rangerPolicyCache.get(policyId);
+        if (trace == null) {
+            trace = createRangerPolicyTrace(policy, isAllow);
+            rangerPolicyCache.put(policyId, trace);
+        }
+
+        // Add principals from this policy item
+        if (users != null) {
+            trace.getApplicableUsers().addAll(users);
+        }
+        if (groups != null) {
+            trace.getApplicableGroups().addAll(groups);
+        }
+        if (roles != null) {
+            trace.getApplicableRoles().addAll(roles);
+        }
+    }
+
+    /**
+     * Records a Ranger policy match from RangerAccessResult (legacy method).
      * Used when we don't have access to the full RangerPolicy object.
      * @param policyId The policy ID
      * @param policyPriority The policy priority
@@ -41,7 +79,9 @@ public class DecisionTraceCollector {
      * @param users List of users this policy applies to
      * @param groups List of groups this policy applies to
      * @param roles List of roles this policy applies to
+     * @deprecated Use recordRangerMatch(RangerPolicy, boolean, List, List, List) instead
      */
+    @Deprecated
     public void recordRangerMatchFromResult(String policyId, int policyPriority, boolean isAllow,
                                            java.util.List<String> users,
                                            java.util.List<String> groups,
@@ -125,9 +165,58 @@ public class DecisionTraceCollector {
     }
 
     /**
-     * Creates a PolicyTrace from RangerAccessResult information.
-     * Used when we don't have access to the full RangerPolicy object.
+     * Creates a PolicyTrace from a full RangerPolicy object.
+     * Determines policy type based on service type and policy name.
      */
+    private PolicyTrace createRangerPolicyTrace(RangerPolicy policy, boolean isAllow) {
+        PolicyTrace trace = new PolicyTrace();
+        trace.setPolicyId(policy.getGuid());
+        trace.setPolicyName(policy.getName());  // Use actual policy name (Atlas qualifiedName for persona/purpose)
+
+        // Determine policy type from service type or policy name
+        String serviceType = policy.getServiceType();
+        String policyName = policy.getName();
+
+        // Try to use service type first (more reliable)
+        if (serviceType != null && serviceType.contains("persona")) {
+            trace.setPolicyType("persona");
+        } else if (serviceType != null && serviceType.contains("purpose")) {
+            trace.setPolicyType("purpose");
+        } else if (policyName != null) {
+            // Fall back to name-based inference
+            // Persona/purpose policies have qualifiedName patterns like "default/persona123/policy456"
+            if (policyName.contains("/") && !policyName.startsWith("ranger-")) {
+                // This is likely an Atlas policy (persona/purpose) with a qualifiedName
+                // Try to infer from the QN pattern
+                if (policyName.matches(".*persona.*")) {
+                    trace.setPolicyType("persona");
+                } else if (policyName.matches(".*purpose.*")) {
+                    trace.setPolicyType("purpose");
+                } else {
+                    // Generic Atlas policy
+                    trace.setPolicyType("atlas");
+                }
+            } else {
+                // Bootstrap Ranger policy
+                trace.setPolicyType("ranger");
+            }
+        } else {
+            trace.setPolicyType("ranger");
+        }
+
+        trace.setPolicyPriority(policy.getPolicyPriority() != null ? policy.getPolicyPriority() : 0);
+        trace.setAllowPolicy(isAllow);
+        trace.setEnforcer("ranger");
+
+        return trace;
+    }
+
+    /**
+     * Creates a PolicyTrace from RangerAccessResult information (legacy method).
+     * Used when we don't have access to the full RangerPolicy object.
+     * @deprecated Use createRangerPolicyTrace(RangerPolicy, boolean) instead
+     */
+    @Deprecated
     private PolicyTrace createRangerPolicyTraceFromResult(String policyId, int policyPriority, boolean isAllow) {
         PolicyTrace trace = new PolicyTrace();
         trace.setPolicyId(policyId);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -2938,10 +2938,12 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
                     // Build trace if enabled
                     if (traceEnabled) {
                         DecisionTraceCollector collector = AccessDecisionContext.getCurrentTrace();
+                        String forUser = accessorRequest.getForUser();
                         List<AtlasAccessDecision> decisions = DecisionTraceBuilder.buildDecisions(
                             result,
                             collector.getRangerPolicies(),
-                            collector.getAbacPolicies()
+                            collector.getAbacPolicies(),
+                            forUser
                         );
                         result.setAccessDecisions(decisions);
                     }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -27,6 +27,9 @@ import org.apache.atlas.authorize.AtlasEntityAccessRequest.AtlasEntityAccessRequ
 import org.apache.atlas.bulkimport.BulkImportResponse;
 import org.apache.atlas.bulkimport.BulkImportResponse.ImportInfo;
 import org.apache.atlas.authorizer.AtlasAuthorizationUtils;
+import org.apache.atlas.authorizer.trace.AccessDecisionContext;
+import org.apache.atlas.authorizer.trace.DecisionTraceBuilder;
+import org.apache.atlas.authorizer.trace.DecisionTraceCollector;
 import org.apache.atlas.discovery.EntityDiscoveryService;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.featureflag.FeatureFlagStore;
@@ -2857,9 +2860,17 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
         for (AtlasAccessorRequest accessorRequest : atlasAccessorRequestList) {
             try {
                 AtlasAccessorResponse result = null;
-                AtlasPrivilege action = AtlasPrivilege.valueOf(accessorRequest.getAction());;
+                boolean traceEnabled = Boolean.TRUE.equals(accessorRequest.getIncludeDecisionTrace());
 
-                switch (action) {
+                // Start trace if requested
+                if (traceEnabled) {
+                    AccessDecisionContext.startTrace();
+                }
+
+                try {
+                    AtlasPrivilege action = AtlasPrivilege.valueOf(accessorRequest.getAction());
+
+                    switch (action) {
                     case ENTITY_READ:
                     case ENTITY_CREATE:
                     case ENTITY_UPDATE:
@@ -2917,14 +2928,31 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
 
                     default:
                         LOG.error("No implementation found for action: {}", accessorRequest.getAction());
-                }
+                    }
 
-                if (result == null) {
-                    throw new AtlasBaseException();
-                }
-                result.populateRequestDetails(accessorRequest);
-                ret.add(result);
+                    if (result == null) {
+                        throw new AtlasBaseException();
+                    }
+                    result.populateRequestDetails(accessorRequest);
 
+                    // Build trace if enabled
+                    if (traceEnabled) {
+                        DecisionTraceCollector collector = AccessDecisionContext.getCurrentTrace();
+                        List<AtlasAccessDecision> decisions = DecisionTraceBuilder.buildDecisions(
+                            result,
+                            collector.getRangerPolicies(),
+                            collector.getAbacPolicies()
+                        );
+                        result.setAccessDecisions(decisions);
+                    }
+
+                    ret.add(result);
+
+                } finally {
+                    if (traceEnabled) {
+                        AccessDecisionContext.endTrace();
+                    }
+                }
             } catch (AtlasBaseException e) {
                 e.getErrorDetailsMap().put("accessorRequest", AtlasType.toJson(accessorRequest));
                 throw e;

--- a/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
@@ -178,7 +178,9 @@ public class EntityREST {
      */
     @POST
     @Path("/accessors")
-    public List<AtlasAccessorResponse> getAccessors(List<AtlasAccessorRequest> atlasAccessorRequestList) throws AtlasBaseException {
+    public List<AtlasAccessorResponse> getAccessors(
+            List<AtlasAccessorRequest> atlasAccessorRequestList,
+            @QueryParam("includeTrace") @DefaultValue("false") boolean includeTrace) throws AtlasBaseException {
         AtlasPerfTracer perf = null;
         List<AtlasAccessorResponse> ret;
 
@@ -188,6 +190,11 @@ public class EntityREST {
 
         try {
             validateAccessorRequest(atlasAccessorRequestList);
+
+            // Set trace flag on requests if enabled
+            if (includeTrace) {
+                atlasAccessorRequestList.forEach(r -> r.setIncludeDecisionTrace(true));
+            }
 
             ret = entitiesStore.getAccessors(atlasAccessorRequestList);
 

--- a/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
@@ -175,13 +175,16 @@ public class EntityREST {
 
     /**
      * API to get accessors info such as roles/groups/users who can perform specific action
+     *
+     * SECURITY: When includeTrace=true, the trace is generated for the AUTHENTICATED USER ONLY
+     * (extracted from the authentication token). This prevents unauthorized users from querying
+     * access decisions for other users.
      */
     @POST
     @Path("/accessors")
     public List<AtlasAccessorResponse> getAccessors(
             List<AtlasAccessorRequest> atlasAccessorRequestList,
-            @QueryParam("includeTrace") @DefaultValue("false") boolean includeTrace,
-            @QueryParam("forUser") String forUser) throws AtlasBaseException {
+            @QueryParam("includeTrace") @DefaultValue("false") boolean includeTrace) throws AtlasBaseException {
         AtlasPerfTracer perf = null;
         List<AtlasAccessorResponse> ret;
 
@@ -192,13 +195,17 @@ public class EntityREST {
         try {
             validateAccessorRequest(atlasAccessorRequestList);
 
-            // Set trace flag and forUser on requests if enabled
+            // Set trace flag and authenticated user on requests if enabled
             if (includeTrace) {
+                String authenticatedUser = AtlasAuthorizationUtils.getCurrentUserName();
+
+                if (authenticatedUser == null || authenticatedUser.isEmpty()) {
+                    throw new AtlasBaseException(AtlasErrorCode.UNAUTHORIZED_ACCESS, "Decision trace requires authentication");
+                }
+
                 atlasAccessorRequestList.forEach(r -> {
                     r.setIncludeDecisionTrace(true);
-                    if (forUser != null && !forUser.isEmpty()) {
-                        r.setForUser(forUser);
-                    }
+                    r.setForUser(authenticatedUser);
                 });
             }
 

--- a/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
@@ -180,7 +180,8 @@ public class EntityREST {
     @Path("/accessors")
     public List<AtlasAccessorResponse> getAccessors(
             List<AtlasAccessorRequest> atlasAccessorRequestList,
-            @QueryParam("includeTrace") @DefaultValue("false") boolean includeTrace) throws AtlasBaseException {
+            @QueryParam("includeTrace") @DefaultValue("false") boolean includeTrace,
+            @QueryParam("forUser") String forUser) throws AtlasBaseException {
         AtlasPerfTracer perf = null;
         List<AtlasAccessorResponse> ret;
 
@@ -191,9 +192,14 @@ public class EntityREST {
         try {
             validateAccessorRequest(atlasAccessorRequestList);
 
-            // Set trace flag on requests if enabled
+            // Set trace flag and forUser on requests if enabled
             if (includeTrace) {
-                atlasAccessorRequestList.forEach(r -> r.setIncludeDecisionTrace(true));
+                atlasAccessorRequestList.forEach(r -> {
+                    r.setIncludeDecisionTrace(true);
+                    if (forUser != null && !forUser.isEmpty()) {
+                        r.setForUser(forUser);
+                    }
+                });
             }
 
             ret = entitiesStore.getAccessors(atlasAccessorRequestList);


### PR DESCRIPTION
## Change description

### 🎯 Problem Statement

The current `/api/meta/entity/accessors` endpoint returns **WHO** has access to resources (users, groups, roles), but not **WHY** they have access. This makes it difficult to:
- Debug permission issues ("Why does this user have access?")
- Audit access policies ("Which policy granted this permission?")
- Understand policy precedence conflicts (deny vs allow policies)
- Troubleshoot complex authorization scenarios involving both Ranger and ABAC policies

### ✨ Solution: Access Decision Trace

This PR adds an **optional decision trace** feature that explains the reasoning behind each access decision. When enabled via query parameter, the endpoint returns detailed policy information including:

1. **Which policies matched** - Specific Ranger and ABAC (persona/purpose) policies
2. **Policy precedence** - 5-level precedence model (Override Deny → Override Allow → Explicit Deny → Normal Allow → Implicit Deny)
3. **Policy details** - Policy ID, name, type (ranger/persona/purpose), priority, and enforcer
4. **Human-readable explanations** - "Override DENY from persona-pii-restricted" or "Normal ALLOW from ranger atlas-entity-read"

### 🏗️ Architecture

#### New Components

**Data Models** (`authorization` module):
- `PrincipalType` - Enum for USER, GROUP, ROLE
- `AccessDecision` - Enum for ALLOW, DENY
- `PolicyTrace` - Policy metadata (ID, name, type, priority, enforcer)
- `AtlasAccessDecision` - Complete decision trace for a principal

**Trace Infrastructure** (`repository` module):
- `AccessDecisionContext` - ThreadLocal manager for trace collection
- `DecisionTraceCollector` - Caches matched policies during evaluation
- `DecisionTraceBuilder` - Applies 5-level precedence logic and builds explanations

#### Integration Points

1. **RangerAtlasAuthorizerUtil** - Records Ranger policy matches from `RangerAccessResult`
2. **AccessorsExtractor** - Records ABAC policy matches (persona/purpose)
3. **EntityREST** - Accepts `includeTrace` query parameter
4. **AtlasEntityStoreV2** - Manages trace context lifecycle and builds final decisions

### 📊 5-Level Precedence Model

The trace applies Atlas's authorization precedence hierarchy:

| Level | Description | Priority | Type | Example |
|-------|-------------|----------|------|---------|
| 1️⃣ | **Override DENY** | 100 | Deny | Blocks even admin access |
| 2️⃣ | **Override ALLOW** | 100 | Allow | Grants access despite denies |
| 3️⃣ | **Explicit DENY** | 0 | Deny | Standard deny policy |
| 4️⃣ | **Normal ALLOW** | 0 | Allow | Standard allow policy |
| 5️⃣ | **Implicit DENY** | - | - | No policies matched |

### 🔧 API Usage

#### Request WITHOUT Trace (Backward Compatible)
```bash
POST /api/meta/entity/accessors
[
  {
    "action": "ENTITY_UPDATE",
    "guid": "71a3dafe-d191-4184-9890-380dfb9063c4",
    "typeName": "Table"
  }
]
```

**Response:**
```json
[{
  "action": "ENTITY_UPDATE",
  "guid": "71a3dafe-d191-4184-9890-380dfb9063c4",
  "users": ["admin", "service-account-atlan-backend"],
  "groups": ["data-engineers"],
  "roles": ["$admin", "$api-token-default-access"],
  "denyUsers": [],
  "denyGroups": [],
  "denyRoles": ["$guest"]
}]
```

#### Request WITH Trace (New Feature)
```bash
POST /api/meta/entity/accessors?includeTrace=true
[
  {
    "action": "ENTITY_UPDATE",
    "guid": "71a3dafe-d191-4184-9890-380dfb9063c4",
    "typeName": "Table"
  }
]
```

**Response:**
```json
[{
  "action": "ENTITY_UPDATE",
  "guid": "71a3dafe-d191-4184-9890-380dfb9063c4",
  "users": ["admin", "service-account-atlan-backend"],
  "roles": ["$admin"],
  "denyRoles": ["$guest"],
  "accessDecisions": [
    {
      "principal": "admin",
      "principalType": "USER",
      "decision": "ALLOW",
      "policies": [
        {
          "policyId": "ranger-admin-policy-123",
          "policyName": "ranger-policy-ranger-admin-policy-123",
          "policyType": "ranger",
          "policyPriority": 100,
          "isAllowPolicy": true,
          "enforcer": "ranger"
        }
      ],
      "finalReason": "Override ALLOW from ranger-policy-ranger-admin-policy-123"
    },
    {
      "principal": "$admin",
      "principalType": "ROLE",
      "decision": "ALLOW",
      "policies": [
        {
          "policyId": "ranger-admin-all-access",
          "policyName": "ranger-policy-ranger-admin-all-access",
          "policyType": "ranger",
          "policyPriority": 100,
          "isAllowPolicy": true,
          "enforcer": "ranger"
        }
      ],
      "finalReason": "Override ALLOW from ranger-policy-ranger-admin-all-access"
    },
    {
      "principal": "$guest",
      "principalType": "ROLE",
      "decision": "DENY",
      "policies": [
        {
          "policyId": "ranger-guest-deny",
          "policyName": "ranger-policy-ranger-guest-deny",
          "policyType": "ranger",
          "policyPriority": 0,
          "isAllowPolicy": false,
          "enforcer": "ranger"
        }
      ],
      "finalReason": "Explicit DENY from ranger-policy-ranger-guest-deny"
    }
  ]
}]
```

### ⚡ Performance Considerations

**Design for <20% Overhead:**
- **Lazy evaluation** - Only collects trace when `includeTrace=true`
- **Policy caching** - Uses `ConcurrentHashMap` to prevent duplicate processing
- **Minimal data** - Stores only essential policy metadata (ID, priority, type)
- **Single if-check** - Early return in hot path when trace disabled
- **ThreadLocal cleanup** - Always cleaned up in `finally` block to prevent memory leaks

**Benchmark Target:** <60ms with trace enabled vs ~50ms baseline

### 🔒 Security & Safety

1. **Backward Compatible** - `accessDecisions` field only appears when requested via `includeTrace=true`
2. **ThreadLocal Safety** - Proper lifecycle management with `try-finally` blocks
3. **No Authorization Bypass** - Trace collection is passive; doesn't affect access decisions
4. **Principal Type Separation** - User "admin" and Group "admin" are correctly distinguished
5. **JSON Serialization** - Uses `@JsonInclude(NON_NULL)` to avoid breaking existing clients

### 📝 Use Cases

1. **Permission Debugging**
   - "Why does Alice have UPDATE access to this table?"
   - Answer: "Normal ALLOW from abac persona-data-engineers"

2. **Policy Audit**
   - "Which policies grant access to financial data?"
   - Get complete list of policies with IDs for compliance reports

3. **Troubleshooting Denials**
   - "Why is Bob denied access despite being in the data-engineers group?"
   - Answer: "Override DENY from persona-pii-restricted (priority 100 beats group allow)"

4. **Access Reviews**
   - "Show me all principals with access and their granting policies"
   - Full trace for security team reviews

### 🚀 Future Enhancements (Out of Scope)

- User simulation (`forUser` parameter to check access for different users)
- Membership path trace (detailed group/role inheritance chains)
- ABAC filter criteria details (show which conditions matched)
- Historical trace storage (persist traces for auditing)

## Type of change
- [x] New feature (adds functionality)

## Related issues

> Fixes [GOVFOUN-349](https://linear.app/atlan-epd/issue/GOVFOUN-349/poc-effective-permission-inspector-show-why-a-permission-is-granted-or)

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [x] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Changes have been reviewed by at least one other contributor (Cursor Bugbot)
- [x] Pull request linked to task tracker where applicable
