### PR TITLE
MS-1019: Port leangraph async ingestion consumer (PR #6091) onto sgp

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -39,6 +39,9 @@ on:
       - ms-610-ranges-policy-cache
       - ms-901-hidelineage
       - ms-894-override-classification
+      - leangraph-dynamic
+      - ms-600-leangraph-ingest
+      - ms-600-leangraph-consumer-on-sgp
     paths-ignore:
       - '.claude/**'
       - '.cursor/**'

--- a/distro/src/conf/atlas-application.properties
+++ b/distro/src/conf/atlas-application.properties
@@ -113,6 +113,25 @@ atlas.notification.hook.retry.interval=1000
 #atlas.notification.kafka.service.principal=kafka/_HOST@EXAMPLE.COM
 #atlas.notification.kafka.keytab.location=/etc/security/keytabs/kafka.service.keytab
 
+#########  Async Ingestion Consumer (leangraph migration)  #########
+atlas.async.ingestion.consumer.enabled=false
+atlas.async.ingestion.consumer.topic=ATLAS_ASYNC_ENTITIES
+atlas.async.ingestion.consumer.group.id=atlas_async_ingestion_consumer
+atlas.async.ingestion.consumer.maxPollRecords=10
+atlas.async.ingestion.consumer.maxPollIntervalMs=600000
+atlas.async.ingestion.consumer.sessionTimeoutMs=90000
+atlas.async.ingestion.consumer.heartbeatIntervalMs=30000
+atlas.async.ingestion.consumer.pollTimeoutSeconds=15
+atlas.async.ingestion.consumer.maxRetries=3
+atlas.async.ingestion.consumer.retryDelayMs=5000
+atlas.async.ingestion.consumer.exponentialBackoff.baseDelayMs=1000
+atlas.async.ingestion.consumer.exponentialBackoff.maxDelayMs=60000
+atlas.async.ingestion.consumer.exponentialBackoff.multiplier=2.0
+atlas.async.ingestion.consumer.dlq.topic=ATLAS_ASYNC_INGESTION_DLQ
+# Entity notifications (ATLAS_ENTITIES topic) are controlled by atlas.enable.entity.notifications.
+# During migration, set atlas.enable.entity.notifications=false on the leangraph stack.
+# After switchover (leangraph becomes primary), flip to true so leangraph generates entity notifications.
+
 ## Server port configuration
 #atlas.server.http.port=21000
 #atlas.server.https.port=21443

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AsyncIngestionProducer.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AsyncIngestionProducer.java
@@ -42,6 +42,10 @@ public class AsyncIngestionProducer {
     private static final String PROPERTY_PREFIX = "atlas.kafka";
     private static final String CONFIG_TOPIC = "atlas.async.ingestion.topic";
     private static final String DEFAULT_TOPIC = "ATLAS_ASYNC_ENTITIES";
+    // All events use the same record key so they hash to a single partition. This gives
+    // global producer-commit ordering on the WAL topic and keeps the consumer's replay
+    // order identical to ZG's commit order.
+    private static final String WAL_PARTITION_KEY = "wal";
 
     private volatile KafkaProducer<String, String> producer;
     private String topic;
@@ -112,7 +116,9 @@ public class AsyncIngestionProducer {
                 return null;
             }
 
-            ProducerRecord<String, String> record = new ProducerRecord<>(topic, eventId, json);
+            // Constant key → single partition → globally ordered replay. eventId stays
+            // in the JSON envelope for dedup/tracing; it just isn't used as the Kafka key.
+            ProducerRecord<String, String> record = new ProducerRecord<>(topic, WAL_PARTITION_KEY, json);
 
             Timer.Sample sample = sendLatencyTimer != null ? Timer.start() : null;
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityChangeNotifier.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityChangeNotifier.java
@@ -103,6 +103,10 @@ public class AtlasEntityChangeNotifier implements IAtlasEntityChangeNotifier {
 
     @Override
     public void onEntitiesMutated(EntityMutationResponse entityMutationResponse, boolean isImport) throws AtlasBaseException {
+        if (RequestContext.get().isSkipEntityChangeNotification()) {
+            return;
+        }
+
         if (CollectionUtils.isEmpty(entityChangeListeners)) {
             return;
         }
@@ -132,6 +136,10 @@ public class AtlasEntityChangeNotifier implements IAtlasEntityChangeNotifier {
 
     @Override
     public void notifyRelationshipMutation(List<AtlasRelationship> relationships, EntityNotification.EntityNotificationV2.OperationType operationType) throws AtlasBaseException {
+        if (RequestContext.get().isSkipEntityChangeNotification()) {
+            return;
+        }
+
         if (CollectionUtils.isEmpty(entityChangeListeners)) {
             return;
         }
@@ -154,6 +162,10 @@ public class AtlasEntityChangeNotifier implements IAtlasEntityChangeNotifier {
 
     @Override
     public void onClassificationAddedToEntity(AtlasEntity entity, List<AtlasClassification> addedClassifications) throws AtlasBaseException {
+        if (RequestContext.get().isSkipEntityChangeNotification()) {
+            return;
+        }
+
         if (isV2EntityNotificationEnabled) {
             doFullTextMapping(entity.getGuid());
 
@@ -184,6 +196,10 @@ public class AtlasEntityChangeNotifier implements IAtlasEntityChangeNotifier {
 
     @Override
     public void onClassificationsAddedToEntities(List<AtlasEntity> entities, List<AtlasClassification> addedClassifications, boolean forceInline) throws AtlasBaseException {
+        if (RequestContext.get().isSkipEntityChangeNotification()) {
+            return;
+        }
+
         if (isV2EntityNotificationEnabled) {
             doFullTextMappingHelper(entities);
 
@@ -238,6 +254,10 @@ public class AtlasEntityChangeNotifier implements IAtlasEntityChangeNotifier {
 
     @Override
     public void onClassificationUpdatedToEntity(AtlasEntity entity, List<AtlasClassification> updatedClassifications) throws AtlasBaseException {
+        if (RequestContext.get().isSkipEntityChangeNotification()) {
+            return;
+        }
+
         doFullTextMapping(entity.getGuid());
 
         if (isV2EntityNotificationEnabled) {
@@ -330,6 +350,10 @@ public class AtlasEntityChangeNotifier implements IAtlasEntityChangeNotifier {
 
     @Override
     public void onClassificationDeletedFromEntity(AtlasEntity entity, List<AtlasClassification> deletedClassifications) throws AtlasBaseException {
+        if (RequestContext.get().isSkipEntityChangeNotification()) {
+            return;
+        }
+
         doFullTextMapping(entity.getGuid());
 
         if (isV2EntityNotificationEnabled) {
@@ -358,6 +382,10 @@ public class AtlasEntityChangeNotifier implements IAtlasEntityChangeNotifier {
 
     @Override
     public void onClassificationsDeletedFromEntities(List<AtlasEntity> entities, List<AtlasClassification> deletedClassifications) throws AtlasBaseException {
+        if (RequestContext.get().isSkipEntityChangeNotification()) {
+            return;
+        }
+
         doFullTextMappingHelper(entities);
 
         if (isV2EntityNotificationEnabled) {
@@ -450,6 +478,10 @@ public class AtlasEntityChangeNotifier implements IAtlasEntityChangeNotifier {
 
     @Override
     public void onTermAddedToEntities(AtlasGlossaryTerm term, List<AtlasRelatedObjectId> entityIds) throws AtlasBaseException {
+        if (RequestContext.get().isSkipEntityChangeNotification()) {
+            return;
+        }
+
         // listeners notified on term-entity association only if v2 notifications are enabled
         if (isV2EntityNotificationEnabled) {
             for (EntityChangeListenerV2 listener : entityChangeListenersV2) {
@@ -470,6 +502,10 @@ public class AtlasEntityChangeNotifier implements IAtlasEntityChangeNotifier {
 
     @Override
     public void onTermDeletedFromEntities(AtlasGlossaryTerm term, List<AtlasRelatedObjectId> entityIds) throws AtlasBaseException {
+        if (RequestContext.get().isSkipEntityChangeNotification()) {
+            return;
+        }
+
         // listeners notified on term-entity disassociation only if v2 notifications are enabled
         if (isV2EntityNotificationEnabled) {
             for (EntityChangeListenerV2 listener : entityChangeListenersV2) {
@@ -490,6 +526,10 @@ public class AtlasEntityChangeNotifier implements IAtlasEntityChangeNotifier {
 
     @Override
     public void onLabelsUpdatedFromEntity(String entityGuid, Set<String> addedLabels, Set<String> deletedLabels) throws AtlasBaseException {
+        if (RequestContext.get().isSkipEntityChangeNotification()) {
+            return;
+        }
+
         doFullTextMapping(entityGuid);
 
         if (isV2EntityNotificationEnabled) {
@@ -516,6 +556,10 @@ public class AtlasEntityChangeNotifier implements IAtlasEntityChangeNotifier {
 
     @Override
     public void onBusinessAttributesUpdated(String entityGuid, Map<String, Map<String, Object>> updatedBusinessAttributes) throws AtlasBaseException{
+        if (RequestContext.get().isSkipEntityChangeNotification()) {
+            return;
+        }
+
         if (isV2EntityNotificationEnabled) {
             AtlasEntity entity = instanceConverter.getEntityWithMandatoryRelations(entityGuid);
 
@@ -997,6 +1041,10 @@ public class AtlasEntityChangeNotifier implements IAtlasEntityChangeNotifier {
 
     @Override
     public void notifyDifferentialEntityChanges(EntityMutationResponse entityMutationResponse, boolean isImport) throws AtlasBaseException {
+        if (RequestContext.get().isSkipEntityChangeNotification()) {
+            return;
+        }
+
         if (!notifyDifferentialEntityChangesEnabled) {
             return; // Early exit if disabled
         }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/BulkRequestContext.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/BulkRequestContext.java
@@ -19,7 +19,6 @@ package org.apache.atlas.repository.store.graph.v2;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.atlas.model.instance.AtlasEntity.AtlasEntitiesWithExtInfo;
-import org.apache.atlas.type.AtlasType;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -165,7 +164,12 @@ public class BulkRequestContext {
         }
 
         public Builder setOriginalEntities(AtlasEntitiesWithExtInfo originalEntities) {
-            this.originalEntities = AtlasType.fromJson(AtlasType.toJson(originalEntities), AtlasEntitiesWithExtInfo.class);
+            // Store by reference, not a pre-write clone. The store layer mutates these
+            // entities in-place to assign real GUIDs (EntityMutationContext.mapAssignedGuid)
+            // and final qualifiedNames (preprocessors). By the time publishAsyncIngestionEvent
+            // runs in the finally block, the reference reflects post-write state — which is
+            // what the WAL consumer needs to pin JG GUIDs/QNs to ZG's assignments.
+            this.originalEntities = originalEntities;
             return this;
         }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/BulkRequestContext.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/BulkRequestContext.java
@@ -17,6 +17,7 @@
  */
 package org.apache.atlas.repository.store.graph.v2;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.atlas.model.instance.AtlasEntity.AtlasEntitiesWithExtInfo;
 import org.apache.atlas.type.AtlasType;
 
@@ -24,15 +25,31 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class BulkRequestContext {
+
+    /**
+     * Reconstruct a BulkRequestContext from the operationMetadata JSON
+     * published by the fatgraph AsyncIngestionProducer.
+     */
+    public static BulkRequestContext fromOperationMetadata(JsonNode opMeta) {
+        return new Builder()
+                .setReplaceClassifications(opMeta.path("replaceClassifications").asBoolean(false))
+                .setReplaceTags(opMeta.path("replaceTags").asBoolean(false))
+                .setAppendTags(opMeta.path("appendTags").asBoolean(false))
+                .setReplaceBusinessAttributes(opMeta.path("replaceBusinessAttributes").asBoolean(false))
+                .setOverwriteBusinessAttributes(opMeta.path("overwriteBusinessAttributes").asBoolean(false))
+                .setSkipProcessEdgeRestoration(opMeta.path("skipProcessEdgeRestoration").asBoolean(false))
+                .build();
+    }
+
     private boolean replaceClassifications;
     private boolean replaceTags;
     private boolean appendTags;
 
     private boolean replaceBusinessAttributes;
     private boolean isOverwriteBusinessAttributes;
+    private boolean skipProcessEdgeRestoration;
 
     private AtlasEntitiesWithExtInfo originalEntities;  // for async ingestion Kafka publish
-    private boolean skipProcessEdgeRestoration;         // query param from REST
 
     public boolean isReplaceClassifications() {
         return replaceClassifications;

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityMutationService.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityMutationService.java
@@ -427,7 +427,14 @@ public class EntityMutationService {
      */
     private void publishAsyncIngestionEvent(boolean isGraphTransactionFailed, String eventType,
                                             Map<String, Object> operationMetadata, Object payload) {
-        if (!isGraphTransactionFailed && DynamicConfigStore.isAsyncIngestionEnabled()) {
+        // Skip publishing when we're already replaying a WAL event on the consumer side.
+        // Without this guard, every entityMutationService.createOrUpdate/delete call made from
+        // AsyncIngestionConsumerService would emit a fresh WAL event, which the same consumer
+        // then reads and replays — an infinite self-amplifying loop that buries the DLQ in
+        // echoes. The consumer sets RequestContext.isImportInProgress(true) before every replay.
+        if (!isGraphTransactionFailed
+                && !RequestContext.get().isImportInProgress()
+                && DynamicConfigStore.isAsyncIngestionEnabled()) {
             try {
                 asyncIngestionProducer.publishEvent(eventType, operationMetadata, payload,
                         RequestMetadata.fromCurrentRequest());

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityMutationService.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityMutationService.java
@@ -418,10 +418,12 @@ public class EntityMutationService {
      * Publish an async ingestion event to Kafka if the graph transaction succeeded
      * and async ingestion is enabled. Best-effort: catches all exceptions.
      *
-     * <p>The payload must be a pre-mutation snapshot of the original REST request body,
-     * so the Kafka event faithfully represents what the caller sent. Callers are
-     * responsible for deep-copying the payload before passing it to any mutating
-     * store operation (e.g. via BulkRequestContext.setOriginalEntities).</p>
+     * <p>For BULK_CREATE_OR_UPDATE, the payload is the post-mutation state of the
+     * entities — i.e. with server-assigned GUIDs and preprocessor-generated
+     * qualifiedNames. The WAL consumer uses these values to pin the replaying
+     * graph (JanusGraph) to the same GUID/QN assignments made by the primary
+     * graph (ZeroGraph), so both graphs end up with identical entity identity
+     * after replay. Other event types pass through real GUIDs already.</p>
      */
     private void publishAsyncIngestionEvent(boolean isGraphTransactionFailed, String eventType,
                                             Map<String, Object> operationMetadata, Object payload) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/AuthPolicyPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/AuthPolicyPreProcessor.java
@@ -123,6 +123,16 @@ public class AuthPolicyPreProcessor implements PreProcessor {
 
     private void processCreatePolicy(AtlasStruct entity) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("processCreatePolicy");
+
+        if (RequestContext.get().isImportInProgress()) {
+            // During import/async-ingestion, skip validation, ES alias creation, keycloak role extraction
+            if (StringUtils.isEmpty((String) entity.getAttribute(QUALIFIED_NAME))) {
+                entity.setAttribute(QUALIFIED_NAME, "import/" + getUUID());
+            }
+            RequestContext.get().endMetricRecord(metricRecorder);
+            return;
+        }
+
         AtlasEntity policy = (AtlasEntity) entity;
 
         AtlasEntityWithExtInfo parent = getAccessControlEntity(policy);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/accesscontrol/StakeholderPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/accesscontrol/StakeholderPreProcessor.java
@@ -139,6 +139,16 @@ public class StakeholderPreProcessor extends PersonaPreProcessor {
     private void processCreateStakeholder(AtlasEntity entity) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("processCreateStakeholder");
 
+        if (RequestContext.get().isImportInProgress()) {
+            // During import/async-ingestion, skip ES-dependent operations, existence checks, keycloak, and authorization
+            if (StringUtils.isEmpty((String) entity.getAttribute(QUALIFIED_NAME))) {
+                String domainQualifiedName = getQualifiedNameFromRelationAttribute(entity, REL_ATTR_STAKEHOLDER_DOMAIN);
+                entity.setAttribute(QUALIFIED_NAME, format("default/%s/%s", getUUID(), domainQualifiedName));
+            }
+            RequestContext.get().endMetricRecord(metricRecorder);
+            return;
+        }
+
         validateNoPoliciesAttached(entity);
 
         if (!entity.hasRelationshipAttribute(REL_ATTR_STAKEHOLDER_TITLE) || !entity.hasRelationshipAttribute(REL_ATTR_STAKEHOLDER_DOMAIN)) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataDomainPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataDomainPreProcessor.java
@@ -88,6 +88,15 @@ public class DataDomainPreProcessor extends AbstractDomainPreProcessor {
     private void processCreateDomain(AtlasEntity entity) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("processCreateDomain");
 
+        if (RequestContext.get().isImportInProgress()) {
+            // During import/async-ingestion, skip ES-dependent operations, existence checks, and authorization
+            if (StringUtils.isEmpty((String) entity.getAttribute(QUALIFIED_NAME))) {
+                entity.setAttribute(QUALIFIED_NAME, createQualifiedName(""));
+            }
+            RequestContext.get().endMetricRecord(metricRecorder);
+            return;
+        }
+
         validateStakeholderRelationship(entity);
 
         String domainName = (String) entity.getAttribute(NAME);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/DataProductPreProcessor.java
@@ -83,6 +83,22 @@ public class DataProductPreProcessor extends AbstractDomainPreProcessor {
 
     private void processCreateProduct(AtlasEntity entity,AtlasVertex vertex) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("processCreateProduct");
+
+        if (RequestContext.get().isImportInProgress()) {
+            // During import/async-ingestion, skip ES-dependent operations, existence checks, and authorization
+            if (StringUtils.isEmpty((String) entity.getAttribute(QUALIFIED_NAME))) {
+                AtlasObjectId parentDomainObject = (AtlasObjectId) entity.getRelationshipAttribute(DATA_DOMAIN_REL_TYPE);
+                String parentDomainQualifiedName = "";
+                if (parentDomainObject != null) {
+                    AtlasVertex parentDomain = retrieverNoRelation.getEntityVertex(parentDomainObject);
+                    parentDomainQualifiedName = parentDomain.getProperty(QUALIFIED_NAME, String.class);
+                }
+                entity.setAttribute(QUALIFIED_NAME, createQualifiedName(parentDomainQualifiedName));
+            }
+            RequestContext.get().endMetricRecord(metricRecorder);
+            return;
+        }
+
         AtlasObjectId parentDomainObject = (AtlasObjectId) entity.getRelationshipAttribute(DATA_DOMAIN_REL_TYPE);
         String productName = (String) entity.getAttribute(NAME);
         String parentDomainQualifiedName = "";

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/StakeholderTitlePreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/datamesh/StakeholderTitlePreProcessor.java
@@ -104,6 +104,14 @@ public class StakeholderTitlePreProcessor implements PreProcessor {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("processCreateStakeholderTitle");
 
         try {
+            if (RequestContext.get().isImportInProgress()) {
+                // During import/async-ingestion, skip ES-dependent operations, existence checks, and authorization
+                if (org.apache.commons.lang.StringUtils.isEmpty((String) entity.getAttribute(QUALIFIED_NAME))) {
+                    entity.setAttribute(QUALIFIED_NAME, format(PATTERN_QUALIFIED_NAME_ALL_DOMAINS, getUUID()));
+                }
+                return;
+            }
+
             validateRelations(entity);
 
             if (RequestContext.get().isSkipAuthorizationCheck()) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/glossary/CategoryPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/glossary/CategoryPreProcessor.java
@@ -116,6 +116,16 @@ public class CategoryPreProcessor extends AbstractGlossaryPreProcessor {
 
     private void processCreateCategory(AtlasEntity entity, AtlasVertex vertex) throws AtlasBaseException {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("processCreateCategory");
+
+        if (RequestContext.get().isImportInProgress()) {
+            // During import/async-ingestion, skip ES-dependent operations, existence checks, and authorization
+            if (StringUtils.isEmpty((String) entity.getAttribute(QUALIFIED_NAME))) {
+                entity.setAttribute(QUALIFIED_NAME, createQualifiedName(vertex));
+            }
+            RequestContext.get().endMetricRecord(metricRecorder);
+            return;
+        }
+
         String catName = trimEntityName(entity);
         String parentQname = null;
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/glossary/GlossaryPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/glossary/GlossaryPreProcessor.java
@@ -85,6 +85,16 @@ public class GlossaryPreProcessor implements PreProcessor {
         if (StringUtils.isEmpty(glossaryName) || isNameInvalid(glossaryName)) {
             throw new AtlasBaseException(AtlasErrorCode.INVALID_DISPLAY_NAME);
         }
+
+        if (RequestContext.get().isImportInProgress()) {
+            // During import/async-ingestion, skip ES-dependent operations and existence checks
+            if (StringUtils.isEmpty((String) entity.getAttribute(QUALIFIED_NAME))) {
+                entity.setAttribute(QUALIFIED_NAME, createQualifiedName());
+            }
+            RequestContext.get().endMetricRecord(metricRecorder);
+            return;
+        }
+
         String lexicographicalSortOrder = (String) entity.getAttribute(LEXICOGRAPHICAL_SORT_ORDER);
 
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/glossary/TermPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/glossary/TermPreProcessor.java
@@ -92,6 +92,15 @@ public class TermPreProcessor extends AbstractGlossaryPreProcessor {
             throw new AtlasBaseException(AtlasErrorCode.INVALID_DISPLAY_NAME);
         }
 
+        if (RequestContext.get().isImportInProgress()) {
+            // During import/async-ingestion, skip ES-dependent operations, existence checks, and authorization
+            if (StringUtils.isEmpty((String) entity.getAttribute(QUALIFIED_NAME))) {
+                entity.setAttribute(QUALIFIED_NAME, createQualifiedName());
+            }
+            RequestContext.get().endMetricRecord(metricRecorder);
+            return;
+        }
+
         String glossaryQName = (String) anchor.getAttribute(QUALIFIED_NAME);
 
         termExists(termName, glossaryQName);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/sql/QueryCollectionPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/sql/QueryCollectionPreProcessor.java
@@ -128,6 +128,14 @@ public class QueryCollectionPreProcessor implements PreProcessor {
         AtlasPerfMetrics.MetricRecorder metricRecorder = RequestContext.get().startMetricRecord("processCreateCollection");
 
         try {
+            if (RequestContext.get().isImportInProgress()) {
+                // During import/async-ingestion, skip keycloak role creation, policy creation, and ES operations
+                if (StringUtils.isEmpty((String) entity.getAttribute(QUALIFIED_NAME))) {
+                    entity.setAttribute(QUALIFIED_NAME, createQualifiedName());
+                }
+                return;
+            }
+
             entity.setAttribute(QUALIFIED_NAME, createQualifiedName());
 
             AtlasEntity collection = (AtlasEntity) entity;

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/sql/QueryFolderPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/sql/QueryFolderPreProcessor.java
@@ -84,6 +84,14 @@ public class QueryFolderPreProcessor implements PreProcessor {
     }
 
     private void processCreate(AtlasStruct entity) throws AtlasBaseException {
+        if (RequestContext.get().isImportInProgress()) {
+            if (StringUtils.isEmpty((String) entity.getAttribute(QUALIFIED_NAME))) {
+                String collectionQualifiedName = (String) entity.getAttribute(COLLECTION_QUALIFIED_NAME);
+                entity.setAttribute(QUALIFIED_NAME, createQualifiedName(collectionQualifiedName));
+            }
+            return;
+        }
+
         String collectionQualifiedName = (String) entity.getAttribute(COLLECTION_QUALIFIED_NAME);
 
         if (StringUtils.isEmpty(collectionQualifiedName)) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/sql/QueryPreProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/preprocessor/sql/QueryPreProcessor.java
@@ -19,6 +19,7 @@ package org.apache.atlas.repository.store.graph.v2.preprocessor.sql;
 
 
 import org.apache.atlas.AtlasErrorCode;
+import org.apache.atlas.RequestContext;
 import org.apache.atlas.authorizer.AtlasAuthorizationUtils;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.instance.AtlasEntity;
@@ -72,6 +73,14 @@ public class QueryPreProcessor implements PreProcessor {
     }
 
     private void processCreateQueryCollection(AtlasStruct entity) throws AtlasBaseException {
+        if (RequestContext.get().isImportInProgress()) {
+            if (StringUtils.isEmpty((String) entity.getAttribute(QUALIFIED_NAME))) {
+                String collectionQualifiedName = (String) entity.getAttribute(COLLECTION_QUALIFIED_NAME);
+                entity.setAttribute(QUALIFIED_NAME, createQualifiedName(collectionQualifiedName));
+            }
+            return;
+        }
+
         String collectionQualifiedName = (String) entity.getAttribute(COLLECTION_QUALIFIED_NAME);
 
         if (StringUtils.isEmpty(collectionQualifiedName)) {

--- a/server-api/src/main/java/org/apache/atlas/RequestContext.java
+++ b/server-api/src/main/java/org/apache/atlas/RequestContext.java
@@ -123,6 +123,7 @@ public class RequestContext {
     private Set<String> deletedEdgesIdsForResetHasLineage = new HashSet<>(0);
     private String requestUri;
     private boolean delayTagNotifications = false;
+    private boolean skipEntityChangeNotification = false;
     private boolean skipHasLineageCalculation = false;
     private boolean isInvokedByIndexSearch = false;
     private boolean isInvokedByLineage = false;
@@ -200,6 +201,7 @@ public class RequestContext {
         this.currentTask = null;
         this.skipAuthorizationCheck = false;
         this.delayTagNotifications = false;
+        this.skipEntityChangeNotification = false;
         deletedClassificationAndVertices.clear();
         addedClassificationAndVertices.clear();
         esDeferredOperations.clear();
@@ -505,6 +507,14 @@ public class RequestContext {
 
     public void setDelayTagNotifications(boolean delayTagNotifications) {
         this.delayTagNotifications = delayTagNotifications;
+    }
+
+    public boolean isSkipEntityChangeNotification() {
+        return skipEntityChangeNotification;
+    }
+
+    public void setSkipEntityChangeNotification(boolean skipEntityChangeNotification) {
+        this.skipEntityChangeNotification = skipEntityChangeNotification;
     }
 
     public Map<AtlasClassification, Collection<Object>> getDeletedClassificationAndVertices() {

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -1030,6 +1030,13 @@
                 </includes>
                 <filtering>true</filtering>
             </testResource>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <includes>
+                    <include>**/*.json</include>
+                </includes>
+                <filtering>false</filtering>
+            </testResource>
         </testResources>
     </build>
 

--- a/webapp/src/main/java/org/apache/atlas/web/rest/AsyncIngestionConsumerController.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/AsyncIngestionConsumerController.java
@@ -1,0 +1,83 @@
+package org.apache.atlas.web.rest;
+
+import org.apache.atlas.web.service.AsyncIngestionConsumerService;
+import org.apache.atlas.web.util.Servlets;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.inject.Singleton;
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * REST endpoints for managing the async ingestion consumer (leangraph migration).
+ */
+@Path("async-ingestion/consumer")
+@Singleton
+@Service
+@Consumes({Servlets.JSON_MEDIA_TYPE, MediaType.APPLICATION_JSON})
+@Produces({Servlets.JSON_MEDIA_TYPE, MediaType.APPLICATION_JSON})
+public class AsyncIngestionConsumerController {
+
+    @Autowired
+    private AsyncIngestionConsumerService consumerService;
+
+    @GET
+    @Path("/status")
+    public Map<String, Object> getStatus() {
+        return consumerService.getStatus();
+    }
+
+    @POST
+    @Path("/start")
+    public Map<String, Object> start() {
+        consumerService.start();
+        return consumerService.getStatus();
+    }
+
+    @POST
+    @Path("/stop")
+    public Map<String, Object> stop() {
+        consumerService.shutdown();
+        return consumerService.getStatus();
+    }
+
+    @GET
+    @Path("/lag")
+    public Map<String, Object> getLag() {
+        return consumerService.getConsumerLag();
+    }
+
+    @POST
+    @Path("/switchover/readiness")
+    public Map<String, Object> checkSwitchoverReadiness() {
+        Map<String, Object> result = new LinkedHashMap<>();
+        Map<String, Object> lagInfo = consumerService.getConsumerLag();
+
+        boolean isRunning = consumerService.isRunning();
+        boolean isHealthy = consumerService.isHealthy();
+        long totalLag = ((Number) lagInfo.getOrDefault("totalLag", -1L)).longValue();
+        boolean ready = isRunning && isHealthy && totalLag == 0;
+
+        result.put("ready", ready);
+        result.put("isRunning", isRunning);
+        result.put("isHealthy", isHealthy);
+        result.put("consumerLag", lagInfo);
+
+        if (!ready) {
+            if (!isRunning) {
+                result.put("reason", "Consumer is not running");
+            } else if (!isHealthy) {
+                result.put("reason", "Consumer is unhealthy");
+            } else if (totalLag > 0) {
+                result.put("reason", "Consumer lag is " + totalLag + " (must be 0)");
+            } else {
+                result.put("reason", "Unable to determine lag");
+            }
+        }
+
+        return result;
+    }
+}

--- a/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/EntityREST.java
@@ -419,6 +419,10 @@ public class EntityREST {
                     .setReplaceClassifications(replaceClassifications)
                     .setReplaceBusinessAttributes(replaceBusinessAttributes)
                     .setOverwriteBusinessAttributes(isOverwriteBusinessAttributes)
+                    // Single-entity path still emits a BULK_CREATE_OR_UPDATE WAL event when async
+                    // ingestion is enabled; wrap the entity so the envelope carries a real payload
+                    // instead of null (which crashes the consumer's deserializer).
+                    .setOriginalEntities(new AtlasEntitiesWithExtInfo(entity))
                     .build();
             return entityMutationService.createOrUpdate(new AtlasEntityStream(entity), context);
         } finally {

--- a/webapp/src/main/java/org/apache/atlas/web/service/AsyncIngestionConsumerService.java
+++ b/webapp/src/main/java/org/apache/atlas/web/service/AsyncIngestionConsumerService.java
@@ -1,0 +1,1259 @@
+package org.apache.atlas.web.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.atlas.ApplicationProperties;
+import org.apache.atlas.RequestContext;
+import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.model.instance.AtlasClassification;
+import org.apache.atlas.model.instance.AtlasEntity;
+import org.apache.atlas.model.instance.AtlasEntity.AtlasEntitiesWithExtInfo;
+import org.apache.atlas.model.instance.AtlasEntityHeaders;
+import org.apache.atlas.model.instance.AtlasObjectId;
+import org.apache.atlas.model.instance.AtlasRelationship;
+import org.apache.atlas.model.typedef.AtlasTypesDef;
+import org.apache.atlas.repository.store.graph.AtlasEntityStore;
+import org.apache.atlas.repository.store.graph.AtlasRelationshipStore;
+import org.apache.atlas.repository.store.graph.v2.AtlasEntityStream;
+import org.apache.atlas.repository.store.graph.v2.BulkRequestContext;
+import org.apache.atlas.repository.store.graph.v2.EntityMutationService;
+import org.apache.atlas.repository.store.bootstrap.AtlasTypeDefStoreInitializer;
+import org.apache.atlas.service.redis.RedisService;
+import org.apache.atlas.store.AtlasTypeDefStore;
+import org.apache.atlas.type.AtlasEntityType;
+import org.apache.atlas.type.AtlasType;
+import org.apache.atlas.type.AtlasTypeRegistry;
+import org.apache.kafka.clients.consumer.*;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.WakeupException;
+import org.janusgraph.diskstorage.TemporaryBackendException;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.locks.Lock;
+import java.util.stream.Collectors;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Kafka consumer for async ingestion events published by the fatgraph stack.
+ * <p>
+ * Reads from the {@code ATLAS_ASYNC_ENTITIES} topic and replays entity/typedef
+ * mutations through leangraph's {@link EntityMutationService} and
+ * {@link AtlasTypeDefStore}. Since {@code LEAN_GRAPH_ENABLED=true} on this stack,
+ * writes automatically go to JanusGraph (5 core props) + Cassandra assets + ES.
+ * <p>
+ * Design principles (modeled after {@link DLQReplayService}):
+ * <ul>
+ *   <li>Pause/resume pattern to avoid {@code max.poll.interval.ms} timeout</li>
+ *   <li>Manual offset commits for at-least-once delivery</li>
+ *   <li>Exponential backoff for transient failures</li>
+ *   <li>Poison pill handling: skip after max retries</li>
+ *   <li>Rebalance listener for cleanup of retry/backoff trackers</li>
+ * </ul>
+ */
+@Service
+public class AsyncIngestionConsumerService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AsyncIngestionConsumerService.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    // ── Configuration ────────────────────────────────────────────────────
+    private String bootstrapServers;
+
+    @Value("${atlas.async.ingestion.consumer.enabled:false}")
+    private boolean consumerEnabled;
+
+    @Value("${atlas.async.ingestion.consumer.topic:ATLAS_ASYNC_ENTITIES}")
+    private String topic;
+
+    @Value("${atlas.async.ingestion.consumer.group.id:atlas_async_ingestion_consumer}")
+    private String consumerGroupId;
+
+    @Value("${atlas.async.ingestion.consumer.maxPollRecords:10}")
+    private int maxPollRecords;
+
+    @Value("${atlas.async.ingestion.consumer.maxPollIntervalMs:600000}")
+    private int maxPollIntervalMs;
+
+    @Value("${atlas.async.ingestion.consumer.sessionTimeoutMs:90000}")
+    private int sessionTimeoutMs;
+
+    @Value("${atlas.async.ingestion.consumer.heartbeatIntervalMs:30000}")
+    private int heartbeatIntervalMs;
+
+    @Value("${atlas.async.ingestion.consumer.autoOffsetReset:earliest}")
+    private String autoOffsetReset;
+
+    @Value("${atlas.async.ingestion.consumer.pollTimeoutSeconds:15}")
+    private int pollTimeoutSeconds;
+
+    @Value("${atlas.async.ingestion.consumer.maxRetries:3}")
+    private int maxRetries;
+
+    @Value("${atlas.async.ingestion.consumer.retryDelayMs:5000}")
+    private long retryDelayMs;
+
+    @Value("${atlas.async.ingestion.consumer.exponentialBackoff.baseDelayMs:1000}")
+    private long baseDelayMs;
+
+    @Value("${atlas.async.ingestion.consumer.exponentialBackoff.maxDelayMs:60000}")
+    private long maxDelayMs;
+
+    @Value("${atlas.async.ingestion.consumer.exponentialBackoff.multiplier:2.0}")
+    private double backoffMultiplier;
+
+    @Value("${atlas.async.ingestion.consumer.shutdownWaitSeconds:60}")
+    private int shutdownWaitSeconds;
+
+    @Value("${atlas.async.ingestion.consumer.consumerCloseTimeoutSeconds:30}")
+    private int consumerCloseTimeoutSeconds;
+
+    @Value("${atlas.async.ingestion.consumer.trackerCleanupIntervalMs:300000}")
+    private long trackerCleanupIntervalMs;
+
+    @Value("${atlas.async.ingestion.consumer.trackerMaxAgeMs:3600000}")
+    private long trackerMaxAgeMs;
+
+    @Value("${atlas.async.ingestion.consumer.dlq.topic:ATLAS_ASYNC_INGESTION_DLQ}")
+    private String dlqTopic;
+
+    @Value("${atlas.async.ingestion.consumer.entityNotificationsEnabled:false}")
+    private boolean entityNotificationsEnabled;
+
+    // ── Dependencies ─────────────────────────────────────────────────────
+    private final EntityMutationService entityMutationService;
+    private final AtlasEntityStore entitiesStore;
+    private final AtlasRelationshipStore relationshipStore;
+    private final AtlasTypeDefStore typeDefStore;
+    private final AtlasTypeRegistry typeRegistry;
+    private final RedisService redisService;
+    private String typeDefLock;
+
+    // ── State ────────────────────────────────────────────────────────────
+    private volatile KafkaConsumer<String, String> consumer;
+    private volatile KafkaProducer<String, String> dlqProducer;
+    private volatile Thread consumerThread;
+
+    private final AtomicBoolean isRunning = new AtomicBoolean(false);
+    private final AtomicBoolean isHealthy = new AtomicBoolean(false);
+    private final AtomicLong processedCount = new AtomicLong(0);
+    private final AtomicLong errorCount = new AtomicLong(0);
+    private final AtomicLong skippedCount = new AtomicLong(0);
+    private final AtomicLong dlqPublishCount = new AtomicLong(0);
+    private volatile long lastProcessedTime = 0;
+    private volatile String lastEventType = null;
+
+    // Cached lag info — updated on the consumer thread, safe to read from HTTP threads
+    private volatile Map<String, Object> cachedLagInfo = Collections.emptyMap();
+
+    // Retry & backoff trackers keyed by "partition-offset"
+    private final ConcurrentHashMap<String, RetryTrackerEntry> retryTracker = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Long> backoffTracker = new ConcurrentHashMap<>();
+    private volatile long lastTrackerCleanupTime = System.currentTimeMillis();
+
+    private static class RetryTrackerEntry {
+        int retryCount;
+        long lastAttemptTime;
+
+        RetryTrackerEntry() {
+            this.retryCount = 0;
+            this.lastAttemptTime = System.currentTimeMillis();
+        }
+    }
+
+    @Inject
+    public AsyncIngestionConsumerService(EntityMutationService entityMutationService,
+                                         AtlasEntityStore entitiesStore,
+                                         AtlasRelationshipStore relationshipStore,
+                                         AtlasTypeDefStore typeDefStore,
+                                         AtlasTypeRegistry typeRegistry,
+                                         RedisService redisService) {
+        this.entityMutationService = entityMutationService;
+        this.entitiesStore = entitiesStore;
+        this.relationshipStore = relationshipStore;
+        this.typeDefStore = typeDefStore;
+        this.typeRegistry = typeRegistry;
+        this.redisService = redisService;
+
+        try {
+            this.typeDefLock = ApplicationProperties.get().getString(ApplicationProperties.TYPEDEF_LOCK_NAME, "atlas:type-def:lock");
+        } catch (Exception e) {
+            this.typeDefLock = "atlas:type-def:lock";
+        }
+    }
+
+    // ── Lifecycle ────────────────────────────────────────────────────────
+
+    @PostConstruct
+    public void init() {
+        if (!consumerEnabled) {
+            LOG.info("AsyncIngestionConsumer is disabled (atlas.async.ingestion.consumer.enabled=false)");
+            return;
+        }
+        start();
+    }
+
+    public synchronized void start() {
+        if (isRunning.get()) {
+            LOG.warn("AsyncIngestionConsumer is already running");
+            return;
+        }
+
+        try {
+            this.bootstrapServers = ApplicationProperties.get().getString("atlas.kafka.bootstrap.servers");
+        } catch (Exception e) {
+            LOG.error("Failed to read Kafka bootstrap servers from config", e);
+            return;
+        }
+
+        try {
+            Properties props = new Properties();
+            props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+            props.put(ConsumerConfig.GROUP_ID_CONFIG, consumerGroupId);
+            props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+            props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+            props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+            props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, autoOffsetReset);
+            props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, String.valueOf(maxPollRecords));
+            props.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, String.valueOf(maxPollIntervalMs));
+            props.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, String.valueOf(sessionTimeoutMs));
+            props.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, String.valueOf(heartbeatIntervalMs));
+
+            consumer = new KafkaConsumer<>(props);
+            consumer.subscribe(Collections.singletonList(topic), new ConsumerRebalanceListener() {
+                @Override
+                public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
+                    LOG.info("Partitions revoked: {}", partitions);
+                    for (TopicPartition tp : partitions) {
+                        String prefix = tp.partition() + "-";
+                        retryTracker.keySet().removeIf(k -> k.startsWith(prefix));
+                        backoffTracker.keySet().removeIf(k -> k.startsWith(prefix));
+                    }
+                }
+
+                @Override
+                public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
+                    LOG.info("Partitions assigned: {}", partitions);
+                    for (TopicPartition tp : partitions) {
+                        try {
+                            long endOffset = consumer.endOffsets(Collections.singleton(tp)).getOrDefault(tp, -1L);
+                            long position = consumer.position(tp);
+                            LOG.info("Partition {} - position: {}, endOffset: {}, lag: {}",
+                                    tp.partition(), position, endOffset, endOffset - position);
+                        } catch (Exception e) {
+                            LOG.warn("Failed to log offset info for partition {}", tp, e);
+                        }
+                    }
+                }
+            });
+
+            isRunning.set(true);
+            isHealthy.set(true);
+
+            consumerThread = new Thread(this::processMessages, "AsyncIngestion-Consumer-Thread");
+            consumerThread.setDaemon(false);
+            consumerThread.start();
+
+            LOG.info("AsyncIngestionConsumer started - topic: {}, group: {}", topic, consumerGroupId);
+
+        } catch (Exception e) {
+            LOG.error("Failed to start AsyncIngestionConsumer", e);
+            isHealthy.set(false);
+        }
+    }
+
+    @PreDestroy
+    public synchronized void shutdown() {
+        if (!isRunning.get()) {
+            return;
+        }
+
+        LOG.info("AsyncIngestionConsumer shutting down...");
+        isRunning.set(false);
+
+        // Wakeup consumer to interrupt poll()
+        if (consumer != null) {
+            try {
+                consumer.wakeup();
+            } catch (Exception e) {
+                LOG.warn("Error waking up consumer", e);
+            }
+        }
+
+        // Wait for consumer thread to finish
+        if (consumerThread != null) {
+            try {
+                consumerThread.join(TimeUnit.SECONDS.toMillis(shutdownWaitSeconds));
+                if (consumerThread.isAlive()) {
+                    LOG.error("AsyncIngestionConsumer thread did not terminate within {} seconds", shutdownWaitSeconds);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                LOG.warn("Interrupted while waiting for consumer thread to stop");
+            }
+        }
+
+        // Close consumer
+        if (consumer != null) {
+            try {
+                consumer.close(Duration.ofSeconds(consumerCloseTimeoutSeconds));
+                LOG.info("AsyncIngestionConsumer: Kafka consumer closed");
+            } catch (Exception e) {
+                LOG.warn("Error closing Kafka consumer", e);
+            }
+            consumer = null;
+        }
+
+        // Close DLQ producer
+        if (dlqProducer != null) {
+            try {
+                dlqProducer.close(Duration.ofSeconds(10));
+                LOG.info("AsyncIngestionConsumer: DLQ producer closed");
+            } catch (Exception e) {
+                LOG.warn("Error closing DLQ producer", e);
+            }
+            dlqProducer = null;
+        }
+
+        isHealthy.set(false);
+        LOG.info("AsyncIngestionConsumer stopped - processed: {}, errors: {}, skipped: {}, dlqPublished: {}",
+                processedCount.get(), errorCount.get(), skippedCount.get(), dlqPublishCount.get());
+    }
+
+    // ── Core Processing Loop ─────────────────────────────────────────────
+
+    private void processMessages() {
+        try {
+            while (isRunning.get()) {
+                try {
+                    cleanupStaleTrackersIfNeeded();
+
+                    ConsumerRecords<String, String> records = consumer.poll(Duration.ofSeconds(pollTimeoutSeconds));
+
+                    // Update lag info on consumer thread (KafkaConsumer is not thread-safe)
+                    updateCachedLagInfo();
+
+                    if (records.isEmpty()) {
+                        continue;
+                    }
+
+                    // Pause all partitions to prevent max.poll.interval.ms timeout
+                    Set<TopicPartition> assignment = consumer.assignment();
+                    consumer.pause(assignment);
+
+                    TopicPartition failedPartition = null;
+                    long failedOffset = -1;
+
+                    try {
+                        for (ConsumerRecord<String, String> record : records) {
+                            String trackerKey = record.partition() + "-" + record.offset();
+
+                            try {
+                                processRecord(record);
+
+                                // Success — clean up trackers, commit offset
+                                retryTracker.remove(trackerKey);
+                                backoffTracker.remove(trackerKey);
+                                consumer.commitSync(Collections.singletonMap(
+                                        new TopicPartition(record.topic(), record.partition()),
+                                        new OffsetAndMetadata(record.offset() + 1)));
+
+                                processedCount.incrementAndGet();
+                                lastProcessedTime = System.currentTimeMillis();
+
+                            } catch (TemporaryBackendException tbe) {
+                                // Transient backend error — exponential backoff without counting toward max retries
+                                errorCount.incrementAndGet();
+                                long backoff = calculateExponentialBackoff(trackerKey);
+                                LOG.warn("AsyncIngestionConsumer: temporary backend exception at partition={} offset={}, " +
+                                                "backoff {}ms. Will retry without incrementing retry count.",
+                                        record.partition(), record.offset(), backoff, tbe);
+                                failedPartition = new TopicPartition(record.topic(), record.partition());
+                                failedOffset = record.offset();
+
+                                try {
+                                    Thread.sleep(backoff);
+                                } catch (InterruptedException ie) {
+                                    Thread.currentThread().interrupt();
+                                    return;
+                                }
+                                break; // Break out of record loop, will seek back
+                            } catch (Exception e) {
+                                errorCount.incrementAndGet();
+                                RetryTrackerEntry entry = retryTracker.computeIfAbsent(trackerKey, k -> new RetryTrackerEntry());
+                                entry.retryCount++;
+                                entry.lastAttemptTime = System.currentTimeMillis();
+
+                                if (entry.retryCount >= maxRetries) {
+                                    // Poison pill — publish to DLQ, then skip
+                                    publishToDlq(record, e, entry.retryCount);
+                                    LOG.error("AsyncIngestionConsumer: skipping poison pill at partition={} offset={} " +
+                                                    "after {} retries. EventId: {}", record.partition(), record.offset(),
+                                            entry.retryCount, record.key(), e);
+                                    skippedCount.incrementAndGet();
+                                    retryTracker.remove(trackerKey);
+                                    backoffTracker.remove(trackerKey);
+                                    consumer.commitSync(Collections.singletonMap(
+                                            new TopicPartition(record.topic(), record.partition()),
+                                            new OffsetAndMetadata(record.offset() + 1)));
+                                } else {
+                                    // Retry with backoff
+                                    long backoff = calculateExponentialBackoff(trackerKey);
+                                    LOG.warn("AsyncIngestionConsumer: retryable failure at partition={} offset={}, " +
+                                                    "retry {}/{}, backoff {}ms", record.partition(), record.offset(),
+                                            entry.retryCount, maxRetries, backoff, e);
+                                    failedPartition = new TopicPartition(record.topic(), record.partition());
+                                    failedOffset = record.offset();
+
+                                    try {
+                                        Thread.sleep(backoff);
+                                    } catch (InterruptedException ie) {
+                                        Thread.currentThread().interrupt();
+                                        return;
+                                    }
+                                    break; // Break out of record loop, will seek back
+                                }
+                            }
+                        }
+                    } finally {
+                        // Seek back to failed offset if needed
+                        if (failedPartition != null && failedOffset >= 0) {
+                            consumer.seek(failedPartition, failedOffset);
+                        }
+                        // Resume all partitions
+                        consumer.resume(assignment);
+                    }
+
+                } catch (WakeupException e) {
+                    if (isRunning.get()) {
+                        LOG.warn("AsyncIngestionConsumer: unexpected wakeup", e);
+                    }
+                    // Expected during shutdown
+                } catch (Exception e) {
+                    LOG.error("AsyncIngestionConsumer: unexpected error in processing loop", e);
+                    try {
+                        Thread.sleep(retryDelayMs);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("AsyncIngestionConsumer: fatal error, marking unhealthy", e);
+            isHealthy.set(false);
+        }
+    }
+
+    // ── Record Processing ────────────────────────────────────────────────
+
+    private void processRecord(ConsumerRecord<String, String> record) throws Exception {
+        JsonNode envelope = MAPPER.readTree(record.value());
+
+        String eventType = envelope.path("eventType").asText();
+        String eventId = envelope.path("eventId").asText();
+        JsonNode requestMetadata = envelope.path("requestMetadata");
+        JsonNode operationMetadata = envelope.path("operationMetadata");
+        JsonNode payload = envelope.path("payload");
+
+        lastEventType = eventType;
+
+        LOG.info("AsyncIngestionConsumer: processing event {} type={} partition={} offset={}",
+                eventId, eventType, record.partition(), record.offset());
+
+        // Set request context from the original request metadata
+        setupRequestContext(requestMetadata);
+
+        try {
+            routeAndProcess(eventType, payload, operationMetadata);
+        } catch (Exception e) {
+            LOG.error("AsyncIngestion: failed to process eventType={}, eventId={}, error={}",
+                    eventType, eventId, e.getMessage(), e);
+            throw e;
+        } finally {
+            RequestContext.clear();
+        }
+    }
+
+    private void setupRequestContext(JsonNode requestMetadata) {
+        RequestContext ctx = RequestContext.get();
+        if (requestMetadata.has("user")) {
+            ctx.setUser(requestMetadata.get("user").asText(), null);
+        }
+        if (requestMetadata.has("traceId")) {
+            ctx.setTraceId(requestMetadata.get("traceId").asText());
+        }
+        ctx.setSkipEntityChangeNotification(!entityNotificationsEnabled);
+        ctx.setImportInProgress(true);
+    }
+
+    private void routeAndProcess(String eventType, JsonNode payload, JsonNode operationMetadata) throws Exception {
+        switch (eventType) {
+            // ── Entity mutations ─────────────────────────────────────
+            case "BULK_CREATE_OR_UPDATE":
+                replayCreateOrUpdate(payload, operationMetadata);
+                break;
+            case "DELETE_BY_GUID":
+                replayDeleteByGuid(payload);
+                break;
+            case "DELETE_BY_GUIDS":
+                replayDeleteByGuids(payload);
+                break;
+            case "RESTORE_BY_GUIDS":
+                replayRestoreByGuids(payload);
+                break;
+            case "DELETE_BY_UNIQUE_ATTRIBUTE":
+                replayDeleteByUniqueAttribute(payload, operationMetadata);
+                break;
+            case "BULK_DELETE_BY_UNIQUE_ATTRIBUTES":
+                replayBulkDeleteByUniqueAttributes(payload);
+                break;
+            case "SET_CLASSIFICATIONS":
+                replaySetClassifications(payload, operationMetadata);
+                break;
+
+            // ── Classification mutations (to be added to fatgraph producer) ──
+            case "ADD_CLASSIFICATIONS":
+                replayAddClassifications(payload);
+                break;
+            case "UPDATE_CLASSIFICATIONS":
+                replayUpdateClassifications(payload);
+                break;
+            case "DELETE_CLASSIFICATION":
+                replayDeleteClassification(payload, operationMetadata);
+                break;
+            case "ADD_CLASSIFICATION_BULK":
+                replayAddClassificationBulk(payload);
+                break;
+
+            // ── Relationship mutations ────────────────────────────────
+            case "DELETE_RELATIONSHIP_BY_GUID":
+                replayDeleteRelationship(payload);
+                break;
+            case "DELETE_RELATIONSHIPS_BY_GUIDS":
+                replayDeleteRelationships(payload);
+                break;
+            case "RELATIONSHIP_CREATE":
+                replayRelationshipCreate(payload);
+                break;
+            case "RELATIONSHIP_BULK_CREATE_OR_UPDATE":
+                replayRelationshipBulkCreateOrUpdate(payload);
+                break;
+            case "RELATIONSHIP_UPDATE":
+                replayRelationshipUpdate(payload);
+                break;
+
+            // ── Partial update mutations ─────────────────────────────
+            case "PARTIAL_UPDATE_BY_GUID":
+                replayPartialUpdateByGuid(payload, operationMetadata);
+                break;
+            case "UPDATE_BY_UNIQUE_ATTRIBUTE":
+                replayUpdateByUniqueAttributes(payload, operationMetadata);
+                break;
+
+            // ── Labels ─────────────────────────────────────────────────
+            case "ADD_LABELS":
+                replayAddLabels(payload);
+                break;
+
+            // ── Business metadata mutations ───────────────────────────
+            case "ADD_OR_UPDATE_BUSINESS_ATTRIBUTES":
+                replayAddOrUpdateBusinessAttributes(payload, operationMetadata);
+                break;
+            case "ADD_OR_UPDATE_BUSINESS_ATTRIBUTES_BY_DISPLAY_NAME":
+                replayAddOrUpdateBusinessAttributesByDisplayName(payload, operationMetadata);
+                break;
+            case "REMOVE_BUSINESS_ATTRIBUTES":
+                replayRemoveBusinessAttributes(payload, operationMetadata);
+                break;
+
+            // ── TypeDef mutations ────────────────────────────────────
+            case "TYPEDEF_CREATE":
+                replayTypeDefCreate(payload, operationMetadata);
+                break;
+            case "TYPEDEF_UPDATE":
+                replayTypeDefUpdate(payload, operationMetadata);
+                break;
+            case "TYPEDEF_DELETE":
+                replayTypeDefDelete(payload);
+                break;
+            case "TYPEDEF_DELETE_BY_NAME":
+                replayTypeDefDeleteByName(payload);
+                break;
+
+            default:
+                LOG.warn("AsyncIngestionConsumer: unknown event type '{}', skipping", eventType);
+                skippedCount.incrementAndGet();
+        }
+    }
+
+    // ── Entity Replay Methods ────────────────────────────────────────────
+
+    /**
+     * BULK_CREATE_OR_UPDATE: payload = {"entities": [{typeName, attributes, guid, ...}, ...]}
+     */
+    private void replayCreateOrUpdate(JsonNode payload, JsonNode operationMetadata) throws AtlasBaseException {
+        AtlasEntitiesWithExtInfo entities = AtlasType.fromJson(payload.toString(), AtlasEntitiesWithExtInfo.class);
+        if (entities == null) {
+            throw new AtlasBaseException("Failed to deserialize AtlasEntitiesWithExtInfo from payload");
+        }
+        normalizeRelationshipAttributes(entities);
+
+        if (entities.getEntities() != null) {
+            LOG.info("AsyncIngestion: BULK_CREATE_OR_UPDATE entityCount={}, types={}, guids={}",
+                    entities.getEntities().size(),
+                    entities.getEntities().stream().map(AtlasEntity::getTypeName).collect(Collectors.toList()),
+                    entities.getEntities().stream().map(AtlasEntity::getGuid).collect(Collectors.toList()));
+        }
+
+        BulkRequestContext ctx = BulkRequestContext.fromOperationMetadata(operationMetadata);
+
+        if (ctx.isSkipProcessEdgeRestoration()) {
+            RequestContext.get().setSkipProcessEdgeRestoration(true);
+        }
+
+        entityMutationService.createOrUpdate(new AtlasEntityStream(entities), ctx);
+        LOG.info("AsyncIngestion: BULK_CREATE_OR_UPDATE completed successfully");
+    }
+
+    /**
+     * After JSON deserialization, relationshipAttributes values are LinkedHashMap (not AtlasObjectId).
+     * Preprocessors like TermPreProcessor.setAnchor() cast them to AtlasObjectId, which fails.
+     * This method normalizes Map values to AtlasObjectId instances.
+     */
+    @SuppressWarnings("unchecked")
+    private void normalizeRelationshipAttributes(AtlasEntitiesWithExtInfo entities) {
+        if (entities == null || entities.getEntities() == null) {
+            return;
+        }
+        for (AtlasEntity entity : entities.getEntities()) {
+            Map<String, Object> relAttrs = entity.getRelationshipAttributes();
+            if (relAttrs == null) {
+                continue;
+            }
+            for (Map.Entry<String, Object> entry : relAttrs.entrySet()) {
+                Object value = entry.getValue();
+                if (value instanceof Map && !(value instanceof AtlasObjectId)) {
+                    entry.setValue(new AtlasObjectId((Map) value));
+                } else if (value instanceof List) {
+                    List<Object> normalized = new ArrayList<>();
+                    for (Object item : (List<?>) value) {
+                        if (item instanceof Map && !(item instanceof AtlasObjectId)) {
+                            normalized.add(new AtlasObjectId((Map) item));
+                        } else {
+                            normalized.add(item);
+                        }
+                    }
+                    entry.setValue(normalized);
+                }
+            }
+        }
+    }
+
+    /**
+     * DELETE_BY_GUID: payload = {"guids": ["guid-table-001"]}
+     */
+    private void replayDeleteByGuid(JsonNode payload) throws AtlasBaseException {
+        List<String> guids = MAPPER.convertValue(payload.get("guids"), new TypeReference<List<String>>() {});
+        entityMutationService.deleteById(guids.get(0));
+    }
+
+    /**
+     * DELETE_BY_GUIDS: payload = {"guids": ["guid1", "guid2", ...]}
+     */
+    private void replayDeleteByGuids(JsonNode payload) throws AtlasBaseException {
+        List<String> guids = MAPPER.convertValue(payload.get("guids"), new TypeReference<List<String>>() {});
+        entityMutationService.deleteByIds(guids);
+    }
+
+    /**
+     * RESTORE_BY_GUIDS: payload = {"guids": ["guid1", "guid2"]}
+     */
+    private void replayRestoreByGuids(JsonNode payload) throws AtlasBaseException {
+        List<String> guids = MAPPER.convertValue(payload.get("guids"), new TypeReference<List<String>>() {});
+        entityMutationService.restoreByIds(guids);
+    }
+
+    /**
+     * DELETE_BY_UNIQUE_ATTRIBUTE: operationMetadata = {"deleteType": "SOFT", "typeName": "Table"}
+     * payload = {"uniqueAttributes": {"qualifiedName": "..."}}
+     */
+    private void replayDeleteByUniqueAttribute(JsonNode payload, JsonNode operationMetadata) throws AtlasBaseException {
+        String typeName = operationMetadata.get("typeName").asText();
+        Map<String, Object> uniqAttrs = MAPPER.convertValue(payload.get("uniqueAttributes"),
+                new TypeReference<Map<String, Object>>() {});
+        AtlasEntityType entityType = typeRegistry.getEntityTypeByName(typeName);
+        if (entityType == null) {
+            throw new AtlasBaseException("Unknown entity type: " + typeName);
+        }
+        entityMutationService.deleteByUniqueAttributes(entityType, uniqAttrs);
+    }
+
+    /**
+     * BULK_DELETE_BY_UNIQUE_ATTRIBUTES: payload = {"objectIds": [{typeName, uniqueAttributes}, ...]}
+     */
+    private void replayBulkDeleteByUniqueAttributes(JsonNode payload) throws AtlasBaseException {
+        List<AtlasObjectId> objectIds = MAPPER.convertValue(payload.get("objectIds"), new TypeReference<List<AtlasObjectId>>() {});
+        entityMutationService.deleteByUniqueAttributes(objectIds);
+    }
+
+    /**
+     * SET_CLASSIFICATIONS: payload = AtlasEntityHeaders JSON {"guidHeaderMap": {"guid1": {...}, ...}}
+     * operationMetadata = {"overrideClassifications": false}
+     */
+    private void replaySetClassifications(JsonNode payload, JsonNode operationMetadata) throws AtlasBaseException {
+        AtlasEntityHeaders entityHeaders = AtlasType.fromJson(payload.toString(), AtlasEntityHeaders.class);
+        boolean override = operationMetadata.path("overrideClassifications").asBoolean(false);
+        entityMutationService.setClassifications(entityHeaders, override);
+    }
+
+    // ── Classification Replay Methods (stubs for future fatgraph producer events) ──
+
+    /**
+     * ADD_CLASSIFICATIONS: payload = {"guid": "...", "classifications": [...]}
+     */
+    private void replayAddClassifications(JsonNode payload) throws AtlasBaseException {
+        String guid = payload.get("guid").asText();
+        List<AtlasClassification> classifications = MAPPER.convertValue(
+                payload.get("classifications"), new TypeReference<List<AtlasClassification>>() {});
+        entityMutationService.addClassifications(guid, classifications);
+    }
+
+    /**
+     * UPDATE_CLASSIFICATIONS: payload = {"guid": "...", "classifications": [...]}
+     */
+    private void replayUpdateClassifications(JsonNode payload) throws AtlasBaseException {
+        String guid = payload.get("guid").asText();
+        List<AtlasClassification> classifications = MAPPER.convertValue(
+                payload.get("classifications"), new TypeReference<List<AtlasClassification>>() {});
+
+        // Diagnostic: dump existing classifications BEFORE update
+        try {
+            List<AtlasClassification> existingCls = entitiesStore.getClassifications(guid);
+            LOG.info("AsyncIngestion: UPDATE_CLASSIFICATIONS BEFORE guid={}, existingCount={}, existingTypes={}",
+                    guid, existingCls.size(),
+                    existingCls.stream().map(c -> c.getTypeName() + ":" + c.getAttributes()).collect(Collectors.toList()));
+        } catch (Exception e) {
+            LOG.warn("AsyncIngestion: UPDATE_CLASSIFICATIONS could not fetch existing classifications for guid={}: {}", guid, e.getMessage());
+        }
+
+        LOG.info("AsyncIngestion: UPDATE_CLASSIFICATIONS incoming guid={}, classificationCount={}, types={}",
+                guid, classifications.size(),
+                classifications.stream().map(c -> c.getTypeName() + ":" + c.getAttributes()).collect(Collectors.toList()));
+
+        entityMutationService.updateClassifications(guid, classifications);
+
+        // Diagnostic: dump classifications AFTER update
+        try {
+            List<AtlasClassification> afterCls = entitiesStore.getClassifications(guid);
+            LOG.info("AsyncIngestion: UPDATE_CLASSIFICATIONS AFTER guid={}, count={}, types={}",
+                    guid, afterCls.size(),
+                    afterCls.stream().map(c -> c.getTypeName() + ":" + c.getAttributes()).collect(Collectors.toList()));
+        } catch (Exception e) {
+            LOG.warn("AsyncIngestion: UPDATE_CLASSIFICATIONS could not fetch post-update classifications for guid={}: {}", guid, e.getMessage());
+        }
+    }
+
+    /**
+     * DELETE_CLASSIFICATION: payload = {"guid": "...", "classificationName": "..."}
+     * or payload = {"guid": "...", "classificationName": "...", "associatedEntityGuid": "..."}
+     */
+    private void replayDeleteClassification(JsonNode payload, JsonNode operationMetadata) throws AtlasBaseException {
+        String guid = payload.get("guid").asText();
+        String classificationName = payload.get("classificationName").asText();
+        String associatedEntityGuid = payload.has("associatedEntityGuid")
+                ? payload.get("associatedEntityGuid").asText() : null;
+
+        if (associatedEntityGuid != null) {
+            entityMutationService.deleteClassification(guid, classificationName, associatedEntityGuid);
+        } else {
+            entityMutationService.deleteClassification(guid, classificationName);
+        }
+    }
+
+    /**
+     * ADD_CLASSIFICATION_BULK: payload = {"guids": [...], "classification": {...}}
+     */
+    private void replayAddClassificationBulk(JsonNode payload) throws AtlasBaseException {
+        List<String> guids = MAPPER.convertValue(payload.get("guids"), new TypeReference<List<String>>() {});
+        AtlasClassification classification = AtlasType.fromJson(
+                payload.get("classification").toString(), AtlasClassification.class);
+        entityMutationService.addClassification(guids, classification);
+    }
+
+    // ── Relationship Replay Methods ─────────────────────────────────────
+
+    /**
+     * DELETE_RELATIONSHIP_BY_GUID: payload = {"guid": "..."}
+     */
+    private void replayDeleteRelationship(JsonNode payload) throws AtlasBaseException {
+        String guid = payload.get("guid").asText();
+        entityMutationService.deleteRelationshipById(guid);
+    }
+
+    /**
+     * DELETE_RELATIONSHIPS_BY_GUIDS: payload = {"guids": [...]}
+     */
+    private void replayDeleteRelationships(JsonNode payload) throws AtlasBaseException {
+        List<String> guids = MAPPER.convertValue(payload.get("guids"), new TypeReference<List<String>>() {});
+        entityMutationService.deleteRelationshipsByIds(guids);
+    }
+
+    /**
+     * RELATIONSHIP_CREATE: payload = AtlasRelationship JSON
+     */
+    private void replayRelationshipCreate(JsonNode payload) throws AtlasBaseException {
+        AtlasRelationship relationship = AtlasType.fromJson(payload.toString(), AtlasRelationship.class);
+        relationshipStore.create(relationship);
+    }
+
+    /**
+     * RELATIONSHIP_BULK_CREATE_OR_UPDATE: payload = List of AtlasRelationship JSON
+     */
+    private void replayRelationshipBulkCreateOrUpdate(JsonNode payload) throws AtlasBaseException {
+        List<AtlasRelationship> relationships = MAPPER.convertValue(payload, new TypeReference<List<AtlasRelationship>>() {});
+        relationshipStore.createOrUpdate(relationships);
+    }
+
+    /**
+     * RELATIONSHIP_UPDATE: payload = AtlasRelationship JSON
+     */
+    private void replayRelationshipUpdate(JsonNode payload) throws AtlasBaseException {
+        AtlasRelationship relationship = AtlasType.fromJson(payload.toString(), AtlasRelationship.class);
+        relationshipStore.update(relationship);
+    }
+
+    // ── Partial Update & Attribute Replay Methods ─────────────────────────
+
+    /**
+     * PARTIAL_UPDATE_BY_GUID: payload = {"guid": "...", "attrName": "...", "attrValue": ...}
+     */
+    private void replayPartialUpdateByGuid(JsonNode payload, JsonNode operationMetadata) throws AtlasBaseException {
+        String guid = payload.get("guid").asText();
+        String attrName = payload.get("attrName").asText();
+        Object attrValue = MAPPER.convertValue(payload.get("attrValue"), Object.class);
+        entitiesStore.updateEntityAttributeByGuid(guid, attrName, attrValue);
+    }
+
+    /**
+     * UPDATE_BY_UNIQUE_ATTRIBUTE: operationMetadata = {"typeName": "Table"}
+     * payload = {"uniqueAttributes": {"qualifiedName": "..."}, "entity": {AtlasEntityWithExtInfo}}
+     */
+    private void replayUpdateByUniqueAttributes(JsonNode payload, JsonNode operationMetadata) throws AtlasBaseException {
+        String typeName = operationMetadata.get("typeName").asText();
+        Map<String, Object> uniqAttrs = MAPPER.convertValue(
+                payload.get("uniqueAttributes"), new TypeReference<Map<String, Object>>() {});
+        AtlasEntityType entityType = typeRegistry.getEntityTypeByName(typeName);
+        if (entityType == null) {
+            throw new AtlasBaseException("Unknown entity type: " + typeName);
+        }
+        AtlasEntity.AtlasEntityWithExtInfo entityInfo = AtlasType.fromJson(
+                payload.get("entity").toString(), AtlasEntity.AtlasEntityWithExtInfo.class);
+        entityMutationService.updateByUniqueAttributes(entityType, uniqAttrs, entityInfo);
+    }
+
+    /**
+     * ADD_LABELS: payload = {"guid": "...", "labels": ["label1", "label2"]}
+     */
+    private void replayAddLabels(JsonNode payload) throws AtlasBaseException {
+        String guid = payload.get("guid").asText();
+        Set<String> labels = MAPPER.convertValue(
+                payload.get("labels"), new TypeReference<Set<String>>() {});
+        entitiesStore.addLabels(guid, labels);
+    }
+
+    // ── Business Metadata Replay Methods ─────────────────────────────────
+
+    /**
+     * ADD_OR_UPDATE_BUSINESS_ATTRIBUTES: operationMetadata = {"guid": "...", "isOverwrite": false}
+     * optionally operationMetadata may contain {"bmName": "..."} for single BM operations.
+     * payload = business attributes map
+     */
+    private void replayAddOrUpdateBusinessAttributes(JsonNode payload, JsonNode operationMetadata) throws AtlasBaseException {
+        String guid = operationMetadata.get("guid").asText();
+        boolean isOverwrite = operationMetadata.path("isOverwrite").asBoolean(false);
+
+        LOG.info("AsyncIngestion: ADD_OR_UPDATE_BM guid={}, isOverwrite={}", guid, isOverwrite);
+
+        if (operationMetadata.has("bmName")) {
+            String bmName = operationMetadata.get("bmName").asText();
+            Map<String, Object> bmAttrs = MAPPER.convertValue(payload, new TypeReference<Map<String, Object>>() {});
+            LOG.info("AsyncIngestion: ADD_OR_UPDATE_BM single bmName={}", bmName);
+            entitiesStore.addOrUpdateBusinessAttributes(guid, Collections.singletonMap(bmName, bmAttrs), isOverwrite);
+        } else {
+            Map<String, Map<String, Object>> bmAttrs = MAPPER.convertValue(payload, new TypeReference<Map<String, Map<String, Object>>>() {});
+            LOG.info("AsyncIngestion: ADD_OR_UPDATE_BM calling entitiesStore with bmNames={}", bmAttrs.keySet());
+            entitiesStore.addOrUpdateBusinessAttributes(guid, bmAttrs, isOverwrite);
+        }
+    }
+
+    /**
+     * ADD_OR_UPDATE_BUSINESS_ATTRIBUTES_BY_DISPLAY_NAME: same format as ADD_OR_UPDATE_BUSINESS_ATTRIBUTES
+     * but calls addOrUpdateBusinessAttributesByDisplayName.
+     */
+    private void replayAddOrUpdateBusinessAttributesByDisplayName(JsonNode payload, JsonNode operationMetadata) throws AtlasBaseException {
+        String guid = operationMetadata.get("guid").asText();
+        boolean isOverwrite = operationMetadata.path("isOverwrite").asBoolean(false);
+        Map<String, Map<String, Object>> bmAttrs = MAPPER.convertValue(payload, new TypeReference<Map<String, Map<String, Object>>>() {});
+        LOG.info("AsyncIngestion: ADD_OR_UPDATE_BM_BY_DISPLAY_NAME guid={}, isOverwrite={}, displayNames={}",
+                guid, isOverwrite, bmAttrs.keySet());
+        entitiesStore.addOrUpdateBusinessAttributesByDisplayName(guid, bmAttrs, isOverwrite);
+    }
+
+    /**
+     * REMOVE_BUSINESS_ATTRIBUTES: operationMetadata = {"guid": "..."}
+     * optionally operationMetadata may contain {"bmName": "..."} for single BM operations.
+     * payload = business attributes map
+     */
+    private void replayRemoveBusinessAttributes(JsonNode payload, JsonNode operationMetadata) throws AtlasBaseException {
+        String guid = operationMetadata.get("guid").asText();
+        if (operationMetadata.has("bmName")) {
+            String bmName = operationMetadata.get("bmName").asText();
+            Map<String, Object> bmAttrs = MAPPER.convertValue(payload, new TypeReference<Map<String, Object>>() {});
+            entitiesStore.removeBusinessAttributes(guid, Collections.singletonMap(bmName, bmAttrs));
+        } else {
+            Map<String, Map<String, Object>> bmAttrs = MAPPER.convertValue(payload, new TypeReference<Map<String, Map<String, Object>>>() {});
+            entitiesStore.removeBusinessAttributes(guid, bmAttrs);
+        }
+    }
+
+    // ── TypeDef Replay Methods ───────────────────────────────────────────
+
+    /**
+     * TYPEDEF_CREATE: payload = AtlasTypesDef JSON
+     * operationMetadata may contain {"allowDuplicateDisplayName": false}
+     */
+    private void replayTypeDefCreate(JsonNode payload, JsonNode operationMetadata) throws AtlasBaseException {
+        Lock lock = null;
+        try {
+            try {
+                lock = redisService.acquireDistributedLockV2(typeDefLock);
+            } catch (Exception e) {
+                throw new AtlasBaseException("AsyncIngestion: Error acquiring typedef lock for TYPEDEF_CREATE", e);
+            }
+            if (lock == null) {
+                throw new AtlasBaseException("AsyncIngestion: Failed to acquire typedef lock for TYPEDEF_CREATE");
+            }
+
+            if (operationMetadata != null && operationMetadata.has("allowDuplicateDisplayName")) {
+                RequestContext.get().setAllowDuplicateDisplayName(
+                        operationMetadata.get("allowDuplicateDisplayName").asBoolean(false));
+            }
+
+            AtlasTypesDef typesDef = AtlasType.fromJson(payload.toString(), AtlasTypesDef.class);
+            typeDefStore.createTypesDef(typesDef);
+
+            incrementTypeDefVersion();
+        } finally {
+            if (lock != null) {
+                redisService.releaseDistributedLockV2(lock, typeDefLock);
+            }
+        }
+    }
+
+    /**
+     * TYPEDEF_UPDATE: payload = AtlasTypesDef JSON
+     * operationMetadata may contain {"allowDuplicateDisplayName": false, "patch": true}
+     */
+    private void replayTypeDefUpdate(JsonNode payload, JsonNode operationMetadata) throws AtlasBaseException {
+        Lock lock = null;
+        try {
+            try {
+                lock = redisService.acquireDistributedLockV2(typeDefLock);
+            } catch (Exception e) {
+                throw new AtlasBaseException("AsyncIngestion: Error acquiring typedef lock for TYPEDEF_UPDATE", e);
+            }
+            if (lock == null) {
+                throw new AtlasBaseException("AsyncIngestion: Failed to acquire typedef lock for TYPEDEF_UPDATE");
+            }
+
+            if (operationMetadata != null && operationMetadata.has("allowDuplicateDisplayName")) {
+                RequestContext.get().setAllowDuplicateDisplayName(
+                        operationMetadata.get("allowDuplicateDisplayName").asBoolean(false));
+            }
+            if (operationMetadata != null && operationMetadata.has("patch")) {
+                RequestContext.get().setInTypePatching(
+                        operationMetadata.get("patch").asBoolean(false));
+            }
+
+            AtlasTypesDef typesDef = AtlasType.fromJson(payload.toString(), AtlasTypesDef.class);
+            typeDefStore.updateTypesDef(typesDef);
+
+            incrementTypeDefVersion();
+        } finally {
+            if (lock != null) {
+                redisService.releaseDistributedLockV2(lock, typeDefLock);
+            }
+        }
+    }
+
+    /**
+     * TYPEDEF_DELETE: payload = AtlasTypesDef JSON
+     */
+    private void replayTypeDefDelete(JsonNode payload) throws AtlasBaseException {
+        Lock lock = null;
+        try {
+            try {
+                lock = redisService.acquireDistributedLockV2(typeDefLock);
+            } catch (Exception e) {
+                throw new AtlasBaseException("AsyncIngestion: Error acquiring typedef lock for TYPEDEF_DELETE", e);
+            }
+            if (lock == null) {
+                throw new AtlasBaseException("AsyncIngestion: Failed to acquire typedef lock for TYPEDEF_DELETE");
+            }
+
+            AtlasTypesDef typesDef = AtlasType.fromJson(payload.toString(), AtlasTypesDef.class);
+            typeDefStore.deleteTypesDef(typesDef);
+
+            incrementTypeDefVersion();
+        } finally {
+            if (lock != null) {
+                redisService.releaseDistributedLockV2(lock, typeDefLock);
+            }
+        }
+    }
+
+    /**
+     * TYPEDEF_DELETE_BY_NAME: payload = {"typeName": "CustomTable"}
+     */
+    private void replayTypeDefDeleteByName(JsonNode payload) throws AtlasBaseException {
+        Lock lock = null;
+        try {
+            try {
+                lock = redisService.acquireDistributedLockV2(typeDefLock);
+            } catch (Exception e) {
+                throw new AtlasBaseException("AsyncIngestion: Error acquiring typedef lock for TYPEDEF_DELETE_BY_NAME", e);
+            }
+            if (lock == null) {
+                throw new AtlasBaseException("AsyncIngestion: Failed to acquire typedef lock for TYPEDEF_DELETE_BY_NAME");
+            }
+
+            String typeName = payload.get("typeName").asText();
+            typeDefStore.deleteTypeByName(typeName);
+
+            incrementTypeDefVersion();
+        } finally {
+            if (lock != null) {
+                redisService.releaseDistributedLockV2(lock, typeDefLock);
+            }
+        }
+    }
+
+    private void incrementTypeDefVersion() {
+        try {
+            long latestVersion = Long.parseLong(redisService.getValue(
+                    AtlasTypeDefStoreInitializer.TYPEDEF_LATEST_VERSION, "1")) + 1;
+            String latestVersionStr = String.valueOf(latestVersion);
+            redisService.putValue(AtlasTypeDefStoreInitializer.TYPEDEF_LATEST_VERSION, latestVersionStr);
+            AtlasTypeDefStoreInitializer.setCurrentTypedefInternalVersion(latestVersion);
+            LOG.info("AsyncIngestion: Incremented TYPEDEF_VERSION to {}", latestVersionStr);
+        } catch (Exception e) {
+            LOG.error("AsyncIngestion: Failed to increment typedef version in Redis", e);
+        }
+    }
+
+    // ── DLQ Publishing ─────────────────────────────────────────────────
+
+    /**
+     * Publish a failed record to the DLQ topic with error context.
+     * Best-effort: logs errors but does not throw.
+     */
+    private void publishToDlq(ConsumerRecord<String, String> record, Exception error, int retryCount) {
+        try {
+            KafkaProducer<String, String> producer = getOrCreateDlqProducer();
+            if (producer == null) {
+                LOG.error("AsyncIngestionConsumer: DLQ producer unavailable, cannot publish failed record " +
+                        "partition={} offset={}", record.partition(), record.offset());
+                return;
+            }
+
+            com.fasterxml.jackson.databind.node.ObjectNode dlqEnvelope = MAPPER.createObjectNode();
+            dlqEnvelope.put("originalTopic", record.topic());
+            dlqEnvelope.put("originalPartition", record.partition());
+            dlqEnvelope.put("originalOffset", record.offset());
+            dlqEnvelope.put("originalKey", record.key());
+            dlqEnvelope.put("originalValue", record.value());
+            dlqEnvelope.put("errorMessage", error.getMessage());
+            dlqEnvelope.put("errorClass", error.getClass().getName());
+            dlqEnvelope.put("retryCount", retryCount);
+            dlqEnvelope.put("failedAt", System.currentTimeMillis());
+
+            String json = MAPPER.writeValueAsString(dlqEnvelope);
+            ProducerRecord<String, String> dlqRecord = new ProducerRecord<>(dlqTopic, record.key(), json);
+            producer.send(dlqRecord).get(10, TimeUnit.SECONDS);
+
+            dlqPublishCount.incrementAndGet();
+            LOG.info("AsyncIngestionConsumer: published failed record to DLQ topic={} partition={} offset={}",
+                    dlqTopic, record.partition(), record.offset());
+
+        } catch (Exception e) {
+            LOG.error("AsyncIngestionConsumer: failed to publish to DLQ (non-fatal) partition={} offset={}",
+                    record.partition(), record.offset(), e);
+        }
+    }
+
+    private KafkaProducer<String, String> getOrCreateDlqProducer() {
+        if (dlqProducer == null) {
+            synchronized (this) {
+                if (dlqProducer == null) {
+                    try {
+                        Properties props = new Properties();
+                        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+                        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+                                "org.apache.kafka.common.serialization.StringSerializer");
+                        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+                                "org.apache.kafka.common.serialization.StringSerializer");
+                        props.put(ProducerConfig.ACKS_CONFIG, "all");
+
+                        dlqProducer = new KafkaProducer<>(props);
+                        LOG.info("AsyncIngestionConsumer: DLQ producer created for topic {}", dlqTopic);
+                    } catch (Exception e) {
+                        LOG.error("AsyncIngestionConsumer: failed to create DLQ producer", e);
+                        return null;
+                    }
+                }
+            }
+        }
+        return dlqProducer;
+    }
+
+    // ── Backoff & Tracker Helpers ────────────────────────────────────────
+
+    private long calculateExponentialBackoff(String trackerKey) {
+        Long currentDelay = backoffTracker.get(trackerKey);
+        if (currentDelay == null) {
+            currentDelay = baseDelayMs;
+        }
+        long nextDelay = Math.min((long) (currentDelay * backoffMultiplier), maxDelayMs);
+        backoffTracker.put(trackerKey, nextDelay);
+        return currentDelay;
+    }
+
+    private void cleanupStaleTrackersIfNeeded() {
+        long now = System.currentTimeMillis();
+        if (now - lastTrackerCleanupTime < trackerCleanupIntervalMs) {
+            return;
+        }
+        lastTrackerCleanupTime = now;
+
+        int removedRetry = 0;
+        Iterator<Map.Entry<String, RetryTrackerEntry>> it = retryTracker.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<String, RetryTrackerEntry> entry = it.next();
+            if (now - entry.getValue().lastAttemptTime > trackerMaxAgeMs) {
+                it.remove();
+                backoffTracker.remove(entry.getKey());
+                removedRetry++;
+            }
+        }
+
+        if (removedRetry > 0) {
+            LOG.info("AsyncIngestionConsumer: cleaned up {} stale tracker entries", removedRetry);
+        }
+    }
+
+    // ── Status & Health ──────────────────────────────────────────────────
+
+    public boolean isHealthy() {
+        return isHealthy.get() && consumerThread != null && consumerThread.isAlive();
+    }
+
+    public boolean isRunning() {
+        return isRunning.get();
+    }
+
+    public Map<String, Object> getStatus() {
+        Map<String, Object> status = new LinkedHashMap<>();
+        status.put("isRunning", isRunning.get());
+        status.put("isHealthy", isHealthy());
+        status.put("processedCount", processedCount.get());
+        status.put("errorCount", errorCount.get());
+        status.put("skippedCount", skippedCount.get());
+        status.put("dlqPublishCount", dlqPublishCount.get());
+        status.put("dlqTopic", dlqTopic);
+        status.put("topic", topic);
+        status.put("consumerGroup", consumerGroupId);
+        status.put("lastProcessedTime", lastProcessedTime > 0 ? new Date(lastProcessedTime).toString() : "N/A");
+        status.put("lastEventType", lastEventType != null ? lastEventType : "N/A");
+        status.put("activeRetries", retryTracker.size());
+        status.put("activeBackoffs", backoffTracker.size());
+        status.put("maxRetries", maxRetries);
+
+        Map<String, Object> backoffConfig = new LinkedHashMap<>();
+        backoffConfig.put("baseDelayMs", baseDelayMs);
+        backoffConfig.put("maxDelayMs", maxDelayMs);
+        backoffConfig.put("multiplier", backoffMultiplier);
+        status.put("exponentialBackoffConfig", backoffConfig);
+
+        return status;
+    }
+
+    /**
+     * Returns per-partition consumer lag. Useful for switchover readiness checks.
+     * Returns a cached snapshot computed on the consumer thread (thread-safe).
+     */
+    public Map<String, Object> getConsumerLag() {
+        if (!isRunning.get()) {
+            Map<String, Object> lagInfo = new LinkedHashMap<>();
+            lagInfo.put("totalLag", -1);
+            lagInfo.put("error", "Consumer is not running");
+            return lagInfo;
+        }
+        return cachedLagInfo;
+    }
+
+    /**
+     * Compute consumer lag on the consumer thread (KafkaConsumer is not thread-safe).
+     * Must only be called from the consumer thread.
+     */
+    private void updateCachedLagInfo() {
+        try {
+            Set<TopicPartition> assignment = consumer.assignment();
+            if (assignment.isEmpty()) {
+                return;
+            }
+            Map<TopicPartition, Long> endOffsets = consumer.endOffsets(assignment);
+            Map<TopicPartition, OffsetAndMetadata> committedOffsets = consumer.committed(assignment);
+            Map<String, Long> partitionLags = new LinkedHashMap<>();
+            long totalLag = 0;
+
+            for (TopicPartition tp : assignment) {
+                long endOffset = endOffsets.getOrDefault(tp, 0L);
+                long committed = 0;
+                OffsetAndMetadata committedMeta = committedOffsets.get(tp);
+                if (committedMeta != null) {
+                    committed = committedMeta.offset();
+                }
+                long lag = Math.max(0, endOffset - committed);
+                partitionLags.put(String.valueOf(tp.partition()), lag);
+                totalLag += lag;
+            }
+
+            Map<String, Object> lagInfo = new LinkedHashMap<>();
+            lagInfo.put("totalLag", totalLag);
+            lagInfo.put("partitions", partitionLags);
+            lagInfo.put("updatedAt", System.currentTimeMillis());
+            cachedLagInfo = lagInfo;
+        } catch (Exception e) {
+            LOG.warn("Failed to compute consumer lag", e);
+        }
+    }
+
+    // TODO: Once ordering by entity GUID is implemented on the producer side,
+    // validate partition-level ordering in the consumer for correctness.
+}

--- a/webapp/src/test/java/org/apache/atlas/web/service/AsyncIngestionConsumerServiceTest.java
+++ b/webapp/src/test/java/org/apache/atlas/web/service/AsyncIngestionConsumerServiceTest.java
@@ -1,0 +1,1278 @@
+package org.apache.atlas.web.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.atlas.RequestContext;
+import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.model.instance.AtlasClassification;
+import org.apache.atlas.model.instance.AtlasEntity;
+import org.apache.atlas.model.instance.AtlasEntity.AtlasEntitiesWithExtInfo;
+import org.apache.atlas.model.instance.AtlasEntityHeaders;
+import org.apache.atlas.model.instance.AtlasObjectId;
+import org.apache.atlas.model.instance.AtlasRelationship;
+import org.apache.atlas.model.typedef.AtlasTypesDef;
+import org.apache.atlas.repository.store.graph.AtlasEntityStore;
+import org.apache.atlas.repository.store.graph.AtlasRelationshipStore;
+import org.apache.atlas.repository.store.graph.v2.BulkRequestContext;
+import org.apache.atlas.repository.store.graph.v2.EntityMutationService;
+import org.apache.atlas.repository.store.graph.v2.EntityStream;
+import org.apache.atlas.service.redis.RedisService;
+import org.apache.atlas.store.AtlasTypeDefStore;
+import org.apache.atlas.type.AtlasEntityType;
+import org.apache.atlas.type.AtlasTypeRegistry;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link AsyncIngestionConsumerService}.
+ * Uses sample payloads from async-ingestion-payloads.json as test fixtures.
+ */
+@ExtendWith(MockitoExtension.class)
+class AsyncIngestionConsumerServiceTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Mock
+    private EntityMutationService entityMutationService;
+    @Mock
+    private AtlasEntityStore entitiesStore;
+    @Mock
+    private AtlasRelationshipStore relationshipStore;
+    @Mock
+    private AtlasTypeDefStore typeDefStore;
+    @Mock
+    private AtlasTypeRegistry typeRegistry;
+    @Mock
+    private RedisService redisService;
+
+    private AsyncIngestionConsumerService consumerService;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        // Mock Redis lock acquisition for typedef operations
+        java.util.concurrent.locks.Lock mockLock = mock(java.util.concurrent.locks.Lock.class);
+        lenient().when(redisService.acquireDistributedLockV2(anyString())).thenReturn(mockLock);
+        lenient().when(redisService.getValue(anyString(), anyString())).thenReturn("1");
+
+        consumerService = new AsyncIngestionConsumerService(entityMutationService, entitiesStore, relationshipStore, typeDefStore, typeRegistry, redisService);
+        ReflectionTestUtils.setField(consumerService, "topic", "ATLAS_ASYNC_ENTITIES");
+        ReflectionTestUtils.setField(consumerService, "consumerGroupId", "test_group");
+        ReflectionTestUtils.setField(consumerService, "maxRetries", 3);
+        ReflectionTestUtils.setField(consumerService, "baseDelayMs", 100L);
+        ReflectionTestUtils.setField(consumerService, "maxDelayMs", 1000L);
+        ReflectionTestUtils.setField(consumerService, "backoffMultiplier", 2.0);
+        ReflectionTestUtils.setField(consumerService, "entityNotificationsEnabled", false);
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestContext.clear();
+    }
+
+    // ── Helper to invoke private processRecord ──────────────────────────
+
+    private void processEvent(String eventJson) throws Exception {
+        ConsumerRecord<String, String> record = new ConsumerRecord<>("ATLAS_ASYNC_ENTITIES", 0, 0, "key", eventJson);
+        ReflectionTestUtils.invokeMethod(consumerService, "processRecord", record);
+    }
+
+    // ── Sample Payloads (from async-ingestion-payloads.json) ─────────────
+
+    // Sample #1: BULK_CREATE_OR_UPDATE
+    private static final String BULK_CREATE_OR_UPDATE_EVENT = """
+            {
+              "eventId": "3124c61f-cf0a-4d6d-b46a-e7808f2de4bc",
+              "eventType": "BULK_CREATE_OR_UPDATE",
+              "eventTime": 1770888880911,
+              "requestMetadata": { "traceId": "trace-e822ec2f", "user": "admin" },
+              "operationMetadata": {
+                "replaceClassifications": false, "replaceTags": false, "appendTags": false,
+                "replaceBusinessAttributes": false, "overwriteBusinessAttributes": false,
+                "skipProcessEdgeRestoration": false
+              },
+              "payload": {
+                "entities": [
+                  {
+                    "typeName": "Table",
+                    "attributes": { "qualifiedName": "default/snowflake/db1/schema1/table1", "name": "table1", "description": "Sample table for async ingestion payload demo" },
+                    "guid": "guid-table-001", "isIncomplete": false, "provenanceType": 0, "version": 0, "superTypeNames": [], "proxy": false
+                  },
+                  {
+                    "typeName": "Column",
+                    "attributes": { "qualifiedName": "default/snowflake/db1/schema1/table1/col1", "dataType": "VARCHAR", "name": "col1" },
+                    "guid": "guid-col-001", "isIncomplete": false, "provenanceType": 0, "version": 0, "superTypeNames": [], "proxy": false
+                  }
+                ]
+              }
+            }
+            """;
+
+    // Sample #2: SET_CLASSIFICATIONS
+    private static final String SET_CLASSIFICATIONS_EVENT = """
+            {
+              "eventId": "8d2bce9c-13a3-4106-b161-d184f0058f73",
+              "eventType": "SET_CLASSIFICATIONS",
+              "eventTime": 1770888880940,
+              "requestMetadata": { "traceId": "trace-d1617835", "user": "admin" },
+              "operationMetadata": {},
+              "payload": {
+                "guidHeaderMap": {
+                  "guid-table-001": {
+                    "guid": "guid-table-001",
+                    "classifications": [
+                      { "typeName": "PII", "attributes": { "level": "HIGH" }, "entityGuid": "guid-table-001", "entityStatus": "ACTIVE" }
+                    ]
+                  },
+                  "guid-col-001": {
+                    "guid": "guid-col-001",
+                    "classifications": [
+                      { "typeName": "Confidential", "entityGuid": "guid-col-001", "entityStatus": "ACTIVE" }
+                    ]
+                  }
+                }
+              }
+            }
+            """;
+
+    // Sample #3: DELETE_BY_GUID
+    private static final String DELETE_BY_GUID_EVENT = """
+            {
+              "eventId": "d6a36da6-c812-492a-89dd-9e7e6dea1452",
+              "eventType": "DELETE_BY_GUID",
+              "eventTime": 1770888880941,
+              "requestMetadata": { "traceId": "trace-1f0c2a7c", "user": "admin" },
+              "operationMetadata": { "deleteType": "SOFT" },
+              "payload": { "guids": ["guid-table-001"] }
+            }
+            """;
+
+    // Sample #4: DELETE_BY_GUIDS
+    private static final String DELETE_BY_GUIDS_EVENT = """
+            {
+              "eventId": "b4cfd8fe-fa84-4251-bc06-1b3d10f54611",
+              "eventType": "DELETE_BY_GUIDS",
+              "eventTime": 1770888880942,
+              "requestMetadata": { "traceId": "trace-3ded4f44", "user": "admin" },
+              "operationMetadata": { "deleteType": "SOFT" },
+              "payload": { "guids": ["guid-table-001", "guid-col-001", "guid-col-002"] }
+            }
+            """;
+
+    // Sample #5: DELETE_BY_UNIQUE_ATTRIBUTE
+    private static final String DELETE_BY_UNIQUE_ATTRIBUTE_EVENT = """
+            {
+              "eventId": "eef519d9-55f5-4e4a-813f-503a7d3964cb",
+              "eventType": "DELETE_BY_UNIQUE_ATTRIBUTE",
+              "eventTime": 1770888880946,
+              "requestMetadata": { "traceId": "trace-ead61c93", "user": "admin" },
+              "operationMetadata": { "deleteType": "SOFT", "typeName": "Table" },
+              "payload": {
+                "uniqueAttributes": { "qualifiedName": "default/snowflake/db1/schema1/table1" }
+              }
+            }
+            """;
+
+    // Sample #6: BULK_DELETE_BY_UNIQUE_ATTRIBUTES
+    private static final String BULK_DELETE_BY_UNIQUE_ATTRIBUTES_EVENT = """
+            {
+              "eventId": "6ce2a427-b564-44e7-8776-3f4dd848582a",
+              "eventType": "BULK_DELETE_BY_UNIQUE_ATTRIBUTES",
+              "eventTime": 1770888880947,
+              "requestMetadata": { "traceId": "trace-cde941ff", "user": "admin" },
+              "operationMetadata": { "deleteType": "SOFT" },
+              "payload": {
+                "objectIds": [
+                  { "typeName": "Table", "uniqueAttributes": { "qualifiedName": "default/snowflake/db1/schema1/table1" } },
+                  { "typeName": "Table", "uniqueAttributes": { "qualifiedName": "default/snowflake/db1/schema1/table2" } }
+                ]
+              }
+            }
+            """;
+
+    // Sample #7: RESTORE_BY_GUIDS
+    private static final String RESTORE_BY_GUIDS_EVENT = """
+            {
+              "eventId": "b166afdc-9bdd-45eb-933f-89ecd528f196",
+              "eventType": "RESTORE_BY_GUIDS",
+              "eventTime": 1770888880948,
+              "requestMetadata": { "traceId": "trace-f7ecb031", "user": "admin" },
+              "operationMetadata": {},
+              "payload": { "guids": ["guid-table-001", "guid-col-001"] }
+            }
+            """;
+
+    // Sample #8: TYPEDEF_CREATE
+    private static final String TYPEDEF_CREATE_EVENT = """
+            {
+              "eventId": "90c3c9bf-1d1d-4251-b18d-961fbf73c48f",
+              "eventType": "TYPEDEF_CREATE",
+              "eventTime": 1770888880953,
+              "requestMetadata": { "traceId": "trace-1b77a9b6", "user": "admin" },
+              "operationMetadata": { "allowDuplicateDisplayName": false },
+              "payload": {
+                "enumDefs": [], "structDefs": [],
+                "classificationDefs": [{ "category": "CLASSIFICATION", "name": "iLnMytPOXuX8ZpKNHgJglH", "description": "Marks data as sensitive", "attributeDefs": [], "superTypes": [], "entityTypes": [], "displayName": "SensitiveData" }],
+                "entityDefs": [{ "category": "ENTITY", "name": "CustomTable", "description": "A custom table type", "attributeDefs": [{ "name": "customField", "typeName": "string", "isOptional": false, "cardinality": "SINGLE", "valuesMinCount": -1, "valuesMaxCount": -1, "isUnique": false, "isIndexable": false, "includeInNotification": false, "skipScrubbing": false, "searchWeight": -1, "isDefaultValueNull": false }], "superTypes": ["DataSet"] }],
+                "relationshipDefs": [], "businessMetadataDefs": []
+              }
+            }
+            """;
+
+    // Sample #9: TYPEDEF_UPDATE
+    private static final String TYPEDEF_UPDATE_EVENT = """
+            {
+              "eventId": "f210e4cf-d787-4fcc-a250-f47a25de52b9",
+              "eventType": "TYPEDEF_UPDATE",
+              "eventTime": 1770888880961,
+              "requestMetadata": { "traceId": "trace-40c0924c", "user": "admin" },
+              "operationMetadata": { "allowDuplicateDisplayName": false, "patch": true },
+              "payload": {
+                "enumDefs": [], "structDefs": [], "classificationDefs": [],
+                "entityDefs": [{ "category": "ENTITY", "name": "CustomTable", "description": "Updated custom table type with new attribute", "attributeDefs": [{ "name": "customField", "typeName": "string", "isOptional": false, "cardinality": "SINGLE", "valuesMinCount": -1, "valuesMaxCount": -1, "isUnique": false, "isIndexable": false, "includeInNotification": false, "skipScrubbing": false, "searchWeight": -1, "isDefaultValueNull": false }, { "name": "newField", "typeName": "int", "isOptional": false, "cardinality": "SINGLE", "valuesMinCount": -1, "valuesMaxCount": -1, "isUnique": false, "isIndexable": false, "includeInNotification": false, "skipScrubbing": false, "searchWeight": -1, "isDefaultValueNull": false }], "superTypes": ["DataSet"] }],
+                "relationshipDefs": [], "businessMetadataDefs": []
+              }
+            }
+            """;
+
+    // Sample #10: TYPEDEF_DELETE
+    private static final String TYPEDEF_DELETE_EVENT = """
+            {
+              "eventId": "31e849c5-e8cc-47e1-a494-ad0d14e88aa9",
+              "eventType": "TYPEDEF_DELETE",
+              "eventTime": 1770888880961,
+              "requestMetadata": { "traceId": "trace-0b6c5eca", "user": "admin" },
+              "operationMetadata": {},
+              "payload": {
+                "enumDefs": [], "structDefs": [],
+                "classificationDefs": [{ "category": "CLASSIFICATION", "name": "USlQR0zIaYDc8BlxMKMCQ6", "attributeDefs": [], "superTypes": [], "entityTypes": [], "displayName": "SensitiveData" }],
+                "entityDefs": [{ "category": "ENTITY", "name": "CustomTable", "attributeDefs": [], "superTypes": [] }],
+                "relationshipDefs": [], "businessMetadataDefs": []
+              }
+            }
+            """;
+
+    // Sample #11: TYPEDEF_DELETE_BY_NAME
+    private static final String TYPEDEF_DELETE_BY_NAME_EVENT = """
+            {
+              "eventId": "cbf285e9-aaa5-474c-9e3d-9673c4d25f8b",
+              "eventType": "TYPEDEF_DELETE_BY_NAME",
+              "eventTime": 1770888880961,
+              "requestMetadata": { "traceId": "trace-21af29be", "user": "admin" },
+              "operationMetadata": {},
+              "payload": { "typeName": "CustomTable" }
+            }
+            """;
+
+    // Sample #12: PARTIAL_UPDATE_BY_GUID
+    private static final String PARTIAL_UPDATE_BY_GUID_EVENT = """
+            {
+              "eventId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+              "eventType": "PARTIAL_UPDATE_BY_GUID",
+              "eventTime": 1770888880970,
+              "requestMetadata": { "traceId": "trace-partial-update", "user": "admin" },
+              "operationMetadata": {},
+              "payload": { "guid": "guid-table-001", "attrName": "description", "attrValue": "updated description" }
+            }
+            """;
+
+    // Sample #13: UPDATE_BY_UNIQUE_ATTRIBUTE (singular — matches fatgraph event type)
+    // Note: "entity" value is AtlasEntityWithExtInfo format (wraps entity inside {"entity": {...}})
+    private static final String UPDATE_BY_UNIQUE_ATTRIBUTE_EVENT = """
+            {
+              "eventId": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+              "eventType": "UPDATE_BY_UNIQUE_ATTRIBUTE",
+              "eventTime": 1770888880971,
+              "requestMetadata": { "traceId": "trace-update-uniq", "user": "admin" },
+              "operationMetadata": { "typeName": "Table" },
+              "payload": {
+                "uniqueAttributes": { "qualifiedName": "default/snowflake/db1/schema1/table1" },
+                "entity": {
+                  "entity": {
+                    "typeName": "Table",
+                    "attributes": { "qualifiedName": "default/snowflake/db1/schema1/table1", "name": "table1", "description": "updated via unique attrs" },
+                    "guid": "guid-table-001"
+                  }
+                }
+              }
+            }
+            """;
+
+    // Sample #14: ADD_LABELS
+    private static final String ADD_LABELS_EVENT = """
+            {
+              "eventId": "d4e5f6a7-b8c9-0123-defa-234567890123",
+              "eventType": "ADD_LABELS",
+              "eventTime": 1770888880973,
+              "requestMetadata": { "traceId": "trace-add-labels", "user": "admin" },
+              "operationMetadata": {},
+              "payload": { "guid": "guid-table-001", "labels": ["label1", "label2", "label3"] }
+            }
+            """;
+
+    // Sample #15: ADD_CLASSIFICATIONS
+    private static final String ADD_CLASSIFICATIONS_EVENT = """
+            {
+              "eventId": "e1f2a3b4-c5d6-7890-abcd-ef1234567001",
+              "eventType": "ADD_CLASSIFICATIONS",
+              "eventTime": 1770888880980,
+              "requestMetadata": { "traceId": "trace-add-cls", "user": "admin" },
+              "operationMetadata": {},
+              "payload": {
+                "guid": "guid-table-001",
+                "classifications": [
+                  { "typeName": "PII", "attributes": { "level": "HIGH" } },
+                  { "typeName": "Confidential" }
+                ]
+              }
+            }
+            """;
+
+    // Sample #16: UPDATE_CLASSIFICATIONS
+    private static final String UPDATE_CLASSIFICATIONS_EVENT = """
+            {
+              "eventId": "e1f2a3b4-c5d6-7890-abcd-ef1234567002",
+              "eventType": "UPDATE_CLASSIFICATIONS",
+              "eventTime": 1770888880981,
+              "requestMetadata": { "traceId": "trace-upd-cls", "user": "admin" },
+              "operationMetadata": {},
+              "payload": {
+                "guid": "guid-table-001",
+                "classifications": [
+                  { "typeName": "PII", "attributes": { "level": "LOW" } }
+                ]
+              }
+            }
+            """;
+
+    // Sample #17: DELETE_CLASSIFICATION (without associatedEntityGuid)
+    private static final String DELETE_CLASSIFICATION_EVENT = """
+            {
+              "eventId": "e1f2a3b4-c5d6-7890-abcd-ef1234567003",
+              "eventType": "DELETE_CLASSIFICATION",
+              "eventTime": 1770888880982,
+              "requestMetadata": { "traceId": "trace-del-cls", "user": "admin" },
+              "operationMetadata": {},
+              "payload": {
+                "guid": "guid-table-001",
+                "classificationName": "PII"
+              }
+            }
+            """;
+
+    // Sample #18: DELETE_CLASSIFICATION (with associatedEntityGuid in payload)
+    private static final String DELETE_CLASSIFICATION_WITH_ASSOCIATED_EVENT = """
+            {
+              "eventId": "e1f2a3b4-c5d6-7890-abcd-ef1234567004",
+              "eventType": "DELETE_CLASSIFICATION",
+              "eventTime": 1770888880983,
+              "requestMetadata": { "traceId": "trace-del-cls-assoc", "user": "admin" },
+              "operationMetadata": {},
+              "payload": {
+                "guid": "guid-table-001",
+                "classificationName": "PII",
+                "associatedEntityGuid": "guid-col-001"
+              }
+            }
+            """;
+
+    // Sample #19: ADD_CLASSIFICATION_BULK
+    private static final String ADD_CLASSIFICATION_BULK_EVENT = """
+            {
+              "eventId": "e1f2a3b4-c5d6-7890-abcd-ef1234567005",
+              "eventType": "ADD_CLASSIFICATION_BULK",
+              "eventTime": 1770888880984,
+              "requestMetadata": { "traceId": "trace-add-cls-bulk", "user": "admin" },
+              "operationMetadata": {},
+              "payload": {
+                "guids": ["guid-table-001", "guid-col-001"],
+                "classification": { "typeName": "Confidential" }
+              }
+            }
+            """;
+
+    // Sample #20: DELETE_RELATIONSHIP_BY_GUID
+    private static final String DELETE_RELATIONSHIP_BY_GUID_EVENT = """
+            {
+              "eventId": "e1f2a3b4-c5d6-7890-abcd-ef1234567006",
+              "eventType": "DELETE_RELATIONSHIP_BY_GUID",
+              "eventTime": 1770888880985,
+              "requestMetadata": { "traceId": "trace-del-rel", "user": "admin" },
+              "operationMetadata": {},
+              "payload": {
+                "guid": "rel-guid-001"
+              }
+            }
+            """;
+
+    // Sample #21: DELETE_RELATIONSHIPS_BY_GUIDS
+    private static final String DELETE_RELATIONSHIPS_BY_GUIDS_EVENT = """
+            {
+              "eventId": "e1f2a3b4-c5d6-7890-abcd-ef1234567007",
+              "eventType": "DELETE_RELATIONSHIPS_BY_GUIDS",
+              "eventTime": 1770888880986,
+              "requestMetadata": { "traceId": "trace-del-rels", "user": "admin" },
+              "operationMetadata": {},
+              "payload": {
+                "guids": ["rel-guid-001", "rel-guid-002"]
+              }
+            }
+            """;
+
+    // Sample #22: RELATIONSHIP_CREATE
+    private static final String RELATIONSHIP_CREATE_EVENT = """
+            {
+              "eventId": "e1f2a3b4-c5d6-7890-abcd-ef1234567008",
+              "eventType": "RELATIONSHIP_CREATE",
+              "eventTime": 1770888880987,
+              "requestMetadata": { "traceId": "trace-rel-create", "user": "admin" },
+              "operationMetadata": {},
+              "payload": {
+                "typeName": "AtlasGlossaryTermAnchor",
+                "end1": { "typeName": "AtlasGlossary", "guid": "guid-glossary-001" },
+                "end2": { "typeName": "AtlasGlossaryTerm", "guid": "guid-term-001" }
+              }
+            }
+            """;
+
+    // Sample #23: RELATIONSHIP_BULK_CREATE_OR_UPDATE
+    private static final String RELATIONSHIP_BULK_CREATE_OR_UPDATE_EVENT = """
+            {
+              "eventId": "e1f2a3b4-c5d6-7890-abcd-ef1234567012",
+              "eventType": "RELATIONSHIP_BULK_CREATE_OR_UPDATE",
+              "eventTime": 1770888880991,
+              "requestMetadata": { "traceId": "trace-rel-bulk", "user": "admin" },
+              "operationMetadata": {},
+              "payload": [
+                {
+                  "typeName": "AtlasGlossaryTermAnchor",
+                  "end1": { "typeName": "AtlasGlossary", "guid": "guid-glossary-001" },
+                  "end2": { "typeName": "AtlasGlossaryTerm", "guid": "guid-term-001" }
+                },
+                {
+                  "typeName": "AtlasGlossaryTermAnchor",
+                  "end1": { "typeName": "AtlasGlossary", "guid": "guid-glossary-001" },
+                  "end2": { "typeName": "AtlasGlossaryTerm", "guid": "guid-term-002" }
+                }
+              ]
+            }
+            """;
+
+    // Sample #24: RELATIONSHIP_UPDATE
+    private static final String RELATIONSHIP_UPDATE_EVENT = """
+            {
+              "eventId": "e1f2a3b4-c5d6-7890-abcd-ef1234567013",
+              "eventType": "RELATIONSHIP_UPDATE",
+              "eventTime": 1770888880992,
+              "requestMetadata": { "traceId": "trace-rel-update", "user": "admin" },
+              "operationMetadata": {},
+              "payload": {
+                "typeName": "AtlasGlossaryTermAnchor",
+                "guid": "rel-guid-existing",
+                "end1": { "typeName": "AtlasGlossary", "guid": "guid-glossary-001" },
+                "end2": { "typeName": "AtlasGlossaryTerm", "guid": "guid-term-003" }
+              }
+            }
+            """;
+
+    // Sample #25: ADD_OR_UPDATE_BUSINESS_ATTRIBUTES
+    private static final String ADD_OR_UPDATE_BUSINESS_ATTRIBUTES_EVENT = """
+            {
+              "eventId": "e1f2a3b4-c5d6-7890-abcd-ef1234567009",
+              "eventType": "ADD_OR_UPDATE_BUSINESS_ATTRIBUTES",
+              "eventTime": 1770888880988,
+              "requestMetadata": { "traceId": "trace-bm-update", "user": "admin" },
+              "operationMetadata": { "guid": "guid-table-001", "isOverwrite": false },
+              "payload": { "bmName": { "attr1": "val1", "attr2": "val2" } }
+            }
+            """;
+
+    // Sample #24: ADD_OR_UPDATE_BUSINESS_ATTRIBUTES_BY_DISPLAY_NAME
+    private static final String ADD_OR_UPDATE_BM_BY_DISPLAY_NAME_EVENT = """
+            {
+              "eventId": "e1f2a3b4-c5d6-7890-abcd-ef1234567010",
+              "eventType": "ADD_OR_UPDATE_BUSINESS_ATTRIBUTES_BY_DISPLAY_NAME",
+              "eventTime": 1770888880989,
+              "requestMetadata": { "traceId": "trace-bm-display", "user": "admin" },
+              "operationMetadata": { "guid": "guid-table-001", "isOverwrite": true },
+              "payload": { "bmDisplayName": { "attr1": "val1" } }
+            }
+            """;
+
+    // Sample #25: REMOVE_BUSINESS_ATTRIBUTES
+    private static final String REMOVE_BUSINESS_ATTRIBUTES_EVENT = """
+            {
+              "eventId": "e1f2a3b4-c5d6-7890-abcd-ef1234567011",
+              "eventType": "REMOVE_BUSINESS_ATTRIBUTES",
+              "eventTime": 1770888880990,
+              "requestMetadata": { "traceId": "trace-bm-remove", "user": "admin" },
+              "operationMetadata": { "guid": "guid-table-001" },
+              "payload": { "bmName": { "attr1": "val1" } }
+            }
+            """;
+
+    // ── Tests ────────────────────────────────────────────────────────────
+
+    @Test
+    void testReplayBulkCreateOrUpdate() throws Exception {
+        when(entityMutationService.createOrUpdate(any(EntityStream.class), any(BulkRequestContext.class)))
+                .thenReturn(null);
+
+        processEvent(BULK_CREATE_OR_UPDATE_EVENT);
+
+        ArgumentCaptor<EntityStream> streamCaptor = ArgumentCaptor.forClass(EntityStream.class);
+        ArgumentCaptor<BulkRequestContext> ctxCaptor = ArgumentCaptor.forClass(BulkRequestContext.class);
+        verify(entityMutationService).createOrUpdate(streamCaptor.capture(), ctxCaptor.capture());
+
+        BulkRequestContext ctx = ctxCaptor.getValue();
+        assertFalse(ctx.isReplaceClassifications());
+        assertFalse(ctx.isReplaceTags());
+        assertFalse(ctx.isAppendTags());
+        assertFalse(ctx.isReplaceBusinessAttributes());
+        assertFalse(ctx.isOverwriteBusinessAttributes());
+    }
+
+    @Test
+    void testReplaySetClassifications() throws Exception {
+        doNothing().when(entityMutationService).setClassifications(any(AtlasEntityHeaders.class), anyBoolean());
+
+        processEvent(SET_CLASSIFICATIONS_EVENT);
+
+        ArgumentCaptor<AtlasEntityHeaders> headersCaptor = ArgumentCaptor.forClass(AtlasEntityHeaders.class);
+        ArgumentCaptor<Boolean> overrideCaptor = ArgumentCaptor.forClass(Boolean.class);
+        verify(entityMutationService).setClassifications(headersCaptor.capture(), overrideCaptor.capture());
+
+        AtlasEntityHeaders headers = headersCaptor.getValue();
+        assertNotNull(headers.getGuidHeaderMap());
+        // Two entities: guid-table-001 and guid-col-001
+        assertEquals(2, headers.getGuidHeaderMap().size());
+        assertTrue(headers.getGuidHeaderMap().containsKey("guid-table-001"));
+        assertTrue(headers.getGuidHeaderMap().containsKey("guid-col-001"));
+        // guid-table-001 has PII classification
+        assertEquals(1, headers.getGuidHeaderMap().get("guid-table-001").getClassifications().size());
+        assertEquals("PII", headers.getGuidHeaderMap().get("guid-table-001").getClassifications().get(0).getTypeName());
+        assertFalse(overrideCaptor.getValue());
+    }
+
+    @Test
+    void testReplayDeleteByGuid() throws Exception {
+        when(entityMutationService.deleteById(anyString())).thenReturn(null);
+
+        processEvent(DELETE_BY_GUID_EVENT);
+
+        verify(entityMutationService).deleteById("guid-table-001");
+    }
+
+    @Test
+    void testReplayDeleteByGuids() throws Exception {
+        when(entityMutationService.deleteByIds(anyList())).thenReturn(null);
+
+        processEvent(DELETE_BY_GUIDS_EVENT);
+
+        ArgumentCaptor<List<String>> guidsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(entityMutationService).deleteByIds(guidsCaptor.capture());
+        assertEquals(3, guidsCaptor.getValue().size());
+        assertTrue(guidsCaptor.getValue().contains("guid-table-001"));
+        assertTrue(guidsCaptor.getValue().contains("guid-col-001"));
+        assertTrue(guidsCaptor.getValue().contains("guid-col-002"));
+    }
+
+    @Test
+    void testReplayDeleteByUniqueAttribute() throws Exception {
+        AtlasEntityType mockEntityType = mock(AtlasEntityType.class);
+        when(typeRegistry.getEntityTypeByName("Table")).thenReturn(mockEntityType);
+        when(entityMutationService.deleteByUniqueAttributes(any(AtlasEntityType.class), anyMap())).thenReturn(null);
+
+        processEvent(DELETE_BY_UNIQUE_ATTRIBUTE_EVENT);
+
+        ArgumentCaptor<AtlasEntityType> typeCaptor = ArgumentCaptor.forClass(AtlasEntityType.class);
+        ArgumentCaptor<Map> attrsCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(entityMutationService).deleteByUniqueAttributes(typeCaptor.capture(), attrsCaptor.capture());
+        assertSame(mockEntityType, typeCaptor.getValue());
+        assertEquals("default/snowflake/db1/schema1/table1", attrsCaptor.getValue().get("qualifiedName"));
+    }
+
+    @Test
+    void testReplayDeleteByUniqueAttribute_UnknownType() throws Exception {
+        when(typeRegistry.getEntityTypeByName("Table")).thenReturn(null);
+
+        assertThrows(Exception.class, () -> processEvent(DELETE_BY_UNIQUE_ATTRIBUTE_EVENT));
+        verify(entityMutationService, never()).deleteByUniqueAttributes(any(AtlasEntityType.class), anyMap());
+    }
+
+    @Test
+    void testReplayBulkDeleteByUniqueAttributes() throws Exception {
+        when(entityMutationService.deleteByUniqueAttributes(anyList())).thenReturn(null);
+
+        processEvent(BULK_DELETE_BY_UNIQUE_ATTRIBUTES_EVENT);
+
+        ArgumentCaptor<List<AtlasObjectId>> captor = ArgumentCaptor.forClass(List.class);
+        verify(entityMutationService).deleteByUniqueAttributes(captor.capture());
+        assertEquals(2, captor.getValue().size());
+    }
+
+    @Test
+    void testReplayRestoreByGuids() throws Exception {
+        when(entityMutationService.restoreByIds(anyList())).thenReturn(null);
+
+        processEvent(RESTORE_BY_GUIDS_EVENT);
+
+        ArgumentCaptor<List<String>> guidsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(entityMutationService).restoreByIds(guidsCaptor.capture());
+        assertEquals(2, guidsCaptor.getValue().size());
+        assertTrue(guidsCaptor.getValue().contains("guid-table-001"));
+        assertTrue(guidsCaptor.getValue().contains("guid-col-001"));
+    }
+
+    @Test
+    void testReplayPartialUpdateByGuid() throws Exception {
+        when(entitiesStore.updateEntityAttributeByGuid(anyString(), anyString(), any())).thenReturn(null);
+
+        processEvent(PARTIAL_UPDATE_BY_GUID_EVENT);
+
+        verify(entitiesStore).updateEntityAttributeByGuid("guid-table-001", "description", "updated description");
+    }
+
+    @Test
+    void testReplayUpdateByUniqueAttributes() throws Exception {
+        AtlasEntityType mockEntityType = mock(AtlasEntityType.class);
+        when(typeRegistry.getEntityTypeByName("Table")).thenReturn(mockEntityType);
+        when(entityMutationService.updateByUniqueAttributes(
+                any(AtlasEntityType.class), anyMap(), any(AtlasEntity.AtlasEntityWithExtInfo.class))).thenReturn(null);
+
+        processEvent(UPDATE_BY_UNIQUE_ATTRIBUTE_EVENT);
+
+        ArgumentCaptor<AtlasEntityType> typeCaptor = ArgumentCaptor.forClass(AtlasEntityType.class);
+        ArgumentCaptor<Map> attrsCaptor = ArgumentCaptor.forClass(Map.class);
+        ArgumentCaptor<AtlasEntity.AtlasEntityWithExtInfo> entityCaptor =
+                ArgumentCaptor.forClass(AtlasEntity.AtlasEntityWithExtInfo.class);
+        verify(entityMutationService).updateByUniqueAttributes(
+                typeCaptor.capture(), attrsCaptor.capture(), entityCaptor.capture());
+        assertSame(mockEntityType, typeCaptor.getValue());
+        assertEquals("default/snowflake/db1/schema1/table1", attrsCaptor.getValue().get("qualifiedName"));
+        assertNotNull(entityCaptor.getValue().getEntity());
+        assertEquals("Table", entityCaptor.getValue().getEntity().getTypeName());
+    }
+
+    @Test
+    void testReplayUpdateByUniqueAttributes_UnknownType() throws Exception {
+        when(typeRegistry.getEntityTypeByName("Table")).thenReturn(null);
+
+        assertThrows(Exception.class, () -> processEvent(UPDATE_BY_UNIQUE_ATTRIBUTE_EVENT));
+        verify(entityMutationService, never()).updateByUniqueAttributes(
+                any(AtlasEntityType.class), anyMap(), any(AtlasEntity.AtlasEntityWithExtInfo.class));
+    }
+
+    @Test
+    void testReplayAddLabels() throws Exception {
+        doNothing().when(entitiesStore).addLabels(anyString(), anySet());
+
+        processEvent(ADD_LABELS_EVENT);
+
+        ArgumentCaptor<String> guidCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Set> labelsCaptor = ArgumentCaptor.forClass(Set.class);
+        verify(entitiesStore).addLabels(guidCaptor.capture(), labelsCaptor.capture());
+        assertEquals("guid-table-001", guidCaptor.getValue());
+        assertEquals(3, labelsCaptor.getValue().size());
+        assertTrue(labelsCaptor.getValue().contains("label1"));
+        assertTrue(labelsCaptor.getValue().contains("label2"));
+        assertTrue(labelsCaptor.getValue().contains("label3"));
+    }
+
+    // ── Classification & Relationship Stub Tests ────────────────────────
+
+    @Test
+    void testReplayAddClassifications() throws Exception {
+        doNothing().when(entityMutationService).addClassifications(anyString(), anyList());
+
+        processEvent(ADD_CLASSIFICATIONS_EVENT);
+
+        ArgumentCaptor<String> guidCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<List<AtlasClassification>> clsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(entityMutationService).addClassifications(guidCaptor.capture(), clsCaptor.capture());
+        assertEquals("guid-table-001", guidCaptor.getValue());
+        assertEquals(2, clsCaptor.getValue().size());
+        assertEquals("PII", clsCaptor.getValue().get(0).getTypeName());
+        assertEquals("Confidential", clsCaptor.getValue().get(1).getTypeName());
+    }
+
+    @Test
+    void testReplayUpdateClassifications() throws Exception {
+        doNothing().when(entityMutationService).updateClassifications(anyString(), anyList());
+
+        processEvent(UPDATE_CLASSIFICATIONS_EVENT);
+
+        ArgumentCaptor<String> guidCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<List<AtlasClassification>> clsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(entityMutationService).updateClassifications(guidCaptor.capture(), clsCaptor.capture());
+        assertEquals("guid-table-001", guidCaptor.getValue());
+        assertEquals(1, clsCaptor.getValue().size());
+        assertEquals("PII", clsCaptor.getValue().get(0).getTypeName());
+    }
+
+    @Test
+    void testReplayDeleteClassification() throws Exception {
+        doNothing().when(entityMutationService).deleteClassification(anyString(), anyString());
+
+        processEvent(DELETE_CLASSIFICATION_EVENT);
+
+        verify(entityMutationService).deleteClassification("guid-table-001", "PII");
+    }
+
+    @Test
+    void testReplayDeleteClassification_WithAssociatedEntityGuid() throws Exception {
+        doNothing().when(entityMutationService).deleteClassification(anyString(), anyString(), anyString());
+
+        processEvent(DELETE_CLASSIFICATION_WITH_ASSOCIATED_EVENT);
+
+        verify(entityMutationService).deleteClassification("guid-table-001", "PII", "guid-col-001");
+    }
+
+    @Test
+    void testReplayAddClassificationBulk() throws Exception {
+        doNothing().when(entityMutationService).addClassification(anyList(), any(AtlasClassification.class));
+
+        processEvent(ADD_CLASSIFICATION_BULK_EVENT);
+
+        ArgumentCaptor<List<String>> guidsCaptor = ArgumentCaptor.forClass(List.class);
+        ArgumentCaptor<AtlasClassification> clsCaptor = ArgumentCaptor.forClass(AtlasClassification.class);
+        verify(entityMutationService).addClassification(guidsCaptor.capture(), clsCaptor.capture());
+        assertEquals(2, guidsCaptor.getValue().size());
+        assertTrue(guidsCaptor.getValue().contains("guid-table-001"));
+        assertTrue(guidsCaptor.getValue().contains("guid-col-001"));
+        assertEquals("Confidential", clsCaptor.getValue().getTypeName());
+    }
+
+    @Test
+    void testReplayDeleteRelationship() throws Exception {
+        doNothing().when(entityMutationService).deleteRelationshipById(anyString());
+
+        processEvent(DELETE_RELATIONSHIP_BY_GUID_EVENT);
+
+        verify(entityMutationService).deleteRelationshipById("rel-guid-001");
+    }
+
+    @Test
+    void testReplayDeleteRelationships() throws Exception {
+        doNothing().when(entityMutationService).deleteRelationshipsByIds(anyList());
+
+        processEvent(DELETE_RELATIONSHIPS_BY_GUIDS_EVENT);
+
+        ArgumentCaptor<List<String>> guidsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(entityMutationService).deleteRelationshipsByIds(guidsCaptor.capture());
+        assertEquals(2, guidsCaptor.getValue().size());
+        assertTrue(guidsCaptor.getValue().contains("rel-guid-001"));
+        assertTrue(guidsCaptor.getValue().contains("rel-guid-002"));
+    }
+
+    @Test
+    void testReplayRelationshipCreate() throws Exception {
+        when(relationshipStore.create(any(AtlasRelationship.class))).thenReturn(null);
+
+        processEvent(RELATIONSHIP_CREATE_EVENT);
+
+        ArgumentCaptor<AtlasRelationship> captor = ArgumentCaptor.forClass(AtlasRelationship.class);
+        verify(relationshipStore).create(captor.capture());
+        assertEquals("AtlasGlossaryTermAnchor", captor.getValue().getTypeName());
+    }
+
+    @Test
+    void testReplayRelationshipBulkCreateOrUpdate() throws Exception {
+        when(relationshipStore.createOrUpdate(anyList())).thenReturn(null);
+
+        processEvent(RELATIONSHIP_BULK_CREATE_OR_UPDATE_EVENT);
+
+        ArgumentCaptor<List<AtlasRelationship>> captor = ArgumentCaptor.forClass(List.class);
+        verify(relationshipStore).createOrUpdate(captor.capture());
+        assertEquals(2, captor.getValue().size());
+        assertEquals("AtlasGlossaryTermAnchor", captor.getValue().get(0).getTypeName());
+        assertEquals("AtlasGlossaryTermAnchor", captor.getValue().get(1).getTypeName());
+    }
+
+    @Test
+    void testReplayRelationshipUpdate() throws Exception {
+        when(relationshipStore.update(any(AtlasRelationship.class))).thenReturn(null);
+
+        processEvent(RELATIONSHIP_UPDATE_EVENT);
+
+        ArgumentCaptor<AtlasRelationship> captor = ArgumentCaptor.forClass(AtlasRelationship.class);
+        verify(relationshipStore).update(captor.capture());
+        assertEquals("AtlasGlossaryTermAnchor", captor.getValue().getTypeName());
+        assertEquals("rel-guid-existing", captor.getValue().getGuid());
+    }
+
+    @Test
+    void testReplayAddOrUpdateBusinessAttributes() throws Exception {
+        doNothing().when(entitiesStore).addOrUpdateBusinessAttributes(anyString(), anyMap(), anyBoolean());
+
+        processEvent(ADD_OR_UPDATE_BUSINESS_ATTRIBUTES_EVENT);
+
+        ArgumentCaptor<String> guidCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Map> bmCaptor = ArgumentCaptor.forClass(Map.class);
+        ArgumentCaptor<Boolean> overwriteCaptor = ArgumentCaptor.forClass(Boolean.class);
+        verify(entitiesStore).addOrUpdateBusinessAttributes(
+                guidCaptor.capture(), bmCaptor.capture(), overwriteCaptor.capture());
+        assertEquals("guid-table-001", guidCaptor.getValue());
+        assertTrue(bmCaptor.getValue().containsKey("bmName"));
+        assertFalse(overwriteCaptor.getValue());
+    }
+
+    @Test
+    void testReplayAddOrUpdateBusinessAttributesByDisplayName() throws Exception {
+        doNothing().when(entitiesStore).addOrUpdateBusinessAttributesByDisplayName(anyString(), anyMap(), anyBoolean());
+
+        processEvent(ADD_OR_UPDATE_BM_BY_DISPLAY_NAME_EVENT);
+
+        ArgumentCaptor<String> guidCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Map> bmCaptor = ArgumentCaptor.forClass(Map.class);
+        ArgumentCaptor<Boolean> overwriteCaptor = ArgumentCaptor.forClass(Boolean.class);
+        verify(entitiesStore).addOrUpdateBusinessAttributesByDisplayName(
+                guidCaptor.capture(), bmCaptor.capture(), overwriteCaptor.capture());
+        assertEquals("guid-table-001", guidCaptor.getValue());
+        assertTrue(bmCaptor.getValue().containsKey("bmDisplayName"));
+        assertTrue(overwriteCaptor.getValue());
+    }
+
+    @Test
+    void testReplayRemoveBusinessAttributes() throws Exception {
+        doNothing().when(entitiesStore).removeBusinessAttributes(anyString(), anyMap());
+
+        processEvent(REMOVE_BUSINESS_ATTRIBUTES_EVENT);
+
+        ArgumentCaptor<String> guidCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Map> bmCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(entitiesStore).removeBusinessAttributes(guidCaptor.capture(), bmCaptor.capture());
+        assertEquals("guid-table-001", guidCaptor.getValue());
+        assertTrue(bmCaptor.getValue().containsKey("bmName"));
+    }
+
+    @Test
+    void testReplayTypeDefCreate() throws Exception {
+        when(typeDefStore.createTypesDef(any(AtlasTypesDef.class))).thenReturn(null);
+
+        processEvent(TYPEDEF_CREATE_EVENT);
+
+        ArgumentCaptor<AtlasTypesDef> captor = ArgumentCaptor.forClass(AtlasTypesDef.class);
+        verify(typeDefStore).createTypesDef(captor.capture());
+        AtlasTypesDef typesDef = captor.getValue();
+        assertNotNull(typesDef);
+        assertFalse(typesDef.getClassificationDefs().isEmpty());
+        assertFalse(typesDef.getEntityDefs().isEmpty());
+        assertEquals("SensitiveData", typesDef.getClassificationDefs().get(0).getDisplayName());
+        assertEquals("CustomTable", typesDef.getEntityDefs().get(0).getName());
+    }
+
+    @Test
+    void testReplayTypeDefUpdate() throws Exception {
+        when(typeDefStore.updateTypesDef(any(AtlasTypesDef.class))).thenReturn(null);
+
+        processEvent(TYPEDEF_UPDATE_EVENT);
+
+        ArgumentCaptor<AtlasTypesDef> captor = ArgumentCaptor.forClass(AtlasTypesDef.class);
+        verify(typeDefStore).updateTypesDef(captor.capture());
+        AtlasTypesDef typesDef = captor.getValue();
+        assertEquals("CustomTable", typesDef.getEntityDefs().get(0).getName());
+        // Updated version has 2 attributeDefs (customField + newField)
+        assertEquals(2, typesDef.getEntityDefs().get(0).getAttributeDefs().size());
+    }
+
+    @Test
+    void testReplayTypeDefDelete() throws Exception {
+        doNothing().when(typeDefStore).deleteTypesDef(any(AtlasTypesDef.class));
+
+        processEvent(TYPEDEF_DELETE_EVENT);
+
+        ArgumentCaptor<AtlasTypesDef> captor = ArgumentCaptor.forClass(AtlasTypesDef.class);
+        verify(typeDefStore).deleteTypesDef(captor.capture());
+        assertFalse(captor.getValue().getClassificationDefs().isEmpty());
+        assertFalse(captor.getValue().getEntityDefs().isEmpty());
+    }
+
+    @Test
+    void testReplayTypeDefDeleteByName() throws Exception {
+        when(typeDefStore.deleteTypeByName("CustomTable")).thenReturn(null);
+
+        processEvent(TYPEDEF_DELETE_BY_NAME_EVENT);
+
+        verify(typeDefStore).deleteTypeByName("CustomTable");
+    }
+
+    @Test
+    void testUnknownEventType() throws Exception {
+        String unknownEvent = """
+                {
+                  "eventId": "test-unknown",
+                  "eventType": "UNKNOWN_TYPE",
+                  "eventTime": 1770888880911,
+                  "requestMetadata": { "traceId": "trace-test", "user": "admin" },
+                  "operationMetadata": {},
+                  "payload": {}
+                }
+                """;
+
+        processEvent(unknownEvent);
+
+        // Should be skipped, not throw
+        verifyNoInteractions(entityMutationService);
+        verifyNoInteractions(typeDefStore);
+        // Check skippedCount incremented
+        long skipped = ((java.util.concurrent.atomic.AtomicLong)
+                ReflectionTestUtils.getField(consumerService, "skippedCount")).get();
+        assertEquals(1, skipped);
+    }
+
+    @Test
+    void testRequestMetadataApplied() throws Exception {
+        when(entityMutationService.deleteById(anyString())).thenReturn(null);
+
+        processEvent(DELETE_BY_GUID_EVENT);
+
+        // The processRecord method sets RequestContext and clears it in finally.
+        // We verify the interaction happened (which means RequestContext was set during the call).
+        verify(entityMutationService).deleteById("guid-table-001");
+    }
+
+    @Test
+    void testEntityChangeNotificationSuppressed_WhenDisabled() throws Exception {
+        // Default: entityNotificationsEnabled=false → skipEntityChangeNotification=true
+        ReflectionTestUtils.setField(consumerService, "entityNotificationsEnabled", false);
+
+        when(entityMutationService.deleteById(anyString())).thenAnswer(invocation -> {
+            // During processing, RequestContext should have skipEntityChangeNotification=true
+            assertTrue(RequestContext.get().isSkipEntityChangeNotification(),
+                    "skipEntityChangeNotification should be true when entityNotificationsEnabled=false");
+            return null;
+        });
+
+        processEvent(DELETE_BY_GUID_EVENT);
+        verify(entityMutationService).deleteById("guid-table-001");
+    }
+
+    @Test
+    void testEntityChangeNotificationEnabled_WhenConfigured() throws Exception {
+        // Override: entityNotificationsEnabled=true → skipEntityChangeNotification=false
+        ReflectionTestUtils.setField(consumerService, "entityNotificationsEnabled", true);
+
+        when(entityMutationService.deleteById(anyString())).thenAnswer(invocation -> {
+            // During processing, RequestContext should have skipEntityChangeNotification=false
+            assertFalse(RequestContext.get().isSkipEntityChangeNotification(),
+                    "skipEntityChangeNotification should be false when entityNotificationsEnabled=true");
+            return null;
+        });
+
+        processEvent(DELETE_BY_GUID_EVENT);
+        verify(entityMutationService).deleteById("guid-table-001");
+    }
+
+    @Test
+    void testGetStatus_AllFields() {
+        ReflectionTestUtils.setField(consumerService, "processedCount",
+                new java.util.concurrent.atomic.AtomicLong(100));
+        ReflectionTestUtils.setField(consumerService, "errorCount",
+                new java.util.concurrent.atomic.AtomicLong(5));
+        ReflectionTestUtils.setField(consumerService, "skippedCount",
+                new java.util.concurrent.atomic.AtomicLong(2));
+        ReflectionTestUtils.setField(consumerService, "dlqPublishCount",
+                new java.util.concurrent.atomic.AtomicLong(1));
+        ReflectionTestUtils.setField(consumerService, "dlqTopic", "ATLAS_ASYNC_INGESTION_DLQ");
+        ReflectionTestUtils.setField(consumerService, "lastEventType", "BULK_CREATE_OR_UPDATE");
+
+        Map<String, Object> status = consumerService.getStatus();
+
+        assertEquals(false, status.get("isRunning"));
+        assertEquals(100L, status.get("processedCount"));
+        assertEquals(5L, status.get("errorCount"));
+        assertEquals(2L, status.get("skippedCount"));
+        assertEquals(1L, status.get("dlqPublishCount"));
+        assertEquals("ATLAS_ASYNC_INGESTION_DLQ", status.get("dlqTopic"));
+        assertEquals("ATLAS_ASYNC_ENTITIES", status.get("topic"));
+        assertEquals("test_group", status.get("consumerGroup"));
+        assertEquals("BULK_CREATE_OR_UPDATE", status.get("lastEventType"));
+    }
+
+    @Test
+    void testExponentialBackoff_Progression() {
+        String retryKey = "0-100";
+
+        long delay1 = ReflectionTestUtils.invokeMethod(consumerService, "calculateExponentialBackoff", retryKey);
+        assertEquals(100, delay1, "First delay should be base delay");
+
+        long delay2 = ReflectionTestUtils.invokeMethod(consumerService, "calculateExponentialBackoff", retryKey);
+        assertEquals(200, delay2, "Second delay should be 100 * 2.0");
+
+        long delay3 = ReflectionTestUtils.invokeMethod(consumerService, "calculateExponentialBackoff", retryKey);
+        assertEquals(400, delay3, "Third delay should be 200 * 2.0");
+    }
+
+    @Test
+    void testExponentialBackoff_CappedAtMax() {
+        String retryKey = "0-100";
+
+        for (int i = 0; i < 10; i++) {
+            ReflectionTestUtils.invokeMethod(consumerService, "calculateExponentialBackoff", retryKey);
+        }
+
+        long finalDelay = ReflectionTestUtils.invokeMethod(consumerService, "calculateExponentialBackoff", retryKey);
+        assertEquals(1000, finalDelay, "Delay should be capped at maxDelayMs (1000)");
+    }
+
+    @Test
+    void testBulkRequestContextFromOperationMetadata() throws Exception {
+        String json = """
+                {
+                  "replaceClassifications": true,
+                  "replaceTags": false,
+                  "appendTags": false,
+                  "replaceBusinessAttributes": true,
+                  "overwriteBusinessAttributes": false,
+                  "skipProcessEdgeRestoration": true
+                }
+                """;
+        JsonNode opMeta = MAPPER.readTree(json);
+        BulkRequestContext ctx = BulkRequestContext.fromOperationMetadata(opMeta);
+
+        // Note: replaceClassifications=true triggers Builder to set replaceTags=false and appendTags=false
+        assertTrue(ctx.isReplaceClassifications());
+        assertFalse(ctx.isReplaceTags());
+        assertFalse(ctx.isAppendTags());
+        assertTrue(ctx.isReplaceBusinessAttributes());
+        assertFalse(ctx.isOverwriteBusinessAttributes());
+        // skipProcessEdgeRestoration is not a field on leangraph's BulkRequestContext — silently ignored
+    }
+
+    // ── End-to-End: Process All Event Types from JSON ──────────────────
+
+    @Test
+    void testProcessAllEventTypes_EndToEnd() throws Exception {
+        // Read all 26 events from the payloads JSON fixture
+        JsonNode events;
+        try (java.io.InputStream is = getClass().getResourceAsStream("/async-ingestion-payloads.json")) {
+            assertNotNull(is, "async-ingestion-payloads.json not found on classpath");
+            events = MAPPER.readTree(is);
+        }
+        assertEquals(26, events.size(), "Expected 26 events in payloads file");
+
+        // Set up mocks for all event types
+        when(entityMutationService.createOrUpdate(any(EntityStream.class), any(BulkRequestContext.class)))
+                .thenReturn(null);
+        doNothing().when(entityMutationService).setClassifications(any(AtlasEntityHeaders.class), anyBoolean());
+        when(entityMutationService.deleteById(anyString())).thenReturn(null);
+        when(entityMutationService.deleteByIds(anyList())).thenReturn(null);
+        AtlasEntityType mockTableType = mock(AtlasEntityType.class);
+        when(typeRegistry.getEntityTypeByName("Table")).thenReturn(mockTableType);
+        when(entityMutationService.deleteByUniqueAttributes(any(AtlasEntityType.class), anyMap())).thenReturn(null);
+        when(entityMutationService.deleteByUniqueAttributes(anyList())).thenReturn(null);
+        when(entityMutationService.restoreByIds(anyList())).thenReturn(null);
+        when(typeDefStore.createTypesDef(any(AtlasTypesDef.class))).thenReturn(null);
+        when(typeDefStore.updateTypesDef(any(AtlasTypesDef.class))).thenReturn(null);
+        doNothing().when(typeDefStore).deleteTypesDef(any(AtlasTypesDef.class));
+        when(typeDefStore.deleteTypeByName(anyString())).thenReturn(null);
+        when(entitiesStore.updateEntityAttributeByGuid(anyString(), anyString(), any())).thenReturn(null);
+        when(entityMutationService.updateByUniqueAttributes(
+                any(AtlasEntityType.class), anyMap(), any(AtlasEntity.AtlasEntityWithExtInfo.class))).thenReturn(null);
+        doNothing().when(entitiesStore).addLabels(anyString(), anySet());
+        // Classification/relationship mocks
+        doNothing().when(entityMutationService).addClassifications(anyString(), anyList());
+        doNothing().when(entityMutationService).updateClassifications(anyString(), anyList());
+        doNothing().when(entityMutationService).deleteClassification(anyString(), anyString());
+        doNothing().when(entityMutationService).addClassification(anyList(), any(AtlasClassification.class));
+        doNothing().when(entityMutationService).deleteRelationshipById(anyString());
+        doNothing().when(entityMutationService).deleteRelationshipsByIds(anyList());
+        when(relationshipStore.create(any(AtlasRelationship.class))).thenReturn(null);
+        when(relationshipStore.createOrUpdate(anyList())).thenReturn(null);
+        when(relationshipStore.update(any(AtlasRelationship.class))).thenReturn(null);
+        // Business metadata mocks
+        doNothing().when(entitiesStore).addOrUpdateBusinessAttributes(anyString(), anyMap(), anyBoolean());
+        doNothing().when(entitiesStore).addOrUpdateBusinessAttributesByDisplayName(anyString(), anyMap(), anyBoolean());
+        doNothing().when(entitiesStore).removeBusinessAttributes(anyString(), anyMap());
+
+        // Process all 26 events sequentially
+        for (JsonNode event : events) {
+            processEvent(MAPPER.writeValueAsString(event));
+        }
+
+        // Verify all downstream calls in order
+        InOrder inOrder = inOrder(entityMutationService, entitiesStore, relationshipStore, typeDefStore, typeRegistry);
+
+        // 1. BULK_CREATE_OR_UPDATE → createOrUpdate
+        inOrder.verify(entityMutationService).createOrUpdate(any(EntityStream.class), any(BulkRequestContext.class));
+
+        // 2. SET_CLASSIFICATIONS → setClassifications (2 classifications across 2 entities, override=false)
+        ArgumentCaptor<AtlasEntityHeaders> headersCaptor = ArgumentCaptor.forClass(AtlasEntityHeaders.class);
+        inOrder.verify(entityMutationService).setClassifications(headersCaptor.capture(), eq(false));
+        assertEquals(2, headersCaptor.getValue().getGuidHeaderMap().size());
+
+        // 3. DELETE_BY_GUID → deleteById("guid-table-001")
+        inOrder.verify(entityMutationService).deleteById("guid-table-001");
+
+        // 4. DELETE_BY_GUIDS → deleteByIds (3 guids)
+        ArgumentCaptor<List<String>> deleteGuidsCaptor = ArgumentCaptor.forClass(List.class);
+        inOrder.verify(entityMutationService).deleteByIds(deleteGuidsCaptor.capture());
+        assertEquals(3, deleteGuidsCaptor.getValue().size());
+        assertTrue(deleteGuidsCaptor.getValue().containsAll(List.of("guid-table-001", "guid-col-001", "guid-col-002")));
+
+        // 5. DELETE_BY_UNIQUE_ATTRIBUTE → typeRegistry lookup + deleteByUniqueAttributes
+        inOrder.verify(typeRegistry).getEntityTypeByName("Table");
+        ArgumentCaptor<Map> uniqAttrsCaptor = ArgumentCaptor.forClass(Map.class);
+        inOrder.verify(entityMutationService).deleteByUniqueAttributes(eq(mockTableType), uniqAttrsCaptor.capture());
+        assertEquals("default/snowflake/db1/schema1/table1", uniqAttrsCaptor.getValue().get("qualifiedName"));
+
+        // 6. BULK_DELETE_BY_UNIQUE_ATTRIBUTES → deleteByUniqueAttributes(list of 2 objectIds)
+        ArgumentCaptor<List<AtlasObjectId>> objIdsCaptor = ArgumentCaptor.forClass(List.class);
+        inOrder.verify(entityMutationService).deleteByUniqueAttributes(objIdsCaptor.capture());
+        assertEquals(2, objIdsCaptor.getValue().size());
+
+        // 7. RESTORE_BY_GUIDS → restoreByIds (2 guids)
+        ArgumentCaptor<List<String>> restoreGuidsCaptor = ArgumentCaptor.forClass(List.class);
+        inOrder.verify(entityMutationService).restoreByIds(restoreGuidsCaptor.capture());
+        assertEquals(2, restoreGuidsCaptor.getValue().size());
+        assertTrue(restoreGuidsCaptor.getValue().containsAll(List.of("guid-table-001", "guid-col-001")));
+
+        // 8. TYPEDEF_CREATE → createTypesDef (1 classificationDef + 1 entityDef)
+        ArgumentCaptor<AtlasTypesDef> createTdCaptor = ArgumentCaptor.forClass(AtlasTypesDef.class);
+        inOrder.verify(typeDefStore).createTypesDef(createTdCaptor.capture());
+        assertEquals("CustomTable", createTdCaptor.getValue().getEntityDefs().get(0).getName());
+        assertEquals("SensitiveData", createTdCaptor.getValue().getClassificationDefs().get(0).getDisplayName());
+
+        // 9. TYPEDEF_UPDATE → updateTypesDef (CustomTable with 2 attributes)
+        ArgumentCaptor<AtlasTypesDef> updateTdCaptor = ArgumentCaptor.forClass(AtlasTypesDef.class);
+        inOrder.verify(typeDefStore).updateTypesDef(updateTdCaptor.capture());
+        assertEquals(2, updateTdCaptor.getValue().getEntityDefs().get(0).getAttributeDefs().size());
+
+        // 10. TYPEDEF_DELETE → deleteTypesDef
+        ArgumentCaptor<AtlasTypesDef> deleteTdCaptor = ArgumentCaptor.forClass(AtlasTypesDef.class);
+        inOrder.verify(typeDefStore).deleteTypesDef(deleteTdCaptor.capture());
+        assertFalse(deleteTdCaptor.getValue().getClassificationDefs().isEmpty());
+        assertFalse(deleteTdCaptor.getValue().getEntityDefs().isEmpty());
+
+        // 11. TYPEDEF_DELETE_BY_NAME → deleteTypeByName("CustomTable")
+        inOrder.verify(typeDefStore).deleteTypeByName("CustomTable");
+
+        // 12. PARTIAL_UPDATE_BY_GUID → updateEntityAttributeByGuid
+        inOrder.verify(entitiesStore).updateEntityAttributeByGuid("guid-table-001", "description", "updated description");
+
+        // 13. UPDATE_BY_UNIQUE_ATTRIBUTE → typeRegistry lookup + updateByUniqueAttributes
+        inOrder.verify(typeRegistry).getEntityTypeByName("Table");
+        inOrder.verify(entityMutationService).updateByUniqueAttributes(
+                eq(mockTableType), anyMap(), any(AtlasEntity.AtlasEntityWithExtInfo.class));
+
+        // 14. ADD_LABELS → addLabels
+        inOrder.verify(entitiesStore).addLabels(eq("guid-table-001"), anySet());
+
+        // 15. ADD_CLASSIFICATIONS → addClassifications
+        inOrder.verify(entityMutationService).addClassifications(eq("guid-table-001"), anyList());
+
+        // 16. UPDATE_CLASSIFICATIONS → updateClassifications
+        inOrder.verify(entityMutationService).updateClassifications(eq("guid-table-001"), anyList());
+
+        // 17. DELETE_CLASSIFICATION → deleteClassification
+        inOrder.verify(entityMutationService).deleteClassification("guid-table-001", "PII");
+
+        // 18. ADD_CLASSIFICATION_BULK → addClassification(guids, classification)
+        inOrder.verify(entityMutationService).addClassification(anyList(), any(AtlasClassification.class));
+
+        // 19. DELETE_RELATIONSHIP_BY_GUID → deleteRelationshipById
+        inOrder.verify(entityMutationService).deleteRelationshipById("rel-guid-001");
+
+        // 20. DELETE_RELATIONSHIPS_BY_GUIDS → deleteRelationshipsByIds
+        inOrder.verify(entityMutationService).deleteRelationshipsByIds(anyList());
+
+        // 21. RELATIONSHIP_CREATE → relationshipStore.create
+        inOrder.verify(relationshipStore).create(any(AtlasRelationship.class));
+
+        // 22. RELATIONSHIP_BULK_CREATE_OR_UPDATE → relationshipStore.createOrUpdate
+        inOrder.verify(relationshipStore).createOrUpdate(anyList());
+
+        // 23. RELATIONSHIP_UPDATE → relationshipStore.update
+        inOrder.verify(relationshipStore).update(any(AtlasRelationship.class));
+
+        // 24. ADD_OR_UPDATE_BUSINESS_ATTRIBUTES → addOrUpdateBusinessAttributes
+        inOrder.verify(entitiesStore).addOrUpdateBusinessAttributes(eq("guid-table-001"), anyMap(), eq(false));
+
+        // 25. ADD_OR_UPDATE_BUSINESS_ATTRIBUTES_BY_DISPLAY_NAME → addOrUpdateBusinessAttributesByDisplayName
+        inOrder.verify(entitiesStore).addOrUpdateBusinessAttributesByDisplayName(eq("guid-table-001"), anyMap(), eq(true));
+
+        // 26. REMOVE_BUSINESS_ATTRIBUTES → removeBusinessAttributes
+        inOrder.verify(entitiesStore).removeBusinessAttributes(eq("guid-table-001"), anyMap());
+
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    // ── DLQ Publishing Tests ─────────────────────────────────────────────
+
+    @Test
+    void testPublishToDlq_ProducesCorrectEnvelope() throws Exception {
+        ReflectionTestUtils.setField(consumerService, "dlqTopic", "TEST_DLQ");
+
+        // Create a mock DLQ producer that captures the sent record
+        org.apache.kafka.clients.producer.KafkaProducer<String, String> mockDlqProducer =
+                mock(org.apache.kafka.clients.producer.KafkaProducer.class);
+        ReflectionTestUtils.setField(consumerService, "dlqProducer", mockDlqProducer);
+
+        java.util.concurrent.Future<org.apache.kafka.clients.producer.RecordMetadata> mockFuture =
+                mock(java.util.concurrent.Future.class);
+        when(mockDlqProducer.send(any(org.apache.kafka.clients.producer.ProducerRecord.class)))
+                .thenReturn(mockFuture);
+        when(mockFuture.get(anyLong(), any(TimeUnit.class))).thenReturn(null);
+
+        ConsumerRecord<String, String> record = new ConsumerRecord<>(
+                "ATLAS_ASYNC_ENTITIES", 2, 42, "event-123", DELETE_BY_GUID_EVENT);
+        Exception error = new RuntimeException("Test error message");
+
+        ReflectionTestUtils.invokeMethod(consumerService, "publishToDlq", record, error, 3);
+
+        ArgumentCaptor<org.apache.kafka.clients.producer.ProducerRecord<String, String>> captor =
+                ArgumentCaptor.forClass(org.apache.kafka.clients.producer.ProducerRecord.class);
+        verify(mockDlqProducer).send(captor.capture());
+
+        org.apache.kafka.clients.producer.ProducerRecord<String, String> dlqRecord = captor.getValue();
+        assertEquals("TEST_DLQ", dlqRecord.topic());
+        assertEquals("event-123", dlqRecord.key());
+
+        JsonNode dlqEnvelope = MAPPER.readTree(dlqRecord.value());
+        assertEquals("ATLAS_ASYNC_ENTITIES", dlqEnvelope.get("originalTopic").asText());
+        assertEquals(2, dlqEnvelope.get("originalPartition").asInt());
+        assertEquals(42, dlqEnvelope.get("originalOffset").asLong());
+        assertEquals("event-123", dlqEnvelope.get("originalKey").asText());
+        assertEquals(DELETE_BY_GUID_EVENT, dlqEnvelope.get("originalValue").asText());
+        assertEquals("Test error message", dlqEnvelope.get("errorMessage").asText());
+        assertEquals("java.lang.RuntimeException", dlqEnvelope.get("errorClass").asText());
+        assertEquals(3, dlqEnvelope.get("retryCount").asInt());
+        assertTrue(dlqEnvelope.has("failedAt"));
+
+        long dlqCount = ((java.util.concurrent.atomic.AtomicLong)
+                ReflectionTestUtils.getField(consumerService, "dlqPublishCount")).get();
+        assertEquals(1, dlqCount);
+    }
+
+    @Test
+    void testPublishToDlq_FailureDoesNotThrow() throws Exception {
+        // DLQ producer is null (not initialized) — should log error but not throw
+        ReflectionTestUtils.setField(consumerService, "dlqProducer", null);
+        ReflectionTestUtils.setField(consumerService, "bootstrapServers", null);
+
+        ConsumerRecord<String, String> record = new ConsumerRecord<>(
+                "ATLAS_ASYNC_ENTITIES", 0, 0, "key", "value");
+        Exception error = new RuntimeException("Test");
+
+        // Should not throw — best-effort
+        assertDoesNotThrow(() ->
+                ReflectionTestUtils.invokeMethod(consumerService, "publishToDlq", record, error, 3));
+    }
+}

--- a/webapp/src/test/resources/async-ingestion-payloads.json
+++ b/webapp/src/test/resources/async-ingestion-payloads.json
@@ -1,0 +1,533 @@
+[ {
+  "eventId" : "3124c61f-cf0a-4d6d-b46a-e7808f2de4bc",
+  "eventType" : "BULK_CREATE_OR_UPDATE",
+  "eventTime" : 1770888880911,
+  "requestMetadata" : {
+    "traceId" : "trace-e822ec2f",
+    "user" : "admin"
+  },
+  "operationMetadata" : {
+    "replaceClassifications" : false,
+    "replaceTags" : false,
+    "appendTags" : false,
+    "replaceBusinessAttributes" : false,
+    "overwriteBusinessAttributes" : false,
+    "skipProcessEdgeRestoration" : false
+  },
+  "payload" : {
+    "entities" : [ {
+      "typeName" : "Table",
+      "attributes" : {
+        "qualifiedName" : "default/snowflake/db1/schema1/table1",
+        "name" : "table1",
+        "description" : "Sample table for async ingestion payload demo"
+      },
+      "guid" : "guid-table-001",
+      "isIncomplete" : false,
+      "provenanceType" : 0,
+      "version" : 0,
+      "superTypeNames" : [ ],
+      "proxy" : false
+    }, {
+      "typeName" : "Column",
+      "attributes" : {
+        "qualifiedName" : "default/snowflake/db1/schema1/table1/col1",
+        "dataType" : "VARCHAR",
+        "name" : "col1"
+      },
+      "guid" : "guid-col-001",
+      "isIncomplete" : false,
+      "provenanceType" : 0,
+      "version" : 0,
+      "superTypeNames" : [ ],
+      "proxy" : false
+    } ]
+  }
+}, {
+  "eventId" : "8d2bce9c-13a3-4106-b161-d184f0058f73",
+  "eventType" : "SET_CLASSIFICATIONS",
+  "eventTime" : 1770888880940,
+  "requestMetadata" : {
+    "traceId" : "trace-d1617835",
+    "user" : "admin"
+  },
+  "operationMetadata" : { },
+  "payload" : {
+    "guidHeaderMap" : {
+      "guid-table-001" : {
+        "guid" : "guid-table-001",
+        "classifications" : [ {
+          "typeName" : "PII",
+          "attributes" : {
+            "level" : "HIGH"
+          },
+          "entityGuid" : "guid-table-001",
+          "entityStatus" : "ACTIVE"
+        } ]
+      },
+      "guid-col-001" : {
+        "guid" : "guid-col-001",
+        "classifications" : [ {
+          "typeName" : "Confidential",
+          "entityGuid" : "guid-col-001",
+          "entityStatus" : "ACTIVE"
+        } ]
+      }
+    }
+  }
+}, {
+  "eventId" : "d6a36da6-c812-492a-89dd-9e7e6dea1452",
+  "eventType" : "DELETE_BY_GUID",
+  "eventTime" : 1770888880941,
+  "requestMetadata" : {
+    "traceId" : "trace-1f0c2a7c",
+    "user" : "admin"
+  },
+  "operationMetadata" : {
+    "deleteType" : "SOFT"
+  },
+  "payload" : {
+    "guids" : [ "guid-table-001" ]
+  }
+}, {
+  "eventId" : "b4cfd8fe-fa84-4251-bc06-1b3d10f54611",
+  "eventType" : "DELETE_BY_GUIDS",
+  "eventTime" : 1770888880942,
+  "requestMetadata" : {
+    "traceId" : "trace-3ded4f44",
+    "user" : "admin"
+  },
+  "operationMetadata" : {
+    "deleteType" : "SOFT"
+  },
+  "payload" : {
+    "guids" : [ "guid-table-001", "guid-col-001", "guid-col-002" ]
+  }
+}, {
+  "eventId" : "eef519d9-55f5-4e4a-813f-503a7d3964cb",
+  "eventType" : "DELETE_BY_UNIQUE_ATTRIBUTE",
+  "eventTime" : 1770888880946,
+  "requestMetadata" : {
+    "traceId" : "trace-ead61c93",
+    "user" : "admin"
+  },
+  "operationMetadata" : {
+    "deleteType" : "SOFT",
+    "typeName" : "Table"
+  },
+  "payload" : {
+    "uniqueAttributes" : {
+      "qualifiedName" : "default/snowflake/db1/schema1/table1"
+    }
+  }
+}, {
+  "eventId" : "6ce2a427-b564-44e7-8776-3f4dd848582a",
+  "eventType" : "BULK_DELETE_BY_UNIQUE_ATTRIBUTES",
+  "eventTime" : 1770888880947,
+  "requestMetadata" : {
+    "traceId" : "trace-cde941ff",
+    "user" : "admin"
+  },
+  "operationMetadata" : {
+    "deleteType" : "SOFT"
+  },
+  "payload" : {
+    "objectIds" : [ {
+      "typeName" : "Table",
+      "uniqueAttributes" : {
+        "qualifiedName" : "default/snowflake/db1/schema1/table1"
+      }
+    }, {
+      "typeName" : "Table",
+      "uniqueAttributes" : {
+        "qualifiedName" : "default/snowflake/db1/schema1/table2"
+      }
+    } ]
+  }
+}, {
+  "eventId" : "b166afdc-9bdd-45eb-933f-89ecd528f196",
+  "eventType" : "RESTORE_BY_GUIDS",
+  "eventTime" : 1770888880948,
+  "requestMetadata" : {
+    "traceId" : "trace-f7ecb031",
+    "user" : "admin"
+  },
+  "operationMetadata" : { },
+  "payload" : {
+    "guids" : [ "guid-table-001", "guid-col-001" ]
+  }
+}, {
+  "eventId" : "90c3c9bf-1d1d-4251-b18d-961fbf73c48f",
+  "eventType" : "TYPEDEF_CREATE",
+  "eventTime" : 1770888880953,
+  "requestMetadata" : {
+    "traceId" : "trace-1b77a9b6",
+    "user" : "admin"
+  },
+  "operationMetadata" : {
+    "allowDuplicateDisplayName" : false
+  },
+  "payload" : {
+    "enumDefs" : [ ],
+    "structDefs" : [ ],
+    "classificationDefs" : [ {
+      "category" : "CLASSIFICATION",
+      "name" : "iLnMytPOXuX8ZpKNHgJglH",
+      "description" : "Marks data as sensitive",
+      "attributeDefs" : [ ],
+      "superTypes" : [ ],
+      "entityTypes" : [ ],
+      "displayName" : "SensitiveData"
+    } ],
+    "entityDefs" : [ {
+      "category" : "ENTITY",
+      "name" : "CustomTable",
+      "description" : "A custom table type",
+      "attributeDefs" : [ {
+        "name" : "customField",
+        "typeName" : "string",
+        "isOptional" : false,
+        "cardinality" : "SINGLE",
+        "valuesMinCount" : -1,
+        "valuesMaxCount" : -1,
+        "isUnique" : false,
+        "isIndexable" : false,
+        "includeInNotification" : false,
+        "skipScrubbing" : false,
+        "searchWeight" : -1,
+        "isDefaultValueNull" : false
+      } ],
+      "superTypes" : [ "DataSet" ]
+    } ],
+    "relationshipDefs" : [ ],
+    "businessMetadataDefs" : [ ]
+  }
+}, {
+  "eventId" : "f210e4cf-d787-4fcc-a250-f47a25de52b9",
+  "eventType" : "TYPEDEF_UPDATE",
+  "eventTime" : 1770888880961,
+  "requestMetadata" : {
+    "traceId" : "trace-40c0924c",
+    "user" : "admin"
+  },
+  "operationMetadata" : {
+    "allowDuplicateDisplayName" : false,
+    "patch" : true
+  },
+  "payload" : {
+    "enumDefs" : [ ],
+    "structDefs" : [ ],
+    "classificationDefs" : [ ],
+    "entityDefs" : [ {
+      "category" : "ENTITY",
+      "name" : "CustomTable",
+      "description" : "Updated custom table type with new attribute",
+      "attributeDefs" : [ {
+        "name" : "customField",
+        "typeName" : "string",
+        "isOptional" : false,
+        "cardinality" : "SINGLE",
+        "valuesMinCount" : -1,
+        "valuesMaxCount" : -1,
+        "isUnique" : false,
+        "isIndexable" : false,
+        "includeInNotification" : false,
+        "skipScrubbing" : false,
+        "searchWeight" : -1,
+        "isDefaultValueNull" : false
+      }, {
+        "name" : "newField",
+        "typeName" : "int",
+        "isOptional" : false,
+        "cardinality" : "SINGLE",
+        "valuesMinCount" : -1,
+        "valuesMaxCount" : -1,
+        "isUnique" : false,
+        "isIndexable" : false,
+        "includeInNotification" : false,
+        "skipScrubbing" : false,
+        "searchWeight" : -1,
+        "isDefaultValueNull" : false
+      } ],
+      "superTypes" : [ "DataSet" ]
+    } ],
+    "relationshipDefs" : [ ],
+    "businessMetadataDefs" : [ ]
+  }
+}, {
+  "eventId" : "31e849c5-e8cc-47e1-a494-ad0d14e88aa9",
+  "eventType" : "TYPEDEF_DELETE",
+  "eventTime" : 1770888880961,
+  "requestMetadata" : {
+    "traceId" : "trace-0b6c5eca",
+    "user" : "admin"
+  },
+  "operationMetadata" : { },
+  "payload" : {
+    "enumDefs" : [ ],
+    "structDefs" : [ ],
+    "classificationDefs" : [ {
+      "category" : "CLASSIFICATION",
+      "name" : "USlQR0zIaYDc8BlxMKMCQ6",
+      "attributeDefs" : [ ],
+      "superTypes" : [ ],
+      "entityTypes" : [ ],
+      "displayName" : "SensitiveData"
+    } ],
+    "entityDefs" : [ {
+      "category" : "ENTITY",
+      "name" : "CustomTable",
+      "attributeDefs" : [ ],
+      "superTypes" : [ ]
+    } ],
+    "relationshipDefs" : [ ],
+    "businessMetadataDefs" : [ ]
+  }
+}, {
+  "eventId" : "cbf285e9-aaa5-474c-9e3d-9673c4d25f8b",
+  "eventType" : "TYPEDEF_DELETE_BY_NAME",
+  "eventTime" : 1770888880961,
+  "requestMetadata" : {
+    "traceId" : "trace-21af29be",
+    "user" : "admin"
+  },
+  "operationMetadata" : { },
+  "payload" : {
+    "typeName" : "CustomTable"
+  }
+}, {
+  "eventId" : "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "eventType" : "PARTIAL_UPDATE_BY_GUID",
+  "eventTime" : 1770888880970,
+  "requestMetadata" : {
+    "traceId" : "trace-partial-update",
+    "user" : "admin"
+  },
+  "operationMetadata" : { },
+  "payload" : {
+    "guid" : "guid-table-001",
+    "attrName" : "description",
+    "attrValue" : "updated description"
+  }
+}, {
+  "eventId" : "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+  "eventType" : "UPDATE_BY_UNIQUE_ATTRIBUTE",
+  "eventTime" : 1770888880971,
+  "requestMetadata" : {
+    "traceId" : "trace-update-uniq",
+    "user" : "admin"
+  },
+  "operationMetadata" : {
+    "typeName" : "Table"
+  },
+  "payload" : {
+    "uniqueAttributes" : {
+      "qualifiedName" : "default/snowflake/db1/schema1/table1"
+    },
+    "entity" : {
+      "entity" : {
+        "typeName" : "Table",
+        "attributes" : {
+          "qualifiedName" : "default/snowflake/db1/schema1/table1",
+          "name" : "table1",
+          "description" : "updated via unique attrs"
+        },
+        "guid" : "guid-table-001"
+      }
+    }
+  }
+}, {
+  "eventId" : "d4e5f6a7-b8c9-0123-defa-234567890123",
+  "eventType" : "ADD_LABELS",
+  "eventTime" : 1770888880973,
+  "requestMetadata" : {
+    "traceId" : "trace-add-labels",
+    "user" : "admin"
+  },
+  "operationMetadata" : { },
+  "payload" : {
+    "guid" : "guid-table-001",
+    "labels" : [ "label1", "label2", "label3" ]
+  }
+}, {
+  "eventId" : "e1f2a3b4-c5d6-7890-abcd-ef1234567001",
+  "eventType" : "ADD_CLASSIFICATIONS",
+  "eventTime" : 1770888880980,
+  "requestMetadata" : {
+    "traceId" : "trace-add-cls",
+    "user" : "admin"
+  },
+  "operationMetadata" : { },
+  "payload" : {
+    "guid" : "guid-table-001",
+    "classifications" : [ {
+      "typeName" : "PII",
+      "attributes" : {
+        "level" : "HIGH"
+      }
+    }, {
+      "typeName" : "Confidential"
+    } ]
+  }
+}, {
+  "eventId" : "e1f2a3b4-c5d6-7890-abcd-ef1234567002",
+  "eventType" : "UPDATE_CLASSIFICATIONS",
+  "eventTime" : 1770888880981,
+  "requestMetadata" : {
+    "traceId" : "trace-upd-cls",
+    "user" : "admin"
+  },
+  "operationMetadata" : { },
+  "payload" : {
+    "guid" : "guid-table-001",
+    "classifications" : [ {
+      "typeName" : "PII",
+      "attributes" : {
+        "level" : "LOW"
+      }
+    } ]
+  }
+}, {
+  "eventId" : "e1f2a3b4-c5d6-7890-abcd-ef1234567003",
+  "eventType" : "DELETE_CLASSIFICATION",
+  "eventTime" : 1770888880982,
+  "requestMetadata" : {
+    "traceId" : "trace-del-cls",
+    "user" : "admin"
+  },
+  "operationMetadata" : { },
+  "payload" : {
+    "guid" : "guid-table-001",
+    "classificationName" : "PII"
+  }
+}, {
+  "eventId" : "e1f2a3b4-c5d6-7890-abcd-ef1234567005",
+  "eventType" : "ADD_CLASSIFICATION_BULK",
+  "eventTime" : 1770888880984,
+  "requestMetadata" : {
+    "traceId" : "trace-add-cls-bulk",
+    "user" : "admin"
+  },
+  "operationMetadata" : { },
+  "payload" : {
+    "guids" : [ "guid-table-001", "guid-col-001" ],
+    "classification" : {
+      "typeName" : "Confidential"
+    }
+  }
+}, {
+  "eventId" : "e1f2a3b4-c5d6-7890-abcd-ef1234567006",
+  "eventType" : "DELETE_RELATIONSHIP_BY_GUID",
+  "eventTime" : 1770888880985,
+  "requestMetadata" : {
+    "traceId" : "trace-del-rel",
+    "user" : "admin"
+  },
+  "operationMetadata" : { },
+  "payload" : {
+    "guid" : "rel-guid-001"
+  }
+}, {
+  "eventId" : "e1f2a3b4-c5d6-7890-abcd-ef1234567007",
+  "eventType" : "DELETE_RELATIONSHIPS_BY_GUIDS",
+  "eventTime" : 1770888880986,
+  "requestMetadata" : {
+    "traceId" : "trace-del-rels",
+    "user" : "admin"
+  },
+  "operationMetadata" : { },
+  "payload" : {
+    "guids" : [ "rel-guid-001", "rel-guid-002" ]
+  }
+}, {
+  "eventId" : "e1f2a3b4-c5d6-7890-abcd-ef1234567008",
+  "eventType" : "RELATIONSHIP_CREATE",
+  "eventTime" : 1770888880987,
+  "requestMetadata" : {
+    "traceId" : "trace-rel-create",
+    "user" : "admin"
+  },
+  "operationMetadata" : { },
+  "payload" : {
+    "typeName" : "AtlasGlossaryTermAnchor",
+    "end1" : { "typeName" : "AtlasGlossary", "guid" : "guid-glossary-001" },
+    "end2" : { "typeName" : "AtlasGlossaryTerm", "guid" : "guid-term-001" }
+  }
+}, {
+  "eventId" : "e1f2a3b4-c5d6-7890-abcd-ef1234567012",
+  "eventType" : "RELATIONSHIP_BULK_CREATE_OR_UPDATE",
+  "eventTime" : 1770888880991,
+  "requestMetadata" : {
+    "traceId" : "trace-rel-bulk",
+    "user" : "admin"
+  },
+  "operationMetadata" : { },
+  "payload" : [ {
+    "typeName" : "AtlasGlossaryTermAnchor",
+    "end1" : { "typeName" : "AtlasGlossary", "guid" : "guid-glossary-001" },
+    "end2" : { "typeName" : "AtlasGlossaryTerm", "guid" : "guid-term-001" }
+  }, {
+    "typeName" : "AtlasGlossaryTermAnchor",
+    "end1" : { "typeName" : "AtlasGlossary", "guid" : "guid-glossary-001" },
+    "end2" : { "typeName" : "AtlasGlossaryTerm", "guid" : "guid-term-002" }
+  } ]
+}, {
+  "eventId" : "e1f2a3b4-c5d6-7890-abcd-ef1234567013",
+  "eventType" : "RELATIONSHIP_UPDATE",
+  "eventTime" : 1770888880992,
+  "requestMetadata" : {
+    "traceId" : "trace-rel-update",
+    "user" : "admin"
+  },
+  "operationMetadata" : { },
+  "payload" : {
+    "typeName" : "AtlasGlossaryTermAnchor",
+    "guid" : "rel-guid-existing",
+    "end1" : { "typeName" : "AtlasGlossary", "guid" : "guid-glossary-001" },
+    "end2" : { "typeName" : "AtlasGlossaryTerm", "guid" : "guid-term-003" }
+  }
+}, {
+  "eventId" : "e1f2a3b4-c5d6-7890-abcd-ef1234567009",
+  "eventType" : "ADD_OR_UPDATE_BUSINESS_ATTRIBUTES",
+  "eventTime" : 1770888880988,
+  "requestMetadata" : {
+    "traceId" : "trace-bm-update",
+    "user" : "admin"
+  },
+  "operationMetadata" : {
+    "guid" : "guid-table-001",
+    "isOverwrite" : false
+  },
+  "payload" : {
+    "bmName" : { "attr1" : "val1", "attr2" : "val2" }
+  }
+}, {
+  "eventId" : "e1f2a3b4-c5d6-7890-abcd-ef1234567010",
+  "eventType" : "ADD_OR_UPDATE_BUSINESS_ATTRIBUTES_BY_DISPLAY_NAME",
+  "eventTime" : 1770888880989,
+  "requestMetadata" : {
+    "traceId" : "trace-bm-display",
+    "user" : "admin"
+  },
+  "operationMetadata" : {
+    "guid" : "guid-table-001",
+    "isOverwrite" : true
+  },
+  "payload" : {
+    "bmDisplayName" : { "attr1" : "val1" }
+  }
+}, {
+  "eventId" : "e1f2a3b4-c5d6-7890-abcd-ef1234567011",
+  "eventType" : "REMOVE_BUSINESS_ATTRIBUTES",
+  "eventTime" : 1770888880990,
+  "requestMetadata" : {
+    "traceId" : "trace-bm-remove",
+    "user" : "admin"
+  },
+  "operationMetadata" : {
+    "guid" : "guid-table-001"
+  },
+  "payload" : {
+    "bmName" : { "attr1" : "val1" }
+  }
+} ]


### PR DESCRIPTION
## Summary

Ports the consumer side from #6091 (base: `leangraph`) onto `switchable-graph-provider` so both the producer (PR #6051, already in sgp) and the consumer can be exercised end-to-end on sgp-based tenants. Verified on `enpla91p19` that the producer side publishes to `ATLAS_ASYNC_ENTITIES` correctly; this branch adds the matching consumer.

## What's in

- `AsyncIngestionConsumerController` + `AsyncIngestionConsumerService` (Kafka consumer for `ATLAS_ASYNC_ENTITIES` that replays write events)
- `BulkRequestContext.fromOperationMetadata(JsonNode)` — rebuilds context from the Kafka envelope
- `isImportInProgress` bypass across 11 preprocessors: glossary (Glossary/Term/Category), datamesh (DataDomain/DataProduct/StakeholderTitle), access-control (Persona/Purpose/Stakeholder/AuthPolicy), sql (Query/QueryCollection/QueryFolder)
- `AtlasEntityChangeNotifier` hooks, `RequestContext` fields for import-in-progress tracking
- `distro` + `webapp` config: atlas-application.properties, pom testResource for JSON fixtures
- `maven.yml` branch trigger additions
- Tests: `AsyncIngestionConsumerServiceTest` (1278 lines) + `async-ingestion-payloads.json` fixtures (533 lines)

## Intentionally excluded from #6091

These were divergence noise from `leangraph` vs `sgp`, not part of the feature — sgp values preserved:
- `enunciate-maven-plugin` → kept sgp's 2.17.0 (PR had 2.18.0)
- Testcontainer cassandra image → kept sgp's 3.11 (PR had 2.1)
- `.github/workflows/maven.yml` branch triggers → merged as union rather than replacing sgp's list

## Test plan

- [ ] Build compiles: `mvn compile -pl webapp,repository -am -DskipTests -Drat.skip=true`
- [ ] Consumer unit tests pass: `mvn test -pl webapp -Dtest=AsyncIngestionConsumerServiceTest -Drat.skip=true`
- [ ] Deploy to an sgp-based tenant with `ENABLE_ASYNC_INGESTION=true` on producer side and verify consumer replays `BULK_CREATE_OR_UPDATE` / `DELETE_BY_GUID` events against the shadow keyspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)