### PR TITLE
fix: remove secrets from atlas ConfigMaps via env var interpolation (INFRA-283)

### DIFF
--- a/helm/atlas-read/templates/configmap.yaml
+++ b/helm/atlas-read/templates/configmap.yaml
@@ -342,7 +342,7 @@ data:
     atlas.graph.cache.redis-cache-sentinel-urls={{ .Values.atlas.redis.sentinel_urls }}
     atlas.graph.cache.redis-cache-lock-watchdog-ms=300000
     atlas.graph.cache.redis-cache-username={{ .Values.atlas.redis.username }}
-    atlas.graph.cache.redis-cache-password={{ .Values.atlas.redis.password }}
+    atlas.graph.cache.redis-cache-password=${env:REDIS_PASSWORD}
     atlas.graph.cache.redis-cache-mastername={{ .Values.atlas.redis.master_name }}
     atlas.graph.cache.redis-cache-connectTimeout=2000
     {{- end }}
@@ -428,7 +428,7 @@ data:
     ########## Add query metastore ###########
     atlan.cache.redis.host={{ .Values.atlas.redis.host }}
     atlan.cache.redis.port={{ .Values.atlas.redis.port }}
-    atlan.cache.redis.password={{ .Values.atlas.redis.password }}
+    atlan.cache.redis.password=${env:REDIS_PASSWORD}
     atlas.cache.redis.maxConnections={{ .Values.atlas.redis.maxConnections }}
     atlas.cache.redis.timeout={{ .Values.atlas.redis.timeout }}
     atlan.EntityCacheListener.impl=org.apache.atlas.repository.cache.EntityCacheListenerV2
@@ -453,7 +453,7 @@ data:
     ########## Ranger Credentials
 
     atlas.ranger.username = admin
-    atlas.ranger.password = {{ .Values.atlas.ranger.RANGER_PASSWORD }}
+    atlas.ranger.password = ${env:RANGER_PASSWORD}
     atlas.ranger.base.url = {{ .Values.atlas.ranger.RANGER_SERVICE_URL }}
 
     ####### Redis credentials #######
@@ -465,7 +465,7 @@ data:
     atlas.redis.url = redis://{{ .Values.atlas.redis.host }}:{{ .Values.atlas.redis.port }}
     atlas.redis.sentinel.urls = {{ .Values.atlas.redis.sentinel_urls }}
     atlas.redis.username = {{ .Values.atlas.redis.username }}
-    atlas.redis.password = {{ .Values.atlas.redis.password }}
+    atlas.redis.password = ${env:REDIS_PASSWORD}
     atlas.redis.master_name = {{ .Values.atlas.redis.master_name }}
     atlas.redis.lock.wait_time.ms=15000
     # Renew lock for every 10mins

--- a/helm/atlas/templates/configmap-leangraph.yaml
+++ b/helm/atlas/templates/configmap-leangraph.yaml
@@ -330,7 +330,7 @@ data:
     atlas.graph.cache.redis-cache-sentinel-urls={{ .Values.atlas.redis.sentinel_urls }}
     atlas.graph.cache.redis-cache-lock-watchdog-ms=300000
     atlas.graph.cache.redis-cache-username={{ .Values.atlas.redis.username }}
-    atlas.graph.cache.redis-cache-password={{ .Values.atlas.redis.password }}
+    atlas.graph.cache.redis-cache-password=${env:REDIS_PASSWORD}
     atlas.graph.cache.redis-cache-mastername={{ .Values.atlas.redis.master_name }}
     atlas.graph.cache.redis-cache-connectTimeout=2000
     {{- end }}
@@ -416,7 +416,7 @@ data:
     ########## Add query metastore ###########
     atlan.cache.redis.host={{ .Values.atlas.redis.host }}
     atlan.cache.redis.port={{ .Values.atlas.redis.port }}
-    atlan.cache.redis.password={{ .Values.atlas.redis.password }}
+    atlan.cache.redis.password=${env:REDIS_PASSWORD}
     atlas.cache.redis.maxConnections={{ .Values.atlas.redis.maxConnections }}
     atlas.cache.redis.timeout={{ .Values.atlas.redis.timeout }}
     atlan.EntityCacheListener.impl=org.apache.atlas.repository.cache.EntityCacheListenerV2
@@ -441,7 +441,7 @@ data:
     ########## Ranger Credentials
 
     atlas.ranger.username = admin
