### PR TITLE
hotfix, added custom deserializer

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,6 +27,7 @@ on:
       - lite_master
       - switchable-graph-provider
       - ring-*
+      - ms-1101-incident-home
     paths-ignore:
       - '.claude/**'
       - '.cursor/**'

--- a/dev-support/test-harness/suites/test_typedefs.py
+++ b/dev-support/test-harness/suites/test_typedefs.py
@@ -29,6 +29,7 @@ class TypeDefSuite:
         self.entity_type_name = unique_type_name("TestEntityType")
         self.bm_display_name = unique_type_name("TestBM")
         self.bm_server_name = None  # Set after creation
+        self.bm_bool_server_name = None  # Set after creation (MS-1101 test)
 
     # ---- GET existing types ----
 
@@ -316,6 +317,95 @@ class TypeDefSuite:
         resp2 = client.get(f"/types/typedef/guid/{type_guid}")
         assert_status(resp2, 200)
         assert_field_equals(resp2, "name", self.enum_name)
+
+    # ---- Boolean options tolerance (MS-1101) ----
+
+    @test("create_bm_with_boolean_options", tags=["typedef", "crud", "ms-1101"], order=26)
+    def test_create_bm_with_boolean_options(self, client, ctx):
+        """Verify that non-string primitives (booleans, numbers) in attribute-def
+        options are accepted and coerced to strings.  Before the MS-1101 fix the
+        server returned 400 Bad Request because Jackson could not deserialize
+        JSON booleans into Map<String, String>.
+        """
+        self.bm_bool_display_name = unique_type_name("TestBMBool")
+        payload = {
+            "businessMetadataDefs": [{
+                "displayName": self.bm_bool_display_name,
+                "description": "BM with boolean options (MS-1101)",
+                "options": {},
+                "attributeDefs": [{
+                    "name": "",
+                    "displayName": "richTextField",
+                    "typeName": "string",
+                    "isOptional": True,
+                    "cardinality": "SINGLE",
+                    "isUnique": False,
+                    "isIndexable": True,
+                    "options": {
+                        "applicableEntityTypes": "[\"Asset\"]",
+                        "showAsFeatured": True,
+                        "showInOverview": False,
+                        "multiValueSelect": False,
+                        "isRichText": True,
+                        "allowSearch": False,
+                        "allowFiltering": True,
+                        "maxStrLength": "100000000",
+                        "isEnum": False,
+                    },
+                }],
+            }]
+        }
+        ok, resp = create_typedef_verified(client, payload)
+        if not ok and resp.status_code in (500, 502, 503):
+            raise SkipTestError(
+                f"BM typedef with boolean options POST returned {resp.status_code} — "
+                f"server-side gateway timeout"
+            )
+        assert ok, (
+            f"BM typedef with boolean options creation failed: POST returned "
+            f"{resp.status_code} — this was the MS-1101 bug (booleans in options)"
+        )
+
+        # Extract server-generated name for cleanup
+        internal_name, _ = extract_bm_names_from_response(resp, self.bm_bool_display_name)
+        if internal_name:
+            self.bm_bool_server_name = internal_name
+            ctx.set("test_bm_bool_name", internal_name)
+        elif resp.status_code == 409:
+            discovered = _discover_bm_by_display_name(client, self.bm_bool_display_name)
+            if discovered:
+                self.bm_bool_server_name = discovered["internal_name"]
+                ctx.set("test_bm_bool_name", self.bm_bool_server_name)
+
+        if resp.status_code == 200:
+            body = resp.json()
+            bm_defs = body.get("businessMetadataDefs", [])
+            assert len(bm_defs) > 0, "Expected businessMetadataDefs in response"
+            # Verify options were stored as strings
+            attr_defs = bm_defs[0].get("attributeDefs", [])
+            assert len(attr_defs) > 0, "Expected at least one attributeDef"
+            opts = attr_defs[0].get("options", {})
+            assert opts.get("isRichText") == "true", (
+                f"Expected isRichText='true' (string), got '{opts.get('isRichText')}'"
+            )
+            assert opts.get("showAsFeatured") == "true", (
+                f"Expected showAsFeatured='true' (string), got '{opts.get('showAsFeatured')}'"
+            )
+            assert opts.get("allowFiltering") == "true", (
+                f"Expected allowFiltering='true' (string), got '{opts.get('allowFiltering')}'"
+            )
+            assert opts.get("isEnum") == "false", (
+                f"Expected isEnum='false' (string), got '{opts.get('isEnum')}'"
+            )
+
+    @test("delete_bm_bool_def", tags=["typedef", "crud", "ms-1101"], order=95,
+          depends_on=["create_bm_with_boolean_options"])
+    def test_delete_bm_bool_def(self, client, ctx):
+        delete_name = getattr(self, "bm_bool_server_name", None) or ctx.get("test_bm_bool_name")
+        if not delete_name:
+            raise SkipTestError("BM bool server name not available")
+        resp = client.delete(f"/types/typedef/name/{delete_name}")
+        assert_status_in(resp, [200, 204, 404])
 
     # ---- DELETE types (cleanup) ----
 

