### PR TITLE
SHA-784 | feat: add /identity/* Redis API client for fast by-ID IAM lookups

### DIFF
--- a/client-auth/src/main/java/org/apache/atlas/auth/client/heracles/AtlasHeraclesClient.java
+++ b/client-auth/src/main/java/org/apache/atlas/auth/client/heracles/AtlasHeraclesClient.java
@@ -4,6 +4,9 @@ import org.apache.atlas.auth.client.config.AuthConfig;
 import org.apache.atlas.auth.client.heracles.models.HeraclesGroupViewRepresentation;
 import org.apache.atlas.auth.client.heracles.models.HeraclesRoleViewRepresentation;
 import org.apache.atlas.auth.client.heracles.models.HeraclesUserViewRepresentation;
+import org.apache.atlas.auth.client.heracles.models.IdentityGroupRepresentation;
+import org.apache.atlas.auth.client.heracles.models.IdentityRoleRepresentation;
+import org.apache.atlas.auth.client.heracles.models.IdentityUserRepresentation;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.slf4j.Logger;
@@ -70,5 +73,46 @@ public class AtlasHeraclesClient {
         var response = HERACLES.getGroupsV2(start, size, new String[]{HeraclesGroupViewRepresentation.sortBy}, columns, null, null, null);
         var body = response.body();
         return body != null ? body.getRecords() : null;
+    }
+
+    // --- Identity API (Redis-backed) ---
+
+    public IdentityRoleRepresentation getIdentityRoleById(String roleId, String... columns) throws AtlasBaseException {
+        String filter = String.format("{\"id\":{\"$eq\":\"%s\"}}", roleId);
+        List<IdentityRoleRepresentation> results = HERACLES.getIdentityRoles(filter, columns);
+        return (results != null && !results.isEmpty()) ? results.get(0) : null;
+    }
+
+    public IdentityUserRepresentation getIdentityUserById(String userId, String... columns) throws AtlasBaseException {
+        String filter = String.format("{\"id\":{\"$eq\":\"%s\"}}", userId);
+        List<IdentityUserRepresentation> results = HERACLES.getIdentityUsers(filter, columns);
+        return (results != null && !results.isEmpty()) ? results.get(0) : null;
+    }
+
+    public IdentityGroupRepresentation getIdentityGroupById(String groupId, String... columns) throws AtlasBaseException {
+        String filter = String.format("{\"id\":{\"$eq\":\"%s\"}}", groupId);
+        List<IdentityGroupRepresentation> results = HERACLES.getIdentityGroups(filter, columns);
+        return (results != null && !results.isEmpty()) ? results.get(0) : null;
+    }
+
+    public List<IdentityUserRepresentation> getIdentityUsersByIds(List<String> userIds, String... columns) throws AtlasBaseException {
+        String ids = userIds.stream().map(id -> "\"" + id + "\"").collect(Collectors.joining(","));
+        String filter = String.format("{\"id\":{\"$in\":[%s]}}", ids);
+        return HERACLES.getIdentityUsers(filter, columns);
+    }
+
+    public List<IdentityRoleRepresentation> getIdentityRolesByIds(List<String> roleIds, String... columns) throws AtlasBaseException {
+        String ids = roleIds.stream().map(id -> "\"" + id + "\"").collect(Collectors.joining(","));
+        String filter = String.format("{\"id\":{\"$in\":[%s]}}", ids);
+        return HERACLES.getIdentityRoles(filter, columns);
+    }
+
+    public List<IdentityGroupRepresentation> getIdentityGroupsForUser(String userId) throws AtlasBaseException {
+        String filter = String.format("{\"id\":{\"$eq\":\"%s\"}}", userId);
+        List<IdentityUserRepresentation> results = HERACLES.getIdentityUsers(filter, "groups");
+        if (results != null && !results.isEmpty() && results.get(0).getGroups() != null) {
+            return results.get(0).getGroups();
+        }
+        return List.of();
     }
 }

--- a/client-auth/src/main/java/org/apache/atlas/auth/client/heracles/HeraclesRestClient.java
+++ b/client-auth/src/main/java/org/apache/atlas/auth/client/heracles/HeraclesRestClient.java
@@ -6,6 +6,9 @@ import org.apache.atlas.auth.client.heracles.models.HeraclesGroupViewRepresentat
 import org.apache.atlas.auth.client.heracles.models.HeraclesGroupsResponse;
 import org.apache.atlas.auth.client.heracles.models.HeraclesRoleViewRepresentation;
 import org.apache.atlas.auth.client.heracles.models.HeraclesUserViewRepresentation;
+import org.apache.atlas.auth.client.heracles.models.IdentityGroupRepresentation;
+import org.apache.atlas.auth.client.heracles.models.IdentityRoleRepresentation;
+import org.apache.atlas.auth.client.heracles.models.IdentityUserRepresentation;
 import org.apache.atlas.exception.AtlasBaseException;
 import retrofit2.Response;
 
@@ -39,5 +42,17 @@ public class HeraclesRestClient extends AbstractAuthClient {
      */
     public Response<HeraclesGroupsResponse> getGroupsV2(int offset, int limit, String[] sort, String[] columns, String filter, Boolean count, String[] relations) throws AtlasBaseException {
         return processResponse(this.retrofitHeraclesClient.getGroupsV2(offset, limit, sort, columns, filter, count, relations));
+    }
+
+    public List<IdentityUserRepresentation> getIdentityUsers(String filter, String... columns) throws AtlasBaseException {
+        return processResponse(this.retrofitHeraclesClient.getIdentityUsers(filter, columns)).body();
+    }
+
+    public List<IdentityRoleRepresentation> getIdentityRoles(String filter, String... columns) throws AtlasBaseException {
+        return processResponse(this.retrofitHeraclesClient.getIdentityRoles(filter, columns)).body();
+    }
+
+    public List<IdentityGroupRepresentation> getIdentityGroups(String filter, String... columns) throws AtlasBaseException {
+        return processResponse(this.retrofitHeraclesClient.getIdentityGroups(filter, columns)).body();
     }
 }

