### PR TITLE
Reduce entity_audits default Elasticsearch shards from 4 to 1

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/ESBasedAuditRepository.java
@@ -975,7 +975,7 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
         lifecycle.put("name", ILM_POLICY_NAME);
         lifecycle.put("rollover_alias", WRITE_ALIAS);
         indexSettings.set("lifecycle", lifecycle);
-        indexSettings.put("number_of_shards", 4);
+        indexSettings.put("number_of_shards", 1);
         indexSettings.put("number_of_replicas", 1);
         indexSettings.put("refresh_interval", "30s");
 
@@ -1177,7 +1177,7 @@ public class ESBasedAuditRepository extends AbstractStorageBasedAuditRepository 
 
         ObjectNode settings      = template.putObject("settings");
         ObjectNode indexSettings  = settings.putObject("index");
-        indexSettings.put("number_of_shards", 4);
+        indexSettings.put("number_of_shards", 1);
         indexSettings.put("number_of_replicas", 1);
         indexSettings.put("refresh_interval", "30s");
         indexSettings.putObject("store").put("type", "niofs");


### PR DESCRIPTION
## Summary

Cherry-pick of the same change as master: set `number_of_shards` to **1** (was 4) in `ESBasedAuditRepository` for:

- Bootstrap concrete index creation
- `entity_audits-*` index template

## Parent

Aligns with master PR (same logical change; target **staging** for deploy path).

## Notes

Existing indices unchanged; applies to new indices after deploy.

Made with [Cursor](https://cursor.com)