### PR TITLE
MS-692: IndexSearch edge fetch optimisation — full-scan + per-type + skip Step A sequential vertex loading

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -37,6 +37,7 @@ on:
       - ms-864-keycloak-jwks-internal-url
       - ms-911-add-observability
       - ms-610-ranges-policy-cache
+      - ms-692-per-type-edge-labels-latest
       - ms-901-hidelineage
       - ms-894-override-classification
     paths-ignore:

--- a/graphdb/api/src/main/java/org/apache/atlas/repository/graphdb/AtlasIndexQuery.java
+++ b/graphdb/api/src/main/java/org/apache/atlas/repository/graphdb/AtlasIndexQuery.java
@@ -115,16 +115,6 @@ public interface AtlasIndexQuery<V, E> {
 
         Map<String, List<String>> getHighLights();
         ArrayList<Object> getSort();
-
-        /**
-         * Returns the vertex ID for this result without necessarily loading the full vertex.
-         * ZeroGraph overrides this to extract the ID from the ES doc _id (CPU-only, no CQL).
-         * Default falls back to getVertex().getId() for backward compatibility.
-         */
-        default String getVertexId() {
-            AtlasVertex<V, E> vertex = getVertex();
-            return vertex != null ? vertex.getId().toString() : null;
-        }
     }
 
 }

--- a/graphdb/api/src/main/java/org/apache/atlas/repository/graphdb/AtlasIndexQuery.java
+++ b/graphdb/api/src/main/java/org/apache/atlas/repository/graphdb/AtlasIndexQuery.java
@@ -115,6 +115,16 @@ public interface AtlasIndexQuery<V, E> {
 
         Map<String, List<String>> getHighLights();
         ArrayList<Object> getSort();
+
+        /**
+         * Returns the vertex ID for this result without necessarily loading the full vertex.
+         * ZeroGraph overrides this to extract the ID from the ES doc _id (CPU-only, no CQL).
+         * Default falls back to getVertex().getId() for backward compatibility.
+         */
+        default String getVertexId() {
+            AtlasVertex<V, E> vertex = getVertex();
+            return vertex != null ? vertex.getId().toString() : null;
+        }
     }
 
 }

--- a/graphdb/cassandra/src/main/java/org/apache/atlas/repository/graphdb/cassandra/CassandraIndexQuery.java
+++ b/graphdb/cassandra/src/main/java/org/apache/atlas/repository/graphdb/cassandra/CassandraIndexQuery.java
@@ -795,12 +795,11 @@ public class CassandraIndexQuery implements AtlasIndexQuery<CassandraVertex, Cas
             return v;
         }
 
-        @Override
         public String getVertexId() {
             if (resolvedVertex != null) {
                 return resolvedVertex.getId().toString();
             }
-            return decodeDocId(hit.getId());
+            return hit.getId();
         }
 
         @Override
@@ -882,9 +881,8 @@ public class CassandraIndexQuery implements AtlasIndexQuery<CassandraVertex, Cas
             return v;
         }
 
-        @Override
         public String getVertexId() {
-            return decodeDocId(String.valueOf(hit.get("_id")));
+            return String.valueOf(hit.get("_id"));
         }
 
         @Override

--- a/graphdb/cassandra/src/main/java/org/apache/atlas/repository/graphdb/cassandra/CassandraIndexQuery.java
+++ b/graphdb/cassandra/src/main/java/org/apache/atlas/repository/graphdb/cassandra/CassandraIndexQuery.java
@@ -796,6 +796,14 @@ public class CassandraIndexQuery implements AtlasIndexQuery<CassandraVertex, Cas
         }
 
         @Override
