### PR TITLE
fix: /attribute/update type coercion for CassandraGraph (MS-897)

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -7097,22 +7097,41 @@ public class EntityGraphMapper {
      * and ES (e.g., "42.5" instead of 42.5).
      */
     private Object coerceAttributeValue(String entityTypeName, String attributeName, String value) {
-        AtlasEntityType entityType = typeRegistry.getEntityTypeByName(entityTypeName);
-        if (entityType != null) {
-            AtlasStructType.AtlasAttribute attribute = entityType.getAttribute(attributeName);
-            if (attribute != null) {
-                String typeName = attribute.getAttributeDef().getTypeName();
-                switch (typeName) {
-                    case "float":   return Float.parseFloat(value);
-                    case "double":  return Double.parseDouble(value);
-                    case "int":     return Integer.parseInt(value);
-                    case "long":    return Long.parseLong(value);
-                    case "boolean": return Boolean.parseBoolean(value);
-                    default:        return value;
-                }
-            }
+        if (value == null) {
+            return null;
         }
-        return value;
+
+        AtlasEntityType entityType = typeRegistry.getEntityTypeByName(entityTypeName);
+        if (entityType == null) {
+            return value;
+        }
+
+        AtlasStructType.AtlasAttribute attribute = entityType.getAttribute(attributeName);
+        if (attribute == null) {
+            return value;
+        }
+
+        String typeName = attribute.getAttributeDef().getTypeName();
+        if (typeName == null) {
+            return value;
+        }
+
+        try {
+            switch (typeName) {
+                case "float":   return Float.parseFloat(value);
+                case "double":  return Double.parseDouble(value);
+                case "int":     return Integer.parseInt(value);
+                case "long":    return Long.parseLong(value);
+                case "boolean": return Boolean.parseBoolean(value);
+                case "short":   return Short.parseShort(value);
+                case "byte":    return Byte.parseByte(value);
+                default:        return value;
+            }
+        } catch (NumberFormatException e) {
+            LOG.warn("Failed to coerce attribute {}.{} value '{}' to type {}, storing as string",
+                     entityTypeName, attributeName, value, typeName);
+            return value;
+        }
     }
 
     private void cacheDifferentialEntityAttributeUpdate(AtlasVertex ev, String property, String value) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -7081,10 +7081,38 @@ public class EntityGraphMapper {
             LOG.warn("Asset with GUID {} not found", assetGuid);
             return null;
         }
-        vertex.setProperty(assetAttributeInfo.getAttributeName(), assetAttributeInfo.getValue());
+        String vertexTypeName = AtlasGraphUtilsV2.getTypeName(vertex);
+        Object typedValue = coerceAttributeValue(vertexTypeName, assetAttributeInfo.getAttributeName(), assetAttributeInfo.getValue());
+        vertex.setProperty(assetAttributeInfo.getAttributeName(), typedValue);
         updateModificationMetadata(vertex);
         cacheDifferentialEntityAttributeUpdate(vertex, assetAttributeInfo.getAttributeName(), assetAttributeInfo.getValue());
         return vertex;
+    }
+
+    /**
+     * Coerce a string value to the correct Java type for the attribute.
+     * JanusGraph does this implicitly via its schema-aware property keys;
+     * CassandraGraph stores properties as-is, so passing a String where a
+     * float is expected causes the wrong type to be persisted in Cassandra
+     * and ES (e.g., "42.5" instead of 42.5).
+     */
+    private Object coerceAttributeValue(String entityTypeName, String attributeName, String value) {
+        AtlasEntityType entityType = typeRegistry.getEntityTypeByName(entityTypeName);
+        if (entityType != null) {
+            AtlasStructType.AtlasAttribute attribute = entityType.getAttribute(attributeName);
+            if (attribute != null) {
+                String typeName = attribute.getAttributeDef().getTypeName();
+                switch (typeName) {
+                    case "float":   return Float.parseFloat(value);
+                    case "double":  return Double.parseDouble(value);
+                    case "int":     return Integer.parseInt(value);
+                    case "long":    return Long.parseLong(value);
+                    case "boolean": return Boolean.parseBoolean(value);
+                    default:        return value;
+                }
+            }
+        }
+        return value;
     }
 
     private void cacheDifferentialEntityAttributeUpdate(AtlasVertex ev, String property, String value) {


### PR DESCRIPTION
## Summary
- **Root cause**: `/attribute/update` endpoint passes string values to `vertex.setProperty()`. JanusGraph coerces types via schema-aware property keys, but CassandraGraph stores properties as-is. Float attributes like `assetInternalPopularityScore` get persisted as strings (`"42.5"` instead of `42.5`) in both Cassandra and ES.
- **Impact**: ES range/sort queries break on string values. Typed `getProperty(name, Float.class)` returns stale data, making updates appear to not persist. Confirmed on duair15p01 — after update, ES shows `"assetInternalPopularityScore":"42.5"` (string) instead of `42.5` (float).
- **Fix**: Look up the attribute's typedef type and parse the string to the correct Java type before calling `setProperty()`. Safe for both backends.

## Test plan
- [x] Confirmed on duair15p01: before fix, `/attribute/update` writes string `"42.5"` to ES instead of float `42.5`
- [ ] Deploy fix, call `/attribute/update`, verify ES stores `42.5` (number) not `"42.5"` (string)
- [ ] Verify `getProperty("assetInternalPopularityScore", Float.class)` returns updated value
- [ ] Verify JanusGraph mode is unaffected (type coercion is a no-op when types already match)

Closes MS-897

🤖 Generated with [Claude Code](https://claude.com/claude-code)