### PR TITLE
fix(MS-913): allow soft-delete of array attribute edges without __typeName in CassandraGraph

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/SoftDeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/SoftDeleteHandlerV1.java
@@ -18,6 +18,7 @@
 
 package org.apache.atlas.repository.store.graph.v1;
 
+import org.apache.atlas.ApplicationProperties;
 import org.apache.atlas.AtlasErrorCode;
 import org.apache.atlas.RequestContext;
 import org.apache.atlas.exception.AtlasBaseException;
@@ -83,8 +84,28 @@ public class SoftDeleteHandlerV1 extends DeleteHandlerV1 {
             //tag vertex do not have typeName, but they have a label
             if (!CLASSIFICATION_LABEL.equalsIgnoreCase(edge.getLabel())
                     && getTypeName(edge) == null) {
-                LOG.warn("Edge is not a tag type and typeName is empty. Nothing to delete");
-                return;
+                // In CassandraGraph mode, array attribute edges (e.g., __sourceReadRecentUserRecordList)
+                // don't carry __typeName in their properties — they never did in JanusGraph either,
+                // but JG cleaned them up through the vertex property removal path and never reached here.
+                // In CassandraGraph, entity updates route these edges through deleteEdge(), so we must
+                // proceed with soft-delete instead of skipping. The downstream code handles null typeName
+                // safely: authorizeRemoveRelation returns early, tag propagation finds nothing,
+                // and the soft-delete just sets __state=DELETED on the edge.
+                // Skipping causes orphaned edges to accumulate in Cassandra (10K+ per crawl cycle).
+                try {
+                    String backend = ApplicationProperties.get().getString(ApplicationProperties.GRAPHDB_BACKEND_CONF, "janus");
+                    if (ApplicationProperties.GRAPHDB_BACKEND_CASSANDRA.equalsIgnoreCase(backend)) {
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("CassandraGraph: edge has no typeName (label={}), proceeding with soft-delete", edge.getLabel());
+                        }
+                    } else {
+                        LOG.warn("Edge is not a tag type and typeName is empty. Nothing to delete");
+                        return;
+                    }
+                } catch (Exception e) {
+                    LOG.warn("Edge is not a tag type and typeName is empty. Nothing to delete");
+                    return;
+                }
             }
 
             boolean isRelationshipEdge = isRelationshipEdge(edge);


### PR DESCRIPTION
## Problem

Array attribute edges (e.g., `__sourceReadRecentUserRecordList`, `__sourceReadTopUserRecordList`) don't have `__typeName` in their edge properties. `SoftDeleteHandlerV1.deleteEdge()` has a guard that skips deletion when `__typeName` is null:

```java
if (!CLASSIFICATION_LABEL.equalsIgnoreCase(edge.getLabel())
        && getTypeName(edge) == null) {
    LOG.warn("Edge is not a tag type and typeName is empty. Nothing to delete");
    return; // ← silently skips
}
```

This causes:
- **10K+ warning bursts** per crawl cycle on all ZeroGraph tenants (confirmed on mesoljap01, hellofresh-sandbox, hyatthot02)
- **Orphaned array attribute edges** accumulating in Cassandra (edges never soft-deleted)

## Why it only affects ZeroGraph

In JanusGraph, array attribute edges are cleaned up through the vertex property removal path — they never reach `SoftDeleteHandlerV1.deleteEdge()`. In CassandraGraph, entity updates route these edges through `deleteEdge()` where they hit the null-typeName guard.

## Fix

In CassandraGraph mode (`atlas.graphdb.backend=cassandra`), bypass the return and proceed with soft-delete. JanusGraph behavior is **completely unchanged** — the existing `return` is preserved for JG.

The downstream code handles null typeName safely:
- `authorizeRemoveRelation()` → returns early (null relationshipDef)
- Tag propagation → finds nothing on struct edges
- Soft-delete → just sets `__state=DELETED` on edge properties
- `isRelationshipEdge` → returns false (no `r:` prefix, no `_r__guid`)

## Verified

- Sampled Cassandra data on hellofresh-sandbox: array edge in-vertices (e.g., PopularityInsights struct) exist in vertices table → no NPE risk in `isRelationshipEdge()`
- `PopularityInsights` is a STRUCT type → `typeRegistry.getEntityTypeByName()` returns null → `isRelationshipEdge = false`
- All code paths after the guard handle null typeName gracefully

## Test plan
- [ ] Build passes
- [ ] Deploy to one ZG tenant and verify "Edge is not a tag type" warnings stop
- [ ] Verify array attribute edges are now soft-deleted (state=DELETED) instead of orphaned
- [ ] Verify JanusGraph tenants are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)