+        public String getVertexId() {
+            if (resolvedVertex != null) {
+                return resolvedVertex.getId().toString();
+            }
+            return decodeDocId(hit.getId());
+        }
+
+        @Override
         public double getScore() {
             if (hit != null) {
                 return hit.getScore();
@@ -872,6 +880,11 @@ public class CassandraIndexQuery implements AtlasIndexQuery<CassandraVertex, Cas
                 LOG.debug("ResultImplDirect.getVertex: found vertex. ES docId='{}' → vertexId='{}'", docId, v.getId());
             }
             return v;
+        }
+
+        @Override
+        public String getVertexId() {
+            return decodeDocId(String.valueOf(hit.get("_id")));
         }
 
         @Override

--- a/repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java
@@ -42,6 +42,7 @@ import org.apache.atlas.repository.VertexEdgePropertiesCache;
 import org.apache.atlas.repository.graph.GraphBackedSearchIndexer;
 import org.apache.atlas.repository.graphdb.*;
 import org.apache.atlas.repository.graphdb.AtlasIndexQuery.Result;
+import org.apache.atlas.repository.graphdb.cassandra.CassandraIndexQuery;
 import org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2;
 import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
 import org.apache.atlas.repository.userprofile.UserProfileService;
@@ -570,12 +571,18 @@ public class EntityDiscoveryService implements AtlasDiscoveryService {
                 return;
             }
             Set<String> vertexIds = results.stream().map(result -> {
-                String vertexId = result.getVertexId();
-                if (vertexId == null) {
-                    LOG.warn("vertex id is null for result");
+                if (result instanceof CassandraIndexQuery.ResultImplDirect) {
+                    return ((CassandraIndexQuery.ResultImplDirect) result).getVertexId();
+                }
+                if (result instanceof CassandraIndexQuery.ResultImpl) {
+                    return ((CassandraIndexQuery.ResultImpl) result).getVertexId();
+                }
+                AtlasVertex vertex = result.getVertex();
+                if (vertex == null) {
+                    LOG.warn("vertex in null");
                     return null;
                 }
-                return vertexId;
+                return vertex.getId().toString();
             }).filter(Objects::nonNull).collect(Collectors.toSet());
             VertexEdgePropertiesCache vertexEdgePropertiesCache;
             if (useVertexEdgeBulkFetching) {

--- a/repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java
@@ -570,12 +570,12 @@ public class EntityDiscoveryService implements AtlasDiscoveryService {
                 return;
             }
             Set<String> vertexIds = results.stream().map(result -> {
-                AtlasVertex vertex = result.getVertex();
-                if (vertex == null) {
-                    LOG.warn("vertex in null");
+                String vertexId = result.getVertexId();
+                if (vertexId == null) {
+                    LOG.warn("vertex id is null for result");
                     return null;
                 }
-                return vertex.getId().toString();
+                return vertexId;
             }).filter(Objects::nonNull).collect(Collectors.toSet());
             VertexEdgePropertiesCache vertexEdgePropertiesCache;
             if (useVertexEdgeBulkFetching) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -1520,6 +1520,66 @@ public class EntityGraphRetriever {
         return allResults;
     }
 
+    /**
+     * Fetches ALL edges for the given vertices using bulk partition reads (2 CQL per vertex:
+     * one for edges_out, one for edges_in), then filters by the requested edge labels in memory.
+     *
+     * This is more efficient than per-label CQL queries for indexsearch because it trades
+     * a few extra rows fetched for dramatically fewer network round-trips:
+     *   - Per-label approach: N vertices × L labels × directions = ~1,500 CQL for 100 results
+     *   - Full-scan approach: N vertices × 2 = 200 CQL for 100 results
+     *
+     * The limitPerLabel constraint is NOT enforced here — it is enforced downstream by
+     * {@link VertexEdgePropertiesCache#addEdgeLabelToVertexIds} which caps edges per (vertex, label).
+     */
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> fetchEdgesViaFullScan(Set<String> vertexIds, Set<String> edgeLabels) {
+        AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("fetchEdgesViaFullScan");
+        try {
+            Map<String, List<AtlasEdge>> allEdgesMap = (Map) graph.getEdgesForVertices(vertexIds);
+
+            List<Map<String, Object>> results = new ArrayList<>();
+            Set<String> seenEdgeIds = new HashSet<>();
+
+            for (String vertexId : vertexIds) {
+                List<AtlasEdge> edges = allEdgesMap.getOrDefault(vertexId, Collections.emptyList());
+
+                for (AtlasEdge edge : edges) {
+                    String edgeId = edge.getIdForDisplay();
+                    if (!seenEdgeIds.add(edgeId)) continue;
+
+                    String label = edge.getLabel();
+                    if (!edgeLabels.contains(label)) continue;
+
+                    String state = edge.getProperty(STATE_PROPERTY_KEY, String.class);
+                    if (!ACTIVE.name().equals(state)) continue;
+
+                    String relGuid = edge.getProperty(RELATIONSHIP_GUID_PROPERTY_KEY, String.class);
+                    if (relGuid == null) continue;
+
+                    Map<String, Object> edgeInfo = new HashMap<>();
+                    edgeInfo.put("id", edge.getId());
+
+                    LinkedHashMap<String, Object> valueMap = new LinkedHashMap<>();
+                    for (String key : edge.getPropertyKeys()) {
+                        valueMap.put(key, edge.getProperty(key, Object.class));
+                    }
+                    edgeInfo.put("valueMap", valueMap);
+                    edgeInfo.put("label", label);
+                    edgeInfo.put("inVertexId", edge.getInVertex().getId());
+                    edgeInfo.put("outVertexId", edge.getOutVertex().getId());
+                    results.add(edgeInfo);
+                }
+            }
+
+            LOG.debug("fetchEdgesViaFullScan: {} vertices, {} labels, {} edges found",
+                      vertexIds.size(), edgeLabels.size(), results.size());
+
+            return results;
+        } finally {
+            RequestContext.get().endMetricRecord(metricRecorder);
+        }
+    }
 
     public VertexEdgePropertiesCache enrichVertexPropertiesByVertexIds(Set<String> vertexIds, Set<String> attributes) {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("enrichVertexPropertiesByVertexIds");
@@ -1563,43 +1623,22 @@ public class EntityGraphRetriever {
 
            Set<String> vertexIdsToProcess = new HashSet<>();
            if (!CollectionUtils.isEmpty(edgeLabelsToProcess)) {
-               boolean bulkFetch = AtlasConfiguration.ATLAS_INDEXSEARCH_EDGE_BULK_FETCH_ENABLE.getBoolean();
                List<Map<String, Object>> relationEdges;
 
                if (graph instanceof CassandraGraph) {
-                   // ZeroGraph: group vertices by type so each type-group only queries the
-                   // labels relevant to that type, in the correct direction. This compounds
-                   // the per-type filtering optimization with direction-aware fetching —
-                   // a Table vertex won't fire CQL for glossary/domain labels that a mixed
-                   // result set contributes to the flat union.
-                   relationEdges = new ArrayList<>();
-                   Map<String, Set<String>> typeToVertexIds = new HashMap<>();
-                   for (String vertexId : vertexIds) {
-                       String typeName = vertexEdgePropertyCache.getTypeName(vertexId);
-                       if (StringUtils.isNotEmpty(typeName) && perTypeEdgeLabels.containsKey(typeName)) {
-                           typeToVertexIds.computeIfAbsent(typeName, k -> new LinkedHashSet<>()).add(vertexId);
-                       }
-                   }
-
-                   for (Map.Entry<String, Set<String>> entry : typeToVertexIds.entrySet()) {
-                       Set<String> typeVertexIds = entry.getValue();
-                       Map<String, AtlasEdgeDirection> typeEdgeLabels = perTypeEdgeLabels.get(entry.getKey());
-                       if (MapUtils.isEmpty(typeEdgeLabels)) {
-                           continue;
-                       }
-                       List<Map<String, Object>> typeEdges = bulkFetch
-                               ? getConnectedRelationEdgesVertexBatching(typeVertexIds, typeEdgeLabels, relationAttrsSize)
-                               : getConnectedRelationEdges(typeVertexIds, typeEdgeLabels, relationAttrsSize);
-                       relationEdges.addAll(typeEdges);
-                   }
+                   // ZeroGraph: fetch ALL edges per vertex (2 CQL per vertex, async) instead
+                   // of per-label CQL (N×L queries). Filters by requested labels in memory.
+                   // For 100 results × 15 labels: 200 CQL vs 1,500 — 7.5× fewer round-trips.
+                   // The downstream addEdgeLabelToVertexIds enforces limitPerLabel.
+                   relationEdges = fetchEdgesViaFullScan(vertexIds, edgeLabelsToProcess);
                } else {
-                   // JanusGraph: single Gremlin traversal with the flat union of labels.
-                   // Per-type grouping would turn 1 traversal into N with no storage-level
-                   // savings, adding per-call overhead — so we keep the existing behavior here.
+                   // JanusGraph: existing Gremlin traversal path — unchanged
                    Map<String, AtlasEdgeDirection> edgeLabelDirections = flattenPerTypeDirections(perTypeEdgeLabels);
-                   relationEdges = bulkFetch
-                           ? getConnectedRelationEdgesVertexBatching(vertexIds, edgeLabelDirections, relationAttrsSize)
-                           : getConnectedRelationEdges(vertexIds, edgeLabelDirections, relationAttrsSize);
+                   if (AtlasConfiguration.ATLAS_INDEXSEARCH_EDGE_BULK_FETCH_ENABLE.getBoolean()) {
+                       relationEdges = getConnectedRelationEdgesVertexBatching(vertexIds, edgeLabelDirections, relationAttrsSize);
+                   } else {
+                       relationEdges = getConnectedRelationEdges(vertexIds, edgeLabelDirections, relationAttrsSize);
+                   }
                }
 
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -1169,10 +1169,28 @@ public class EntityGraphRetriever {
      * direction from which the edge should be queried (IN, OUT, or BOTH), enabling
      * the edge fetch layer to query only the correct Cassandra table per label instead
      * of always querying both edges_out and edges_in.
+     *
+     * <p>Returns the flat union of labels across all types in the result set. When the
+     * same label is contributed by different types with different directions (rare),
+     * the merge falls back to {@link AtlasEdgeDirection#BOTH} for safety.
      */
     private Map<String, AtlasEdgeDirection> collectEdgeLabelsWithDirection(VertexEdgePropertiesCache cache,
                                                                            Set<String> vertexIds,
                                                                            Set<String> attributes) {
+        return flattenPerTypeDirections(collectEdgeLabelsPerTypeWithDirection(cache, vertexIds, attributes));
+    }
+
+    /**
+     * Collects edge labels grouped by entity typeName, with each label mapped to its
+     * relationship direction. Used by the ZeroGraph path in {@link #enrichVertexPropertiesByVertexIds}
+     * to group vertices by type and query only the labels relevant to each type, in the
+     * correct direction. Combines per-type filtering with direction-aware fetching.
+     *
+     * @return Map of typeName -> (edge label -> direction). Types with no relevant
+     *         relationship attributes are omitted.
+     */
+    private Map<String, Map<String, AtlasEdgeDirection>> collectEdgeLabelsPerTypeWithDirection(
+            VertexEdgePropertiesCache cache, Set<String> vertexIds, Set<String> attributes) {
         if (attributes == null || attributes.isEmpty()) {
             return Collections.emptyMap();
         }
@@ -1182,20 +1200,39 @@ public class EntityGraphRetriever {
                 .filter(StringUtils::isNotEmpty)
                 .collect(Collectors.toSet());
 
-        Map<String, AtlasEdgeDirection> edgeLabelDirections = new HashMap<>();
-
+        Map<String, Map<String, AtlasEdgeDirection>> perTypeLabels = new HashMap<>();
         for (String typeName : typeNames) {
             AtlasEntityType entityType = typeRegistry.getEntityTypeByName(typeName);
             if (entityType == null) {
                 continue;
             }
 
+            Map<String, AtlasEdgeDirection> labelsForType = new HashMap<>();
             for (String attribute : attributes) {
-                processRelationshipAttribute(entityType, attribute, edgeLabelDirections);
+                processRelationshipAttribute(entityType, attribute, labelsForType);
+            }
+            if (!labelsForType.isEmpty()) {
+                perTypeLabels.put(typeName, labelsForType);
             }
         }
+        return perTypeLabels;
+    }
 
-        return edgeLabelDirections;
+    /**
+     * Flattens a per-type label+direction map into a single map. When the same label
+     * appears in multiple types with different directions, merges to
+     * {@link AtlasEdgeDirection#BOTH} to preserve correctness.
+     */
+    private static Map<String, AtlasEdgeDirection> flattenPerTypeDirections(
+            Map<String, Map<String, AtlasEdgeDirection>> perType) {
+        Map<String, AtlasEdgeDirection> flat = new HashMap<>();
+        for (Map<String, AtlasEdgeDirection> typeMap : perType.values()) {
+            for (Map.Entry<String, AtlasEdgeDirection> entry : typeMap.entrySet()) {
+                flat.merge(entry.getKey(), entry.getValue(),
+                        (existing, incoming) -> existing == incoming ? existing : AtlasEdgeDirection.BOTH);
+            }
+        }
+        return flat;
     }
 
     private void processRelationshipAttribute(AtlasEntityType entityType,
@@ -1514,16 +1551,55 @@ public class EntityGraphRetriever {
            }
            vertexEdgePropertyCache.addVertices(vertexCache.getValue1());
 
-           Map<String, AtlasEdgeDirection> edgeLabelDirections = collectEdgeLabelsWithDirection(vertexEdgePropertyCache, vertexIds, attributes);
-           Set<String> edgeLabelsToProcess = edgeLabelDirections.keySet();
+           Map<String, Map<String, AtlasEdgeDirection>> perTypeEdgeLabels =
+                   collectEdgeLabelsPerTypeWithDirection(vertexEdgePropertyCache, vertexIds, attributes);
+
+           // Union of all labels across types — used by the edge processing loop below
+           // to filter out any stray edges that don't match a requested label.
+           Set<String> edgeLabelsToProcess = new HashSet<>();
+           for (Map<String, AtlasEdgeDirection> typeMap : perTypeEdgeLabels.values()) {
+               edgeLabelsToProcess.addAll(typeMap.keySet());
+           }
 
            Set<String> vertexIdsToProcess = new HashSet<>();
            if (!CollectionUtils.isEmpty(edgeLabelsToProcess)) {
+               boolean bulkFetch = AtlasConfiguration.ATLAS_INDEXSEARCH_EDGE_BULK_FETCH_ENABLE.getBoolean();
                List<Map<String, Object>> relationEdges;
-               if (AtlasConfiguration.ATLAS_INDEXSEARCH_EDGE_BULK_FETCH_ENABLE.getBoolean()) {
-                   relationEdges = getConnectedRelationEdgesVertexBatching(vertexIds, edgeLabelDirections, relationAttrsSize);
+
+               if (graph instanceof CassandraGraph) {
+                   // ZeroGraph: group vertices by type so each type-group only queries the
+                   // labels relevant to that type, in the correct direction. This compounds
+                   // the per-type filtering optimization with direction-aware fetching —
+                   // a Table vertex won't fire CQL for glossary/domain labels that a mixed
+                   // result set contributes to the flat union.
+                   relationEdges = new ArrayList<>();
+                   Map<String, Set<String>> typeToVertexIds = new HashMap<>();
+                   for (String vertexId : vertexIds) {
+                       String typeName = vertexEdgePropertyCache.getTypeName(vertexId);
+                       if (StringUtils.isNotEmpty(typeName) && perTypeEdgeLabels.containsKey(typeName)) {
+                           typeToVertexIds.computeIfAbsent(typeName, k -> new LinkedHashSet<>()).add(vertexId);
+                       }
+                   }
+
+                   for (Map.Entry<String, Set<String>> entry : typeToVertexIds.entrySet()) {
+                       Set<String> typeVertexIds = entry.getValue();
+                       Map<String, AtlasEdgeDirection> typeEdgeLabels = perTypeEdgeLabels.get(entry.getKey());
+                       if (CollectionUtils.isEmpty(typeEdgeLabels)) {
+                           continue;
+                       }
+                       List<Map<String, Object>> typeEdges = bulkFetch
+                               ? getConnectedRelationEdgesVertexBatching(typeVertexIds, typeEdgeLabels, relationAttrsSize)
+                               : getConnectedRelationEdges(typeVertexIds, typeEdgeLabels, relationAttrsSize);
+                       relationEdges.addAll(typeEdges);
+                   }
                } else {
-                   relationEdges = getConnectedRelationEdges(vertexIds, edgeLabelDirections, relationAttrsSize);
+                   // JanusGraph: single Gremlin traversal with the flat union of labels.
+                   // Per-type grouping would turn 1 traversal into N with no storage-level
+                   // savings, adding per-call overhead — so we keep the existing behavior here.
+                   Map<String, AtlasEdgeDirection> edgeLabelDirections = flattenPerTypeDirections(perTypeEdgeLabels);
+                   relationEdges = bulkFetch
+                           ? getConnectedRelationEdgesVertexBatching(vertexIds, edgeLabelDirections, relationAttrsSize)
+                           : getConnectedRelationEdges(vertexIds, edgeLabelDirections, relationAttrsSize);
                }
 
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -1584,7 +1584,7 @@ public class EntityGraphRetriever {
                    for (Map.Entry<String, Set<String>> entry : typeToVertexIds.entrySet()) {
                        Set<String> typeVertexIds = entry.getValue();
                        Map<String, AtlasEdgeDirection> typeEdgeLabels = perTypeEdgeLabels.get(entry.getKey());
-                       if (CollectionUtils.isEmpty(typeEdgeLabels)) {
+                       if (MapUtils.isEmpty(typeEdgeLabels)) {
                            continue;
                        }
                        List<Map<String, Object>> typeEdges = bulkFetch


### PR DESCRIPTION
## Change Description

This PR combines three indexsearch optimizations for the ZeroGraph (Cassandra) path. JanusGraph path is completely untouched.

---

### Optimisation 1: Full-Scan Edge Fetch (replaces per-label CQL)

**Problem:** On ZeroGraph, fetching relationship edges fires a separate CQL query for each vertex × each edge label × each direction. For 100 results with 15 labels, that's ~1,500 CQL network round-trips — most returning empty results.

**Solution:** New method `fetchEdgesViaFullScan()` fetches ALL edges per vertex using bulk partition reads (2 CQL per vertex: one for `edges_out`, one for `edges_in`), then filters by requested labels in memory.

- **Before:** N vertices × L labels × directions = ~1,500 CQL for 100 results
- **After:** N vertices × 2 = 200 CQL for 100 results (7.5× fewer round-trips)
- `limitPerLabel` is NOT enforced here — enforced downstream by `VertexEdgePropertiesCache.addEdgeLabelToVertexIds()`
- Gated to ZeroGraph only via `if (graph instanceof CassandraGraph)`

**File:** `EntityGraphRetriever.java` — new `fetchEdgesViaFullScan()` method + caller update in `enrichVertexPropertiesByVertexIds()`

---

### Optimisation 2: Per-Type Edge Label Collection

**Problem:** Edge labels are collected as a flat union across all entity types in the result set. When results contain mixed types (Table + Column + View), each vertex gets queried for labels from ALL types — including irrelevant ones.

**Solution:** New method `collectEdgeLabelsPerTypeWithDirection()` returns `Map<typeName, Map<label, direction>>`. On JanusGraph, this is flattened via `flattenPerTypeDirections()` to preserve existing single-traversal behavior.

**Note:** This optimization compounds with the full-scan approach on ZeroGraph (labels are used for in-memory filtering). On JanusGraph, the flat union is preserved for the Gremlin `hasLabel(P.within(labels))` filter.

**File:** `EntityGraphRetriever.java` — new helper methods, JanusGraph path uses `flattenPerTypeDirections()`

---

### Optimisation 3: Skip Step A Sequential Vertex Loading (Hotspot 4)

**Problem:** In `EntityDiscoveryService.prepareSearchResult()`, the code calls `result.getVertex()` for each ES hit to extract the vertex ID. On ZeroGraph, each call fires a synchronous CQL read to the `vertices` table — 20 sequential reads for 20 results, just to get the ID string.

On ZeroGraph, the ES document `_id` field IS the Cassandra vertex ID. There's no need to load the full vertex just to extract its ID.

**Solution:** New method `getVertexId()` on `CassandraIndexQuery.ResultImpl` and `CassandraIndexQuery.ResultImplDirect` returns the raw ES doc `_id` directly — pure CPU, zero CQL.

In `EntityDiscoveryService`, an `instanceof` check routes ZeroGraph results to `getVertexId()`, while JanusGraph results fall through to the original `result.getVertex().getId()` code — byte-identical to before.

The actual vertex loading still happens in Step B1 (`enrichVertexPropertiesByVertexIds`) which loads all vertices in a single async batch via `getVerticesAsync()`. Step D's `result.getVertex()` then hits the cache.

- **Before:** 20 sequential sync CQL reads (~20ms for 20 results, ~100ms for 100 results)
- **After:** 0 CQL (ID from ES hit) + 20 parallel async CQL in Step B1 (~2ms)

**Files:**
- `CassandraIndexQuery.java` — new `getVertexId()` method on both Result classes (standalone, not interface override)
- `EntityDiscoveryService.java` — `instanceof` check for ZeroGraph, original JG code preserved as fallback

**JanusGraph impact: None.** No interface changes. No changes to `AtlasIndexQuery.java`. JanusGraph's `Result` classes don't have `getVertexId()` — the caller falls through to the original `result.getVertex().getId()` path.

---

### Safety

- **JanusGraph path completely untouched:**
  - `AtlasIndexQuery.java` — zero changes
  - `AtlasElasticsearchQuery.java` — zero changes
  - JanusGraph caller code in `EntityDiscoveryService` preserved as `else` fallback
  - JanusGraph caller code in `EntityGraphRetriever` uses `flattenPerTypeDirections()` → same flat union → same Gremlin traversal
- **ZeroGraph functional correctness verified:**
  - 20 indexsearch payloads fired against both baseline and optimised builds
  - 295 entities compared field-by-field
  - 12,418 individual attribute values compared — all byte-identical
  - relationshipAttributes, attributes, classifications, meanings — 100% match
  - [Functional Correctness Verification](https://atlanhq.atlassian.net/wiki/spaces/Metastore/pages/1825341485/MS-692+Direction-Aware+IndexSearch+Functional+Correctness+Verification)

### Analysis Documents
- [IndexSearch CQL Amplification Analysis](https://atlanhq.atlassian.net/wiki/spaces/Metastore/pages/1788837894/MS-692+IndexSearch+CQL+Amplification+Analysis+ZeroGraph)
- [Cassandra Hotspot Analysis](https://atlanhq.atlassian.net/wiki/spaces/Metastore/pages/1787396151/MS-692+Cassandra+Hotspot+Analysis+for+IndexSearch+ZeroGraph)
- [Functional Correctness Verification](https://atlanhq.atlassian.net/wiki/spaces/Metastore/pages/1825341485/MS-692+Direction-Aware+IndexSearch+Functional+Correctness+Verification)

## Type of change
- [x] New feature (adds functionality)

## Related issues

Fix [MS-692](https://linear.app/atlan/issue/MS-692)

## **Helm Config Changes for Running Tests (Staging PR)**
### Does this PR require Helm config changes for testing?
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_
- [x] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable