### PR TITLE
addOverrride classification null fix

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -37,6 +37,7 @@ on:
       - ms-864-keycloak-jwks-internal-url
       - ms-610-ranges-policy-cache
       - ms-901-hidelineage
+      - ms-894-override-classification
     paths-ignore:
       - '.claude/**'
       - '.cursor/**'

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/ClassificationAssociator.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/ClassificationAssociator.java
@@ -294,13 +294,8 @@ public class ClassificationAssociator {
             if (CollectionUtils.isEmpty(incomingRaw)) {
                 incomingRaw = incomingEntityHeader.getClassifications();
             }
-            List<AtlasClassification> filteredClassifications = Optional.ofNullable(incomingRaw)
-                    .orElse(Collections.emptyList())
-                    .stream()
-                    .filter(classification -> classification.getEntityGuid().equals(entityToBeChanged.getGuid()))
-                    .collect(Collectors.toList());
-
-            List<AtlasClassification> incomingClassifications = listOps.filter(incomingEntityHeader.getGuid(), filteredClassifications);
+            List<AtlasClassification> incomingClassifications = listOps.filter(entityToBeChanged.getGuid(),
+                    Optional.ofNullable(incomingRaw).orElse(Collections.emptyList()));
             List<AtlasClassification> entityClassifications = listOps.filter(entityToBeChanged.getGuid(), entityToBeChanged.getClassifications());
 
             bucket(PROCESS_DELETE, operationListMap, filteredRemoveClassifications);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/ClassificationAssociator.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/ClassificationAssociator.java
@@ -290,7 +290,12 @@ public class ClassificationAssociator {
                 }
             }
 
-            List<AtlasClassification> filteredClassifications = Optional.ofNullable(incomingEntityHeader.getAddOrUpdateClassifications())
+            List<AtlasClassification> incomingRaw = incomingEntityHeader.getAddOrUpdateClassifications();
+            if (CollectionUtils.isEmpty(incomingRaw)) {
+                incomingRaw = incomingEntityHeader.getClassifications();
+            }
+
+            List<AtlasClassification> filteredClassifications = Optional.ofNullable(incomingRaw)
                     .orElse(Collections.emptyList())
                     .stream()
                     .filter(classification -> classification.getEntityGuid().equals(entityToBeChanged.getGuid()))

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/ClassificationAssociator.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/ClassificationAssociator.java
@@ -294,7 +294,6 @@ public class ClassificationAssociator {
             if (CollectionUtils.isEmpty(incomingRaw)) {
                 incomingRaw = incomingEntityHeader.getClassifications();
             }
-
             List<AtlasClassification> filteredClassifications = Optional.ofNullable(incomingRaw)
                     .orElse(Collections.emptyList())
                     .stream()


### PR DESCRIPTION
## Change description

> 
1. POST /entity/bulk/setClassifications?overrideClassifications=false silently did nothing - new classifications were never added and existing ones were never updated
2. Two bugs in ClassificationAssociator.validateAndTransfer():
- Read incoming classifications from getAddOrUpdateClassifications() which is never populated by clients (always null), instead of getClassifications() where all clients send data
- Inline .filter() called classification.getEntityGuid().equals(...) without null-safety -  clients don't set entityGuid on request classifications, so this would NPE if the first bug were fixed alone
 - Fixed by reading from addOrUpdateClassifications with fallback to classifications, and replacing the NPE-unsafe inline filter with the existing null-safe listOps.filter() — the same pattern the working overrideClassifications=true path already uses
 - 
## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1](https://linear.app/atlan-epd/issue/MS-894/overrideclassificationsfalse-reads-from-getaddorupdateclassifications) 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
