### PR TITLE
MS-759: Entity audits ILM policy + index template (staging)

### DIFF
--- a/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
@@ -198,8 +198,8 @@ public enum AtlasConfiguration {
 
     // Entity audit ILM: retention default -1 means delete phase is disabled (compliance-safe)
     ENTITY_AUDIT_RETENTION_DAYS("atlas.audit.retention.days", -1),
+    // ILM rollover: total index max_size only (atlas.audit.ilm.rollover.max.size); no max_age
     ENTITY_AUDIT_ILM_ROLLOVER_SIZE("atlas.audit.ilm.rollover.max.size", "50gb"),
-    ENTITY_AUDIT_ILM_ROLLOVER_AGE("atlas.audit.ilm.rollover.max.age", "30d"),
 
     MIN_EDGES_SUPER_VERTEX("atlas.jg.super.vertex.min.edge.count", 100),
 

--- a/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
@@ -192,6 +192,11 @@ public enum AtlasConfiguration {
     ENTITY_AUDIT_DLQ_TOPIC("atlas.entity.audit.dlq.topic", "ENTITY_AUDIT_DLQ"),
     ENTITY_AUDIT_DLQ_PUBLISH_TO_KAFKA_ENABLED("atlas.entity.audit.dlq.publish.to.kafka.enabled", true),
 
+    // Entity audit ILM: retention default -1 means delete phase is disabled (compliance-safe)
+    ENTITY_AUDIT_RETENTION_DAYS("atlas.audit.retention.days", -1),
+    ENTITY_AUDIT_ILM_ROLLOVER_SIZE("atlas.audit.ilm.rollover.max.size", "50gb"),
+    ENTITY_AUDIT_ILM_ROLLOVER_AGE("atlas.audit.ilm.rollover.max.age", "30d"),
+
     MIN_EDGES_SUPER_VERTEX("atlas.jg.super.vertex.min.edge.count", 100),
 
     // Task resource management configuration

--- a/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
@@ -972,16 +972,15 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
 
             int    retentionDays = AtlasConfiguration.ENTITY_AUDIT_RETENTION_DAYS.getInt();
             String rolloverSize  = AtlasConfiguration.ENTITY_AUDIT_ILM_ROLLOVER_SIZE.getString();
-            String rolloverAge   = AtlasConfiguration.ENTITY_AUDIT_ILM_ROLLOVER_AGE.getString();
 
-            String policyBody = buildIlmPolicyJson(retentionDays, rolloverSize, rolloverAge);
+            String policyBody = buildIlmPolicyJson(retentionDays, rolloverSize);
 
             Request putPolicy = new Request("PUT", "/_ilm/policy/" + ILM_POLICY_NAME);
             putPolicy.setEntity(new NStringEntity(policyBody, ContentType.APPLICATION_JSON));
             Response response = lowLevelClient.performRequest(putPolicy);
             if (isSuccess(response)) {
-                LOG.info("ILM policy '{}' created (retention={}d, rollover={}/@{})",
-                         ILM_POLICY_NAME, retentionDays, rolloverSize, rolloverAge);
+                LOG.info("ILM policy '{}' created (retention={}d, rollover max_size={})",
+                         ILM_POLICY_NAME, retentionDays, rolloverSize);
             }
         } catch (Exception e) {
             LOG.warn("Failed to ensure ILM policy '{}', will retry on next startup: {}",
@@ -992,9 +991,10 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
     /**
      * Builds the ILM policy JSON with hot (rollover) and warm (forcemerge) phases.
      * No shrink action in warm — avoids shard relocation failures on heap-constrained 3-node clusters.
+     * Rollover is size-only ({@code max_size}) — no {@code max_age}, to avoid time-based small-index proliferation.
      * Delete phase included only when {@code retentionDays > 0}.
      */
-    private String buildIlmPolicyJson(int retentionDays, String rolloverSize, String rolloverAge) {
+    private String buildIlmPolicyJson(int retentionDays, String rolloverSize) {
         ObjectMapper mapper = new ObjectMapper();
         ObjectNode root   = mapper.createObjectNode();
         ObjectNode policy = root.putObject("policy");
@@ -1004,8 +1004,7 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
         hot.put("min_age", "0ms");
         ObjectNode hotActions = hot.putObject("actions");
         ObjectNode rollover   = hotActions.putObject("rollover");
-        rollover.put("max_primary_shard_size", rolloverSize);
-        rollover.put("max_age", rolloverAge);
+        rollover.put("max_size", rolloverSize);
         hotActions.putObject("set_priority").put("priority", 100);
 
         ObjectNode warm        = phases.putObject("warm");

--- a/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
@@ -116,6 +116,9 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
     private static final String ENTITY_AUDITS_INDEX;
     private static final String WRITE_ALIAS;
     private static final String NIOFS_MIGRATION_MARKER_ID = "entity_audits_niofs_migrated";
+    public  static final String ILM_POLICY_NAME    = "entity_audits_policy";
+    public  static final String INDEX_TEMPLATE_NAME = "entity_audits_template";
+    private static final String INDEX_PATTERN;
     private static final int DLQ_POLL_TIMEOUT_SECONDS = 5;
 
     /**
@@ -147,6 +150,7 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
         INDEX_NAME = auditIndex;
         ENTITY_AUDITS_INDEX = auditIndex;
         WRITE_ALIAS = auditIndex + "_write";
+        INDEX_PATTERN = auditIndex + "-*";
         bulkMetadata = String.format("{ \"index\" : { \"_index\" : \"%s\" } }%n", INDEX_NAME);
         LOG.info("ES audit index name: '{}', write alias: '{}'", INDEX_NAME, WRITE_ALIAS);
     }
@@ -775,6 +779,8 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
                 LOG.info("Create ES index for entity audits in ES Based Audit Repo");
                 createAuditIndex();
             }
+            ensureIlmPolicy();
+            ensureIndexTemplate();
             detectAndConfigureWriteAlias();
             WriteConfig cfg = this.writeConfig;
             LOG.info("Entity audit ES config: aliasMode={}, writeIndex='{}', readIndex='{}', writeAlias='{}'",
@@ -858,6 +864,24 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
         aliases.set(WRITE_ALIAS, writeAliasNode);
         rootObj.set("aliases", aliases);
 
+        ObjectNode settings = (ObjectNode) rootObj.get("settings");
+        if (settings == null) {
+            settings = mapper.createObjectNode();
+            rootObj.set("settings", settings);
+        }
+        ObjectNode indexSettings = (ObjectNode) settings.get("index");
+        if (indexSettings == null) {
+            indexSettings = mapper.createObjectNode();
+            settings.set("index", indexSettings);
+        }
+        ObjectNode lifecycle = mapper.createObjectNode();
+        lifecycle.put("name", ILM_POLICY_NAME);
+        lifecycle.put("rollover_alias", WRITE_ALIAS);
+        indexSettings.set("lifecycle", lifecycle);
+        indexSettings.put("number_of_shards", 4);
+        indexSettings.put("number_of_replicas", 1);
+        indexSettings.put("refresh_interval", "30s");
+
         HttpEntity entity = new NStringEntity(rootObj.toString(), ContentType.APPLICATION_JSON);
         Request request = new Request("PUT", concreteIndexName);
         request.setEntity(entity);
@@ -922,6 +946,154 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
         } catch (IOException e) {
             LOG.error("Error while updating the field limit", e);
         }
+    }
+
+    /**
+     * Creates the ILM policy for entity audits if it does not already exist.
+     * Respects manual operator overrides: if the policy exists (with any settings), it is not overwritten.
+     * The delete phase is only included when {@code atlas.audit.retention.days > 0} (default -1 = disabled).
+     */
+    private void ensureIlmPolicy() {
+        try {
+            Request getPolicy = new Request("GET", "/_ilm/policy/" + ILM_POLICY_NAME);
+            try {
+                Response response = lowLevelClient.performRequest(getPolicy);
+                if (isSuccess(response)) {
+                    LOG.info("ILM policy '{}' already exists", ILM_POLICY_NAME);
+                    return;
+                }
+            } catch (ResponseException e) {
+                if (e.getResponse().getStatusLine().getStatusCode() != 404) {
+                    LOG.warn("Unexpected response checking ILM policy '{}': {}",
+                             ILM_POLICY_NAME, e.getResponse().getStatusLine());
+                    return;
+                }
+            }
+
+            int    retentionDays = AtlasConfiguration.ENTITY_AUDIT_RETENTION_DAYS.getInt();
+            String rolloverSize  = AtlasConfiguration.ENTITY_AUDIT_ILM_ROLLOVER_SIZE.getString();
+            String rolloverAge   = AtlasConfiguration.ENTITY_AUDIT_ILM_ROLLOVER_AGE.getString();
+
+            String policyBody = buildIlmPolicyJson(retentionDays, rolloverSize, rolloverAge);
+
+            Request putPolicy = new Request("PUT", "/_ilm/policy/" + ILM_POLICY_NAME);
+            putPolicy.setEntity(new NStringEntity(policyBody, ContentType.APPLICATION_JSON));
+            Response response = lowLevelClient.performRequest(putPolicy);
+            if (isSuccess(response)) {
+                LOG.info("ILM policy '{}' created (retention={}d, rollover={}/@{})",
+                         ILM_POLICY_NAME, retentionDays, rolloverSize, rolloverAge);
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to ensure ILM policy '{}', will retry on next startup: {}",
+                     ILM_POLICY_NAME, e.getMessage());
+        }
+    }
+
+    /**
+     * Builds the ILM policy JSON with hot (rollover) and warm (forcemerge) phases.
+     * No shrink action in warm — avoids shard relocation failures on heap-constrained 3-node clusters.
+     * Delete phase included only when {@code retentionDays > 0}.
+     */
+    private String buildIlmPolicyJson(int retentionDays, String rolloverSize, String rolloverAge) {
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode root   = mapper.createObjectNode();
+        ObjectNode policy = root.putObject("policy");
+        ObjectNode phases = policy.putObject("phases");
+
+        ObjectNode hot        = phases.putObject("hot");
+        hot.put("min_age", "0ms");
+        ObjectNode hotActions = hot.putObject("actions");
+        ObjectNode rollover   = hotActions.putObject("rollover");
+        rollover.put("max_primary_shard_size", rolloverSize);
+        rollover.put("max_age", rolloverAge);
+        hotActions.putObject("set_priority").put("priority", 100);
+
+        ObjectNode warm        = phases.putObject("warm");
+        warm.put("min_age", "2d");
+        ObjectNode warmActions = warm.putObject("actions");
+        warmActions.putObject("forcemerge").put("max_num_segments", 1);
+        warmActions.putObject("set_priority").put("priority", 50);
+
+        if (retentionDays > 0) {
+            ObjectNode delete = phases.putObject("delete");
+            delete.put("min_age", retentionDays + "d");
+            delete.putObject("actions").putObject("delete");
+        }
+
+        return root.toString();
+    }
+
+    /**
+     * Creates the index template for {@code entity_audits-*} if it does not already exist.
+     * Uses the legacy {@code _template} API (ES 7.x). Mappings are loaded from
+     * {@code es-audit-mappings.json} (only the mappings node — file-level settings are discarded).
+     */
+    private void ensureIndexTemplate() {
+        try {
+            Request headTemplate = new Request("HEAD", "/_template/" + INDEX_TEMPLATE_NAME);
+            try {
+                Response response = lowLevelClient.performRequest(headTemplate);
+                if (response.getStatusLine().getStatusCode() == 200) {
+                    LOG.info("Index template '{}' already exists", INDEX_TEMPLATE_NAME);
+                    return;
+                }
+            } catch (ResponseException e) {
+                if (e.getResponse().getStatusLine().getStatusCode() != 404) {
+                    LOG.warn("Unexpected response checking index template '{}': {}",
+                             INDEX_TEMPLATE_NAME, e.getResponse().getStatusLine());
+                    return;
+                }
+            }
+
+            String templateBody = buildIndexTemplateJson();
+
+            Request putTemplate = new Request("PUT", "/_template/" + INDEX_TEMPLATE_NAME);
+            putTemplate.setEntity(new NStringEntity(templateBody, ContentType.APPLICATION_JSON));
+            Response response = lowLevelClient.performRequest(putTemplate);
+            if (isSuccess(response)) {
+                LOG.info("Index template '{}' created for pattern '{}'",
+                         INDEX_TEMPLATE_NAME, INDEX_PATTERN);
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to ensure index template '{}', will retry on next startup: {}",
+                     INDEX_TEMPLATE_NAME, e.getMessage());
+        }
+    }
+
+    /**
+     * Builds the index template JSON for {@code entity_audits-*}.
+     * Extracts only the {@code mappings} node from {@code es-audit-mappings.json} to avoid
+     * settings conflicts (the file has refresh_interval=60s, template uses 30s).
+     * Template settings are the single source of truth for shard count, refresh interval, etc.
+     */
+    private String buildIndexTemplateJson() throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+
+        JsonNode fileRoot    = mapper.readTree(getAuditIndexMappings());
+        JsonNode mappingsNode = fileRoot.get("mappings");
+        if (mappingsNode == null) {
+            throw new IllegalStateException("es-audit-mappings.json missing 'mappings' node");
+        }
+
+        ObjectNode template = mapper.createObjectNode();
+
+        template.putArray("index_patterns").add(INDEX_PATTERN);
+
+        ObjectNode settings      = template.putObject("settings");
+        ObjectNode indexSettings  = settings.putObject("index");
+        indexSettings.put("number_of_shards", 4);
+        indexSettings.put("number_of_replicas", 1);
+        indexSettings.put("refresh_interval", "30s");
+        indexSettings.putObject("store").put("type", "niofs");
+        ObjectNode lifecycle = indexSettings.putObject("lifecycle");
+        lifecycle.put("name", ILM_POLICY_NAME);
+        lifecycle.put("rollover_alias", WRITE_ALIAS);
+
+        template.putObject("aliases").putObject(INDEX_NAME);
+
+        template.set("mappings", mappingsNode);
+
+        return template.toString();
     }
 
     /**

--- a/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
@@ -19,6 +19,7 @@ package org.apache.atlas.repository.audit;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.atlas.ApplicationProperties;
 import org.apache.atlas.AtlasConfiguration;
@@ -52,6 +53,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.slf4j.Logger;
@@ -112,6 +114,7 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
     private static final String bulkMetadata;
     private static final Set<String> ALLOWED_LINKED_ATTRIBUTES = new HashSet<>(Arrays.asList(DOMAIN_GUIDS, CATALOG_DATASET_GUID_ATTR));
     private static final String ENTITY_AUDITS_INDEX;
+    private static final String WRITE_ALIAS;
     private static final String NIOFS_MIGRATION_MARKER_ID = "entity_audits_niofs_migrated";
     private static final int DLQ_POLL_TIMEOUT_SECONDS = 5;
 
@@ -143,8 +146,9 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
         }
         INDEX_NAME = auditIndex;
         ENTITY_AUDITS_INDEX = auditIndex;
+        WRITE_ALIAS = auditIndex + "_write";
         bulkMetadata = String.format("{ \"index\" : { \"_index\" : \"%s\" } }%n", INDEX_NAME);
-        LOG.info("ES audit index name: '{}'", INDEX_NAME);
+        LOG.info("ES audit index name: '{}', write alias: '{}'", INDEX_NAME, WRITE_ALIAS);
     }
 
     /*
@@ -158,6 +162,17 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
 
     /** Holder for failed audit events enqueued to async DLQ for retry. */
     private static record EntityAuditDLQEntry(List<EntityAuditEventV2> events, int retryCount) {}
+
+    /**
+     * Immutable snapshot of write-path configuration. A single volatile reference swap
+     * guarantees that request threads always see a consistent (writeIndex, writeBulkMetadata, aliasMode)
+     * triple — no torn reads across three separate volatile fields.
+     */
+    private record WriteConfig(String writeIndex, String writeBulkMetadata, boolean aliasMode) {}
+
+    private static final WriteConfig DEFAULT_WRITE_CONFIG = new WriteConfig(INDEX_NAME, bulkMetadata, false);
+
+    private volatile WriteConfig writeConfig = DEFAULT_WRITE_CONFIG;
 
     /**
      * Record audit DLQ failure metric to the existing Micrometer/Prometheus registry (scraped by Victoria Metrics).
@@ -277,6 +292,9 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
             return;
         }
 
+        // Snapshot the write config once — consistent writeIndex and bulkMetadata for the entire call
+        WriteConfig cfg = this.writeConfig;
+
         Map<String, String> requestContextHeaders = RequestContext.get().getRequestContextHeaders();
         String entityPayloadTemplate = getQueryTemplate(requestContextHeaders);
 
@@ -319,14 +337,14 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
                     created,
                     "" + updateTimestamp);
 
-            bulkRequestBody.append(bulkMetadata);
+            bulkRequestBody.append(cfg.writeBulkMetadata());
             bulkRequestBody.append(bulkItem);
             bulkRequestBody.append("\n");
         }
         if (bulkRequestBody.length() == 0) {
             return;
         }
-        String endpoint = INDEX_NAME + "/_bulk";
+        String endpoint = cfg.writeIndex() + "/_bulk";
         HttpEntity entity = new NStringEntity(bulkRequestBody.toString(), ContentType.APPLICATION_JSON);
         Request request = new Request("POST", endpoint);
         request.setEntity(entity);
@@ -757,6 +775,10 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
                 LOG.info("Create ES index for entity audits in ES Based Audit Repo");
                 createAuditIndex();
             }
+            detectAndConfigureWriteAlias();
+            WriteConfig cfg = this.writeConfig;
+            LOG.info("Entity audit ES config: aliasMode={}, writeIndex='{}', readIndex='{}', writeAlias='{}'",
+                     cfg.aliasMode(), cfg.writeIndex(), INDEX_NAME, WRITE_ALIAS);
             if (shouldUpdateFieldLimitSetting()) {
                 LOG.info("Updating ES total field limit");
                 updateFieldLimit();
@@ -767,10 +789,10 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
             LOG.error("error", e);
             throw new AtlasException(e);
         }
-
     }
 
     private boolean checkIfIndexExists() throws IOException {
+        // HEAD works for both concrete index name and alias — returns 200 for either
         Request request = new Request("HEAD", INDEX_NAME);
         Response response = lowLevelClient.performRequest(request);
         int statusCode = response.getStatusLine().getStatusCode();
@@ -782,14 +804,76 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
         return false;
     }
 
+    /**
+     * Probes ES for the write alias and atomically switches the write config.
+     * If the write alias exists, writes go through it (alias mode).
+     * If not, falls back to direct index mode (current behavior — backward compatible).
+     */
+    private void detectAndConfigureWriteAlias() {
+        try {
+            Request request = new Request("HEAD", "/_alias/" + WRITE_ALIAS);
+            Response response = lowLevelClient.performRequest(request);
+            if (response.getStatusLine().getStatusCode() == 200) {
+                String newBulkMeta = String.format("{ \"index\" : { \"_index\" : \"%s\" } }%n", WRITE_ALIAS);
+                writeConfig = new WriteConfig(WRITE_ALIAS, newBulkMeta, true);
+                LOG.info("Write alias '{}' detected, using alias mode for entity audits", WRITE_ALIAS);
+            } else {
+                writeConfig = DEFAULT_WRITE_CONFIG;
+                LOG.info("Write alias '{}' not available (HTTP {}), using direct index '{}'",
+                         WRITE_ALIAS, response.getStatusLine().getStatusCode(), INDEX_NAME);
+            }
+        } catch (ResponseException e) {
+            writeConfig = DEFAULT_WRITE_CONFIG;
+            LOG.info("Write alias '{}' not found (HTTP {}), using direct index '{}'",
+                     WRITE_ALIAS, e.getResponse().getStatusLine().getStatusCode(), INDEX_NAME);
+        } catch (Exception e) {
+            writeConfig = DEFAULT_WRITE_CONFIG;
+            LOG.warn("Failed to check write alias '{}', using direct index '{}': {}",
+                     WRITE_ALIAS, INDEX_NAME, e.getMessage());
+        }
+    }
+
+    /**
+     * Creates the entity audits index for fresh tenants. Creates a concrete index named
+     * {@code entity_audits-000001} with both read alias ({@code entity_audits}) and write alias
+     * ({@code entity_audits_write}) configured, making fresh tenants ILM-ready from day one.
+     *
+     * Handles concurrent pod creation race (multiple pods seeing "index not found" simultaneously)
+     * by catching the 400 "resource_already_exists_exception" and re-verifying existence.
+     */
     private boolean createAuditIndex() throws IOException {
-        LOG.info("ESBasedAuditRepo - createAuditIndex!");
+        String concreteIndexName = INDEX_NAME + "-000001";
+        LOG.info("ESBasedAuditRepo - createAuditIndex! Creating '{}' with aliases ['{}', '{}']",
+                 concreteIndexName, INDEX_NAME, WRITE_ALIAS);
+
         String esMappingsString = getAuditIndexMappings();
-        HttpEntity entity = new NStringEntity(esMappingsString, ContentType.APPLICATION_JSON);
-        Request request = new Request("PUT", INDEX_NAME);
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root = mapper.readTree(esMappingsString);
+        ObjectNode rootObj = (ObjectNode) root;
+
+        ObjectNode aliases = mapper.createObjectNode();
+        aliases.set(INDEX_NAME, mapper.createObjectNode());
+        ObjectNode writeAliasNode = mapper.createObjectNode();
+        writeAliasNode.put("is_write_index", true);
+        aliases.set(WRITE_ALIAS, writeAliasNode);
+        rootObj.set("aliases", aliases);
+
+        HttpEntity entity = new NStringEntity(rootObj.toString(), ContentType.APPLICATION_JSON);
+        Request request = new Request("PUT", concreteIndexName);
         request.setEntity(entity);
-        Response response = lowLevelClient.performRequest(request);
-        return isSuccess(response);
+
+        try {
+            Response response = lowLevelClient.performRequest(request);
+            return isSuccess(response);
+        } catch (ResponseException e) {
+            int status = e.getResponse().getStatusLine().getStatusCode();
+            if (status == 400) {
+                LOG.info("Index '{}' already exists (likely created by another pod concurrently), proceeding",
+                         concreteIndexName);
+                return checkIfIndexExists();
+            }
+            throw e;
+        }
     }
 
     private boolean shouldUpdateFieldLimitSetting() {
@@ -808,9 +892,18 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
         Request request = new Request("GET", INDEX_NAME + "/_settings");
         Response response = lowLevelClient.performRequest(request);
         ObjectMapper objectMapper = new ObjectMapper();
-        String fieldPath = String.format("/%s/settings/index/mapping/total_fields/limit", INDEX_NAME);
+        JsonNode root = objectMapper.readTree(copyToString(response.getEntity().getContent(), Charset.defaultCharset()));
 
-        return objectMapper.readTree(copyToString(response.getEntity().getContent(), Charset.defaultCharset())).at(fieldPath);
+        // Iterate over concrete index names — works for both alias and direct index.
+        // When INDEX_NAME is an alias, response keys are concrete names (e.g. entity_audits-000001).
+        for (Iterator<String> it = root.fieldNames(); it.hasNext(); ) {
+            String indexName = it.next();
+            JsonNode limit = root.at("/" + indexName + "/settings/index/mapping/total_fields/limit");
+            if (!limit.isMissingNode()) {
+                return limit;
+            }
+        }
+        return null;
     }
 
     private void updateFieldLimit() {
@@ -844,8 +937,16 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
      * Uses a marker document to ensure the migration runs exactly once across all pods and deployments.
      * On every startup, each pod does a single cheap HEAD request to check for the marker.
      * Requires a brief close/open cycle (~2-3 seconds of audit write unavailability) on first run only.
+     *
+     * SKIPPED in alias mode: fresh/rollover indices inherit niofs from es-audit-mappings.json settings.
+     * Running _close on an alias would close ALL backing indices — catastrophic for multi-index setups.
      */
     private void ensureStoreTypeNiofs() {
+        if (writeConfig.aliasMode()) {
+            LOG.info("Skipping niofs store type migration in alias mode (fresh/rollover indices inherit niofs from template)");
+            return;
+        }
+
         try {
             // Fast path: check if migration was already completed (cheap HEAD request)
             if (isNiofsMigrationDone()) {
@@ -856,7 +957,17 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
             Request getSettings = new Request("GET", INDEX_NAME + "/_settings");
             Response settingsResponse = lowLevelClient.performRequest(getSettings);
             String responseBody = copyToString(settingsResponse.getEntity().getContent(), defaultCharset());
-            JsonNode storeType = new ObjectMapper().readTree(responseBody).at("/" + INDEX_NAME + "/settings/index/store/type");
+
+            // Iterate response keys for defense-in-depth (works even if INDEX_NAME is an alias)
+            JsonNode root = new ObjectMapper().readTree(responseBody);
+            JsonNode storeType = null;
+            for (Iterator<String> it = root.fieldNames(); it.hasNext(); ) {
+                JsonNode candidate = root.at("/" + it.next() + "/settings/index/store/type");
+                if (candidate != null && !candidate.isMissingNode()) {
+                    storeType = candidate;
+                    break;
+                }
+            }
 
             if (storeType != null && "niofs".equals(storeType.asText())) {
                 // Already niofs (e.g. set manually) — just write the marker so we skip next time
@@ -918,11 +1029,14 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
 
     private void writeNiofsMigrationMarker() {
         try {
-            Request request = new Request("PUT", INDEX_NAME + "/_doc/" + NIOFS_MIGRATION_MARKER_ID);
+            // Use writeConfig.writeIndex() so the marker doc goes through the writable target
+            // (defense-in-depth: in alias mode the ensureStoreTypeNiofs guard skips before reaching here)
+            String target = writeConfig.writeIndex();
+            Request request = new Request("PUT", target + "/_doc/" + NIOFS_MIGRATION_MARKER_ID);
             String body = "{\"migration\":\"niofs\",\"timestamp\":" + System.currentTimeMillis() + "}";
             request.setEntity(new NStringEntity(body, ContentType.APPLICATION_JSON));
             lowLevelClient.performRequest(request);
-            LOG.info("entity_audits niofs migration marker written");
+            LOG.info("entity_audits niofs migration marker written via '{}'", target);
         } catch (Exception e) {
             LOG.warn("Failed to write niofs migration marker, migration will re-check on next startup", e);
         }
@@ -1013,6 +1127,16 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
             LOG.error("ESBasedAuditRepo - error while closing es lowlevel client", e);
             throw new AtlasException(e);
         }
+    }
+
+    /** Returns the resolved write target (alias name or direct index name). */
+    public String getWriteIndex() {
+        return writeConfig.writeIndex();
+    }
+
+    /** Returns true if the write alias was detected and writes go through it. */
+    public boolean isAliasMode() {
+        return writeConfig.aliasMode();
     }
 
     private void setLowLevelClient() throws AtlasException {


### PR DESCRIPTION
## Summary

Staging PR for [MS-759](https://linear.app/atlan-epd/issue/MS-759): ILM policy (`entity_audits_policy`), index template (`entity_audits_template`), and fresh-tenant index settings for `entity_audits-*` rollover, plus MS-758 read/write alias behavior.

**Branch:** `ms-759/entity-audits-ilm-template-staging` (based on staging + MS-758 staging + MS-759).

**Latest (this PR):** ILM hot-phase rollover is **size-only** — `max_size` from `atlas.audit.ilm.rollover.max.size` (default `50gb`). Removed `max_age` and `max_primary_shard_size` to avoid time-based small-index proliferation (same as master PR).

## Related

- Master: https://github.com/atlanhq/atlas-metastore/pull/6511
- MS-758 staging: #6509 (merged into this branch history)

## Test plan

- [ ] Deploy to staging environment
- [ ] Confirm `ensureIlmPolicy` / `ensureIndexTemplate` on startup (idempotent)
- [ ] Fresh tenant: `entity_audits-000001` with lifecycle + aliases
- [ ] Existing tenant: no impact on concrete index until migration workflow runs

Made with [Cursor](https://cursor.com)