### PR TITLE
MS-927 [STAGING] filter disabled policies in getPoliciesDelta and emit DELETE delta on disable

### DIFF
--- a/auth-agents-common/src/main/java/org/apache/atlas/policytransformer/CachePolicyTransformerImpl.java
+++ b/auth-agents-common/src/main/java/org/apache/atlas/policytransformer/CachePolicyTransformerImpl.java
@@ -383,21 +383,35 @@ public class CachePolicyTransformerImpl {
             policyDeltas.add(delta);
         }
 
-        // handle delete changes separately as they won't be present in atlas policies
+        // Collect GUIDs of enabled policies that were actually fetched for this service
+        Set<String> fetchedEnabledGuids = atlasPolicies.stream()
+                .map(AtlasEntityHeader::getGuid)
+                .collect(Collectors.toSet());
+
+        // Handle delete changes separately as they won't be present in atlas policies.
+        // Also treat policies that had a non-DELETE audit event but are absent from the
+        // fetched results as deletes — this covers policies that were disabled (isEnabled=false)
+        // since getAtlasPolicies now always filters on isEnabled=true.
         List<RangerPolicyDelta> deletedPolicyDeltas = new ArrayList<>();
         for (String policyGuid : policyGuids) {
             Integer deltaChangeType = auditEventToDeltaChangeType.get(policyChanges.get(policyGuid));
             if (deltaChangeType == null) {
                 continue;
             }
-            if (deltaChangeType == RangerPolicyDelta.CHANGE_TYPE_POLICY_DELETE) {
+            boolean isActualDelete = deltaChangeType == RangerPolicyDelta.CHANGE_TYPE_POLICY_DELETE;
+            boolean isNowDisabled  = !isActualDelete && !fetchedEnabledGuids.contains(policyGuid);
+
+            if (isActualDelete || isNowDisabled) {
+                if (isNowDisabled) {
+                    LOG.info("PolicyDelta: {}: policy guid={} is disabled, emitting DELETE delta", serviceName, policyGuid);
+                }
                 RangerPolicy deletedPolicy = new RangerPolicy();
                 deletedPolicy.setGuid(policyGuid);
                 deletedPolicy.setService(serviceName);
                 deletedPolicy.setServiceType(serviceType);
                 RangerPolicyDelta deletedPolicyDelta = new RangerPolicyDelta(
                         deletedPolicy.getId(),
-                        deltaChangeType,
+                        RangerPolicyDelta.CHANGE_TYPE_POLICY_DELETE,
                         deletedPolicy.getVersion(),
                         deletedPolicy
                 );
@@ -713,8 +727,8 @@ public class CachePolicyTransformerImpl {
                 mustClauseList.add(getMap("terms", getMap("__guid", policyGuids)));
             } else {
                 mustClauseList.add(getMap("term", getMap(ATTR_POLICY_SERVICE_NAME, serviceName)));
-                mustClauseList.add(getMap("term", getMap(ATTR_POLICY_IS_ENABLED, true)));
             }
+            mustClauseList.add(getMap("term", getMap(ATTR_POLICY_IS_ENABLED, true)));
 
             dsl.put("query", getMap("bool", getMap("must", mustClauseList)));
 


### PR DESCRIPTION


- Move isEnabled=true ES filter outside the else-branch in getAtlasPolicies so it applies in both the full-load path (empty policyGuids) and the delta path (non-empty policyGuids). Previously the filter was skipped in the delta path, causing disabled policies to be fetched and pushed into Ranger's cache as active.

- Extend the delete-delta loop in getRangerPolicyDelta to also emit CHANGE_TYPE_POLICY_DELETE for policies that had a non-DELETE audit event but are absent from the fetched enabled results. This handles the enabled->disabled transition: Ranger now evicts the policy from its cache instead of retaining it.

(cherry picked from commit a121ad3e1b9395f67c32b3aa228a4d44dff393dc)

## Change description

> Description here

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
