### PR TITLE
Reduce entity_audits default Elasticsearch shards from 4 to 1

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
@@ -974,7 +974,7 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
         lifecycle.put("name", ILM_POLICY_NAME);
         lifecycle.put("rollover_alias", WRITE_ALIAS);
         indexSettings.set("lifecycle", lifecycle);
-        indexSettings.put("number_of_shards", 4);
+        indexSettings.put("number_of_shards", 1);
         indexSettings.put("number_of_replicas", 1);
         indexSettings.put("refresh_interval", "30s");
         HttpEntity entity = new NStringEntity(rootObj.toString(), ContentType.APPLICATION_JSON);
@@ -1175,7 +1175,7 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
 
         ObjectNode settings      = template.putObject("settings");
         ObjectNode indexSettings  = settings.putObject("index");
-        indexSettings.put("number_of_shards", 4);
+        indexSettings.put("number_of_shards", 1);
         indexSettings.put("number_of_replicas", 1);
         indexSettings.put("refresh_interval", "30s");
         indexSettings.putObject("store").put("type", "niofs");


### PR DESCRIPTION
## Summary

Sets `number_of_shards` to **1** (was 4) for the entity audit index in two places in `ESBasedAuditRepository`:

1. **Bootstrap concrete index** creation (ILM rollover path)
2. **`entity_audits-*` index template** (`buildIndexTemplateJson`)

## Rationale

At ~50GB scale, four primary shards is unnecessary overhead (shard coordination, more small Lucene indices). One shard is a better default for this footprint.

## Notes

- **Existing indices** are unchanged; this affects **new** indices created from the template or bootstrap path after deploy.
- Beta/staging: cherry-pick this commit as planned.

## Testing

- `mvn compile -pl repository -am -DskipTests -Drat.skip=true` (optional CI verification)

Made with [Cursor](https://cursor.com)