### PR TITLE
fix: (ms-1008) edge index missing keyword mapping for relationship attrs; lineage aggs fail HTTP 400

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphBackedSearchIndexer.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphBackedSearchIndexer.java
@@ -284,12 +284,29 @@ public class GraphBackedSearchIndexer implements SearchIndexer, ActiveStateChang
 
         typeDefs.addAll(typeRegistry.getAllEntityDefs());
         typeDefs.addAll(typeRegistry.getAllBusinessMetadataDefs());
+        // MS-1008: Include relationship types so edge-index property keys (toTypeLabel,
+        // fromTypeLabel, etc.) are re-registered on startup. Without this, pod restarts
+        // after ES edge-index recreation leave relationship attributes without keyword
+        // mappings — ES falls back to dynamic text mapping, breaking aggregations/sorts.
+        typeDefs.addAll(typeRegistry.getAllRelationshipDefs());
 
         ChangedTypeDefs      changedTypeDefs = new ChangedTypeDefs(null, new ArrayList<>(typeDefs), null);
         AtlasGraphManagement management      = null;
 
         try {
             management = provider.get().getManagementSystem();
+
+            // MS-1008: Ensure edge index exists in ES and has dynamic_templates BEFORE
+            // processing typedefs. CassandraGraph's schema says the edge index exists (from
+            // Cassandra) but the actual ES index may be missing (ES maintenance, cluster
+            // recovery, manual deletion). Without the ES index, updateIndexForTypeDef's
+            // addMixedIndex calls fail silently. Also applies dynamic_templates so any
+            // unregistered string fields default to keyword instead of text.
+            try {
+                ESConnector.ensureEdgeIndexDynamicTemplates();
+            } catch (Exception e) {
+                LOG.warn("Failed to ensure edge index — non-fatal, typedef processing may partially fail", e);
+            }
 
             // Ensure property keys and mixed index entries exist for all entity attributes.
             // For persistent-schema backends (JanusGraph) this is a no-op since the schema

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/ESConnector.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/ESConnector.java
@@ -25,6 +25,7 @@ import static org.apache.atlas.repository.Constants.CLASSIFICATION_TEXT_KEY;
 import static org.apache.atlas.repository.Constants.PROPAGATED_CLASSIFICATION_NAMES_KEY;
 import static org.apache.atlas.repository.Constants.PROPAGATED_TRAIT_NAMES_PROPERTY_KEY;
 import static org.apache.atlas.repository.Constants.TRAIT_NAMES_PROPERTY_KEY;
+import static org.apache.atlas.repository.Constants.EDGE_INDEX_NAME;
 import static org.apache.atlas.repository.Constants.VERTEX_INDEX_NAME;
 import static org.apache.atlas.repository.audit.ESBasedAuditRepository.getHttpHosts;
 
@@ -400,6 +401,61 @@ public class ESConnector implements Closeable {
     public void close() throws IOException {
         if (lowLevelClient != null) {
             lowLevelClient.close();
+        }
+    }
+
+    /**
+     * MS-1008: Ensure the edge index exists in ES and has dynamic_templates mapping
+     * strings to keyword. Prevents relationship attributes (toTypeLabel, fromTypeLabel)
+     * from being dynamically mapped as text — which breaks aggregations/sorts with HTTP 400.
+     *
+     * Handles two failure scenarios:
+     *   1. Edge index missing in ES (JG schema still references it from Cassandra) — creates it
+     *   2. Edge index exists but has no dynamic_templates — applies them
+     *
+     * Idempotent. Safe to call on every startup.
+     */
+    public static void ensureEdgeIndexDynamicTemplates() {
+        try {
+            // Ensure the ES index exists — JG's schema may reference an edge index
+            // that was deleted/lost in ES (cluster recovery, manual deletion).
+            try {
+                Request headReq = new Request("HEAD", "/" + EDGE_INDEX_NAME);
+                Response headResp = lowLevelClient.performRequest(headReq);
+                if (headResp.getStatusLine().getStatusCode() == 404) {
+                    Request createReq = new Request("PUT", "/" + EDGE_INDEX_NAME);
+                    createReq.setEntity(new StringEntity("{}", ContentType.APPLICATION_JSON));
+                    lowLevelClient.performRequest(createReq);
+                    LOG.info("ESConnector: created missing ES edge index: {}", EDGE_INDEX_NAME);
+                }
+            } catch (org.elasticsearch.client.ResponseException re) {
+                if (re.getResponse().getStatusLine().getStatusCode() == 404) {
+                    Request createReq = new Request("PUT", "/" + EDGE_INDEX_NAME);
+                    createReq.setEntity(new StringEntity("{}", ContentType.APPLICATION_JSON));
+                    lowLevelClient.performRequest(createReq);
+                    LOG.info("ESConnector: created missing ES edge index: {}", EDGE_INDEX_NAME);
+                }
+            }
+
+            String body = "{\"dynamic_templates\":[{\"edge_strings\":" +
+                    "{\"match_mapping_type\":\"string\",\"mapping\":" +
+                    "{\"type\":\"keyword\",\"ignore_above\":5120}}}]}";
+
+            Request request = new Request("PUT", "/" + EDGE_INDEX_NAME + "/_mapping");
+            request.setEntity(new StringEntity(body, ContentType.APPLICATION_JSON));
+
+            Response response = lowLevelClient.performRequest(request);
+            int statusCode = response.getStatusLine().getStatusCode();
+
+            if (statusCode >= 200 && statusCode < 300) {
+                LOG.info("ESConnector: ensured dynamic_templates on edge index (strings → keyword)");
+            } else {
+                String responseBody = EntityUtils.toString(response.getEntity());
+                LOG.warn("ESConnector: failed to apply dynamic_templates to edge index (HTTP {}): {}",
+                        statusCode, responseBody);
+            }
+        } catch (Exception e) {
+            LOG.warn("ESConnector: failed to ensure edge index dynamic_templates — non-fatal, existing mappings may suffice", e);
         }
     }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/ESConnector.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/ESConnector.java
@@ -456,7 +456,10 @@ public class ESConnector implements Closeable {
             }
         } catch (Exception e) {
             LOG.warn("ESConnector: failed to ensure edge index dynamic_templates — non-fatal, existing mappings may suffice", e);
-     * MS-973: Fetch the set of field names currently mapped in the vertex_index ES index.
+        }
+    }
+
+    /** MS-973: Fetch the set of field names currently mapped in the vertex_index ES index.
      * Used by IndexHealthMetricService as a ground-truth cross-check against JG's
      * schema cache — catches cases where JG reports a propertyKey as registered but
      * ES has no actual mapping for it (cache-divergence bug observed on olympus).


### PR DESCRIPTION
## Change description

> onLoadCompletion only iterated entity + BM types, skipping relationship types.                                                                                                                                   
  On CassandraGraph (in-memory schema), property keys and fieldKeys are lost on                                                                                                                                    
  restart — relationship attributes like toTypeLabel/fromTypeLabel were never                                                                                                                                      
  re-registered in the edge mixed index. If the ES edge index was recreated                                                                                                                                        
  (maintenance, cluster recovery), these fields got dynamically mapped as text                                                                                                                                     
  instead of keyword. ES rejects terms aggregations on text fields with HTTP 400,                                                                                                                                  
  breaking lineage for large datasets (Colgate CSKPI: 456+ upstream tables).                                                                                                                                       
                                                                                                                                                                                                                   
  Fix 1: Add typeRegistry.getAllRelationshipDefs() to onLoadCompletion so                                                                                                                                          
  relationship attributes are re-registered on every startup — matching what                                                                                                                                       
  onChange already does for typedef create/update events.                                                                                                                                                          
                                                                  
  Fix 2: Add ESConnector.ensureEdgeIndexDynamicTemplates() called before typedef                                                                                                                                   
  processing in onLoadCompletion. Creates the ES edge index if missing (JG schema
  can reference it from Cassandra while ES lost it), then PUTs dynamic_templates                                                                                                                                   
  mapping all strings to keyword. Matches the vertex index behavior from                                                                                                                                           
  es-mappings.json. Idempotent, runs every startup.

## Type of change
- [X] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
