### PR TITLE
Harden ZG migrator index creation to guarantee JG mapping parity

### DIFF
--- a/addons/elasticsearch/es-mappings.json
+++ b/addons/elasticsearch/es-mappings.json
@@ -36,11 +36,6 @@
       "type": "keyword",
       "copy_to": ["all"]
     },
-    "__qualifiedNameHierarchy": {
-      "type": "text",
-      "analyzer": "atlan_path_analyzer",
-      "search_analyzer": "keyword"
-    },
     "nestedColumnOrder": {
       "type": "nested",
       "properties": {

--- a/graphdb/migrator/src/main/java/org/apache/atlas/repository/graphdb/migrator/ElasticsearchReindexer.java
+++ b/graphdb/migrator/src/main/java/org/apache/atlas/repository/graphdb/migrator/ElasticsearchReindexer.java
@@ -202,20 +202,24 @@ public class ElasticsearchReindexer implements AutoCloseable {
         verifyEsDocCount(esIndex, totalBulkItemSuccesses);
     }
 
-    void ensureIndexExists(String esIndex) {
-        try {
-            Response response = esClient.performRequest(new Request("HEAD", "/" + esIndex));
-            if (response.getStatusLine().getStatusCode() == 200) {
-                LOG.info("ES index '{}' already exists", esIndex);
-                return;
-            }
-        } catch (IOException e) {
-            // Index doesn't exist, create it below
-        }
+    // Name of the ES index template covering the atlas_graph_* pattern. We delete
+    // it prior to creating the target vertex index so its mappings cannot merge
+    // with the JG-copied body and produce validation conflicts (e.g. on
+    // __qualifiedNameHierarchy, where JG's keyword shape clashes with the
+    // template's text+search_analyzer shape). Atlas re-creates this template on
+    // its next startup via initElasticsearch().
+    private static final String ATLAS_GRAPH_TEMPLATE = "atlas-graph-template";
 
-        // Try to copy mappings + settings from the source JanusGraph index (migrated tenant).
-        // If the source index doesn't exist (fresh tenant), fall back to empty body
-        // so the ES index template (atlan-template) applies its defaults.
+    void ensureIndexExists(String esIndex) {
+        // Wipe anything that could shape the new index differently from the
+        // JG source: (1) the matching template, (2) any pre-existing index.
+        // Without these, a partial overlap (template + body, or prior
+        // dynamically-mapped index) silently corrupts the system-field shapes.
+        deleteTemplateIfExists(ATLAS_GRAPH_TEMPLATE);
+        deleteIndexIfExists(esIndex);
+
+        // Copy mappings + settings from the source JanusGraph index (migrated tenant).
+        // If the source index doesn't exist (fresh tenant), fall back to empty body.
         String sourceIndex = config.getSourceEsIndex();
         String createBody = getCreateBodyFromSourceIndex(sourceIndex);
 
@@ -228,13 +232,42 @@ public class ElasticsearchReindexer implements AutoCloseable {
             esClient.performRequest(createReq);
 
             if ("{}".equals(createBody)) {
-                LOG.info("Created ES index '{}' (fresh tenant — settings from ES index template)", esIndex);
+                LOG.info("Created ES index '{}' (fresh tenant — empty body, no template merge)", esIndex);
             } else {
                 LOG.info("Created ES index '{}' with mappings+settings copied from source index '{}'",
                          esIndex, sourceIndex);
             }
         } catch (IOException e) {
-            LOG.warn("Failed to create ES index '{}' (may already exist): {}", esIndex, e.getMessage());
+            // Primary path failed — this must not be silent, otherwise ES auto-creates the
+            // index later via dynamic mapping with shapes that diverge from JG parity.
+            throw new RuntimeException(
+                "Failed to create ES index '" + esIndex + "' with JG-copied mappings. "
+                + "Migration cannot proceed safely — the index would be auto-created with "
+                + "the wrong field shapes on first bulk write. Original error: " + e.getMessage(), e);
+        }
+    }
+
+    private void deleteTemplateIfExists(String templateName) {
+        try {
+            esClient.performRequest(new Request("DELETE", "/_template/" + templateName));
+            LOG.info("Deleted ES index template '{}' (will be recreated on next Atlas startup)", templateName);
+        } catch (IOException e) {
+            // 404 is expected when the template is absent. Any other error we log
+            // and continue — the subsequent PUT will fail loudly if the template
+            // is still present and conflicts.
+            LOG.debug("Template '{}' delete skipped ({}): {}",
+                      templateName, e.getClass().getSimpleName(), e.getMessage());
+        }
+    }
+
+    private void deleteIndexIfExists(String index) {
+        try {
+            esClient.performRequest(new Request("DELETE", "/" + index));
+            LOG.info("Deleted existing ES index '{}'", index);
+        } catch (IOException e) {
+            // 404 is expected when the index doesn't exist.
+            LOG.debug("Index '{}' delete skipped ({}): {}",
+                      index, e.getClass().getSimpleName(), e.getMessage());
         }
     }
 

--- a/webapp/src/main/java/org/apache/atlas/Atlas.java
+++ b/webapp/src/main/java/org/apache/atlas/Atlas.java
@@ -360,11 +360,11 @@ public final class Atlas {
 
         // Also create a template for atlas_graph_* pattern so the Cassandra graph backend
         // gets the same analyzers, normalizers, and dynamic templates when its index is created.
-        // This is best-effort — failure does not block startup.
-        if (!INDEX_PREFIX.equals("atlas_graph_")) {
-            createESTemplateIfNotExists(esClient, "atlas-graph-template",
-                    Arrays.asList("atlas_graph_*"), settingsJson, mappingsJson, false);
-        }
+        // Always invoked — regardless of current INDEX_PREFIX — so the template is present
+        // for the migrator to rely on even when Atlas boots in janus mode before a migration.
+        // Best-effort — failure does not block startup.
+        createESTemplateIfNotExists(esClient, "atlas-graph-template",
+                Arrays.asList("atlas_graph_*"), settingsJson, mappingsJson, false);
 
         // Create a unified alias "atlas_vertex_index" pointing to the actual vertex index.
         // This allows consumers to use a stable alias regardless of the backend-specific index name.

--- a/webapp/src/test/resources/deploy/elasticsearch/es-mappings.json
+++ b/webapp/src/test/resources/deploy/elasticsearch/es-mappings.json
@@ -36,11 +36,6 @@
       "type": "keyword",
       "copy_to": ["all"]
     },
-    "__qualifiedNameHierarchy": {
-      "type": "text",
-      "analyzer": "atlan_path_analyzer",
-      "search_analyzer": "keyword"
-    },
     "nestedColumnOrder": {
       "type": "nested",
       "properties": {


### PR DESCRIPTION
## Summary

Make the ZG vertex index creation path deterministic so `atlas_graph_vertex_index` ends up byte-identical to `janusgraph_vertex_index`'s shape for system fields like `__typeName`, `__superTypeNames`, `__timestamp`, etc. Follow-up to #6589 after seeing the same divergence return on enginemp02 — root-caused to a three-way interaction between `es-mappings.json`, the migrator's silent PUT failure, and Atlas's startup template guard.

## Why the prior fix wasn't enough

#6589 updated `es-mappings.json` with explicit system-field mappings. Enginemp02 still landed with `__typeName: keyword+ignore_above:5120` (no `.keyword` subfield) after re-migration. Migrator log showed:

```
INFO  ElasticsearchReindexer - Copied mappings+settings from source index 'janusgraph_vertex_index' for target index creation
WARN  ElasticsearchReindexer - Failed to create ES index 'atlas_graph_vertex_index' (may already exist):
  HTTP/1.1 400 Bad Request
  {"error": ... "unknown parameter [search_analyzer] on mapper [__qualifiedNameHierarchy] of type [keyword]"}
```

Three stacked bugs:

1. **Template/body merge conflict on `__qualifiedNameHierarchy`**: `es-mappings.json` declares it as `text + analyzer: atlan_path_analyzer + search_analyzer: keyword`, but JanusGraph's `addMixedIndex` registers it as plain `keyword`. The migrator copies JG's body; ES matches `atlas-graph-template` and merges template's `search_analyzer` onto body's `keyword` type → `search_analyzer` isn't allowed on keyword fields → **400**.
2. **Silent PUT failure**: `ensureIndexExists` caught the 400 as a `WARN`, then bulk writes auto-created the index via template-only mapping. That path doesn't know about the fields in the body, so fields dynamically discovered on first write get the dynamic-template shape (flat keyword), not the JG shape.
3. **Atlas template guard**: `initElasticsearch` only invoked `createESTemplateIfNotExists("atlas-graph-template", ...)` when `INDEX_PREFIX != "atlas_graph_"`. So once a tenant was already on cassandra, atlas-graph-template was never re-established on restarts.

## Changes

### 1. `addons/elasticsearch/es-mappings.json` (and webapp test-resources mirror)
Remove the `__qualifiedNameHierarchy` property declaration. JG registers it as `keyword` via `addMixedIndex`; having a conflicting `text + search_analyzer` in the template was the source of the merge conflict and never actually applied to JG indices anyway (JG's explicit mapping won per-field).

### 2. `ElasticsearchReindexer.ensureIndexExists`
Always runs this sequence now, no early return, no swallowed failures:

```
1. DELETE /_template/atlas-graph-template   // removed so it cannot merge with body
2. DELETE /atlas_graph_vertex_index         // fresh recreation every time
3. getCreateBodyFromSourceIndex(JG)         // copy mappings+settings from JG source
4. PUT /atlas_graph_vertex_index            // throws on failure (no more silent WARN)
```

Atlas recreates the deleted template on its next startup (after the backend switch), so we're not leaving the cluster permanently template-less.

A PUT failure now throws `RuntimeException` rather than `WARN` + continue. Silent fallback to template-only auto-create was the mechanism that masked this bug; stopping that means any future mapping mismatch fails loud.

### 3. `Atlas.initElasticsearch`
Removed the `if (!INDEX_PREFIX.equals("atlas_graph_"))` guard around the `atlas-graph-template` creation. Now `createESTemplateIfNotExists("atlas-graph-template", ...)` runs on every Atlas startup regardless of current backend. Atlas in cassandra mode will also register/maintain the template so that subsequent re-migrations have it available.

`createESTemplateIfNotExists` itself is unchanged — still creates only if absent (per your direction).

## Test plan

- [x] `mvn compile -pl graphdb/migrator,webapp -am` — passes.
- [x] JSON validated (`__qualifiedNameHierarchy` removed cleanly, no other shapes disturbed).
- [ ] Deploy to a dev tenant, trigger `--fresh` migration:
  - Expect: migrator logs `Deleted ES index template 'atlas-graph-template'` → `Deleted existing ES index 'atlas_graph_vertex_index'` (if present) → `Created ES index 'atlas_graph_vertex_index' with mappings+settings copied from source index 'janusgraph_vertex_index'`.
  - Verify: `GET /atlas_graph_vertex_index/_mapping/field/__typeName` returns `text + .keyword(atlan_normalizer) + copy_to:[all]` (full JG parity).
  - Verify: `GET /atlas_graph_vertex_index/_mapping/field/__timestamp` returns `long + fields.date(epoch_millis)`.
- [ ] Post-migration `__typeName.keyword:Table`-style queries return correct counts.
- [ ] Atlas restart in cassandra mode: verify `atlas-graph-template` still present / gets recreated (was previously skipped).
- [ ] Atlas restart in janus mode on a fresh tenant (no prior template): verify template now covers `atlas_graph_*` so a future migrator run doesn't need the delete-first dance to be perfect.

## Rollback

Revert is safe. The migrator's new delete-first flow is symmetric with the old flow's eventual state (target index exists with JG mappings); rolling back reinstates the fragile silent-WARN behavior but doesn't leave anything corrupt on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)