--- a/client-auth/src/main/java/org/apache/atlas/auth/client/heracles/RetrofitHeraclesClient.java
+++ b/client-auth/src/main/java/org/apache/atlas/auth/client/heracles/RetrofitHeraclesClient.java
@@ -4,6 +4,9 @@ import org.apache.atlas.auth.client.heracles.models.HeraclesGroupViewRepresentat
 import org.apache.atlas.auth.client.heracles.models.HeraclesGroupsResponse;
 import org.apache.atlas.auth.client.heracles.models.HeraclesRoleViewRepresentation;
 import org.apache.atlas.auth.client.heracles.models.HeraclesUserViewRepresentation;
+import org.apache.atlas.auth.client.heracles.models.IdentityGroupRepresentation;
+import org.apache.atlas.auth.client.heracles.models.IdentityRoleRepresentation;
+import org.apache.atlas.auth.client.heracles.models.IdentityUserRepresentation;
 import retrofit2.Call;
 import retrofit2.http.GET;
 import retrofit2.http.Headers;
@@ -44,4 +47,16 @@ public interface RetrofitHeraclesClient {
                                              @Query("filter") String filter,
                                              @Query("count") Boolean count,
                                              @Query("relations") String[] relations);
+
+    @Headers({"Accept: application/json,text/plain", "Cache-Control: no-store", "Cache-Control: no-cache"})
+    @GET("/identity/users")
+    Call<List<IdentityUserRepresentation>> getIdentityUsers(@Query("filter") String filter, @Query("columns") String... columns);
+
+    @Headers({"Accept: application/json,text/plain", "Cache-Control: no-store", "Cache-Control: no-cache"})
+    @GET("/identity/roles")
+    Call<List<IdentityRoleRepresentation>> getIdentityRoles(@Query("filter") String filter, @Query("columns") String... columns);
+
+    @Headers({"Accept: application/json,text/plain", "Cache-Control: no-store", "Cache-Control: no-cache"})
+    @GET("/identity/groups")
+    Call<List<IdentityGroupRepresentation>> getIdentityGroups(@Query("filter") String filter, @Query("columns") String... columns);
 }

