### PR TITLE
MS-758: Replace hardcoded entity_audits index name with read/write aliases

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
@@ -286,19 +286,20 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
     /**
      * Performs the actual ES bulk write for audit events. Throws on failure; callers are expected to
      * catch and handle gracefully so the main request does not fail (see putEventsV2).
+     *
+     * Self-healing: if a write fails with a 4xx client error (e.g. alias mis-routing after ILM
+     * migration), the method re-probes ES for the write alias once. If the write config changed,
+     * it rebuilds the request and retries — no Atlas restart required.
      */
     private void putEventsV2Internal(List<EntityAuditEventV2> events) throws AtlasBaseException {
         if (CollectionUtils.isEmpty(events)) {
             return;
         }
 
-        // Snapshot the write config once — consistent writeIndex and bulkMetadata for the entire call
-        WriteConfig cfg = this.writeConfig;
-
         Map<String, String> requestContextHeaders = RequestContext.get().getRequestContextHeaders();
         String entityPayloadTemplate = getQueryTemplate(requestContextHeaders);
 
-        StringBuilder bulkRequestBody = new StringBuilder();
+        List<String> eventPayloads = new ArrayList<>();
         for (EntityAuditEventV2 event : events) {
             String created = String.format("%s", event.getTimestamp());
             String auditDetailPrefix = EntityAuditListenerV2.getV2AuditPrefix(event.getAction());
@@ -326,7 +327,7 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
                         event.getEntityId(), typeName);
             }
 
-            String bulkItem = MessageFormat.format(entityPayloadTemplate,
+            eventPayloads.add(MessageFormat.format(entityPayloadTemplate,
                     event.getEntityId(),
                     event.getAction(),
                     details,
@@ -335,22 +336,18 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
                     event.getEntityQualifiedName(),
                     typeName,
                     created,
-                    "" + updateTimestamp);
-
-            bulkRequestBody.append(cfg.writeBulkMetadata());
-            bulkRequestBody.append(bulkItem);
-            bulkRequestBody.append("\n");
+                    "" + updateTimestamp));
         }
-        if (bulkRequestBody.length() == 0) {
+        if (eventPayloads.isEmpty()) {
             return;
         }
-        String endpoint = cfg.writeIndex() + "/_bulk";
-        HttpEntity entity = new NStringEntity(bulkRequestBody.toString(), ContentType.APPLICATION_JSON);
-        Request request = new Request("POST", endpoint);
-        request.setEntity(entity);
+
+        WriteConfig cfg = this.writeConfig;
+        Request request = buildBulkAuditRequest(cfg, eventPayloads);
 
         int maxRetries = AtlasConfiguration.ES_MAX_RETRIES.getInt();
         long initialRetryDelay = AtlasConfiguration.ES_RETRY_DELAY_MS.getLong();
+        boolean aliasRedetected = false;
 
         for (int retryCount = 0; retryCount < maxRetries; retryCount++) {
             Response response = null;
@@ -382,6 +379,16 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
 
                 String responseBody = EntityUtils.toString(response.getEntity());
 
+                if (!aliasRedetected && statusCode >= 400 && statusCode < 500) {
+                    request = redetectAliasAndRebuild(cfg, eventPayloads, "HTTP " + statusCode);
+                    if (request != null) {
+                        cfg = this.writeConfig;
+                        aliasRedetected = true;
+                        continue;
+                    }
+                    aliasRedetected = true;
+                }
+
                 if ((statusCode >= 500 && statusCode < 600) || statusCode==429) {
                     LOG.warn("Failed to push entity audits to ES due to server error ({}). Retrying... ({}/{}) Response: {}",
                             statusCode, retryCount + 1, maxRetries, responseBody);
@@ -390,6 +397,15 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
                 }
 
             } catch (IOException e) {
+                if (!aliasRedetected) {
+                    Request rebuilt = redetectAliasAndRebuild(cfg, eventPayloads, "IOException: " + e.getMessage());
+                    aliasRedetected = true;
+                    if (rebuilt != null) {
+                        request = rebuilt;
+                        cfg = this.writeConfig;
+                        continue;
+                    }
+                }
                 LOG.warn("Failed to push entity audits to ES due to IOException. Retrying... ({}/{})", retryCount + 1, maxRetries, e);
             }
 
@@ -406,6 +422,36 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
 
         LOG.error("Failed to push entity audits to ES after {} retries", maxRetries);
         throw new AtlasBaseException("Unable to push entity audits to ES after " + maxRetries + " retries");
+    }
+
+    /**
+     * Re-probes ES for the write alias after a write failure. If the config changed (e.g. ILM
+     * migration created the write alias while Atlas was running), returns a rebuilt request
+     * targeting the new write index. Returns null if the config is unchanged.
+     */
+    private Request redetectAliasAndRebuild(WriteConfig prevCfg, List<String> eventPayloads, String trigger) {
+        detectAndConfigureWriteAlias();
+        WriteConfig newCfg = this.writeConfig;
+        if (!newCfg.writeIndex().equals(prevCfg.writeIndex())) {
+            LOG.info("Write alias config changed after re-detection (trigger='{}', old='{}', new='{}'), rebuilding audit bulk request",
+                    trigger, prevCfg.writeIndex(), newCfg.writeIndex());
+            return buildBulkAuditRequest(newCfg, eventPayloads);
+        }
+        LOG.debug("Write alias re-detection triggered by '{}' but config unchanged (writeIndex='{}')",
+                trigger, prevCfg.writeIndex());
+        return null;
+    }
+
+    private Request buildBulkAuditRequest(WriteConfig cfg, List<String> eventPayloads) {
+        StringBuilder body = new StringBuilder();
+        for (String payload : eventPayloads) {
+            body.append(cfg.writeBulkMetadata());
+            body.append(payload);
+            body.append("\n");
+        }
+        Request request = new Request("POST", cfg.writeIndex() + "/_bulk");
+        request.setEntity(new NStringEntity(body.toString(), ContentType.APPLICATION_JSON));
+        return request;
     }
 
     private String getQueryTemplate(Map<String, String> requestContextHeaders) {

--- a/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
@@ -170,6 +170,9 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
      */
     private record WriteConfig(String writeIndex, String writeBulkMetadata, boolean aliasMode) {}
 
+    /** Pair returned from {@link #redetectAliasAndRebuild} so local {@code cfg} matches the built {@link Request}. */
+    private record WriteAliasRedetectResult(WriteConfig config, Request request) {}
+
     private static final WriteConfig DEFAULT_WRITE_CONFIG = new WriteConfig(INDEX_NAME, bulkMetadata, false);
 
     private volatile WriteConfig writeConfig = DEFAULT_WRITE_CONFIG;
@@ -361,6 +364,22 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
                     Map<String, Object> responseMap = AtlasType.fromJson(responseString, Map.class);
 
                     if ((boolean) responseMap.get("errors")) {
+                        // Bulk often returns HTTP 200 with per-item failures (e.g. no write index on a
+                        // multi-target alias after ILM). Re-probe the write alias once before failing —
+                        // otherwise we never hit the 4xx/IOException paths and alias mode stays stale.
+                        // ES may mark the overall bulk as "errors" even if some actions succeeded; for
+                        // entity audit we still treat any failed item as a failed batch and recover/retry.
+                        if (!aliasRedetected) {
+                            Optional<WriteAliasRedetectResult> rebuilt = redetectAliasAndRebuild(cfg, eventPayloads,
+                                    "bulk errors=true (HTTP 200)");
+                            if (rebuilt.isPresent()) {
+                                WriteAliasRedetectResult r = rebuilt.get();
+                                request = r.request();
+                                cfg = r.config();
+                                aliasRedetected = true;
+                                continue;
+                            }
+                        }
                         LOG.error("Elasticsearch returned errors for bulk audit event request. Full response: {}", responseString);
                         List<String> errors = new ArrayList<>();
                         List<Map<String, Object>> resultItems = (List<Map<String, Object>>) responseMap.get("items");
@@ -380,10 +399,11 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
                 String responseBody = EntityUtils.toString(response.getEntity());
 
                 if (!aliasRedetected && statusCode >= 400 && statusCode < 500) {
-                    Optional<Request> rebuilt = redetectAliasAndRebuild(cfg, eventPayloads, "HTTP " + statusCode);
+                    Optional<WriteAliasRedetectResult> rebuilt = redetectAliasAndRebuild(cfg, eventPayloads, "HTTP " + statusCode);
                     if (rebuilt.isPresent()) {
-                        request = rebuilt.get();
-                        cfg = this.writeConfig;
+                        WriteAliasRedetectResult r = rebuilt.get();
+                        request = r.request();
+                        cfg = r.config();
                         aliasRedetected = true;
                         continue;
                     }
@@ -401,11 +421,12 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
                 // RestClient may throw for error statuses (depending on API/version); treat like HTTP branch above.
                 if (!aliasRedetected) {
                     int status = e.getResponse().getStatusLine().getStatusCode();
-                    Optional<Request> rebuilt = redetectAliasAndRebuild(cfg, eventPayloads,
+                    Optional<WriteAliasRedetectResult> rebuilt = redetectAliasAndRebuild(cfg, eventPayloads,
                             "ResponseException HTTP " + status);
                     if (rebuilt.isPresent()) {
-                        request = rebuilt.get();
-                        cfg = this.writeConfig;
+                        WriteAliasRedetectResult r = rebuilt.get();
+                        request = r.request();
+                        cfg = r.config();
                         aliasRedetected = true;
                         continue;
                     }
@@ -422,12 +443,13 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
             } catch (IOException e) {
                 // Transport-level failures (connection reset, timeout, etc.); alias HEAD may still succeed after ILM change.
                 if (!aliasRedetected) {
-                    Optional<Request> rebuilt = redetectAliasAndRebuild(cfg, eventPayloads,
+                    Optional<WriteAliasRedetectResult> rebuilt = redetectAliasAndRebuild(cfg, eventPayloads,
                             "IOException: " + e.getMessage());
                     aliasRedetected = true;
                     if (rebuilt.isPresent()) {
-                        request = rebuilt.get();
-                        cfg = this.writeConfig;
+                        WriteAliasRedetectResult r = rebuilt.get();
+                        request = r.request();
+                        cfg = r.config();
                         continue;
                     }
                 }
@@ -451,19 +473,23 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
 
     /**
      * Re-probes ES for the write alias after a write failure. If the config changed (e.g. ILM
-     * migration created the write alias while Atlas was running), returns a rebuilt request
-     * targeting the new write index. Empty if the write target is unchanged.
+     * migration created the write alias while Atlas was running), returns the new {@link WriteConfig}
+     * snapshot and a {@link Request} built from that same snapshot (avoids re-reading
+     * {@link #writeConfig} and diverging from the bulk body). Empty if the write target is unchanged.
      */
-    private Optional<Request> redetectAliasAndRebuild(WriteConfig prevCfg, List<String> eventPayloads, String trigger) {
+    private Optional<WriteAliasRedetectResult> redetectAliasAndRebuild(WriteConfig prevCfg, List<String> eventPayloads, String trigger) {
+        // detectAndConfigureWriteAlias() logs INFO when the write alias appears or is missing (404).
+        // This method adds an explicit line when the *effective* write target did not change after re-probe.
         detectAndConfigureWriteAlias();
         WriteConfig newCfg = this.writeConfig;
         if (!newCfg.writeIndex().equals(prevCfg.writeIndex())) {
             LOG.info("Write alias config changed after re-detection (trigger='{}', old='{}', new='{}'), rebuilding audit bulk request",
                     trigger, prevCfg.writeIndex(), newCfg.writeIndex());
-            return Optional.of(buildBulkAuditRequest(newCfg, eventPayloads));
+            Request rebuilt = buildBulkAuditRequest(newCfg, eventPayloads);
+            return Optional.of(new WriteAliasRedetectResult(newCfg, rebuilt));
         }
-        LOG.debug("Write alias re-detection triggered by '{}' but config unchanged (writeIndex='{}')",
-                trigger, prevCfg.writeIndex());
+        LOG.info("Entity audit write-alias re-probe finished (trigger='{}'): writeIndex still '{}', aliasMode={} — no request rebuild",
+                trigger, prevCfg.writeIndex(), newCfg.aliasMode());
         return Optional.empty();
     }
 

--- a/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
@@ -380,8 +380,9 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
                 String responseBody = EntityUtils.toString(response.getEntity());
 
                 if (!aliasRedetected && statusCode >= 400 && statusCode < 500) {
-                    request = redetectAliasAndRebuild(cfg, eventPayloads, "HTTP " + statusCode);
-                    if (request != null) {
+                    Optional<Request> rebuilt = redetectAliasAndRebuild(cfg, eventPayloads, "HTTP " + statusCode);
+                    if (rebuilt.isPresent()) {
+                        request = rebuilt.get();
                         cfg = this.writeConfig;
                         aliasRedetected = true;
                         continue;
@@ -396,12 +397,36 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
                     throw new AtlasBaseException("Unable to push entity audits to ES. Status code: " + statusCode + ", Response: " + responseBody);
                 }
 
-            } catch (IOException e) {
+            } catch (ResponseException e) {
+                // RestClient may throw for error statuses (depending on API/version); treat like HTTP branch above.
                 if (!aliasRedetected) {
-                    Request rebuilt = redetectAliasAndRebuild(cfg, eventPayloads, "IOException: " + e.getMessage());
+                    int status = e.getResponse().getStatusLine().getStatusCode();
+                    Optional<Request> rebuilt = redetectAliasAndRebuild(cfg, eventPayloads,
+                            "ResponseException HTTP " + status);
+                    if (rebuilt.isPresent()) {
+                        request = rebuilt.get();
+                        cfg = this.writeConfig;
+                        aliasRedetected = true;
+                        continue;
+                    }
                     aliasRedetected = true;
-                    if (rebuilt != null) {
-                        request = rebuilt;
+                }
+                int status = e.getResponse().getStatusLine().getStatusCode();
+                String errBody = e.getMessage();
+                if ((status >= 500 && status < 600) || status == 429) {
+                    LOG.warn("Failed to push entity audits to ES due to server error ({}). Retrying... ({}/{}) Response: {}",
+                            status, retryCount + 1, maxRetries, errBody);
+                } else {
+                    throw new AtlasBaseException("Unable to push entity audits to ES. Status code: " + status + ", Response: " + errBody, e);
+                }
+            } catch (IOException e) {
+                // Transport-level failures (connection reset, timeout, etc.); alias HEAD may still succeed after ILM change.
+                if (!aliasRedetected) {
+                    Optional<Request> rebuilt = redetectAliasAndRebuild(cfg, eventPayloads,
+                            "IOException: " + e.getMessage());
+                    aliasRedetected = true;
+                    if (rebuilt.isPresent()) {
+                        request = rebuilt.get();
                         cfg = this.writeConfig;
                         continue;
                     }
@@ -427,19 +452,19 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
     /**
      * Re-probes ES for the write alias after a write failure. If the config changed (e.g. ILM
      * migration created the write alias while Atlas was running), returns a rebuilt request
-     * targeting the new write index. Returns null if the config is unchanged.
+     * targeting the new write index. Empty if the write target is unchanged.
      */
-    private Request redetectAliasAndRebuild(WriteConfig prevCfg, List<String> eventPayloads, String trigger) {
+    private Optional<Request> redetectAliasAndRebuild(WriteConfig prevCfg, List<String> eventPayloads, String trigger) {
         detectAndConfigureWriteAlias();
         WriteConfig newCfg = this.writeConfig;
         if (!newCfg.writeIndex().equals(prevCfg.writeIndex())) {
             LOG.info("Write alias config changed after re-detection (trigger='{}', old='{}', new='{}'), rebuilding audit bulk request",
                     trigger, prevCfg.writeIndex(), newCfg.writeIndex());
-            return buildBulkAuditRequest(newCfg, eventPayloads);
+            return Optional.of(buildBulkAuditRequest(newCfg, eventPayloads));
         }
         LOG.debug("Write alias re-detection triggered by '{}' but config unchanged (writeIndex='{}')",
                 trigger, prevCfg.writeIndex());
-        return null;
+        return Optional.empty();
     }
 
     private Request buildBulkAuditRequest(WriteConfig cfg, List<String> eventPayloads) {

--- a/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
@@ -19,6 +19,7 @@ package org.apache.atlas.repository.audit;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.atlas.ApplicationProperties;
 import org.apache.atlas.AtlasConfiguration;
@@ -52,6 +53,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.slf4j.Logger;
@@ -112,6 +114,7 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
     private static final String bulkMetadata;
     private static final Set<String> ALLOWED_LINKED_ATTRIBUTES = new HashSet<>(Arrays.asList(DOMAIN_GUIDS, CATALOG_DATASET_GUID_ATTR));
     private static final String ENTITY_AUDITS_INDEX;
+    private static final String WRITE_ALIAS;
     private static final String NIOFS_MIGRATION_MARKER_ID = "entity_audits_niofs_migrated";
     private static final int DLQ_POLL_TIMEOUT_SECONDS = 5;
 
@@ -143,8 +146,9 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
         }
         INDEX_NAME = auditIndex;
         ENTITY_AUDITS_INDEX = auditIndex;
+        WRITE_ALIAS = auditIndex + "_write";
         bulkMetadata = String.format("{ \"index\" : { \"_index\" : \"%s\" } }%n", INDEX_NAME);
-        LOG.info("ES audit index name: '{}'", INDEX_NAME);
+        LOG.info("ES audit index name: '{}', write alias: '{}'", INDEX_NAME, WRITE_ALIAS);
     }
 
     /*
@@ -158,6 +162,17 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
 
     /** Holder for failed audit events enqueued to async DLQ for retry. */
     private static record EntityAuditDLQEntry(List<EntityAuditEventV2> events, int retryCount) {}
+
+    /**
+     * Immutable snapshot of write-path configuration. A single volatile reference swap
+     * guarantees that request threads always see a consistent (writeIndex, writeBulkMetadata, aliasMode)
+     * triple — no torn reads across three separate volatile fields.
+     */
+    private record WriteConfig(String writeIndex, String writeBulkMetadata, boolean aliasMode) {}
+
+    private static final WriteConfig DEFAULT_WRITE_CONFIG = new WriteConfig(INDEX_NAME, bulkMetadata, false);
+
+    private volatile WriteConfig writeConfig = DEFAULT_WRITE_CONFIG;
 
     /**
      * Record audit DLQ failure metric to the existing Micrometer/Prometheus registry (scraped by Victoria Metrics).
@@ -277,6 +292,9 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
             return;
         }
 
+        // Snapshot the write config once — consistent writeIndex and bulkMetadata for the entire call
+        WriteConfig cfg = this.writeConfig;
+
         Map<String, String> requestContextHeaders = RequestContext.get().getRequestContextHeaders();
         String entityPayloadTemplate = getQueryTemplate(requestContextHeaders);
 
@@ -319,14 +337,14 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
                     created,
                     "" + updateTimestamp);
 
-            bulkRequestBody.append(bulkMetadata);
+            bulkRequestBody.append(cfg.writeBulkMetadata());
             bulkRequestBody.append(bulkItem);
             bulkRequestBody.append("\n");
         }
         if (bulkRequestBody.length() == 0) {
             return;
         }
-        String endpoint = INDEX_NAME + "/_bulk";
+        String endpoint = cfg.writeIndex() + "/_bulk";
         HttpEntity entity = new NStringEntity(bulkRequestBody.toString(), ContentType.APPLICATION_JSON);
         Request request = new Request("POST", endpoint);
         request.setEntity(entity);
@@ -757,6 +775,10 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
                 LOG.info("Create ES index for entity audits in ES Based Audit Repo");
                 createAuditIndex();
             }
+            detectAndConfigureWriteAlias();
+            WriteConfig cfg = this.writeConfig;
+            LOG.info("Entity audit ES config: aliasMode={}, writeIndex='{}', readIndex='{}', writeAlias='{}'",
+                     cfg.aliasMode(), cfg.writeIndex(), INDEX_NAME, WRITE_ALIAS);
             if (shouldUpdateFieldLimitSetting()) {
                 LOG.info("Updating ES total field limit");
                 updateFieldLimit();
@@ -767,10 +789,10 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
             LOG.error("error", e);
             throw new AtlasException(e);
         }
-
     }
 
     private boolean checkIfIndexExists() throws IOException {
+        // HEAD works for both concrete index name and alias — returns 200 for either
         Request request = new Request("HEAD", INDEX_NAME);
         Response response = lowLevelClient.performRequest(request);
         int statusCode = response.getStatusLine().getStatusCode();
@@ -782,14 +804,76 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
         return false;
     }
 
+    /**
+     * Probes ES for the write alias and atomically switches the write config.
+     * If the write alias exists, writes go through it (alias mode).
+     * If not, falls back to direct index mode (current behavior — backward compatible).
+     */
+    private void detectAndConfigureWriteAlias() {
+        try {
+            Request request = new Request("HEAD", "/_alias/" + WRITE_ALIAS);
+            Response response = lowLevelClient.performRequest(request);
+            if (response.getStatusLine().getStatusCode() == 200) {
+                String newBulkMeta = String.format("{ \"index\" : { \"_index\" : \"%s\" } }%n", WRITE_ALIAS);
+                writeConfig = new WriteConfig(WRITE_ALIAS, newBulkMeta, true);
+                LOG.info("Write alias '{}' detected, using alias mode for entity audits", WRITE_ALIAS);
+            } else {
+                writeConfig = DEFAULT_WRITE_CONFIG;
+                LOG.info("Write alias '{}' not available (HTTP {}), using direct index '{}'",
+                         WRITE_ALIAS, response.getStatusLine().getStatusCode(), INDEX_NAME);
+            }
+        } catch (ResponseException e) {
+            writeConfig = DEFAULT_WRITE_CONFIG;
+            LOG.info("Write alias '{}' not found (HTTP {}), using direct index '{}'",
+                     WRITE_ALIAS, e.getResponse().getStatusLine().getStatusCode(), INDEX_NAME);
+        } catch (Exception e) {
+            writeConfig = DEFAULT_WRITE_CONFIG;
+            LOG.warn("Failed to check write alias '{}', using direct index '{}': {}",
+                     WRITE_ALIAS, INDEX_NAME, e.getMessage());
+        }
+    }
+
+    /**
+     * Creates the entity audits index for fresh tenants. Creates a concrete index named
+     * {@code entity_audits-000001} with both read alias ({@code entity_audits}) and write alias
+     * ({@code entity_audits_write}) configured, making fresh tenants ILM-ready from day one.
+     *
+     * Handles concurrent pod creation race (multiple pods seeing "index not found" simultaneously)
+     * by catching the 400 "resource_already_exists_exception" and re-verifying existence.
+     */
     private boolean createAuditIndex() throws IOException {
-        LOG.info("ESBasedAuditRepo - createAuditIndex!");
+        String concreteIndexName = INDEX_NAME + "-000001";
+        LOG.info("ESBasedAuditRepo - createAuditIndex! Creating '{}' with aliases ['{}', '{}']",
+                 concreteIndexName, INDEX_NAME, WRITE_ALIAS);
+
         String esMappingsString = getAuditIndexMappings();
-        HttpEntity entity = new NStringEntity(esMappingsString, ContentType.APPLICATION_JSON);
-        Request request = new Request("PUT", INDEX_NAME);
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root = mapper.readTree(esMappingsString);
+        ObjectNode rootObj = (ObjectNode) root;
+
+        ObjectNode aliases = mapper.createObjectNode();
+        aliases.set(INDEX_NAME, mapper.createObjectNode());
+        ObjectNode writeAliasNode = mapper.createObjectNode();
+        writeAliasNode.put("is_write_index", true);
+        aliases.set(WRITE_ALIAS, writeAliasNode);
+        rootObj.set("aliases", aliases);
+
+        HttpEntity entity = new NStringEntity(rootObj.toString(), ContentType.APPLICATION_JSON);
+        Request request = new Request("PUT", concreteIndexName);
         request.setEntity(entity);
-        Response response = lowLevelClient.performRequest(request);
-        return isSuccess(response);
+
+        try {
+            Response response = lowLevelClient.performRequest(request);
+            return isSuccess(response);
+        } catch (ResponseException e) {
+            int status = e.getResponse().getStatusLine().getStatusCode();
+            if (status == 400) {
+                LOG.info("Index '{}' already exists (likely created by another pod concurrently), proceeding",
+                         concreteIndexName);
+                return checkIfIndexExists();
+            }
+            throw e;
+        }
     }
 
     private boolean shouldUpdateFieldLimitSetting() {
@@ -808,9 +892,18 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
         Request request = new Request("GET", INDEX_NAME + "/_settings");
         Response response = lowLevelClient.performRequest(request);
         ObjectMapper objectMapper = new ObjectMapper();
-        String fieldPath = String.format("/%s/settings/index/mapping/total_fields/limit", INDEX_NAME);
+        JsonNode root = objectMapper.readTree(copyToString(response.getEntity().getContent(), Charset.defaultCharset()));
 
-        return objectMapper.readTree(copyToString(response.getEntity().getContent(), Charset.defaultCharset())).at(fieldPath);
+        // Iterate over concrete index names — works for both alias and direct index.
+        // When INDEX_NAME is an alias, response keys are concrete names (e.g. entity_audits-000001).
+        for (Iterator<String> it = root.fieldNames(); it.hasNext(); ) {
+            String indexName = it.next();
+            JsonNode limit = root.at("/" + indexName + "/settings/index/mapping/total_fields/limit");
+            if (!limit.isMissingNode()) {
+                return limit;
+            }
+        }
+        return null;
     }
 
     private void updateFieldLimit() {
@@ -844,8 +937,16 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
      * Uses a marker document to ensure the migration runs exactly once across all pods and deployments.
      * On every startup, each pod does a single cheap HEAD request to check for the marker.
      * Requires a brief close/open cycle (~2-3 seconds of audit write unavailability) on first run only.
+     *
+     * SKIPPED in alias mode: fresh/rollover indices inherit niofs from es-audit-mappings.json settings.
+     * Running _close on an alias would close ALL backing indices — catastrophic for multi-index setups.
      */
     private void ensureStoreTypeNiofs() {
+        if (writeConfig.aliasMode()) {
+            LOG.info("Skipping niofs store type migration in alias mode (fresh/rollover indices inherit niofs from template)");
+            return;
+        }
+
         try {
             // Fast path: check if migration was already completed (cheap HEAD request)
             if (isNiofsMigrationDone()) {
@@ -856,7 +957,17 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
             Request getSettings = new Request("GET", INDEX_NAME + "/_settings");
             Response settingsResponse = lowLevelClient.performRequest(getSettings);
             String responseBody = copyToString(settingsResponse.getEntity().getContent(), defaultCharset());
-            JsonNode storeType = new ObjectMapper().readTree(responseBody).at("/" + INDEX_NAME + "/settings/index/store/type");
+
+            // Iterate response keys for defense-in-depth (works even if INDEX_NAME is an alias)
+            JsonNode root = new ObjectMapper().readTree(responseBody);
+            JsonNode storeType = null;
+            for (Iterator<String> it = root.fieldNames(); it.hasNext(); ) {
+                JsonNode candidate = root.at("/" + it.next() + "/settings/index/store/type");
+                if (candidate != null && !candidate.isMissingNode()) {
+                    storeType = candidate;
+                    break;
+                }
+            }
 
             if (storeType != null && "niofs".equals(storeType.asText())) {
                 // Already niofs (e.g. set manually) — just write the marker so we skip next time
@@ -918,11 +1029,14 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
 
     private void writeNiofsMigrationMarker() {
         try {
-            Request request = new Request("PUT", INDEX_NAME + "/_doc/" + NIOFS_MIGRATION_MARKER_ID);
+            // Use writeConfig.writeIndex() so the marker doc goes through the writable target
+            // (defense-in-depth: in alias mode the ensureStoreTypeNiofs guard skips before reaching here)
+            String target = writeConfig.writeIndex();
+            Request request = new Request("PUT", target + "/_doc/" + NIOFS_MIGRATION_MARKER_ID);
             String body = "{\"migration\":\"niofs\",\"timestamp\":" + System.currentTimeMillis() + "}";
             request.setEntity(new NStringEntity(body, ContentType.APPLICATION_JSON));
             lowLevelClient.performRequest(request);
-            LOG.info("entity_audits niofs migration marker written");
+            LOG.info("entity_audits niofs migration marker written via '{}'", target);
         } catch (Exception e) {
             LOG.warn("Failed to write niofs migration marker, migration will re-check on next startup", e);
         }
@@ -1013,6 +1127,16 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
             LOG.error("ESBasedAuditRepo - error while closing es lowlevel client", e);
             throw new AtlasException(e);
         }
+    }
+
+    /** Returns the resolved write target (alias name or direct index name). */
+    public String getWriteIndex() {
+        return writeConfig.writeIndex();
+    }
+
+    /** Returns true if the write alias was detected and writes go through it. */
+    public boolean isAliasMode() {
+        return writeConfig.aliasMode();
     }
 
     private void setLowLevelClient() throws AtlasException {


### PR DESCRIPTION
## Summary

Replace the hardcoded `entity_audits` ES index name in `ESBasedAuditRepository` with alias-aware write path, enabling ILM rollover for entity audit indices across ~500 tenants. This is the **critical path** for the [entity_audits ILM + Alias Migration](https://linear.app/atlan-epd/project/entity-audits-ilm-alias-migration-8d5409e36b39/overview) project — all other tasks (MS-759 through MS-766) depend on this being deployed first.

**Key design decisions:**
- **Auto-detection over config flags**: Probes ES at startup for `entity_audits_write` alias; falls back to direct index mode if not found. ES is the source of truth — no config drift risk.
- **Atomic config swap**: Immutable `WriteConfig` record with single volatile reference prevents torn reads across request threads.
- **Zero-downtime deploy**: All existing tenants continue working in direct index mode until migration workflow (MS-766) creates aliases and pods restart.

## Changes

- **Write path**: `putEventsV2Internal()` snapshots `WriteConfig` once per call, uses `writeIndex` (alias or direct) for both bulk metadata and endpoint
- **Fresh tenants**: `createAuditIndex()` now creates `entity_audits-000001` with read alias (`entity_audits`) + write alias (`entity_audits_write`), ILM-ready from day one
- **Alias detection**: New `detectAndConfigureWriteAlias()` method in `createSession()` — single cheap `HEAD /_alias/entity_audits_write` probe
- **Settings path fix**: `getIndexFieldLimit()` iterates response keys instead of hardcoded `INDEX_NAME` JSON path (breaks when `INDEX_NAME` is an alias — ES returns concrete index names)
- **niofs guard**: `ensureStoreTypeNiofs()` skips entirely in alias mode — prevents catastrophic `_close` on ALL backing indices behind the alias
- **Defense-in-depth**: niofs marker write uses `writeConfig.writeIndex()`, niofs settings parsing iterates response keys
- **Concurrent pod race**: `createAuditIndex()` catches 400 `resource_already_exists_exception` for multi-pod fresh tenant startup
- **Observability**: `getWriteIndex()`/`isAliasMode()` public accessors + structured startup log for fleet-wide verification

## Backward Compatibility

| Scenario | Behavior |
|----------|----------|
| Existing tenant, no aliases | Direct index mode (identical to current behavior) |
| Existing tenant, after MS-766 migration + restart | Alias mode (writes through `entity_audits_write`) |
| Fresh tenant (new deployment) | Creates `entity_audits-000001` with both aliases |
| External repos reading `entity_audits` | Works unchanged (concrete index or read alias) |

## Rollout Sequence

1. **Deploy this PR** — zero impact, all tenants auto-detect no alias and fall back
2. **MS-766** (migration workflow) — adds `entity_audits_write` alias to existing concrete index per cluster
3. **Rolling restart** — pods detect write alias, switch to alias mode
4. **MS-759** (ILM policy) — can now be attached, rollover works transparently

## Edge Cases Handled

- `WriteConfig` initialized with safe defaults before `createSession()` (prevents NPE during Spring bootstrap)
- `ensureStoreTypeNiofs()` guarded in alias mode (prevents `_close` on all rollover indices)
- `getIndexFieldLimit()` works with alias (iterates concrete index names from response)
- Concurrent fresh-tenant pod creation (catches 400, re-verifies)
- Non-atomic volatile reads (single immutable record swap)

## Test plan

- [x] Build succeeds: `mvn compile -pl repository -am -DskipTests -Drat.skip=true`
- [ ] Existing unit tests pass (no behavioral change in direct mode)
- [ ] Manual verification on staging: deploy, confirm `aliasMode=false` in startup logs
- [ ] After alias creation: confirm `aliasMode=true` in startup logs, audit writes succeed

Fixes: [MS-758](https://linear.app/atlan-epd/issue/MS-758)

Made with [Cursor](https://cursor.com)