### PR TITLE
Fix __typeName.keyword parity for atlas_graph_vertex_index

### DIFF
--- a/addons/elasticsearch/es-mappings.json
+++ b/addons/elasticsearch/es-mappings.json
@@ -1,5 +1,41 @@
 {
   "properties": {
+    "__typeName": {
+      "type": "text",
+      "copy_to": ["all"],
+      "fields": {
+        "keyword": {
+          "type": "keyword",
+          "normalizer": "atlan_normalizer"
+        }
+      }
+    },
+    "__superTypeNames": {
+      "type": "text",
+      "copy_to": ["all"],
+      "fields": {
+        "keyword": {
+          "type": "keyword",
+          "normalizer": "atlan_normalizer"
+        }
+      }
+    },
+    "__guid": {
+      "type": "keyword",
+      "copy_to": ["all"]
+    },
+    "__state": {
+      "type": "keyword",
+      "copy_to": ["all"]
+    },
+    "__traitNames": {
+      "type": "keyword",
+      "copy_to": ["all"]
+    },
+    "__propagatedTraitNames": {
+      "type": "keyword",
+      "copy_to": ["all"]
+    },
     "__qualifiedNameHierarchy": {
       "type": "text",
       "analyzer": "atlan_path_analyzer",

--- a/graphdb/migrator/src/main/java/org/apache/atlas/repository/graphdb/migrator/ElasticsearchReindexer.java
+++ b/graphdb/migrator/src/main/java/org/apache/atlas/repository/graphdb/migrator/ElasticsearchReindexer.java
@@ -239,51 +239,32 @@ public class ElasticsearchReindexer implements AutoCloseable {
     }
 
     /**
-     * Default mappings applied when the source index doesn't exist (e.g., deleted during
-     * remigration cleanup). Maps all strings to keyword to match the Atlas ES schema
-     * (addons/elasticsearch/es-mappings.json). Without this, ES dynamic mapping creates
-     * text fields which break sort/aggregation queries on __guid, __typeName, etc.
-     */
-    private static final String DEFAULT_MAPPINGS_JSON =
-        "{\"properties\":{" +
-        "\"nestedColumnOrder\":{\"type\":\"nested\",\"properties\":" +
-        "{\"version\":{\"type\":\"version\"},\"order\":{\"type\":\"keyword\"}}}," +
-        "\"relationshipList\":{\"type\":\"nested\",\"properties\":" +
-        "{\"typeName\":{\"type\":\"keyword\"},\"guid\":{\"type\":\"keyword\"}," +
-        "\"provenanceType\":{\"type\":\"integer\"},\"endName\":{\"type\":\"keyword\"}," +
-        "\"endGuid\":{\"type\":\"keyword\"},\"endTypeName\":{\"type\":\"keyword\"}," +
-        "\"endQualifiedName\":{\"type\":\"keyword\"},\"label\":{\"type\":\"keyword\"}," +
-        "\"propagateTags\":{\"type\":\"keyword\"},\"status\":{\"type\":\"keyword\"}," +
-        "\"createdBy\":{\"type\":\"keyword\"},\"updatedBy\":{\"type\":\"keyword\"}," +
-        "\"createTime\":{\"type\":\"long\"},\"updateTime\":{\"type\":\"long\"}," +
-        "\"version\":{\"type\":\"long\"}}}}," +
-        "\"dynamic_templates\":[{\"custom_metadata_strings\":" +
-        "{\"match_mapping_type\":\"string\",\"mapping\":{\"type\":\"keyword\",\"ignore_above\":5120}}}]}";
-
-    /**
      * Reads mappings and settings from the source JanusGraph ES index and returns
      * a JSON body suitable for PUT /{index} to create the target index with
      * identical field mappings and analyzer settings.
      *
-     * Falls back to default Atlas mappings (keyword for strings) if the source
-     * index doesn't exist (e.g., deleted during remigration cleanup).
+     * Returns "{}" on source absence or read failure so the matching ES index
+     * template (atlas-graph-template / atlan-template) owns the mappings. An
+     * explicit partial mappings body here would suppress the template's own
+     * properties merge, locking __typeName and other system fields into plain
+     * keyword via the dynamic template.
      */
     private String getCreateBodyFromSourceIndex(String sourceIndex) {
         if (sourceIndex == null || sourceIndex.isEmpty()) {
-            LOG.info("No source ES index configured, using default Atlas mappings");
-            return "{\"mappings\":" + DEFAULT_MAPPINGS_JSON + "}";
+            LOG.info("No source ES index configured, deferring to ES index template");
+            return "{}";
         }
 
         try {
             // Check if source index exists
             Response headResp = esClient.performRequest(new Request("HEAD", "/" + sourceIndex));
             if (headResp.getStatusLine().getStatusCode() != 200) {
-                LOG.info("Source ES index '{}' does not exist, using default Atlas mappings", sourceIndex);
-                return "{\"mappings\":" + DEFAULT_MAPPINGS_JSON + "}";
+                LOG.info("Source ES index '{}' does not exist, deferring to ES index template", sourceIndex);
+                return "{}";
             }
         } catch (IOException e) {
-            LOG.info("Source ES index '{}' not found, using default Atlas mappings", sourceIndex);
-            return "{\"mappings\":" + DEFAULT_MAPPINGS_JSON + "}";
+            LOG.info("Source ES index '{}' not found, deferring to ES index template", sourceIndex);
+            return "{}";
         }
 
         try {
@@ -341,9 +322,9 @@ public class ElasticsearchReindexer implements AutoCloseable {
             return createBody.toString();
 
         } catch (Exception e) {
-            LOG.warn("Failed to read mappings/settings from source index '{}', falling back to default Atlas mappings: {}",
+            LOG.warn("Failed to read mappings/settings from source index '{}', deferring to ES index template: {}",
                      sourceIndex, e.getMessage());
-            return "{\"mappings\":" + DEFAULT_MAPPINGS_JSON + "}";
+            return "{}";
         }
     }
 

--- a/webapp/src/test/resources/deploy/elasticsearch/es-mappings.json
+++ b/webapp/src/test/resources/deploy/elasticsearch/es-mappings.json
@@ -1,5 +1,46 @@
 {
   "properties": {
+    "__typeName": {
+      "type": "text",
+      "copy_to": ["all"],
+      "fields": {
+        "keyword": {
+          "type": "keyword",
+          "normalizer": "atlan_normalizer"
+        }
+      }
+    },
+    "__superTypeNames": {
+      "type": "text",
+      "copy_to": ["all"],
+      "fields": {
+        "keyword": {
+          "type": "keyword",
+          "normalizer": "atlan_normalizer"
+        }
+      }
+    },
+    "__guid": {
+      "type": "keyword",
+      "copy_to": ["all"]
+    },
+    "__state": {
+      "type": "keyword",
+      "copy_to": ["all"]
+    },
+    "__traitNames": {
+      "type": "keyword",
+      "copy_to": ["all"]
+    },
+    "__propagatedTraitNames": {
+      "type": "keyword",
+      "copy_to": ["all"]
+    },
+    "__qualifiedNameHierarchy": {
+      "type": "text",
+      "analyzer": "atlan_path_analyzer",
+      "search_analyzer": "keyword"
+    },
     "nestedColumnOrder": {
       "type": "nested",
       "properties": {


### PR DESCRIPTION
## Summary

Restore JG parity for `__typeName` and `__superTypeNames` in the Cassandra-backend ES vertex index. Two regressions were producing `__typeName: keyword+ignore_above:5120` (no `.keyword` subfield) on `atlas_graph_vertex_index`, breaking the migration verification script and every consumer that queries `__typeName.keyword:X`.

**Regression 1** — `ElasticsearchReindexer.getCreateBodyFromSourceIndex` (commit `41803ddbe7`, Mar 4)
On source-absence / copy-failure the fallback was changed from `"{}"` to an explicit `DEFAULT_MAPPINGS_JSON` body. A partial explicit `mappings` block in `PUT /{index}` suppresses the matching index template's `properties` merge, so `__typeName` was never explicitly mapped and got dynamic-templated as plain keyword on first bulk write.

**Regression 2** — `addons/elasticsearch/es-mappings.json`
Never declared the system-field mappings. JG masked this because JanusGraph's own mixed-index registration fills them in; the Cassandra backend has no such implicit pass, so any creation path that defers to the template (including `CassandraGraphManagement.createESIndex`, fresh tenants, and the reverted reindexer fallback) produced a broken shape.

Observed on `enginemp02` (MS-1070):
```
JG:  __typeName = {text + .keyword(atlan_normalizer) + copy_to:[all]}
ZG:  __typeName = {keyword + ignore_above:5120}         ← broken
```
Verification script's `__typeName.keyword:X` → 0 hits; `__typeName:X` → correct counts.

## Changes

- **`ElasticsearchReindexer.java`**: revert all four fallback returns in `getCreateBodyFromSourceIndex` to `"{}"`; delete `DEFAULT_MAPPINGS_JSON`. Source-copy primary path is unchanged — happy-path migrations already produce the correct mapping.
- **`addons/elasticsearch/es-mappings.json`** (and the webapp test-resources mirror): add explicit mappings for
  - `__typeName`, `__superTypeNames` → `text + copy_to:[all] + fields.keyword(atlan_normalizer)` (exact JG shape)
  - `__guid`, `__state`, `__traitNames`, `__propagatedTraitNames` → `keyword + copy_to:[all]` (exact JG shape)

Both templates `atlan-template` and `atlas-graph-template` consume this file at Atlas startup, so JG and ZG indices pick up the same mappings.

## Why this is the right fix

- **One JSON change covers three creation paths**: `ElasticsearchReindexer.ensureIndexExists` fallback, `CassandraGraphManagement.createESIndex`, and any fresh-tenant `PUT {}` — all rely on the template.
- **No behavior change for JG tenants**: `atlan-template` was already fed the same file; making the mappings explicit is belt-and-braces. JanusGraph's own `addMixedIndex` still registers these fields at startup, which is idempotent against the template.
- **Removes dead code** (`DEFAULT_MAPPINGS_JSON`) that was re-encoding template contents out of band — a classic source of drift.

## Scope caveats

- **Existing diverged indices** (like enginemp02's current `atlas_graph_vertex_index`): `__typeName` is locked as base `keyword`; ES won't let us swap to `text` in place. Remediation is to delete the ZG index and re-run the migration, or hand-edit the mapping to add the subfield via `addSubFieldsToExistingField` style PUT.
- Does not touch Phase 7 verification script — not needed once mappings are correct.

## Test plan

- [x] `mvn compile -pl graphdb/migrator -am` passes on this branch.
- [x] Live reproduction on enginemp02 cluster: PUT of JG-source mappings into a fresh ES index produces `__typeName: text + .keyword(atlan_normalizer)` — the copy path works end-to-end.
- [ ] Deploy migrator jar + ES template update to a dev tenant, run `--fresh` migration, verify `GET /atlas_graph_vertex_index/_mapping/field/__typeName` shows the JG shape.
- [ ] Re-run `atlas_migrate_tenant.sh` Phase 7 verification on a freshly-migrated tenant — expect Tables/Connections/AuthPolicy/AuthService to pass without script changes.
- [ ] Fresh-tenant (no JG source) install: confirm `atlas_graph_vertex_index` picks up the correct mappings from `atlas-graph-template` alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)