### PR TITLE
FPLT-83 | Add bootstrap entity policies for Knowledge assets

### DIFF
--- a/addons/policies/bootstrap_entity_policies.json
+++ b/addons/policies/bootstrap_entity_policies.json
@@ -4096,6 +4096,70 @@
                     "entity-delete"
                 ]
             }
+        },
+        {
+            "typeName": "AuthPolicy",
+            "attributes": {
+                "name": "READ_KNOWLEDGE_ENTITIES",
+                "qualifiedName": "READ_KNOWLEDGE_ENTITIES",
+                "description": "Allows all users to read Knowledge assets.",
+                "policyCategory": "bootstrap",
+                "policySubCategory": "default",
+                "policyServiceName": "atlas",
+                "policyType": "allow",
+                "policyPriority": 0,
+                "policyUsers": [],
+                "policyGroups": [],
+                "policyRoles": [
+                    "$admin",
+                    "$member",
+                    "$guest",
+                    "$api-token-default-access"
+                ],
+                "policyResourceCategory": "ENTITY",
+                "isPolicyEnabled": true,
+                "policyResources": [
+                    "entity-type:KnowledgeFolder",
+                    "entity-type:KnowledgeFile",
+                    "entity-classification:*",
+                    "entity:*"
+                ],
+                "policyActions": [
+                    "entity-read"
+                ]
+            }
+        },
+        {
+            "typeName": "AuthPolicy",
+            "attributes": {
+                "name": "CUD_KNOWLEDGE_ENTITIES",
+                "qualifiedName": "CUD_KNOWLEDGE_ENTITIES",
+                "description": "Allows admins and API tokens to perform CUD operations on Knowledge assets.",
+                "policyCategory": "bootstrap",
+                "policySubCategory": "default",
+                "policyServiceName": "atlas",
+                "policyType": "allow",
+                "policyPriority": 0,
+                "policyUsers": [],
+                "policyGroups": [],
+                "policyRoles": [
+                    "$admin",
+                    "$api-token-default-access"
+                ],
+                "policyResourceCategory": "ENTITY",
+                "isPolicyEnabled": true,
+                "policyResources": [
+                    "entity-type:KnowledgeFolder",
+                    "entity-type:KnowledgeFile",
+                    "entity-classification:*",
+                    "entity:*"
+                ],
+                "policyActions": [
+                    "entity-create",
+                    "entity-update",
+                    "entity-delete"
+                ]
+            }
         }
     ]
 }

--- a/addons/policies/bootstrap_relationship_policies.json
+++ b/addons/policies/bootstrap_relationship_policies.json
@@ -1225,6 +1225,45 @@
                     "remove-relationship"
                 ]
             }
+        },
+        {
+            "typeName": "AuthPolicy",
+            "attributes":
+            {
+                "name": "LINK_KNOWLEDGE_FOLDER_TO_FILE",
+                "qualifiedName": "LINK_KNOWLEDGE_FOLDER_TO_FILE",
+                "policyCategory": "bootstrap",
+                "policySubCategory": "default",
+                "policyServiceName": "atlas",
+                "policyType": "allow",
+                "policyPriority": 0,
+                "policyUsers":
+                [],
+                "policyGroups":
+                [],
+                "policyRoles":
+                [
+                    "$admin",
+                    "$api-token-default-access"
+                ],
+                "policyResourceCategory": "RELATIONSHIP",
+                "policyResources":
+                [
+                    "end-one-entity-classification:*",
+                    "end-two-entity-classification:*",
+                    "end-one-entity:*",
+                    "end-two-entity:*",
+                    "end-one-entity-type:KnowledgeFolder",
+                    "end-two-entity-type:KnowledgeFile",
+                    "relationship-type:*"
+                ],
+                "policyActions":
+                [
+                    "add-relationship",
+                    "update-relationship",
+                    "remove-relationship"
+                ]
+            }
         }
     ]
 }


### PR DESCRIPTION
## What this PR does

Adds bootstrap entity and relationship policies for the new Knowledge layer typedefs — KnowledgeFolder and KnowledgeFile.

### Entity Policies

| Policy | Types | Roles | Actions |
|---|---|---|---|
| `READ_KNOWLEDGE_ENTITIES` | KnowledgeFolder, KnowledgeFile | admin, member, guest, api-token | entity-read |
| `CUD_KNOWLEDGE_ENTITIES` | KnowledgeFolder, KnowledgeFile | admin, api-token | entity-create, update, delete |

### Relationship Policies

| Policy | Parent → Child | Roles | Actions |
|---|---|---|---|
| `LINK_KNOWLEDGE_FOLDER_TO_FILE` | KnowledgeFolder → KnowledgeFile | admin, api-token | add, update, remove |

Knowledge policies support independent permission management as the knowledge layer expands.

### Related PRs

| PR | Repo | What it does |
|---|---|---|
| [#1939](https://github.com/atlanhq/models/pull/1939) | models | KnowledgeFolder + KnowledgeFile typedefs |

### Test plan

- [x] JSON validates (\`jq\`)
- [x] Policy names and entity types match typedef names
- [x] Existing policies not affected
- [x] Relationship policies cover KnowledgeFolder → KnowledgeFile containment