--- a/client-auth/src/main/java/org/apache/atlas/auth/client/heracles/models/IdentityGroupRepresentation.java
+++ b/client-auth/src/main/java/org/apache/atlas/auth/client/heracles/models/IdentityGroupRepresentation.java
@@ -1,0 +1,36 @@
+package org.apache.atlas.auth.client.heracles.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+import java.util.Map;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class IdentityGroupRepresentation {
+    protected String id;
+    protected String name;
+    protected String parentGroup;
+    protected String realmId;
+    protected List<IdentityRoleRepresentation> roles;
+    protected Map<String, String> attributes;
+
+    public IdentityGroupRepresentation() {}
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getParentGroup() { return parentGroup; }
+    public void setParentGroup(String parentGroup) { this.parentGroup = parentGroup; }
+
+    public String getRealmId() { return realmId; }
+    public void setRealmId(String realmId) { this.realmId = realmId; }
+
+    public List<IdentityRoleRepresentation> getRoles() { return roles; }
+    public void setRoles(List<IdentityRoleRepresentation> roles) { this.roles = roles; }
+
+    public Map<String, String> getAttributes() { return attributes; }
+    public void setAttributes(Map<String, String> attributes) { this.attributes = attributes; }
+}

--- a/client-auth/src/main/java/org/apache/atlas/auth/client/heracles/models/IdentityRoleRepresentation.java
+++ b/client-auth/src/main/java/org/apache/atlas/auth/client/heracles/models/IdentityRoleRepresentation.java
@@ -1,0 +1,39 @@
+package org.apache.atlas.auth.client.heracles.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.keycloak.representations.idm.RoleRepresentation;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class IdentityRoleRepresentation {
+    protected String id;
+    protected String name;
+    protected String description;
+    protected String realmId;
+    protected boolean clientRole;
+
+    public IdentityRoleRepresentation() {}
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public String getRealmId() { return realmId; }
+    public void setRealmId(String realmId) { this.realmId = realmId; }
+
+    public boolean isClientRole() { return clientRole; }
+    public void setClientRole(boolean clientRole) { this.clientRole = clientRole; }
+
+    public RoleRepresentation toKeycloakRole() {
+        RoleRepresentation role = new RoleRepresentation();
+        role.setId(this.id);
+        role.setName(this.name);
+        role.setDescription(this.description);
+        role.setClientRole(this.clientRole);
+        return role;
+    }
+}

--- a/client-auth/src/main/java/org/apache/atlas/auth/client/heracles/models/IdentityUserRepresentation.java
+++ b/client-auth/src/main/java/org/apache/atlas/auth/client/heracles/models/IdentityUserRepresentation.java
@@ -1,0 +1,60 @@
+package org.apache.atlas.auth.client.heracles.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+import java.util.Map;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class IdentityUserRepresentation {
+    protected String id;
+    protected String username;
+    protected String email;
+    protected String firstName;
+    protected String lastName;
+    protected String status;
+    protected String realmId;
+    protected boolean enabled;
+    protected long createdTimestamp;
+    protected List<IdentityRoleRepresentation> roles;
+    protected List<IdentityGroupRepresentation> groups;
+    protected Map<String, String> attributes;
+
+    public IdentityUserRepresentation() {}
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+
+    public String getFirstName() { return firstName; }
+    public void setFirstName(String firstName) { this.firstName = firstName; }
+
+    public String getLastName() { return lastName; }
+    public void setLastName(String lastName) { this.lastName = lastName; }
+
+    public String getStatus() { return status; }
+    public void setStatus(String status) { this.status = status; }
+
+    public String getRealmId() { return realmId; }
+    public void setRealmId(String realmId) { this.realmId = realmId; }
+
+    public boolean isEnabled() { return enabled; }
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+
+    public long getCreatedTimestamp() { return createdTimestamp; }
+    public void setCreatedTimestamp(long createdTimestamp) { this.createdTimestamp = createdTimestamp; }
+
+    public List<IdentityRoleRepresentation> getRoles() { return roles; }
+    public void setRoles(List<IdentityRoleRepresentation> roles) { this.roles = roles; }
+
+    public List<IdentityGroupRepresentation> getGroups() { return groups; }
+    public void setGroups(List<IdentityGroupRepresentation> groups) { this.groups = groups; }
+
+    public Map<String, String> getAttributes() { return attributes; }
+    public void setAttributes(Map<String, String> attributes) { this.attributes = attributes; }
+}

--- a/repository/src/main/java/org/apache/atlas/repository/store/users/KeycloakStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/users/KeycloakStore.java
@@ -35,6 +35,9 @@ import java.util.stream.Collectors;
 import static org.apache.atlas.AtlasErrorCode.RESOURCE_NOT_FOUND;
 import static org.apache.atlas.auth.client.keycloak.AtlasKeycloakClient.getKeycloakClient;
 
+import org.apache.atlas.auth.client.heracles.AtlasHeraclesClient;
+import org.apache.atlas.auth.client.heracles.models.IdentityRoleRepresentation;
+
 public class KeycloakStore {
     private static final Logger LOG = LoggerFactory.getLogger(KeycloakStore.class);
 
@@ -383,12 +386,22 @@ public class KeycloakStore {
     }
 
     private RoleRepresentation getRoleById(String roleId) throws AtlasBaseException {
+        // Try Redis-backed identity API first (fast path)
+        try {
+            IdentityRoleRepresentation identity = AtlasHeraclesClient.getHeraclesClient()
+                    .getIdentityRoleById(roleId, "clientRole", "description");
+            if (identity != null) {
+                return identity.toKeycloakRole();
+            }
+        } catch (Exception e) {
+            LOG.warn("Identity API lookup failed for role {}, falling back to Keycloak: {}", roleId, e.getMessage());
+        }
 
+        // Fallback to Keycloak
         try {
             return getKeycloakClient().getRoleById(roleId);
         } catch (Exception e) {
-            if(e instanceof AtlasBaseException && Objects.equals(RESOURCE_NOT_FOUND.getErrorCode(), ((AtlasBaseException) e).getAtlasErrorCode().getErrorCode()))
-            {
+            if (e instanceof AtlasBaseException && Objects.equals(RESOURCE_NOT_FOUND.getErrorCode(), ((AtlasBaseException) e).getAtlasErrorCode().getErrorCode())) {
                 LOG.error("Role not found with id {}", roleId);
                 throw new AtlasBaseException(RESOURCE_NOT_FOUND, "Role with id " + roleId);
             }


### PR DESCRIPTION
## Summary
Adds client layer for the new heracles `GET /identity/users`, `/identity/roles`, `/identity/groups` Redis-backed endpoints. These serve IAM data from Redis (CDC-synced from Keycloak) with ~1-5ms latency vs ~50-100ms for direct Keycloak API calls.

**Replaces:** `KeycloakStore.getRoleById()` now tries Redis first, falls back to Keycloak.

## Changes

### New model classes
- `IdentityUserRepresentation` — flat response: id, username, email, enabled, status, firstName, lastName, roles, groups, attributes
- `IdentityRoleRepresentation` — id, name, clientRole, description, realmId + `toKeycloakRole()` converter
- `IdentityGroupRepresentation` — id, name, parentGroup, roles, attributes

### Client layer
- `RetrofitHeraclesClient` — 3 new `@GET` endpoints for `/identity/users`, `/identity/roles`, `/identity/groups`
- `HeraclesRestClient` — wrapper methods with `processResponse()`
- `AtlasHeraclesClient` — convenience methods:
  - `getIdentityRoleById(roleId, columns...)` — single role by UUID
  - `getIdentityUserById(userId, columns...)` — single user by UUID
  - `getIdentityGroupById(groupId, columns...)` — single group by UUID
  - `getIdentityUsersByIds(userIds, columns...)` — bulk users by UUIDs
  - `getIdentityRolesByIds(roleIds, columns...)` — bulk roles by UUIDs
  - `getIdentityGroupsForUser(userId)` — user's groups via identity API

### Caller replacement
- `KeycloakStore.getRoleById()` — tries identity API first (Redis), falls back to Keycloak on failure
- Called during: persona create/update, connection create/update (per-request)

## What's NOT changed
- Polling loop (`KeycloakUserStore`) — fetches ALL entities paginated, identity API is for targeted lookups
- `searchUserByUserName` / `searchGroupByName` — requires name-based search (identity API needs UUID)
- Write operations — stay on Keycloak (createRole, updateRole, deleteRole, etc.)

## Depends on
- heracles PR [#5518](https://github.com/atlanhq/heracles/pull/5518) — the `GET /identity/*` endpoints
- heracles PR [#5538](https://github.com/atlanhq/heracles/pull/5538) — go-common/rql package update (staging)

## Test plan
- [ ] CI build passes
- [ ] Persona create/update still works (getRoleById now uses Redis → Keycloak fallback)
- [ ] Connection create/update still works
- [ ] Check heracles logs for `/identity/roles` calls during persona/connection operations