### PR TITLE
fix: migrate secrets from atlas-config ConfigMap to env var interpolation (MS-1006)

### DIFF
--- a/helm/atlas/templates/configmap.yaml
+++ b/helm/atlas/templates/configmap.yaml
@@ -344,7 +344,7 @@ data:
     {{- end }}
     atlas.graph.cache.redis-cache-lock-watchdog-ms=300000
     atlas.graph.cache.redis-cache-username={{ .Values.atlas.redis.username }}
-    atlas.graph.cache.redis-cache-password={{ .Values.atlas.redis.password }}
+    atlas.graph.cache.redis-cache-password=${env:REDIS_PASSWORD}
     atlas.graph.cache.redis-cache-mastername={{ .Values.atlas.redis.master_name }}
     atlas.graph.cache.redis-cache-connectTimeout=2000
     {{- end }}
@@ -430,7 +430,7 @@ data:
     ########## Add query metastore ###########
     atlan.cache.redis.host={{ .Values.atlas.redis.host }}
     atlan.cache.redis.port={{ .Values.atlas.redis.port }}
-    atlan.cache.redis.password={{ .Values.atlas.redis.password }}
+    atlan.cache.redis.password=${env:REDIS_PASSWORD}
     atlas.cache.redis.maxConnections={{ .Values.atlas.redis.maxConnections }}
     atlas.cache.redis.timeout={{ .Values.atlas.redis.timeout }}
     atlan.EntityCacheListener.impl=org.apache.atlas.repository.cache.EntityCacheListenerV2
@@ -455,7 +455,7 @@ data:
     ########## Ranger Credentials
 
     atlas.ranger.username = admin
-    atlas.ranger.password = {{ .Values.atlas.ranger.RANGER_PASSWORD }}
+    atlas.ranger.password = ${env:RANGER_PASSWORD}
     atlas.ranger.base.url = {{ .Values.atlas.ranger.RANGER_SERVICE_URL }}
 
     ####### Redis credentials #######
@@ -471,7 +471,7 @@ data:
     atlas.redis.sentinel.urls = {{ .Values.atlas.redis.sentinel_urls }}
     {{- end }}
     atlas.redis.username = {{ .Values.atlas.redis.username }}
-    atlas.redis.password = {{ .Values.atlas.redis.password }}
+    atlas.redis.password = ${env:REDIS_PASSWORD}
     atlas.redis.master_name = {{ .Values.atlas.redis.master_name }}
     atlas.redis.lock.wait_time.ms=15000
     # Renew lock for every 10mins


### PR DESCRIPTION
## Summary

Migrates 4 hardcoded secrets from the `atlas-config` ConfigMap to env var interpolation, enabling removal of secret values from ArgoCD tenant manifests.

## Changes

`helm/atlas/templates/configmap.yaml`:
- `atlas.graph.cache.redis-cache-password` → `${env:REDIS_PASSWORD}`
- `atlan.cache.redis.password` → `${env:REDIS_PASSWORD}`
- `atlas.ranger.password` → `${env:RANGER_PASSWORD}`
- `atlas.redis.password` → `${env:REDIS_PASSWORD}`

## Why this works

Atlas uses Apache Commons Configuration interpolation already (`${sys:atlas.home}` is used in the same file). The same engine supports `${env:VAR_NAME}`. `RANGER_PASSWORD` is already injected into Atlas pods via `atlas-secret-manager` ExternalSecret. `REDIS_PASSWORD` will be added in the companion PR to `atlanhq/atlan`.

## Dependencies

Merge the `atlanhq/atlan` ExternalSecret PR first so `REDIS_PASSWORD` is available in the K8s Secret before this ConfigMap change goes live.

## Testing

Smoke test on a beta tenant after staging merge — confirm Atlas connects to Redis and Ranger successfully.

Linear: MS-1006