### PR TITLE
fix: migrate secrets from atlas-config ConfigMap to env var interpolation (MS-1006)

### DIFF
--- a/helm/atlas/templates/configmap.yaml
+++ b/helm/atlas/templates/configmap.yaml
@@ -345,7 +345,7 @@ data:
     {{- end }}
     atlas.graph.cache.redis-cache-lock-watchdog-ms=300000
     atlas.graph.cache.redis-cache-username={{ .Values.atlas.redis.username }}
-    atlas.graph.cache.redis-cache-password={{ .Values.atlas.redis.password }}
+    atlas.graph.cache.redis-cache-password=${env:REDIS_PASSWORD}
     atlas.graph.cache.redis-cache-mastername={{ .Values.atlas.redis.master_name }}
     atlas.graph.cache.redis-cache-connectTimeout=2000
     {{- end }}
@@ -433,7 +433,7 @@ data:
     ########## Add query metastore ###########
     atlan.cache.redis.host={{ .Values.atlas.redis.host }}
     atlan.cache.redis.port={{ .Values.atlas.redis.port }}
-    atlan.cache.redis.password={{ .Values.atlas.redis.password }}
+    atlan.cache.redis.password=${env:REDIS_PASSWORD}
     atlas.cache.redis.maxConnections={{ .Values.atlas.redis.maxConnections }}
     atlas.cache.redis.timeout={{ .Values.atlas.redis.timeout }}
     atlan.EntityCacheListener.impl=org.apache.atlas.repository.cache.EntityCacheListenerV2
@@ -458,7 +458,7 @@ data:
     ########## Ranger Credentials
 
     atlas.ranger.username = admin
-    atlas.ranger.password = {{ .Values.atlas.ranger.RANGER_PASSWORD }}
+    atlas.ranger.password = ${env:RANGER_PASSWORD}
     atlas.ranger.base.url = {{ .Values.atlas.ranger.RANGER_SERVICE_URL }}
 
     ####### Redis credentials #######
@@ -474,7 +474,7 @@ data:
     atlas.redis.sentinel.urls = {{ .Values.atlas.redis.sentinel_urls }}
     {{- end }}
     atlas.redis.username = {{ .Values.atlas.redis.username }}
-    atlas.redis.password = {{ .Values.atlas.redis.password }}
+    atlas.redis.password = ${env:REDIS_PASSWORD}
     atlas.redis.master_name = {{ .Values.atlas.redis.master_name }}
     atlas.redis.lock.wait_time.ms=15000
     # Renew lock for every 10mins


### PR DESCRIPTION
## Summary

Migrates hardcoded secrets from the `atlas-config` ConfigMap to Apache Commons Configuration env var interpolation (`${env:VAR_NAME}`).

The same configmap already uses `${sys:}` interpolation (e.g. `${sys:atlas.home}`), so `${env:}` works through the same mechanism — no Java code changes needed.

## Changes

| Line | Before | After |
|------|--------|-------|
| 348 | `atlas.graph.cache.redis-cache-password={{ .Values.atlas.redis.password }}` | `atlas.graph.cache.redis-cache-password=${env:REDIS_PASSWORD}` |
| 436 | `atlan.cache.redis.password={{ .Values.atlas.redis.password }}` | `atlan.cache.redis.password=${env:REDIS_PASSWORD}` |
| 461 | `atlas.ranger.password = {{ .Values.atlas.ranger.RANGER_PASSWORD }}` | `atlas.ranger.password = ${env:RANGER_PASSWORD}` |
| 477 | `atlas.redis.password = {{ .Values.atlas.redis.password }}` | `atlas.redis.password = ${env:REDIS_PASSWORD}` |

## Prerequisites

- `RANGER_PASSWORD` is already injected into Atlas pods via `envFrom: secretRef` (atlas-secret-manager) — no infra change needed.
- `REDIS_PASSWORD` needs to be added to the `atlas-secret-manager` ExternalSecret — covered in the companion PR on `atlanhq/atlan`.

## Validation

Smoke test on a beta tenant after merge to confirm `${env:}` interpolation resolves correctly at runtime.

Closes MS-1006