--- a/intg/src/main/java/org/apache/atlas/model/typedef/AtlasBaseTypeDef.java
+++ b/intg/src/main/java/org/apache/atlas/model/typedef/AtlasBaseTypeDef.java
@@ -20,6 +20,7 @@ package org.apache.atlas.model.typedef;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.apache.atlas.model.TypeCategory;
 import org.apache.commons.collections.CollectionUtils;
@@ -300,6 +301,7 @@ public abstract class AtlasBaseTypeDef implements java.io.Serializable {
         return options;
     }
 
+    @JsonDeserialize(using = StringMapDeserializer.class)
     public void setOptions(Map<String, String> options) {
         if (options != null) {
             this.options = new HashMap<>(options);

--- a/intg/src/main/java/org/apache/atlas/model/typedef/AtlasStructDef.java
+++ b/intg/src/main/java/org/apache/atlas/model/typedef/AtlasStructDef.java
@@ -20,6 +20,7 @@ package org.apache.atlas.model.typedef;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import java.io.Serializable;
@@ -547,6 +548,7 @@ public class AtlasStructDef extends AtlasBaseTypeDef implements Serializable {
             return options;
         }
 
+        @JsonDeserialize(using = StringMapDeserializer.class)
         public void setOptions(Map<String, String> options) {
             if (options != null) {
                 this.options = new HashMap<>(options);

--- a/intg/src/main/java/org/apache/atlas/model/typedef/StringMapDeserializer.java
+++ b/intg/src/main/java/org/apache/atlas/model/typedef/StringMapDeserializer.java
@@ -1,0 +1,96 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.atlas.model.typedef;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Custom Jackson deserializer for {@code Map<String, String>} that tolerates
+ * non-string JSON primitives (booleans, numbers, nulls) by coercing them
+ * to their string representations.
+ * <p>
+ * This handles the case where API clients send:
+ * <pre>{"options": {"isRichText": true, "maxLength": 100}}</pre>
+ * instead of:
+ * <pre>{"options": {"isRichText": "true", "maxLength": "100"}}</pre>
+ */
+public class StringMapDeserializer extends JsonDeserializer<Map<String, String>> {
+
+    @Override
+    public Map<String, String> deserialize(JsonParser parser, DeserializationContext ctxt)
+            throws IOException {
+        if (parser.currentToken() != JsonToken.START_OBJECT) {
+            ctxt.reportWrongTokenException(this, JsonToken.START_OBJECT,
+                    "Expected JSON object for Map<String, String>");
+            return null;
+        }
+
+        Map<String, String> result = new HashMap<>();
+
+        while (parser.nextToken() != JsonToken.END_OBJECT) {
+            String key = parser.currentName();
+            parser.nextToken();
+
+            JsonToken valueToken = parser.currentToken();
+            String value;
+
+            switch (valueToken) {
+                case VALUE_STRING:
+                    value = parser.getText();
+                    break;
+                case VALUE_NUMBER_INT:
+                case VALUE_NUMBER_FLOAT:
+                    value = parser.getText();
+                    break;
+                case VALUE_TRUE:
+                    value = "true";
+                    break;
+                case VALUE_FALSE:
+                    value = "false";
+                    break;
+                case VALUE_NULL:
+                    value = null;
+                    break;
+                case START_OBJECT:
+                case START_ARRAY:
+                    value = parser.readValueAsTree().toString();
+                    break;
+                default:
+                    value = parser.getText();
+                    break;
+            }
+
+            result.put(key, value);
+        }
+
+        return result;
+    }
+
+    @Override
+    public Map<String, String> getNullValue(DeserializationContext ctxt) {
+        return null;
+    }
+}

--- a/repository/src/test/java/org/apache/atlas/model/typedef/StringMapDeserializerTest.java
+++ b/repository/src/test/java/org/apache/atlas/model/typedef/StringMapDeserializerTest.java
@@ -1,0 +1,220 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas.model.typedef;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link StringMapDeserializer} verifying that non-string JSON
+ * primitives in options maps are coerced to strings during deserialization.
+ */
+public class StringMapDeserializerTest {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    // =========================================================================
+    // AtlasBaseTypeDef options (type-def level)
+    // =========================================================================
+
+    @Test
+    public void testTypeDefOptionsWithAllStringValues() throws Exception {
+        String json = "{\"name\":\"test\",\"options\":{\"key1\":\"value1\",\"key2\":\"value2\"}}";
+        AtlasEntityDef def = mapper.readValue(json, AtlasEntityDef.class);
+
+        assertNotNull(def.getOptions());
+        assertEquals("value1", def.getOptions().get("key1"));
+        assertEquals("value2", def.getOptions().get("key2"));
+    }
+
+    @Test
+    public void testTypeDefOptionsWithBooleanValues() throws Exception {
+        String json = "{\"name\":\"test\",\"options\":{\"enabled\":true,\"disabled\":false}}";
+        AtlasEntityDef def = mapper.readValue(json, AtlasEntityDef.class);
+
+        assertNotNull(def.getOptions());
+        assertEquals("true", def.getOptions().get("enabled"));
+        assertEquals("false", def.getOptions().get("disabled"));
+    }
+
+    @Test
+    public void testTypeDefOptionsWithNumericValues() throws Exception {
+        String json = "{\"name\":\"test\",\"options\":{\"maxLength\":100,\"ratio\":3.14}}";
+        AtlasEntityDef def = mapper.readValue(json, AtlasEntityDef.class);
+
+        assertNotNull(def.getOptions());
+        assertEquals("100", def.getOptions().get("maxLength"));
+        assertEquals("3.14", def.getOptions().get("ratio"));
+    }
+
+    @Test
+    public void testTypeDefOptionsWithMixedValues() throws Exception {
+        String json = "{\"name\":\"test\",\"options\":{\"str\":\"hello\",\"bool\":true,\"num\":42,\"flt\":1.5}}";
+        AtlasEntityDef def = mapper.readValue(json, AtlasEntityDef.class);
+
+        assertNotNull(def.getOptions());
+        assertEquals("hello", def.getOptions().get("str"));
+        assertEquals("true", def.getOptions().get("bool"));
+        assertEquals("42", def.getOptions().get("num"));
+        assertEquals("1.5", def.getOptions().get("flt"));
+    }
+
+    @Test
+    public void testTypeDefOptionsWithNullEntry() throws Exception {
+        String json = "{\"name\":\"test\",\"options\":{\"key1\":\"value1\",\"key2\":null}}";
+        AtlasEntityDef def = mapper.readValue(json, AtlasEntityDef.class);
+
+        assertNotNull(def.getOptions());
+        assertEquals("value1", def.getOptions().get("key1"));
+        assertNull(def.getOptions().get("key2"));
+        assertTrue(def.getOptions().containsKey("key2"));
+    }
+
+    @Test
+    public void testTypeDefOptionsNull() throws Exception {
+        String json = "{\"name\":\"test\",\"options\":null}";
+        AtlasEntityDef def = mapper.readValue(json, AtlasEntityDef.class);
+
+        assertNull(def.getOptions());
+    }
+
+    @Test
+    public void testTypeDefOptionsEmpty() throws Exception {
+        String json = "{\"name\":\"test\",\"options\":{}}";
+        AtlasEntityDef def = mapper.readValue(json, AtlasEntityDef.class);
+
+        assertNotNull(def.getOptions());
+        assertTrue(def.getOptions().isEmpty());
+    }
+
+    @Test
+    public void testTypeDefOptionsMissing() throws Exception {
+        String json = "{\"name\":\"test\"}";
+        AtlasEntityDef def = mapper.readValue(json, AtlasEntityDef.class);
+
+        assertNull(def.getOptions());
+    }
+
+    // =========================================================================
+    // AtlasAttributeDef options (attribute-def level) -- the failing field
+    // =========================================================================
+
+    @Test
+    public void testAttributeDefOptionsWithBooleans() throws Exception {
+        String json = "{\"name\":\"attr1\",\"typeName\":\"string\",\"options\":{\"isRichText\":true,\"allowFiltering\":false}}";
+        AtlasStructDef.AtlasAttributeDef attrDef = mapper.readValue(json, AtlasStructDef.AtlasAttributeDef.class);
+
+        assertNotNull(attrDef.getOptions());
+        assertEquals("true", attrDef.getOptions().get("isRichText"));
+        assertEquals("false", attrDef.getOptions().get("allowFiltering"));
+    }
+
+    @Test
+    public void testAttributeDefOptionsWithMixedTypes() throws Exception {
+        String json = "{\"name\":\"attr1\",\"typeName\":\"string\",\"options\":{" +
+                "\"applicableEntityTypes\":\"[\\\"Asset\\\"]\"," +
+                "\"showAsFeatured\":true," +
+                "\"showInOverview\":false," +
+                "\"multiValueSelect\":false," +
+                "\"isRichText\":\"true\"," +
+                "\"allowSearch\":false," +
+                "\"allowFiltering\":true," +
+                "\"maxStrLength\":\"100000000\"," +
+                "\"isEnum\":\"false\"" +
+                "}}";
+        AtlasStructDef.AtlasAttributeDef attrDef = mapper.readValue(json, AtlasStructDef.AtlasAttributeDef.class);
+
+        assertNotNull(attrDef.getOptions());
+        assertEquals("[\"Asset\"]", attrDef.getOptions().get("applicableEntityTypes"));
+        assertEquals("true", attrDef.getOptions().get("showAsFeatured"));
+        assertEquals("false", attrDef.getOptions().get("showInOverview"));
+        assertEquals("false", attrDef.getOptions().get("multiValueSelect"));
+        assertEquals("true", attrDef.getOptions().get("isRichText"));
+        assertEquals("false", attrDef.getOptions().get("allowSearch"));
+        assertEquals("true", attrDef.getOptions().get("allowFiltering"));
+        assertEquals("100000000", attrDef.getOptions().get("maxStrLength"));
+        assertEquals("false", attrDef.getOptions().get("isEnum"));
+    }
+
+    @Test
+    public void testAttributeDefOptionsWithNestedArray() throws Exception {
+        String json = "{\"name\":\"attr1\",\"typeName\":\"string\",\"options\":{\"types\":[\"Table\",\"Column\"]}}";
+        AtlasStructDef.AtlasAttributeDef attrDef = mapper.readValue(json, AtlasStructDef.AtlasAttributeDef.class);
+
+        assertNotNull(attrDef.getOptions());
+        String types = attrDef.getOptions().get("types");
+        assertNotNull(types);
+        assertTrue(types.contains("Table"));
+        assertTrue(types.contains("Column"));
+    }
+
+    @Test
+    public void testAttributeDefOptionsWithNestedObject() throws Exception {
+        String json = "{\"name\":\"attr1\",\"typeName\":\"string\",\"options\":{\"config\":{\"a\":1,\"b\":\"x\"}}}";
+        AtlasStructDef.AtlasAttributeDef attrDef = mapper.readValue(json, AtlasStructDef.AtlasAttributeDef.class);
+
+        assertNotNull(attrDef.getOptions());
+        String config = attrDef.getOptions().get("config");
+        assertNotNull(config);
+        assertTrue(config.contains("\"a\""));
+        assertTrue(config.contains("\"b\""));
+    }
+
+    // =========================================================================
+    // Roundtrip test: deserialize with booleans -> serialize -> deserialize
+    // =========================================================================
+
+    @Test
+    public void testSerializationRoundtrip() throws Exception {
+        String json = "{\"name\":\"test\",\"options\":{\"isRichText\":true,\"count\":5,\"label\":\"hello\"}}";
+        AtlasEntityDef def = mapper.readValue(json, AtlasEntityDef.class);
+
+        assertEquals("true", def.getOptions().get("isRichText"));
+        assertEquals("5", def.getOptions().get("count"));
+        assertEquals("hello", def.getOptions().get("label"));
+
+        // Serialize back
+        String serialized = mapper.writeValueAsString(def);
+
+        // Serialized form should have string values
+        assertTrue(serialized.contains("\"isRichText\":\"true\""));
+        assertTrue(serialized.contains("\"count\":\"5\""));
+
+        // Deserialize again from the serialized form (all strings now)
+        AtlasEntityDef def2 = mapper.readValue(serialized, AtlasEntityDef.class);
+        assertEquals(def.getOptions().get("isRichText"), def2.getOptions().get("isRichText"));
+        assertEquals(def.getOptions().get("count"), def2.getOptions().get("count"));
+        assertEquals(def.getOptions().get("label"), def2.getOptions().get("label"));
+    }
+
+    // =========================================================================
+    // BusinessMetadataDef (the exact type from the failing request)
+    // =========================================================================
+
+    @Test
+    public void testBusinessMetadataDefWithBooleanOptions() throws Exception {
+        String json = "{\"category\":\"BUSINESS_METADATA\",\"name\":\"TestBM\",\"options\":{\"logoType\":\"icon\",\"imageId\":null}}";
+        AtlasBusinessMetadataDef bmDef = mapper.readValue(json, AtlasBusinessMetadataDef.class);
+
+        assertNotNull(bmDef.getOptions());
+        assertEquals("icon", bmDef.getOptions().get("logoType"));
+        assertNull(bmDef.getOptions().get("imageId"));
+    }
+}


### PR DESCRIPTION
## Change description

 The PUT /api/meta/types/typedefs API returned 400 Bad Request because the frontend sent options values as JSON primitives (true, false, 100) instead of strings ("true", "false", "100"). Jackson's default deserializer for Map<String, String> rejects non-string values.     

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
