### PR TITLE
fix: ensure janusgraph_vertex_index has atlan_normalizer before field mapping registration

### DIFF
--- a/graphdb/api/src/main/java/org/apache/atlas/repository/graphdb/AtlasGraphIndexClient.java
+++ b/graphdb/api/src/main/java/org/apache/atlas/repository/graphdb/AtlasGraphIndexClient.java
@@ -60,4 +60,30 @@ public interface AtlasGraphIndexClient {
      * @return returns true if index client is active
      */
     boolean isHealthy();
+
+    /**
+     * Ensures the JanusGraph vertex index has the required Atlan analysis settings
+     * (normalizers, analyzers) before field mappings that reference them are registered.
+     *
+     * <p>JanusGraph creates {@code janusgraph_vertex_index} with empty settings. Atlan fields
+     * like {@code ENTITY_TYPE_PROPERTY_KEY} and {@code SUPER_TYPES_PROPERTY_KEY} use
+     * {@code atlan_normalizer} on their keyword sub-fields. If the normalizer is not defined
+     * on the index at registration time, Elasticsearch rejects the PUT mapping with HTTP 400,
+     * causing the Spring context to fail and Atlas to crash-loop.
+     *
+     * <p>Behaviour:
+     * <ul>
+     *   <li>Index has correct settings → no-op, returns {@code true}.</li>
+     *   <li>Index exists without settings AND has 0 documents → deletes and recreates with
+     *       correct settings, returns {@code true}.</li>
+     *   <li>Index exists without settings AND has documents → logs a critical error and returns
+     *       {@code false} (cannot safely change analysis settings on a populated index without
+     *       a full reindex).</li>
+     *   <li>Index does not exist → creates it with correct settings so that JanusGraph inherits
+     *       them when it registers the index in its own schema, returns {@code true}.</li>
+     * </ul>
+     *
+     * @return {@code true} if the index has (or was brought to have) the correct settings.
+     */
+    boolean ensureVertexIndexSettings();
 }

--- a/graphdb/cassandra/src/main/java/org/apache/atlas/repository/graphdb/cassandra/CassandraGraphIndexClient.java
+++ b/graphdb/cassandra/src/main/java/org/apache/atlas/repository/graphdb/cassandra/CassandraGraphIndexClient.java
@@ -3,6 +3,7 @@ package org.apache.atlas.repository.graphdb.cassandra;
 import org.apache.atlas.model.discovery.AtlasAggregationEntry;
 import org.apache.atlas.repository.graphdb.AggregationContext;
 import org.apache.atlas.repository.graphdb.AtlasGraphIndexClient;
+import org.apache.atlas.repository.graphdb.elasticsearch.AtlasElasticsearchIndexClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,5 +56,10 @@ public class CassandraGraphIndexClient implements AtlasGraphIndexClient {
             LOG.warn("ES health check failed: {}", e.getMessage());
             return false;
         }
+    }
+
+    @Override
+    public boolean ensureVertexIndexSettings() {
+        return new AtlasElasticsearchIndexClient(null).ensureVertexIndexSettings();
     }
 }

