### PR TITLE
fix: Cassandra Reaper CronJob now uses the actual cluster size for keyspace replication factor and seed host list instead of hardcoding 3, fixing the CronJob failure on single-node tenants.

### DIFF
--- a/helm/atlas-read/charts/cassandra-online-dc/templates/reaper/cronjob.yaml
+++ b/helm/atlas-read/charts/cassandra-online-dc/templates/reaper/cronjob.yaml
@@ -79,7 +79,11 @@ spec:
                     )
                     session = cluster.connect()
                     
+                    {{- if eq .Values.global.Infra_Tier "Lite" }}
+                    rf = 1
+                    {{- else }}
                     rf = min({{ .Values.config.cluster_size }}, 3)
+                    {{- end }}
                     print("Creating keyspace reaper_db with RF=" + str(rf) + "...")
                     session.execute(
                         "CREATE KEYSPACE IF NOT EXISTS reaper_db "
@@ -169,7 +173,11 @@ spec:
                   {{- end }}
                   {{- end }}
                     - name: CLUSTER_SEED_HOST
+                    {{- if eq .Values.global.Infra_Tier "Lite" }}
+                      value: "atlas-cassandra-online-dc-0.atlas-cassandra-online-dc.atlas.svc.cluster.local"
+                    {{- else }}
                       value: "{{ $seeds := list }}{{- range $i := until (int $.Values.config.cluster_size) }}{{ $seeds = append $seeds (printf "atlas-cassandra-online-dc-%d.atlas-cassandra-online-dc.atlas.svc.cluster.local" $i) }}{{- end }}{{ join "," $seeds }}"
+                    {{- end }}
                   resources:
                     {{- toYaml .Values.reaper.sidecar.resources | nindent 20 }}
             imagePullSecrets: 

--- a/helm/atlas-read/charts/cassandra-online-dc/templates/reaper/cronjob.yaml
+++ b/helm/atlas-read/charts/cassandra-online-dc/templates/reaper/cronjob.yaml
@@ -79,12 +79,13 @@ spec:
                     )
                     session = cluster.connect()
                     
-                    print("Creating keyspace reaper_db...")
-                    session.execute("""
-                        CREATE KEYSPACE IF NOT EXISTS reaper_db 
-                        WITH replication = {'class': 'NetworkTopologyStrategy', 'online-dc': 3}
-                        AND durable_writes = true
-                    """)
+                    rf = min({{ .Values.config.cluster_size }}, 3)
+                    print("Creating keyspace reaper_db with RF=" + str(rf) + "...")
+                    session.execute(
+                        "CREATE KEYSPACE IF NOT EXISTS reaper_db "
+                        "WITH replication = {'class': 'NetworkTopologyStrategy', 'online-dc': " + str(rf) + "} "
+                        "AND durable_writes = true"
+                    )
                     print("Keyspace reaper_db created/verified successfully!")
                     
                     # Clean stale cluster entries to force Reaper to re-discover with current pod IPs
@@ -162,9 +163,13 @@ spec:
                   imagePullPolicy: {{.Values.reaper.sidecar.image.pullPolicy}}
                   env:
                   {{- range $key, $value := .Values.reaper.sidecar.env }}
+                  {{- if ne $key "CLUSTER_SEED_HOST" }}
                     - name: {{ $key }}
                       value: {{ $value | quote }}
                   {{- end }}
+                  {{- end }}
+                    - name: CLUSTER_SEED_HOST
+                      value: "{{ $seeds := list }}{{- range $i := until (int $.Values.config.cluster_size) }}{{ $seeds = append $seeds (printf "atlas-cassandra-online-dc-%d.atlas-cassandra-online-dc.atlas.svc.cluster.local" $i) }}{{- end }}{{ join "," $seeds }}"
                   resources:
                     {{- toYaml .Values.reaper.sidecar.resources | nindent 20 }}
             imagePullSecrets: 

--- a/helm/atlas/charts/cassandra/templates/reaper/cronjob.yaml
+++ b/helm/atlas/charts/cassandra/templates/reaper/cronjob.yaml
@@ -65,7 +65,11 @@ spec:
                     )
                     session = cluster.connect()
                     
+                    {{- if eq .Values.global.Infra_Tier "Lite" }}
+                    rf = 1
+                    {{- else }}
                     rf = min({{ .Values.config.cluster_size }}, 3)
+                    {{- end }}
                     print("Creating keyspace reaper_db with RF=" + str(rf) + "...")
                     session.execute(
                         "CREATE KEYSPACE IF NOT EXISTS reaper_db "
@@ -155,7 +159,11 @@ spec:
                   {{- end }}
                   {{- end }}
                     - name: CLUSTER_SEED_HOST
+                    {{- if eq .Values.global.Infra_Tier "Lite" }}
+                      value: "atlas-cassandra-0.atlas-cassandra.atlas.svc.cluster.local"
+                    {{- else }}
                       value: "{{ $seeds := list }}{{- range $i := until (int $.Values.config.cluster_size) }}{{ $seeds = append $seeds (printf "atlas-cassandra-%d.atlas-cassandra.atlas.svc.cluster.local" $i) }}{{- end }}{{ join "," $seeds }}"
+                    {{- end }}
                   resources:
                     {{- toYaml .Values.reaper.sidecar.resources | nindent 20 }}
             imagePullSecrets: 

--- a/helm/atlas/charts/cassandra/templates/reaper/cronjob.yaml
+++ b/helm/atlas/charts/cassandra/templates/reaper/cronjob.yaml
@@ -65,12 +65,13 @@ spec:
                     )
                     session = cluster.connect()
                     
-                    print("Creating keyspace reaper_db...")
-                    session.execute("""
-                        CREATE KEYSPACE IF NOT EXISTS reaper_db 
-                        WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 3}
-                        AND durable_writes = true
-                    """)
+                    rf = min({{ .Values.config.cluster_size }}, 3)
+                    print("Creating keyspace reaper_db with RF=" + str(rf) + "...")
+                    session.execute(
+                        "CREATE KEYSPACE IF NOT EXISTS reaper_db "
+                        "WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': " + str(rf) + "} "
+                        "AND durable_writes = true"
+                    )
                     print("Keyspace reaper_db created/verified successfully!")
                     
                     # Clean stale cluster entries to force Reaper to re-discover with current pod IPs
@@ -148,9 +149,13 @@ spec:
                   imagePullPolicy: {{.Values.reaper.sidecar.image.pullPolicy}}
                   env:
                   {{- range $key, $value := .Values.reaper.sidecar.env }}
+                  {{- if ne $key "CLUSTER_SEED_HOST" }}
                     - name: {{ $key }}
                       value: {{ $value | quote }}
                   {{- end }}
+                  {{- end }}
+                    - name: CLUSTER_SEED_HOST
+                      value: "{{ $seeds := list }}{{- range $i := until (int $.Values.config.cluster_size) }}{{ $seeds = append $seeds (printf "atlas-cassandra-%d.atlas-cassandra.atlas.svc.cluster.local" $i) }}{{- end }}{{ join "," $seeds }}"
                   resources:
                     {{- toYaml .Values.reaper.sidecar.resources | nindent 20 }}
             imagePullSecrets: 


### PR DESCRIPTION
## Change description

>  Cassandra Reaper CronJob now uses the actual cluster size for keyspace replication factor and seed host list instead of hardcoding 3, fixing the CronJob failure on single-node tenants.

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