-    atlas.ranger.password = {{ .Values.atlas.ranger.RANGER_PASSWORD }}
+    atlas.ranger.password = ${env:RANGER_PASSWORD}
     atlas.ranger.base.url = {{ .Values.atlas.ranger.RANGER_SERVICE_URL }}
 
     ####### Redis credentials #######
@@ -453,7 +453,7 @@ data:
     atlas.redis.url = redis://{{ .Values.atlas.redis.host }}:{{ .Values.atlas.redis.port }}
     atlas.redis.sentinel.urls = {{ .Values.atlas.redis.sentinel_urls }}
     atlas.redis.username = {{ .Values.atlas.redis.username }}
-    atlas.redis.password = {{ .Values.atlas.redis.password }}
+    atlas.redis.password = ${env:REDIS_PASSWORD}
     atlas.redis.master_name = {{ .Values.atlas.redis.master_name }}
     atlas.redis.lock.wait_time.ms=15000
     # Renew lock for every 10mins

--- a/helm/atlas/templates/configmap.yaml
+++ b/helm/atlas/templates/configmap.yaml
@@ -344,7 +344,7 @@ data:
     {{- end }}
     atlas.graph.cache.redis-cache-lock-watchdog-ms=300000
     atlas.graph.cache.redis-cache-username={{ .Values.atlas.redis.username }}
-    atlas.graph.cache.redis-cache-password={{ .Values.atlas.redis.password }}
+    atlas.graph.cache.redis-cache-password=${env:REDIS_PASSWORD}
     atlas.graph.cache.redis-cache-mastername={{ .Values.atlas.redis.master_name }}
     atlas.graph.cache.redis-cache-connectTimeout=2000
     {{- end }}
@@ -430,7 +430,7 @@ data:
     ########## Add query metastore ###########
     atlan.cache.redis.host={{ .Values.atlas.redis.host }}
     atlan.cache.redis.port={{ .Values.atlas.redis.port }}
-    atlan.cache.redis.password={{ .Values.atlas.redis.password }}
+    atlan.cache.redis.password=${env:REDIS_PASSWORD}
     atlas.cache.redis.maxConnections={{ .Values.atlas.redis.maxConnections }}
     atlas.cache.redis.timeout={{ .Values.atlas.redis.timeout }}
     atlan.EntityCacheListener.impl=org.apache.atlas.repository.cache.EntityCacheListenerV2
@@ -455,7 +455,7 @@ data:
     ########## Ranger Credentials
 
     atlas.ranger.username = admin
-    atlas.ranger.password = {{ .Values.atlas.ranger.RANGER_PASSWORD }}
+    atlas.ranger.password = ${env:RANGER_PASSWORD}
     atlas.ranger.base.url = {{ .Values.atlas.ranger.RANGER_SERVICE_URL }}
 
     ####### Redis credentials #######
@@ -471,7 +471,7 @@ data:
     atlas.redis.sentinel.urls = {{ .Values.atlas.redis.sentinel_urls }}
     {{- end }}
     atlas.redis.username = {{ .Values.atlas.redis.username }}
-    atlas.redis.password = {{ .Values.atlas.redis.password }}
+    atlas.redis.password = ${env:REDIS_PASSWORD}
     atlas.redis.master_name = {{ .Values.atlas.redis.master_name }}
     atlas.redis.lock.wait_time.ms=15000
     # Renew lock for every 10mins


### PR DESCRIPTION
## Summary

- Replaces `{{ .Values.atlas.redis.password }}` and `{{ .Values.atlas.ranger.RANGER_PASSWORD }}` Helm values (which write secrets into the ConfigMap in plaintext) with `${env:REDIS_PASSWORD}` and `${env:RANGER_PASSWORD}` across all three atlas configmaps
- `RANGER_PASSWORD` and `REDIS_PASSWORD` are both injected into pods via `atlas-secret-manager` ExternalSecret (companion PRs already merged)

## Files changed

| File | Changes |
|---|---|
| `helm/atlas/templates/configmap.yaml` | 4 substitutions |
| `helm/atlas/templates/configmap-leangraph.yaml` | 4 substitutions |
| `helm/atlas-read/templates/configmap.yaml` | 4 substitutions |

## Test plan

- [ ] Deploy to a dev/staging tenant and confirm Atlas starts cleanly (Redis and Ranger auth work)
- [ ] Verify the ConfigMap no longer contains plaintext password values (`kubectl get cm atlas-config -o yaml | grep password` should show `${env:REDIS_PASSWORD}`)

Linear: [INFRA-283](https://linear.app/atlan-epd/issue/INFRA-283/remove-secrets-from-the-atlas-configmap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)