--- a/graphdb/cassandra/src/main/java/org/apache/atlas/repository/graphdb/elasticsearch/AtlasElasticsearchIndexClient.java
+++ b/graphdb/cassandra/src/main/java/org/apache/atlas/repository/graphdb/elasticsearch/AtlasElasticsearchIndexClient.java
@@ -26,15 +26,26 @@ import org.apache.commons.configuration.Configuration;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
+import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.core.CountRequest;
+import org.elasticsearch.client.core.CountResponse;
+import org.elasticsearch.client.indices.CreateIndexRequest;
+import org.elasticsearch.client.indices.GetIndexRequest;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.RestStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -89,6 +100,189 @@ public class AtlasElasticsearchIndexClient implements AtlasGraphIndexClient {
     @Override
     public List<String> getSuggestions(String prefixString, String indexFieldName) {
         return Collections.EMPTY_LIST;
+    }
+
+    /**
+     * Ensures janusgraph_vertex_index exists in ES with the Atlan analysis settings
+     * (atlan_normalizer and associated analyzers) that field mappings depend on.
+     *
+     * JanusGraph creates the index with empty settings via its management API. Atlan's
+     * GraphBackedSearchIndexer then registers field mappings that reference atlan_normalizer.
+     * Without this method, any startup after an index deletion causes a HTTP 400 from ES
+     * ("normalizer not found"), crashing the Spring context in a permanent restart loop.
+     */
+    @Override
+    public boolean ensureVertexIndexSettings() {
+        RestHighLevelClient client = AtlasElasticsearchDatabase.getClient();
+        String indexName = VERTEX_INDEX;
+
+        try {
+            boolean indexExists = client.indices().exists(new GetIndexRequest(indexName), RequestOptions.DEFAULT);
+
+            if (indexExists) {
+                GetSettingsResponse settingsResponse = client.indices()
+                        .getSettings(new GetSettingsRequest().indices(indexName), RequestOptions.DEFAULT);
+                Settings idxSettings = settingsResponse.getIndexToSettings().get(indexName);
+
+                boolean hasNormalizer = idxSettings != null
+                        && idxSettings.get("index.analysis.normalizer.atlan_normalizer.type") != null;
+
+                if (hasNormalizer) {
+                    LOG.info("ensureVertexIndexSettings: {} has correct analysis settings.", indexName);
+                    return true;
+                }
+
+                // Normalizer missing — check whether it is safe to recreate
+                CountResponse countResponse = client.count(new CountRequest(indexName), RequestOptions.DEFAULT);
+                long docCount = countResponse.getCount();
+
+                if (docCount > 0) {
+                    LOG.error("ensureVertexIndexSettings: {} is missing atlan_normalizer but has {} documents. "
+                            + "Atlas will fail to register field mappings. Manual intervention required: "
+                            + "close the index, apply analysis settings, then reopen.", indexName, docCount);
+                    return false;
+                }
+
+                LOG.warn("ensureVertexIndexSettings: {} is missing atlan_normalizer with 0 documents — "
+                        + "deleting and recreating with correct settings.", indexName);
+                AcknowledgedResponse deleteResponse = client.indices()
+                        .delete(new DeleteIndexRequest(indexName), RequestOptions.DEFAULT);
+                if (!deleteResponse.isAcknowledged()) {
+                    LOG.error("ensureVertexIndexSettings: failed to delete {} for recreation.", indexName);
+                    return false;
+                }
+            }
+
+            // Index does not exist (or was just deleted) — create with correct settings.
+            // JanusGraph will attempt its own createVertexMixedIndex call and ES will respond
+            // with resource_already_exists_exception, which JanusGraph handles gracefully.
+            CreateIndexRequest createRequest = new CreateIndexRequest(indexName);
+            createRequest.settings(buildVertexIndexSettings());
+            client.indices().create(createRequest, RequestOptions.DEFAULT);
+            LOG.info("ensureVertexIndexSettings: created {} with correct analysis settings.", indexName);
+            return true;
+
+        } catch (Exception e) {
+            LOG.error("ensureVertexIndexSettings: failed for {}: {}", indexName, e.getMessage(), e);
+            return false;
+        }
+    }
+
+    /**
+     * Builds the ES index settings required by Atlan's janusgraph_vertex_index.
+     * Mirrors addons/elasticsearch/es-settings.json — the two must be kept in sync.
+     * The critical entry is atlan_normalizer, referenced by KEYWORD_MULTIFIELD in
+     * GraphBackedSearchIndexer for fields like ENTITY_TYPE_PROPERTY_KEY and SUPER_TYPES_PROPERTY_KEY.
+     */
+    private Map<String, Object> buildVertexIndexSettings() {
+        // --- normalizer ---
+        Map<String, Object> atlNormalizer = new HashMap<>();
+        atlNormalizer.put("type", "custom");
+        atlNormalizer.put("filter", Arrays.asList("lowercase"));
+
+        Map<String, Object> normalizers = new HashMap<>();
+        normalizers.put("atlan_normalizer", atlNormalizer);
+
+        // --- tokenizers ---
+        Map<String, Object> atlanTokenizer = new HashMap<>();
+        atlanTokenizer.put("type", "pattern");
+        atlanTokenizer.put("pattern", "( |_|-|'|/|@)");
+
+        Map<String, Object> atlanGlossaryTokenizer = new HashMap<>();
+        atlanGlossaryTokenizer.put("type", "char_group");
+        atlanGlossaryTokenizer.put("tokenize_on_chars", Arrays.asList("whitespace", "punctuation", "symbol"));
+
+        Map<String, Object> atlanCommaTokenizer = new HashMap<>();
+        atlanCommaTokenizer.put("type", "pattern");
+        atlanCommaTokenizer.put("pattern", ",");
+
+        Map<String, Object> atlanPathTokenizer = new HashMap<>();
+        atlanPathTokenizer.put("type", "path_hierarchy");
+        atlanPathTokenizer.put("delimiter", "/");
+
+        Map<String, Object> tokenizers = new HashMap<>();
+        tokenizers.put("atlan_tokenizer", atlanTokenizer);
+        tokenizers.put("atlan_glossary_tokenizer", atlanGlossaryTokenizer);
+        tokenizers.put("atlan_comma_tokenizer", atlanCommaTokenizer);
+        tokenizers.put("atlan_path_tokenizer", atlanPathTokenizer);
+
+        // --- char filters ---
+        Map<String, Object> numberFilter = new HashMap<>();
+        numberFilter.put("type", "pattern_replace");
+        numberFilter.put("pattern", "\\d+");
+        numberFilter.put("replacement", " $0");
+
+        Map<String, Object> truncateFilter = new HashMap<>();
+        truncateFilter.put("type", "pattern_replace");
+        truncateFilter.put("pattern", "(.{0,100000}).*");
+        truncateFilter.put("replacement", "$1");
+        truncateFilter.put("flags", "DOTALL");
+
+        Map<String, Object> letterNumberFilter = new HashMap<>();
+        letterNumberFilter.put("type", "pattern_replace");
+        letterNumberFilter.put("pattern", "\\d+");
+        letterNumberFilter.put("replacement", " $0 ");
+
+        Map<String, Object> charFilters = new HashMap<>();
+        charFilters.put("number_filter", numberFilter);
+        charFilters.put("truncate_filter", truncateFilter);
+        charFilters.put("letter_number_filter", letterNumberFilter);
+
+        // --- analyzers ---
+        Map<String, Object> atlanTextAnalyzer = new HashMap<>();
+        atlanTextAnalyzer.put("type", "custom");
+        atlanTextAnalyzer.put("tokenizer", "atlan_tokenizer");
+        atlanTextAnalyzer.put("filter", Arrays.asList("apostrophe", "lowercase"));
+        atlanTextAnalyzer.put("char_filter", Arrays.asList("truncate_filter", "number_filter"));
+
+        Map<String, Object> atlanGlossaryAnalyzer = new HashMap<>();
+        atlanGlossaryAnalyzer.put("type", "custom");
+        atlanGlossaryAnalyzer.put("tokenizer", "atlan_glossary_tokenizer");
+        atlanGlossaryAnalyzer.put("filter", Arrays.asList("lowercase"));
+        atlanGlossaryAnalyzer.put("char_filter", Arrays.asList("letter_number_filter"));
+
+        Map<String, Object> atlanTextCommaAnalyzer = new HashMap<>();
+        atlanTextCommaAnalyzer.put("type", "custom");
+        atlanTextCommaAnalyzer.put("tokenizer", "atlan_comma_tokenizer");
+        atlanTextCommaAnalyzer.put("filter", Arrays.asList("lowercase"));
+
+        Map<String, Object> atlanPathAnalyzer = new HashMap<>();
+        atlanPathAnalyzer.put("type", "custom");
+        atlanPathAnalyzer.put("tokenizer", "atlan_path_tokenizer");
+        atlanPathAnalyzer.put("filter", Arrays.asList("trim", "remove_duplicates"));
+
+        Map<String, Object> analyzers = new HashMap<>();
+        analyzers.put("atlan_text_analyzer", atlanTextAnalyzer);
+        analyzers.put("atlan_glossary_analyzer", atlanGlossaryAnalyzer);
+        analyzers.put("atlan_text_comma_analyzer", atlanTextCommaAnalyzer);
+        analyzers.put("atlan_path_analyzer", atlanPathAnalyzer);
+
+        // --- analysis block ---
+        Map<String, Object> analysis = new HashMap<>();
+        analysis.put("normalizer", normalizers);
+        analysis.put("tokenizer", tokenizers);
+        analysis.put("char_filter", charFilters);
+        analysis.put("analyzer", analyzers);
+
+        // --- top-level settings ---
+        Map<String, Object> totalFields = new HashMap<>();
+        totalFields.put("limit", "5000");
+        Map<String, Object> nestedObjects = new HashMap<>();
+        nestedObjects.put("limit", "100000");
+        Map<String, Object> mapping = new HashMap<>();
+        mapping.put("total_fields", totalFields);
+        mapping.put("nested_objects", nestedObjects);
+
+        Map<String, Object> defaultSimilarity = new HashMap<>();
+        defaultSimilarity.put("type", "boolean");
+        Map<String, Object> similarity = new HashMap<>();
+        similarity.put("default", defaultSimilarity);
+
+        Map<String, Object> settings = new HashMap<>();
+        settings.put("analysis", analysis);
+        settings.put("mapping", mapping);
+        settings.put("similarity", similarity);
+        return settings;
     }
 
     private boolean isElasticsearchHealthy() throws ElasticsearchException, IOException {

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusGraphIndexClient.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusGraphIndexClient.java
@@ -113,6 +113,12 @@ public class AtlasJanusGraphIndexClient implements AtlasGraphIndexClient {
         return Collections.EMPTY_LIST;
     }
 
+    @Override
+    public boolean ensureVertexIndexSettings() {
+        // Not applicable for Solr/Janus backend — settings are managed externally.
+        return true;
+    }
+
     private boolean isSolrHealthy() throws SolrServerException, IOException {
         return true;
     }

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphBackedSearchIndexer.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphBackedSearchIndexer.java
@@ -357,6 +357,14 @@ public class GraphBackedSearchIndexer implements SearchIndexer, ActiveStateChang
         AtlasGraphManagement management = null;
 
         try {
+            // Ensure janusgraph_vertex_index has required analysis settings before field mapping registration.
+            // Fields use atlan_normalizer which must be defined on the index. JanusGraph creates the index
+            // with empty settings — this call ensures correctness before any PUT mapping requests are sent.
+            AtlasGraphIndexClient indexClient = graph.getGraphIndexClient();
+            if (!indexClient.ensureVertexIndexSettings()) {
+                LOG.warn("GraphBackedSearchIndexer: could not verify vertex index analysis settings — field registration may fail.");
+            }
+
             management = graph.getManagementSystem();
             LOG.debug("Creating indexes for graph.");
 


### PR DESCRIPTION
## Problem

When `janusgraph_vertex_index` is deleted and recreated, JanusGraph recreates it with empty ES settings. `GraphBackedSearchIndexer` then tries to register field mappings that reference `atlan_normalizer` (via `KEYWORD_MULTIFIELD` on `ENTITY_TYPE_PROPERTY_KEY`, `SUPER_TYPES_PROPERTY_KEY`, `MEANING_NAMES_PROPERTY_KEY`). ES rejects the PUT mapping with HTTP 400 → `PermanentBackendException` → Spring context failure → Jetty UNAVAILABLE → liveness kill → crash loop.

**Root cause confirmed on production tenant** — Atlas was stuck in a 40-restart loop over 10 hours. The normalizer had always been applied at initial provisioning (one-time manual step); first-ever index deletion exposed this gap.

## Solution

Add `ensureVertexIndexSettings()` to `AtlasGraphIndexClient` interface and call it from `GraphBackedSearchIndexer.initialize()` **before** JanusGraph creates any mixed index or registers any field mappings.

Behaviour:
- Index has correct settings → no-op, returns `true`
- Index exists, missing normalizer, **0 docs** → delete + recreate with correct settings
- Index exists, missing normalizer, **has docs** → log critical error, return `false` (cannot safely change analysis settings without a full reindex)
- Index does not exist → create with correct settings so JanusGraph inherits them

Settings applied mirror `addons/elasticsearch/es-settings.json` exactly (atlan_normalizer, all tokenizers, char filters, analyzers, mapping limits, boolean similarity).

## Files Changed

| File | Change |
|------|--------|
| `graphdb/api/.../AtlasGraphIndexClient.java` | Added `ensureVertexIndexSettings()` to interface |
| `graphdb/cassandra/.../AtlasElasticsearchIndexClient.java` | Full implementation + `buildVertexIndexSettings()` |
| `graphdb/cassandra/.../CassandraGraphIndexClient.java` | Delegates to `AtlasElasticsearchIndexClient` |
| `graphdb/janus/.../AtlasJanusGraphIndexClient.java` | No-op stub (`return true`) |
| `repository/.../GraphBackedSearchIndexer.java` | Call site added before mixed index creation |

## Test Plan

- [ ] Start Atlas against a fresh ES with no `janusgraph_vertex_index` — verify index is created with correct settings and Atlas starts successfully
- [ ] Start Atlas with `janusgraph_vertex_index` already having correct settings — verify no-op (check logs: "has correct analysis settings")
- [ ] Delete `janusgraph_vertex_index` while Atlas is down, restart — verify Atlas auto-remediates and starts without crash loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)