### PR TITLE
TTD-700 | Add relationship policies for Skill and Context Repository associations

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,6 +27,7 @@ on:
       - lite_master
       - switchable-graph-provider
       - ring-*
+      - ttd-700
     paths-ignore:
       - '.claude/**'
       - '.cursor/**'

--- a/addons/policies/bootstrap_relationship_policies.json
+++ b/addons/policies/bootstrap_relationship_policies.json
@@ -1191,6 +1191,108 @@
             "typeName": "AuthPolicy",
             "attributes":
             {
+                "name": "LINK_SKILL_TO_REFERENCED_ASSETS",
+                "qualifiedName": "LINK_SKILL_TO_REFERENCED_ASSETS",
+                "policyCategory": "bootstrap",
+                "policySubCategory": "default",
+                "policyServiceName": "atlas",
+                "policyType": "allow",
+                "policyPriority": 0,
+                "policyUsers": [],
+                "policyGroups": [],
+                "policyRoles": [
+                    "$admin",
+                    "$api-token-default-access"
+                ],
+                "policyResourceCategory": "RELATIONSHIP",
+                "policyResources": [
+                    "end-one-entity-classification:*",
+                    "end-two-entity-classification:*",
+                    "end-one-entity:*",
+                    "end-two-entity:*",
+                    "end-one-entity-type:Asset",
+                    "end-two-entity-type:Skill",
+                    "relationship-type:*"
+                ],
+                "policyActions": [
+                    "add-relationship",
+                    "update-relationship",
+                    "remove-relationship"
+                ]
+            }
+        },
+        {
+            "typeName": "AuthPolicy",
+            "attributes":
+            {
+                "name": "LINK_CONTEXT_REPOSITORY_TO_OUTPUT_SKILL",
+                "qualifiedName": "LINK_CONTEXT_REPOSITORY_TO_OUTPUT_SKILL",
+                "policyCategory": "bootstrap",
+                "policySubCategory": "default",
+                "policyServiceName": "atlas",
+                "policyType": "allow",
+                "policyPriority": 0,
+                "policyUsers": [],
+                "policyGroups": [],
+                "policyRoles": [
+                    "$admin",
+                    "$api-token-default-access"
+                ],
+                "policyResourceCategory": "RELATIONSHIP",
+                "policyResources": [
+                    "end-one-entity-classification:*",
+                    "end-two-entity-classification:*",
+                    "end-one-entity:*",
+                    "end-two-entity:*",
+                    "end-one-entity-type:Skill",
+                    "end-two-entity-type:ContextRepository",
+                    "relationship-type:*"
+                ],
+                "policyActions": [
+                    "add-relationship",
+                    "update-relationship",
+                    "remove-relationship"
+                ]
+            }
+        },
+        {
+            "typeName": "AuthPolicy",
+            "attributes":
+            {
+                "name": "LINK_CONTEXT_REPOSITORY_TO_INPUT_ASSETS",
+                "qualifiedName": "LINK_CONTEXT_REPOSITORY_TO_INPUT_ASSETS",
+                "policyCategory": "bootstrap",
+                "policySubCategory": "default",
+                "policyServiceName": "atlas",
+                "policyType": "allow",
+                "policyPriority": 0,
+                "policyUsers": [],
+                "policyGroups": [],
+                "policyRoles": [
+                    "$admin",
+                    "$api-token-default-access"
+                ],
+                "policyResourceCategory": "RELATIONSHIP",
+                "policyResources": [
+                    "end-one-entity-classification:*",
+                    "end-two-entity-classification:*",
+                    "end-one-entity:*",
+                    "end-two-entity:*",
+                    "end-one-entity-type:Asset",
+                    "end-two-entity-type:ContextRepository",
+                    "relationship-type:*"
+                ],
+                "policyActions": [
+                    "add-relationship",
+                    "update-relationship",
+                    "remove-relationship"
+                ]
+            }
+        },
+        {
+            "typeName": "AuthPolicy",
+            "attributes":
+            {
                 "name": "LINK_ASSET_GROUPING_STRATEGY_TO_COLLECTION",
                 "qualifiedName": "LINK_ASSET_GROUPING_STRATEGY_TO_COLLECTION",
                 "policyCategory": "bootstrap",

--- a/addons/policies/bootstrap_relationship_policies.json
+++ b/addons/policies/bootstrap_relationship_policies.json
@@ -1191,40 +1191,6 @@
             "typeName": "AuthPolicy",
             "attributes":
             {
-                "name": "LINK_SKILL_TO_REFERENCED_ASSETS",
-                "qualifiedName": "LINK_SKILL_TO_REFERENCED_ASSETS",
-                "policyCategory": "bootstrap",
-                "policySubCategory": "default",
-                "policyServiceName": "atlas",
-                "policyType": "allow",
-                "policyPriority": 0,
-                "policyUsers": [],
-                "policyGroups": [],
-                "policyRoles": [
-                    "$admin",
-                    "$api-token-default-access"
-                ],
-                "policyResourceCategory": "RELATIONSHIP",
-                "policyResources": [
-                    "end-one-entity-classification:*",
-                    "end-two-entity-classification:*",
-                    "end-one-entity:*",
-                    "end-two-entity:*",
-                    "end-one-entity-type:Asset",
-                    "end-two-entity-type:Skill",
-                    "relationship-type:*"
-                ],
-                "policyActions": [
-                    "add-relationship",
-                    "update-relationship",
-                    "remove-relationship"
-                ]
-            }
-        },
-        {
-            "typeName": "AuthPolicy",
-            "attributes":
-            {
                 "name": "LINK_CONTEXT_REPOSITORY_TO_OUTPUT_SKILL",
                 "qualifiedName": "LINK_CONTEXT_REPOSITORY_TO_OUTPUT_SKILL",
                 "policyCategory": "bootstrap",


### PR DESCRIPTION
## What this PR does

Adds bootstrap relationship policies for the new Skill/Context ASSOCIATION relationships introduced in models PR #1954. Merged with latest master.

### Relationship Policies

| Policy | Relationship | endDef1 → endDef2 | Roles |
|---|---|---|---|
| `LINK_SKILL_TO_SKILL_ARTIFACT` | Skill → SkillArtifact | Containment | admin, api-token |
| `LINK_CONTEXT_REPOSITORY_TO_ARTIFACT` | ContextRepo → ContextArtifact | Containment | admin, api-token |
| `LINK_CONTEXT_REPOSITORY_TO_OUTPUT_SKILL` | ContextRepo ↔ Skill | Association | admin, api-token |
| `LINK_CONTEXT_REPOSITORY_TO_INPUT_ASSETS` | ContextRepo ↔ Asset | Association | admin, api-token |

### Related PRs

| PR | Repo | What it does |
|---|---|---|
| [#1954](https://github.com/atlanhq/models/pull/1954) | models | Skill relationships + skillType enum |

### Test plan

- [x] JSON validates
- [x] Policy names match relationship endpoint types
- [x] Existing policies unaffected
- [x] Types seeded and validated on eops1

[TTD-700](https://linear.app/atlan-epd/issue/TTD-700)