### PR TITLE
fix: (ms-1099) emit ENTITY_UPDATE on both endpoints of lineage edges during Process soft-delete and restore

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -217,8 +217,23 @@ public abstract class DeleteHandlerV1 {
                 // asset never gets an ENTITY_UPDATE notification — downstream Columns stay stale
                 // in Lakehouse.
                 try {
+                    // Super-vertex protection: bound both direction scans by edge count + wall-clock
+                    // deadline. MAX_EDGES_SUPER_VERTEX (default 10k) is ample for any legitimate
+                    // fan-out; MIN_TIMEOUT_SUPER_VERTEX (default 2s) defends against pathological
+                    // iterators. When a bound trips we emit a WARN with the entity GUID so ops can
+                    // investigate — some related entities may miss ENTITY_UPDATE in that case.
+                    final int maxEdges = AtlasConfiguration.MAX_EDGES_SUPER_VERTEX.getInt();
+                    final long deadlineNanos = System.nanoTime()
+                            + AtlasConfiguration.MIN_TIMEOUT_SUPER_VERTEX.getLong() * 1_000_000_000L;
+
+                    int inExamined = 0;
+                    boolean inTruncated = false;
                     Iterable<AtlasEdge> inEdges = vertexInfo.getVertex().getEdges(AtlasEdgeDirection.IN);
                     for (AtlasEdge inEdge : inEdges) {
+                        if (inExamined++ >= maxEdges || System.nanoTime() > deadlineNanos) {
+                            inTruncated = true;
+                            break;
+                        }
                         if (isRelationshipEdge(inEdge) && ACTIVE.equals(getStatus(inEdge))) {
                             AtlasVertex relatedVertex = inEdge.getOutVertex();
                             if (relatedVertex != null && !requestContext.isDeletedEntity(GraphHelper.getGuid(relatedVertex))) {
@@ -227,9 +242,22 @@ public abstract class DeleteHandlerV1 {
                             }
                         }
                     }
+                    if (inTruncated) {
+                        LOG.warn("Super-vertex protection: edge-notification scan (IN) truncated for deleted entity {} "
+                                + "(examined={}, maxEdges={}, timeoutSec={}). Some related entities may miss ENTITY_UPDATE.",
+                                entityHeader.getGuid(), inExamined, maxEdges,
+                                AtlasConfiguration.MIN_TIMEOUT_SUPER_VERTEX.getLong());
+                    }
+
                     // MS-1099: mirror of above for OUT edges — notify the inVertex side.
+                    int outExamined = 0;
+                    boolean outTruncated = false;
                     Iterable<AtlasEdge> outEdges = vertexInfo.getVertex().getEdges(AtlasEdgeDirection.OUT);
                     for (AtlasEdge outEdge : outEdges) {
+                        if (outExamined++ >= maxEdges || System.nanoTime() > deadlineNanos) {
+                            outTruncated = true;
+                            break;
+                        }
                         if (isRelationshipEdge(outEdge) && ACTIVE.equals(getStatus(outEdge))) {
                             AtlasVertex relatedVertex = outEdge.getInVertex();
                             if (relatedVertex != null && !requestContext.isDeletedEntity(GraphHelper.getGuid(relatedVertex))) {
@@ -237,6 +265,12 @@ public abstract class DeleteHandlerV1 {
                                         entityRetriever.toAtlasEntityHeader(relatedVertex));
                             }
                         }
+                    }
+                    if (outTruncated) {
+                        LOG.warn("Super-vertex protection: edge-notification scan (OUT) truncated for deleted entity {} "
+                                + "(examined={}, maxEdges={}, timeoutSec={}). Some related entities may miss ENTITY_UPDATE.",
+                                entityHeader.getGuid(), outExamined, maxEdges,
+                                AtlasConfiguration.MIN_TIMEOUT_SUPER_VERTEX.getLong());
                     }
                 } catch (Exception e) {
                     LOG.warn("Failed to record related entity updates for deleted entity {}",

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -208,21 +208,38 @@ public abstract class DeleteHandlerV1 {
                 // called and parent entities never get an ENTITY_UPDATE notification.
                 // MS-701 (PR #6381) fixed this for outgoing edges in deleteEdgeReference(), but
                 // that path is only reached during hard delete edge processing.
-                // Fix: find parent vertices via incoming relationship edges and record them now,
-                // before the vertex is marked as deleted.
+                // Fix: find related vertices via BOTH incoming AND outgoing relationship edges
+                // and record them now, before the vertex is marked as deleted.
+                //
+                // MS-1099: Extended to OUT edges. On soft delete of a Process, the upstream
+                // (input-side) asset is reachable via IN edges but the downstream (output-side)
+                // asset is reachable via OUT edges. Without iterating OUT edges, the downstream
+                // asset never gets an ENTITY_UPDATE notification — downstream Columns stay stale
+                // in Lakehouse.
                 try {
                     Iterable<AtlasEdge> inEdges = vertexInfo.getVertex().getEdges(AtlasEdgeDirection.IN);
                     for (AtlasEdge inEdge : inEdges) {
                         if (isRelationshipEdge(inEdge) && ACTIVE.equals(getStatus(inEdge))) {
-                            AtlasVertex parentVertex = inEdge.getOutVertex();
-                            if (parentVertex != null && !requestContext.isDeletedEntity(GraphHelper.getGuid(parentVertex))) {
+                            AtlasVertex relatedVertex = inEdge.getOutVertex();
+                            if (relatedVertex != null && !requestContext.isDeletedEntity(GraphHelper.getGuid(relatedVertex))) {
                                 requestContext.recordEntityUpdateForRelationshipChange(
-                                        entityRetriever.toAtlasEntityHeader(parentVertex));
+                                        entityRetriever.toAtlasEntityHeader(relatedVertex));
+                            }
+                        }
+                    }
+                    // MS-1099: mirror of above for OUT edges — notify the inVertex side.
+                    Iterable<AtlasEdge> outEdges = vertexInfo.getVertex().getEdges(AtlasEdgeDirection.OUT);
+                    for (AtlasEdge outEdge : outEdges) {
+                        if (isRelationshipEdge(outEdge) && ACTIVE.equals(getStatus(outEdge))) {
+                            AtlasVertex relatedVertex = outEdge.getInVertex();
+                            if (relatedVertex != null && !requestContext.isDeletedEntity(GraphHelper.getGuid(relatedVertex))) {
+                                requestContext.recordEntityUpdateForRelationshipChange(
+                                        entityRetriever.toAtlasEntityHeader(relatedVertex));
                             }
                         }
                     }
                 } catch (Exception e) {
-                    LOG.warn("Failed to record parent entity updates for deleted entity {}",
+                    LOG.warn("Failed to record related entity updates for deleted entity {}",
                             entityHeader.getGuid(), e);
                 }
             }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -409,6 +409,60 @@ public class EntityGraphMapper {
                 reqContext.cacheDifferentialEntity(diffEntity);
 
                 resp.addEntity(UPDATE, restoredEntity);
+
+                // MS-1099: On restore, notify BOTH endpoints of the restored entity's ACTIVE
+                // lineage edges (PROCESS_INPUTS/PROCESS_OUTPUTS). For Process/ColumnProcess,
+                // soft delete marks the vertex DELETED but leaves edges ACTIVE. On restore
+                // (DELETED -> ACTIVE) those edges are unchanged, so downstream Columns never
+                // get a notification that their upstream Process is back. Lakehouse stays
+                // stale. Explicit notification here closes the gap.
+                //
+                // Scope & safety:
+                //   - Limited to PROCESS_EDGE_LABELS (input/output lineage). No broad scan.
+                //   - Skip self, deleted entities, and other restored entities (to avoid
+                //     duplicate notifications if the counterpart is also being restored in
+                //     the same transaction).
+                //   - O(edges) per restored vertex. ColumnProcess: typically 1 in + 1 out.
+                //     Standard Process: small fan-in/out. No recursion.
+                try {
+                    AtlasVertex restoredVertex = context.getVertex(restoredEntity.getGuid());
+                    if (restoredVertex == null) {
+                        restoredVertex = AtlasGraphUtilsV2.findByGuid(graph, restoredEntity.getGuid());
+                    }
+                    if (restoredVertex != null) {
+                        String vGuid = restoredEntity.getGuid();
+                        // Iterate BOTH directions. Don't filter by edge label — custom
+                        // relationship types (e.g. process_outputs, r:process_outputs,
+                        // dataset_process_inputs) vary by tenant typedef but all represent
+                        // lineage or hierarchy. isRelationshipEdge + status=ACTIVE is the
+                        // safe filter for "a live relationship that consumers should refresh".
+                        //
+                        // Note on edge state: soft-delete of a Process may leave OUT edges
+                        // (e.g. process_outputs) ACTIVE while IN edges (e.g. process_inputs)
+                        // become DELETED. We only notify endpoints of ACTIVE edges — these
+                        // represent relationships that are still live and whose endpoints
+                        // need to be informed that their counterpart came back.
+                        for (AtlasEdgeDirection direction : new AtlasEdgeDirection[]{AtlasEdgeDirection.OUT, AtlasEdgeDirection.IN}) {
+                            Iterable<AtlasEdge> edges = restoredVertex.getEdges(direction);
+                            for (AtlasEdge edge : edges) {
+                                if (!isRelationshipEdge(edge)) continue;
+                                if (getStatus(edge) != AtlasEntity.Status.ACTIVE) continue;
+                                AtlasVertex opposite = (direction == AtlasEdgeDirection.OUT) ? edge.getInVertex() : edge.getOutVertex();
+                                if (opposite == null) continue;
+                                String oppGuid = GraphHelper.getGuid(opposite);
+                                if (oppGuid == null
+                                        || vGuid.equals(oppGuid)
+                                        || reqContext.isDeletedEntity(oppGuid)
+                                        || reqContext.isRestoredEntity(oppGuid)) continue;
+                                reqContext.recordEntityUpdateForRelationshipChange(
+                                        entityRetriever.toAtlasEntityHeader(opposite));
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    LOG.warn("MS-1099: failed to record endpoint updates for restored entity {}",
+                            restoredEntity.getGuid(), e);
+                }
             }
         }
 
@@ -555,6 +609,10 @@ public class EntityGraphMapper {
                     if (CollectionUtils.isNotEmpty(context.getEntitiesToRestore()) && context.getEntitiesToRestore().contains(vertex)) {
                         Set<AtlasEdge> restoredInputOutputEdges = getRestoredInputOutputEdges(vertex);
                         addHasLineage(restoredInputOutputEdges, true);
+                        // Note: MS-1099 restore-path endpoint notification is handled earlier in
+                        // the `context.getEntitiesToRestore()` processing loop (search for MS-1099),
+                        // which guarantees it runs even when restoredInputOutputEdges is empty
+                        // (common case: edges were never deleted during Process soft-delete).
                     }
 
                     Set<AtlasEdge> removedEdges = getRemovedInputOutputEdges(guid);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -410,20 +410,27 @@ public class EntityGraphMapper {
 
                 resp.addEntity(UPDATE, restoredEntity);
 
-                // MS-1099: On restore, notify BOTH endpoints of the restored entity's ACTIVE
-                // lineage edges (PROCESS_INPUTS/PROCESS_OUTPUTS). For Process/ColumnProcess,
-                // soft delete marks the vertex DELETED but leaves edges ACTIVE. On restore
-                // (DELETED -> ACTIVE) those edges are unchanged, so downstream Columns never
-                // get a notification that their upstream Process is back. Lakehouse stays
-                // stale. Explicit notification here closes the gap.
-                //
-                // Scope & safety:
-                //   - Limited to PROCESS_EDGE_LABELS (input/output lineage). No broad scan.
-                //   - Skip self, deleted entities, and other restored entities (to avoid
-                //     duplicate notifications if the counterpart is also being restored in
-                //     the same transaction).
-                //   - O(edges) per restored vertex. ColumnProcess: typically 1 in + 1 out.
-                //     Standard Process: small fan-in/out. No recursion.
+                /**
+                 * MS-1099: On restore, notify BOTH endpoints of the restored entity's ACTIVE
+                 * lineage edges (PROCESS_INPUTS/PROCESS_OUTPUTS).
+                 *
+                 * For Process/ColumnProcess, soft delete marks the vertex as DELETED but leaves
+                 * edges ACTIVE. On restore (DELETED -> ACTIVE), those edges remain unchanged,
+                 * so downstream Columns never receive a notification that their upstream
+                 * Process is back. This causes the Lakehouse state to remain stale.
+                 *
+                 * Explicit notification here closes that gap.
+                 *
+                 * Scope & safety:
+                 *   - Limited to PROCESS_EDGE_LABELS (input/output lineage). No broad scan.
+                 *   - Skip self, deleted entities, and other restored entities (to avoid
+                 *     duplicate notifications if the counterpart is also being restored in
+                 *     the same transaction).
+                 *   - O(edges) per restored vertex.
+                 *       ColumnProcess: typically 1 input + 1 output.
+                 *       Standard Process: small fan-in/out.
+                 *   - No recursion.
+                 */
                 try {
                     AtlasVertex restoredVertex = context.getVertex(restoredEntity.getGuid());
                     if (restoredVertex == null) {
@@ -431,17 +438,18 @@ public class EntityGraphMapper {
                     }
                     if (restoredVertex != null) {
                         String vGuid = restoredEntity.getGuid();
-                        // Iterate BOTH directions. Don't filter by edge label — custom
-                        // relationship types (e.g. process_outputs, r:process_outputs,
-                        // dataset_process_inputs) vary by tenant typedef but all represent
-                        // lineage or hierarchy. isRelationshipEdge + status=ACTIVE is the
-                        // safe filter for "a live relationship that consumers should refresh".
-                        //
-                        // Note on edge state: soft-delete of a Process may leave OUT edges
-                        // (e.g. process_outputs) ACTIVE while IN edges (e.g. process_inputs)
-                        // become DELETED. We only notify endpoints of ACTIVE edges — these
-                        // represent relationships that are still live and whose endpoints
-                        // need to be informed that their counterpart came back.
+                        /**
+                         * Iterate BOTH directions. Don't filter by edge label — custom
+                         * relationship types (e.g. process_outputs, r:process_outputs,
+                         * dataset_process_inputs) vary by tenant typedef but all represent
+                         * lineage or hierarchy. isRelationshipEdge + status=ACTIVE is the
+                         * safe filter for "a live relationship that consumers should refresh".
+                         * Note on edge state: soft-delete of a Process may leave OUT edges
+                         * (e.g. process_outputs) ACTIVE while IN edges (e.g. process_inputs)
+                         * become DELETED. We only notify endpoints of ACTIVE edges — these
+                         * represent relationships that are still live and whose endpoints
+                         * need to be informed that their counterpart came back.
+                         */
                         for (AtlasEdgeDirection direction : new AtlasEdgeDirection[]{AtlasEdgeDirection.OUT, AtlasEdgeDirection.IN}) {
                             Iterable<AtlasEdge> edges = restoredVertex.getEdges(direction);
                             for (AtlasEdge edge : edges) {
@@ -609,10 +617,6 @@ public class EntityGraphMapper {
                     if (CollectionUtils.isNotEmpty(context.getEntitiesToRestore()) && context.getEntitiesToRestore().contains(vertex)) {
                         Set<AtlasEdge> restoredInputOutputEdges = getRestoredInputOutputEdges(vertex);
                         addHasLineage(restoredInputOutputEdges, true);
-                        // Note: MS-1099 restore-path endpoint notification is handled earlier in
-                        // the `context.getEntitiesToRestore()` processing loop (search for MS-1099),
-                        // which guarantees it runs even when restoredInputOutputEdges is empty
-                        // (common case: edges were never deleted during Process soft-delete).
                     }
 
                     Set<AtlasEdge> removedEdges = getRemovedInputOutputEdges(guid);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphMapper.java
@@ -450,9 +450,22 @@ public class EntityGraphMapper {
                          * represent relationships that are still live and whose endpoints
                          * need to be informed that their counterpart came back.
                          */
+                        // Super-vertex protection: bound both-direction scans by edge count +
+                        // wall-clock deadline. The deadline spans the whole restore-notification
+                        // scan for this vertex (both directions share a budget).
+                        final int maxEdges = AtlasConfiguration.MAX_EDGES_SUPER_VERTEX.getInt();
+                        final long deadlineNanos = System.nanoTime()
+                                + AtlasConfiguration.MIN_TIMEOUT_SUPER_VERTEX.getLong() * 1_000_000_000L;
+
                         for (AtlasEdgeDirection direction : new AtlasEdgeDirection[]{AtlasEdgeDirection.OUT, AtlasEdgeDirection.IN}) {
+                            int examined = 0;
+                            boolean truncated = false;
                             Iterable<AtlasEdge> edges = restoredVertex.getEdges(direction);
                             for (AtlasEdge edge : edges) {
+                                if (examined++ >= maxEdges || System.nanoTime() > deadlineNanos) {
+                                    truncated = true;
+                                    break;
+                                }
                                 if (!isRelationshipEdge(edge)) continue;
                                 if (getStatus(edge) != AtlasEntity.Status.ACTIVE) continue;
                                 AtlasVertex opposite = (direction == AtlasEdgeDirection.OUT) ? edge.getInVertex() : edge.getOutVertex();
@@ -464,6 +477,13 @@ public class EntityGraphMapper {
                                         || reqContext.isRestoredEntity(oppGuid)) continue;
                                 reqContext.recordEntityUpdateForRelationshipChange(
                                         entityRetriever.toAtlasEntityHeader(opposite));
+                            }
+                            if (truncated) {
+                                LOG.warn("MS-1099: super-vertex protection — edge-notification scan ({}) truncated for "
+                                        + "restored entity {} (examined={}, maxEdges={}, timeoutSec={}). Some related "
+                                        + "entities may miss ENTITY_UPDATE.",
+                                        direction, vGuid, examined, maxEdges,
+                                        AtlasConfiguration.MIN_TIMEOUT_SUPER_VERTEX.getLong());
                             }
                         }
                     }


### PR DESCRIPTION
## Change description

Problem:
Downstream Columns do not receive Kafka ENTITY_UPDATE notifications when their upstream Process (or ColumnProcess) is soft-deleted or re-created. MDLH/Lakehouse is event-driven — missing notifications leave Column records stale (wrong outputFromProcesses, stale updatedBy, etc.) in LH for months. DQ runs flag hundreds of Columns as mismatched (hyatthot02: 144 stale Columns; atlan-vc LH-1412: 1,430 mismatches).

Root cause:
Two gaps in the notification path, both downstream of MS-903's existing fix:

1. Soft delete (DeleteHandlerV1.deleteEntities): MS-903 iterates IN edges of the deleted vertex and notifies the outVertex (covers parent/upstream). It does NOT iterate OUT edges, so the inVertex (downstream) side of outgoing relationship edges (e.g. __Process.outputs) never gets recorded as updated. Soft-deleting a Process notifies its input DataSets but not its output DataSets.

2. Restore (EntityGraphMapper, inside the entitiesToRestore processing loop): Soft-delete leaves relationship edges in a mixed state (OUT edges ACTIVE, IN edges DELETED on this minimal typedef setup). On restore via ENTITY_UPDATE with status=ACTIVE, the Process flips DELETED->ACTIVE but the existing hasLineage differential-notification path is a no-op when hasLineage doesn't actually flip (common case — downstream Columns have other lineage sources). Result: endpoints are never added to mutatedEntities, no ENTITY_UPDATE Kafka emission.

Fix:
1. DeleteHandlerV1.deleteEntities: mirror MS-903's IN-edge iteration for OUT edges. Iterate OUT relationship edges of the deleted vertex and record inVertex via recordEntityUpdateForRelationshipChange(). Guarded by !isDeletedEntity to skip cascade-deleted children. Same performance profile as MS-903 (O(edges) per vertex, no recursion).

2. EntityGraphMapper.mapEntitiesInternal (inside the getEntitiesToRestore() processing loop, next to MS-1044's addRestoredEntityRelationshipsToDiffEntity call): for each restored entity, iterate its ACTIVE relationship edges in BOTH directions and notify the opposite endpoint via recordEntityUpdateForRelationshipChange(). Guards skip self, deleted entities, and other restored entities (to avoid double-counting when both sides restore in the same transaction). Bypasses the differential filter so notifications fire unconditionally on restore.

Performance: O(edges) per deleted/restored vertex. Typical ColumnProcess has 1 input + 1 output — negligible. Large fan-out Processes (e.g. 100 outputs) get 100 notifications which is the correct semantic — all downstream need to be informed. updatedEntities map is GUID-keyed, so natural dedup prevents duplicate notifications across IN/OUT iteration and across deleteEntities + deleteRelationships paths.

Verification (tested locally end-to-end, including Kafka):

1. Pre-fix reproduction (baseline master):
   - Create DataSet -> Process -> DataSet lineage
   - Soft-delete Process: mutatedEntities has UPDATE for upstream only
   - Restore Process: mutatedEntities has UPDATE for Process only
   - Matches customer audit evidence (downstream Column has zero audit entries on delete/restore dates)

2. Post-fix (this commit):
   - Soft-delete Process: mutatedEntities has UPDATE for BOTH upstream and downstream + DELETE for Process
   - Restore Process: mutatedEntities has UPDATE for Process AND downstream
   - Confirmed via ATLAS_ENTITIES Kafka topic: 3 messages emitted on soft-delete (ENTITY_UPDATE upstream, ENTITY_UPDATE downstream, ENTITY_DELETE process) — vs 2 before the fix

3. Edge cases (all pass):
   - Process with no inputs/outputs: only Process in mutatedEntities (no spurious notifications)
   - Hard delete: each endpoint notified exactly once (no duplicate despite both new code and MS-903 Hunk 2 in deleteRelationships running)
   - Cascade delete (Table with children): no crash, HTTP 200, no regression
   - Self-reference (same DataSet as both input and output): 1 notification, deduped via GUID-keyed updatedEntities map

## Type of change
- [X] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
