### PR TITLE
fix: (ms-973) extend self-heal to ENUM/array<string> + detect JG/ES drift in metric

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphBackedSearchIndexer.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphBackedSearchIndexer.java
@@ -652,13 +652,28 @@ public class GraphBackedSearchIndexer implements SearchIndexer, ActiveStateChang
 
     private void resolveIndexFieldName(AtlasGraphManagement managementSystem, AtlasAttribute attribute) {
         try {
-            if (attribute.getIndexFieldName() == null && TypeCategory.PRIMITIVE.equals(attribute.getAttributeType().getTypeCategory())) {
-                AtlasStructType definedInType = attribute.getDefinedInType();
-                AtlasAttribute  baseInstance  = definedInType != null ? definedInType.getAttribute(attribute.getName()) : null;
+            if (attribute.getIndexFieldName() != null) {
+                return;
+            }
 
-                if (baseInstance != null && baseInstance.getIndexFieldName() != null) {
-                    attribute.setIndexFieldName(baseInstance.getIndexFieldName());
-                } else if (isIndexApplicable(getPrimitiveClass(attribute.getTypeName()), toAtlasCardinality(attribute.getAttributeDef().getCardinality()))) {
+            // MS-973: resolve the index "primitive" Class based on TypeCategory so self-heal
+            // also covers ENUM and array<string> attributes (previously only PRIMITIVE attrs
+            // reached this method's body — all other categories fell through silently).
+            //   - PRIMITIVE → the corresponding Java class (String, Integer, etc.)
+            //   - ENUM     → String.class (JG stores enum values as strings in the mixed index)
+            //   - ARRAY<string> → String.class (element is primitive string)
+            //   - other categories → null, self-heal not applicable here
+            Class primitiveClass = resolveIndexPrimitiveClass(attribute);
+            if (primitiveClass == null) {
+                return;
+            }
+
+            AtlasStructType definedInType = attribute.getDefinedInType();
+            AtlasAttribute  baseInstance  = definedInType != null ? definedInType.getAttribute(attribute.getName()) : null;
+
+            if (baseInstance != null && baseInstance.getIndexFieldName() != null) {
+                attribute.setIndexFieldName(baseInstance.getIndexFieldName());
+            } else if (isIndexApplicable(primitiveClass, toAtlasCardinality(attribute.getAttributeDef().getCardinality()))) {
                     AtlasPropertyKey propertyKey = managementSystem.getPropertyKey(attribute.getVertexPropertyName());
                     boolean isStringField = AtlasAttributeDef.IndexType.STRING.equals(attribute.getIndexType());
                     if (propertyKey != null) {
@@ -698,7 +713,6 @@ public class GraphBackedSearchIndexer implements SearchIndexer, ActiveStateChang
                                 + "attempting auto-repair for vertexPropertyName={}",
                                 attribute.getQualifiedName(), attribute.getVertexPropertyName());
                         try {
-                            Class primitiveClass = getPrimitiveClass(attribute.getTypeName());
                             AtlasCardinality cardinality = toAtlasCardinality(attribute.getAttributeDef().getCardinality());
                             // Match createIndexForAttribute logic: isStringField only true
                             // when the primitive class IS String AND indexType is STRING
@@ -783,10 +797,46 @@ public class GraphBackedSearchIndexer implements SearchIndexer, ActiveStateChang
                         }
                     }
                 }
-            }
         } catch (Exception excp) {
             LOG.warn("resolveIndexFieldName(attribute={}) failed.", attribute.getQualifiedName(), excp);
         }
+    }
+
+    /**
+     * MS-973: Resolve the Class used for mixed-index registration based on the attribute's TypeCategory.
+     * Returns null when self-heal is not applicable for the attribute's category.
+     * <p>
+     * Supported categories:
+     * <ul>
+     *   <li>PRIMITIVE — the matching Java class (String, Integer, etc.)</li>
+     *   <li>ENUM — String.class (JG stores enum values as strings in the mixed index)</li>
+     *   <li>ARRAY&lt;string&gt; — String.class</li>
+     * </ul>
+     * All other categories (STRUCT, MAP, CLASSIFICATION, ENTITY, array of non-string, etc.)
+     * return null and are skipped by the caller.
+     */
+    private Class resolveIndexPrimitiveClass(AtlasAttribute attribute) {
+        AtlasType    attributeType = attribute.getAttributeType();
+        TypeCategory category      = attributeType.getTypeCategory();
+
+        if (category == TypeCategory.PRIMITIVE) {
+            // May throw IllegalArgumentException for unknown primitive typenames —
+            // let it propagate to the outer try-catch in resolveIndexFieldName, which
+            // logs a WARN. Preserves pre-MS973 observability for this edge case.
+            return getPrimitiveClass(attribute.getTypeName());
+        } else if (category == TypeCategory.ENUM) {
+            return String.class;
+        } else if (category == TypeCategory.ARRAY && attributeType instanceof AtlasArrayType) {
+            AtlasType elementType = ((AtlasArrayType) attributeType).getElementType();
+            // Scope (MS-973): only array<string> for now. Other array<primitive> variants
+            // (int/long/boolean/date) or array<enum> can be added later if observed.
+            if (elementType != null
+                    && elementType.getTypeCategory() == TypeCategory.PRIMITIVE
+                    && AtlasBaseTypeDef.ATLAS_TYPE_STRING.equalsIgnoreCase(elementType.getTypeName())) {
+                return String.class;
+            }
+        }
+        return null;
     }
 
     private void createCommonVertexIndex(AtlasGraphManagement management,

--- a/repository/src/main/java/org/apache/atlas/repository/metrics/IndexHealthMetricService.java
+++ b/repository/src/main/java/org/apache/atlas/repository/metrics/IndexHealthMetricService.java
@@ -21,9 +21,12 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import org.apache.atlas.model.TypeCategory;
+import org.apache.atlas.model.typedef.AtlasStructDef.AtlasAttributeDef;
+import org.apache.atlas.repository.Constants;
 import org.apache.atlas.repository.graphdb.AtlasGraphIndex;
 import org.apache.atlas.repository.graphdb.AtlasGraphManagement;
 import org.apache.atlas.repository.graphdb.AtlasPropertyKey;
+import org.apache.atlas.repository.store.graph.v2.ESConnector;
 import org.apache.atlas.type.AtlasEntityType;
 import org.apache.atlas.type.AtlasBusinessMetadataType;
 import org.apache.atlas.type.AtlasStructType.AtlasAttribute;
@@ -80,6 +83,10 @@ public class IndexHealthMetricService {
     private final AtomicInteger bmMissing = new AtomicInteger(0);
     private final AtomicInteger coreMissingTotal = new AtomicInteger(0);
     private final AtomicInteger healthStatus = new AtomicInteger(1);
+    // MS-973: counts attributes where JG says "indexed" but ES has no mapping.
+    // Non-zero indicates JG schema cache / ES drift — a silent-failure class that
+    // the original audit couldn't detect (see olympus MS-973).
+    private final AtomicInteger cacheDriftTotal = new AtomicInteger(0);
     // Bounded cardinality: one entry per entity type (~100-500 per tenant, not user-generated)
     private final Map<String, AtomicInteger> perTypeMissing = new HashMap<>();
     private boolean gaugesRegistered = false;
@@ -150,6 +157,10 @@ public class IndexHealthMetricService {
                 .description("Overall index health: 1 = healthy, 0 = unhealthy")
                 .tags(tenantTag).register(meterRegistry);
 
+        Gauge.builder(METRIC_PREFIX + "_cache_drift_total", cacheDriftTotal, AtomicInteger::get)
+                .description("MS-973: attributes where JG schema reports indexed but ES mapping is missing — silent-failure drift signal")
+                .tags(tenantTag).register(meterRegistry);
+
         gaugesRegistered = true;
     }
 
@@ -188,6 +199,19 @@ public class IndexHealthMetricService {
         }
         Set<AtlasPropertyKey> indexedFieldKeys = new HashSet<>(vertexIndex.getFieldKeys());
 
+        // MS-973: Ground-truth cross-check against ES.
+        // JanusGraph's schema cache can diverge from ES mapping (e.g., a propertyKey is
+        // reported as registered by JG but ES has no mapping for it — observed on olympus).
+        // Fetch ES mapping once per audit; empty set = ES unreachable → skip cross-check
+        // and fall back to JG-only (never under-report missing by ES unavailability).
+        Set<String> esMappedFields = ESConnector.getVertexIndexMappedFields();
+        boolean esCrossCheckAvailable = !esMappedFields.isEmpty();
+        int driftCount = 0;
+        if (!esCrossCheckAvailable) {
+            LOG.warn("INDEX HEALTH AUDIT: ES vertex_index mapping fetch returned empty or failed — "
+                    + "cross-check disabled for this audit, counts reflect JG-only view");
+        }
+
         // Audit entity types
         for (AtlasEntityType entityType : typeRegistry.getAllEntityDefs()
                 .stream()
@@ -209,10 +233,24 @@ public class IndexHealthMetricService {
 
                 totalExpected++;
 
-                // Check mixed index registration — not just property key existence.
-                // A property key can exist in the schema but NOT be in the vertex_index.
                 AtlasPropertyKey propertyKey = managementSystem.getPropertyKey(attribute.getVertexPropertyName());
-                if (propertyKey != null && indexedFieldKeys.contains(propertyKey)) {
+                boolean jgIndexed = propertyKey != null && indexedFieldKeys.contains(propertyKey);
+
+                // ES-side cross-check — only meaningful when JG claims indexed (see class javadoc)
+                boolean esIndexed = true;
+                if (jgIndexed && esCrossCheckAvailable) {
+                    boolean isStringField = AtlasAttributeDef.IndexType.STRING.equals(attribute.getIndexType());
+                    String esFieldName = managementSystem.getIndexFieldName(Constants.VERTEX_INDEX, propertyKey, isStringField);
+                    esIndexed = esFieldName != null && esMappedFields.contains(esFieldName);
+                    if (!esIndexed) {
+                        driftCount++;
+                        LOG.warn("INDEX HEALTH DRIFT: JG reports {}.{} as indexed (propertyKey={}) but ES has no mapping "
+                                + "for field '{}'. JG schema cache likely diverged from ES — counting as missing.",
+                                typeName, attribute.getName(), propertyKey.getName(), esFieldName);
+                    }
+                }
+
+                if (jgIndexed && esIndexed) {
                     totalIndexed++;
                 } else {
                     totalMissing++;
@@ -248,7 +286,22 @@ public class IndexHealthMetricService {
                 totalBmExpected++;
 
                 AtlasPropertyKey propertyKey = managementSystem.getPropertyKey(attribute.getVertexPropertyName());
-                if (propertyKey != null && indexedFieldKeys.contains(propertyKey)) {
+                boolean jgIndexed = propertyKey != null && indexedFieldKeys.contains(propertyKey);
+
+                boolean esIndexed = true;
+                if (jgIndexed && esCrossCheckAvailable) {
+                    boolean isStringField = AtlasAttributeDef.IndexType.STRING.equals(attribute.getIndexType());
+                    String esFieldName = managementSystem.getIndexFieldName(Constants.VERTEX_INDEX, propertyKey, isStringField);
+                    esIndexed = esFieldName != null && esMappedFields.contains(esFieldName);
+                    if (!esIndexed) {
+                        driftCount++;
+                        LOG.warn("INDEX HEALTH DRIFT: JG reports BM {}.{} as indexed (propertyKey={}) but ES has no mapping "
+                                + "for field '{}'. JG schema cache likely diverged from ES — counting as missing.",
+                                bmType.getTypeName(), attribute.getName(), propertyKey.getName(), esFieldName);
+                    }
+                }
+
+                if (jgIndexed && esIndexed) {
                     totalBmIndexed++;
                 } else {
                     totalBmMissing++;
@@ -267,6 +320,7 @@ public class IndexHealthMetricService {
         bmIndexed.set(totalBmIndexed);
         bmMissing.set(totalBmMissing);
         coreMissingTotal.set(totalCoreMissing);
+        cacheDriftTotal.set(driftCount);
 
         boolean isHealthy = (totalMissing + totalBmMissing) == 0;
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/ESConnector.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/ESConnector.java
@@ -404,6 +404,51 @@ public class ESConnector implements Closeable {
     }
 
     /**
+     * MS-973: Fetch the set of field names currently mapped in the vertex_index ES index.
+     * Used by IndexHealthMetricService as a ground-truth cross-check against JG's
+     * schema cache — catches cases where JG reports a propertyKey as registered but
+     * ES has no actual mapping for it (cache-divergence bug observed on olympus).
+     *
+     * Returns an empty set on failure (ES unreachable, parse error, etc.), which the
+     * caller treats as "skip ES cross-check, fall back to JG-only".
+     */
+    public static Set<String> getVertexIndexMappedFields() {
+        try {
+            Request request = new Request("GET", "/" + VERTEX_INDEX_NAME + "/_mapping");
+            Response response = lowLevelClient.performRequest(request);
+            int statusCode = response.getStatusLine().getStatusCode();
+            if (statusCode < 200 || statusCode >= 300) {
+                LOG.warn("ESConnector: failed to fetch {}/_mapping (HTTP {}); index-health cross-check will skip",
+                        VERTEX_INDEX_NAME, statusCode);
+                return Collections.emptySet();
+            }
+            String body = EntityUtils.toString(response.getEntity());
+            // Response shape: { "<actual_index_name>": { "mappings": { "properties": { "field1": {...}, ... } } } }
+            // The outer key may be the index name or an alias; iterate over all top-level entries.
+            Map<String, Object> parsed = AtlasType.fromJson(body, Map.class);
+            Set<String> fieldNames = new HashSet<>();
+            if (parsed != null) {
+                for (Object indexValue : parsed.values()) {
+                    if (!(indexValue instanceof Map)) continue;
+                    Object mappings = ((Map<?, ?>) indexValue).get("mappings");
+                    if (!(mappings instanceof Map)) continue;
+                    Object properties = ((Map<?, ?>) mappings).get("properties");
+                    if (!(properties instanceof Map)) continue;
+                    for (Object key : ((Map<?, ?>) properties).keySet()) {
+                        if (key instanceof String) {
+                            fieldNames.add((String) key);
+                        }
+                    }
+                }
+            }
+            return fieldNames;
+        } catch (Exception e) {
+            LOG.warn("ESConnector: getVertexIndexMappedFields failed — returning empty set; index-health cross-check will skip", e);
+            return Collections.emptySet();
+        }
+    }
+
+    /**
      * Result of a bulk ES write operation for tag denorm attributes.
      */
     public static class TagDenormESWriteResult {


### PR DESCRIPTION
## Change description

>GraphBackedSearchIndexer.resolveIndexFieldName was gated by                                                                                                                                                    
  TypeCategory.PRIMITIVE only, so ENUM and array<string> attributes never                                                                                                                                          
  reached the null-propertyKey self-heal from PRs #6306/#6416/#6436. This                                                                                                                                          
  is why the Squad attribute on olympus (typeName=Squads) hasn't self-                                                                                                                                             
  healed for 11+ days. Extract resolveIndexPrimitiveClass() helper that                                                                                                                                            
  maps PRIMITIVE/ENUM/array<string> to the right Class; replace the outer                                                                                                                                          
  gate with early-return when helper returns null. Three call sites that                                                                                                                                           
  used getPrimitiveClass(attribute.getTypeName()) now share one computed                                                                                                                                           
  primitiveClass.                                                                                                                                                                                                  
                                                                                                                                                                                                                   
  IndexHealthMetricService only checked JG's in-memory schema cache, which                                                                                                                                         
  can diverge from actual ES mapping (olympus: JG reported Squad as                                                                                                                                              
  indexed while ES had no mapping). Add ESConnector.getVertexIndexMapped                                                                                                                                           
  Fields() and cross-check each JG-indexed attr against the ES mapping.                                                                                                                                          
  Mismatch increments new atlas_index_health_cache_drift_total gauge and                                                                                                                                           
  counts as missing. Graceful fallback if ES unreachable.                                                                                                                                                          
                                                                                                                                                                                                                   
  Verified live: 69 pre-existing drift cases correctly detected on local                                                                                                                                           
  env (vs 0 previously); ENUM self-heal fires end-to-end through                                                                                                                                                   
  resolveIndexFieldName for an injected null-propertyKey state.

## Type of change
- [X] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
