### PR TITLE
ring: authz-deny-logging → pes0cp02 validation

### DIFF
--- a/authorization/src/main/java/org/apache/atlas/authorize/AtlasAccessResult.java
+++ b/authorization/src/main/java/org/apache/atlas/authorize/AtlasAccessResult.java
@@ -26,6 +26,7 @@ public class AtlasAccessResult {
 
     private boolean isAllowed = false;
     private String  policyId  = "-1";
+    private String  policyName = null;
     private int  policyPriority = -1;
     private boolean explicitDeny = false;
     private String enforcer = "abac_auth";
@@ -72,6 +73,14 @@ public class AtlasAccessResult {
 
     public void setPolicyId(String policyId) {
         this.policyId = policyId;
+    }
+
+    public String getPolicyName() {
+        return policyName;
+    }
+
+    public void setPolicyName(String policyName) {
+        this.policyName = policyName;
     }
 
     public void setPolicyPriority(int policyPriority) {

--- a/docs/observability/authz-deny-logging.md
+++ b/docs/observability/authz-deny-logging.md
@@ -1,0 +1,100 @@
+# AUTHZ_DENY logging
+
+Centralized WARN-level log emitted every time Atlas authorization denies an operation and would throw `ATLAS-403-00-001 UNAUTHORIZED_ACCESS`. Intended for SRE / support to answer "who got denied doing what to which asset, and which policy caused it" without attaching a debugger or re-running the workflow with DEBUG.
+
+This is observability only. The 403 response returned to the client is **unchanged**.
+
+## Where it fires
+
+`AtlasAuthorizationUtils.verifyAccess(...)` for all four access-request shapes:
+
+| Scope | Privileges this covers |
+|---|---|
+| Entity | `entity-create`, `entity-update`, `entity-delete`, `entity-read`, `entity-*-classification`, `entity-add/remove-label`, `entity-update-business-metadata` |
+| Relationship | `add-relationship`, `update-relationship`, `remove-relationship` |
+| Type | `type-create`, `type-update`, `type-delete`, `type-read` |
+| Admin | `admin-export`, `admin-import`, `admin-purge`, `admin-audits`, etc. |
+
+This covers the entity CRUD paths that connector publish-phase workflows hit (bulk entity, relationships, classifications).
+
+**Not covered** (direct role-check denies in REST layer; already include the user in their thrown message): `AttributeREST`, `BusinessLineageREST`, `DirectSearchREST`, `PurposeDiscoveryREST`, and `DataProductPreProcessor` lineage-status guard.
+
+## Log line format
+
+Single-line, key=value pairs, logger name `org.apache.atlas.authz.deny`.
+
+### Entity / relationship / type / admin
+
+```
+AUTHZ_DENY user="<user>" groups=<N> action="<privilege>" entity="<type>/<guid>" qn="<qualifiedName>"
+           cause="UNAUTHORIZED_ACCESS" policyId="<id|implicit>" policyName="<name|null>"
+           enforcer="<atlas|abac_auth|merged_auth>" explicitDeny=<bool> priority=<int>
+           purposes="[<guid>, ...]" msg="<errorMsgParam>"
+```
+
+Relationship denies replace `entity`/`qn` with `relationshipType="..." end1="<type>/<guid>" end1Qn="..." end2="<type>/<guid>" end2Qn="..."`.
+Type denies replace `entity`/`qn` with `typeDef="<name>"`.
+Admin denies use `scope="admin"`.
+
+### Field meanings
+
+| Field | Meaning |
+|---|---|
+| `user` | `RequestContext.getCurrentUser()` at the moment of the deny. |
+| `groups` | Count of user groups (not names — avoids leaking group membership into logs). |
+| `action` | `AtlasPrivilege.getType()` — stable string like `entity-delete`. |
+| `entity` / `end1` / `end2` | `<typeName>/<guid>` — both are cheaply available from the request header; no graph lookup. |
+| `qn` | `qualifiedName` attribute from the entity header. Truncated to 512 chars with `...` suffix. `"null"` if missing. |
+| `cause` | Always `UNAUTHORIZED_ACCESS` for denies emitted by this logger. |
+| `policyId` | ID of the policy that produced the deny. `"implicit"` if no specific policy matched (implicit deny). |
+| `policyName` | Display name of the matched policy. Populated for ABAC denies (via `RangerPolicy.getName()`); `"null"` for implicit denies and for Ranger-engine denies (the Ranger plugin only propagates policy GUIDs). Use `policyId` as the canonical handle; `policyName` is a human-readable hint. |
+| `enforcer` | `atlas` (Ranger/ACL engine), `abac_auth` (ABAC), or `merged_auth` (post-merge of both). |
+| `explicitDeny` | `true` if a policy explicitly denied; `false` for implicit deny. |
+| `priority` | Policy priority. `100` = OVERRIDE, `0` = NORMAL, `-1` = not set. |
+| `purposes` | Best-effort list of Purpose GUIDs the user has access to (see below). |
+| `msg` | Free-form context from the caller (e.g. `"delete entity: default.db.tbl"`). Truncated to 512 chars. |
+
+## Purpose enrichment (best-effort)
+
+When `atlas.authz.deny-logging.enrich-personas-purposes=true` (**default**), every deny triggers two ES queries against the `AuthPolicy` and `Purpose` indices via `PurposeDiscoveryServiceImpl.getUniquePurposeGuids(user, groups)` — the same lightweight path used by the `/api/meta/purposes/user` endpoint. The resulting GUIDs are appended as `purposes="[...]"`.
+
+- Limited to 10 GUIDs per deny so both the ES cost and the log-line size stay bounded.
+- Any failure (ES unavailable, timeout, null response) is swallowed: the base line is still emitted with `purposes=""`.
+- **Persona reverse-lookup is not included**: the Atlas repository does not expose a cheap mapping from `(user, groups)` → Personas. Use the `policyId` field to trace back to the parent Persona/Purpose entity via the policy store.
+
+Flip `atlas.authz.deny-logging.enrich-personas-purposes=false` in `atlas-application.properties` to disable the enrichment (e.g. if a cluster sees a pathologically high deny rate and the extra ES calls become noticeable).
+
+## Config
+
+| Key | Default | Effect |
+|---|---|---|
+| `atlas.authz.deny-logging.enabled` | `true` | Master switch for the entire `AUTHZ_DENY` line. Flip to `false` as an emergency escape hatch. |
+| `atlas.authz.deny-logging.enrich-personas-purposes` | `true` | Toggle for the `purposes=[...]` enrichment only. |
+
+Both are read once at class-load time.
+
+## Logger routing
+
+The line uses a dedicated logger name so operators can route / filter independently from the broader `org.apache.atlas.authorizer` logger:
+
+```xml
+<logger name="org.apache.atlas.authz.deny" level="WARN" additivity="false">
+    <appender-ref ref="AUTHZ_DENY_FILE"/>
+</logger>
+```
+
+Level is `WARN` by default. Set to `OFF` in `atlas-logback.xml` to suppress at the logger level while leaving the Atlas config flag alone (useful for noisy test environments).
+
+## Example
+
+Incoming `DELETE /api/atlas/v2/entity/guid/abc-123` from a connector publish step, denied by an ABAC policy:
+
+```
+AUTHZ_DENY user="svc.csa-bigquery" groups=2 action="entity-delete" entity="bigquery_table/abc-123"
+           qn="default/bq/project.dataset.tbl@production" cause="UNAUTHORIZED_ACCESS"
+           policyId="pol-99f8e2" policyName="deny-prod-tables" enforcer="merged_auth"
+           explicitDeny=true priority=100 purposes="[purpose-prod-ro, purpose-finance-guard]"
+           msg="delete entity"
+```
+
+From the `policyId`, look up the full AuthPolicy via `/api/atlas/v2/entity/guid/pol-99f8e2` to see which Persona or Purpose it belongs to and what filter criteria triggered the deny. `policyName` is a convenience hint and is only present for ABAC-path denies.

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -131,6 +131,12 @@
         </dependency>
 
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-all</artifactId>
             <exclusions>

--- a/repository/src/main/java/org/apache/atlas/authorizer/AtlasAuthorizationUtils.java
+++ b/repository/src/main/java/org/apache/atlas/authorizer/AtlasAuthorizationUtils.java
@@ -72,17 +72,21 @@ public class AtlasAuthorizationUtils {
     }
 
     public static void verifyAccess(AtlasAdminAccessRequest request, Object... errorMsgParams) throws AtlasBaseException {
-        if (! isAccessAllowed(request)) {
+        AtlasAccessResult result = isAccessAllowedResult(request);
+        if (!result.isAllowed()) {
             String message = (errorMsgParams != null && errorMsgParams.length > 0) ? StringUtils.join(errorMsgParams) : "";
 
+            AuthzDenyLogger.logAdminDeny(request, result, message);
             throw new AtlasBaseException(AtlasErrorCode.UNAUTHORIZED_ACCESS, request.getUser(), message);
         }
     }
 
     public static void verifyAccess(AtlasTypeAccessRequest request, Object... errorMsgParams) throws AtlasBaseException {
-        if (! isAccessAllowed(request)) {
+        AtlasAccessResult result = isAccessAllowedResult(request);
+        if (!result.isAllowed()) {
             String message = (errorMsgParams != null && errorMsgParams.length > 0) ? StringUtils.join(errorMsgParams) : "";
 
+            AuthzDenyLogger.logTypeDeny(request, result, message);
             throw new AtlasBaseException(AtlasErrorCode.UNAUTHORIZED_ACCESS, request.getUser(), message);
         }
     }
@@ -102,15 +106,18 @@ public class AtlasAuthorizationUtils {
     }
 
     public static void verifyAccess(AtlasEntityAccessRequest request, Object... errorMsgParams) throws AtlasBaseException {
-        if (! isAccessAllowed(request)) {
+        AtlasAccessResult result = isAccessAllowedResult(request, true);
+        if (!result.isAllowed()) {
             String message = (errorMsgParams != null && errorMsgParams.length > 0) ? StringUtils.join(errorMsgParams) : "";
 
+            AuthzDenyLogger.logEntityDeny(request, result, message);
             throw new AtlasBaseException(AtlasErrorCode.UNAUTHORIZED_ACCESS, request.getUser(), message);
         }
     }
 
     public static void verifyAccess(AtlasRelationshipAccessRequest request, Object... errorMsgParams) throws AtlasBaseException {
-        if (!isAccessAllowed(request)) {
+        AtlasAccessResult result = isAccessAllowedResult(request);
+        if (!result.isAllowed()) {
             String message = (errorMsgParams != null && errorMsgParams.length > 0) ? StringUtils.join(errorMsgParams) : "";
             if (StringUtils.isEmpty(message)){
                 String end1Type = request.getEnd1Entity() != null ? request.getEnd1Entity().getTypeName() : null;
@@ -143,9 +150,11 @@ public class AtlasAuthorizationUtils {
                 errorMap.put("end1", request.getEnd1Entity().getGuid());
                 errorMap.put("end2", request.getEnd2Entity().getGuid());
 
+                AuthzDenyLogger.logRelationshipDeny(request, result, message);
                 throw new AtlasBaseException(AtlasErrorCode.UNAUTHORIZED_ACCESS, errorMap, request.getUser(), message);
 
             } else {
+                AuthzDenyLogger.logRelationshipDeny(request, result, message);
                 throw new AtlasBaseException(AtlasErrorCode.UNAUTHORIZED_ACCESS, request.getUser(), message);
             }
         }
@@ -173,10 +182,14 @@ public class AtlasAuthorizationUtils {
     }
 
     public static boolean isAccessAllowed(AtlasAdminAccessRequest request) {
+        return isAccessAllowedResult(request).isAllowed();
+    }
+
+    static AtlasAccessResult isAccessAllowedResult(AtlasAdminAccessRequest request) {
         MetricRecorder metric = RequestContext.get().startMetricRecord("isAccessAllowed");
 
-        boolean ret      = false;
-        String  userName = getCurrentUserName();
+        AtlasAccessResult ret      = new AtlasAccessResult(false);
+        String            userName = getCurrentUserName();
 
         if (StringUtils.isNotEmpty(userName)) {
             try {
@@ -186,14 +199,12 @@ public class AtlasAuthorizationUtils {
                 request.setClientIPAddress(RequestContext.get().getClientIPAddress());
                 request.setForwardedAddresses(RequestContext.get().getForwardedAddresses());
                 request.setRemoteIPAddress(RequestContext.get().getClientIPAddress());
-                AtlasAccessResult atlasPoliciesResult = authorizer.isAccessAllowed(request);
-
-                ret = atlasPoliciesResult.isAllowed();
+                ret = authorizer.isAccessAllowed(request);
             } catch (AtlasAuthorizationException e) {
                 LOG.error("Unable to obtain AtlasAuthorizer", e);
             }
         } else {
-            ret = true;
+            ret = new AtlasAccessResult(true);
         }
 
         RequestContext.get().endMetricRecord(metric);
@@ -202,13 +213,17 @@ public class AtlasAuthorizationUtils {
     }
 
     public static boolean isAccessAllowed(AtlasEntityAccessRequest request) {
-        return isAccessAllowed(request, true);
+        return isAccessAllowedResult(request, true).isAllowed();
     }
 
     public static boolean isAccessAllowed(AtlasEntityAccessRequest request, boolean isAuditLogEnabled) {
+        return isAccessAllowedResult(request, isAuditLogEnabled).isAllowed();
+    }
+
+    static AtlasAccessResult isAccessAllowedResult(AtlasEntityAccessRequest request, boolean isAuditLogEnabled) {
         MetricRecorder metric = RequestContext.get().startMetricRecord("isAccessAllowed");
 
-        String  userName = getCurrentUserName();
+        String userName = getCurrentUserName();
 
         if (StringUtils.isNotEmpty(userName) && !RequestContext.get().isImportInProgress()) {
             try {
@@ -218,11 +233,11 @@ public class AtlasAuthorizationUtils {
                 request.setClientIPAddress(RequestContext.get().getClientIPAddress());
                 request.setForwardedAddresses(RequestContext.get().getForwardedAddresses());
                 request.setRemoteIPAddress(RequestContext.get().getClientIPAddress());
-                AtlasAccessResult atlasPoliciesResult =  authorizer.isAccessAllowed(request, isAuditLogEnabled);
+                AtlasAccessResult atlasPoliciesResult = authorizer.isAccessAllowed(request, isAuditLogEnabled);
 
                 RequestContext.get().endMetricRecord(metric);
                 if (!isABACAuthorizerEnabled()) {
-                    return atlasPoliciesResult.isAllowed();
+                    return atlasPoliciesResult;
                 }
 
                 metric = RequestContext.get().startMetricRecord("isAccessAllowed.abac");
@@ -232,7 +247,7 @@ public class AtlasAuthorizationUtils {
                     // if priority is override, then it's an explicit deny as implicit deny won't have priority set to override
                     if (!atlasPoliciesResult.isAllowed() && atlasPoliciesResult.getPolicyPriority() == RangerPolicy.POLICY_PRIORITY_OVERRIDE) {
                         finalResult = atlasPoliciesResult;
-                        return finalResult.isAllowed();
+                        return finalResult;
                     }
 
                     AtlasAccessResult abacPoliciesResult = ABACAuthorizerUtils.isAccessAllowed(request.getEntity(), request.getAction());
@@ -279,7 +294,7 @@ public class AtlasAuthorizationUtils {
                         }
                     }
 
-                    return finalResult.isAllowed();
+                    return finalResult;
                 } finally {
                     // log final result audit
                     NewAtlasAuditHandler auditHandler = new NewAtlasAuditHandler(request, SERVICE_DEF_ATLAS);
@@ -297,18 +312,22 @@ public class AtlasAuthorizationUtils {
                 LOG.error("Unable to obtain AtlasAuthorizer", e);
             }
         } else {
-            return true;
+            return new AtlasAccessResult(true);
         }
 
         LOG.warn("ABAC_AUTH: authorizer returning false by default, no case matched");
-        return false;
+        return new AtlasAccessResult(false);
     }
 
     public static boolean isAccessAllowed(AtlasTypeAccessRequest request) {
+        return isAccessAllowedResult(request).isAllowed();
+    }
+
+    static AtlasAccessResult isAccessAllowedResult(AtlasTypeAccessRequest request) {
         MetricRecorder metric = RequestContext.get().startMetricRecord("isAccessAllowed");
 
-        boolean ret      = false;
-        String  userName = getCurrentUserName();
+        AtlasAccessResult ret      = new AtlasAccessResult(false);
+        String            userName = getCurrentUserName();
 
         if (StringUtils.isNotEmpty(userName) && !RequestContext.get().isImportInProgress()) {
             try {
@@ -318,14 +337,12 @@ public class AtlasAuthorizationUtils {
                 request.setClientIPAddress(RequestContext.get().getClientIPAddress());
                 request.setForwardedAddresses(RequestContext.get().getForwardedAddresses());
                 request.setRemoteIPAddress(RequestContext.get().getClientIPAddress());
-                AtlasAccessResult atlasPoliciesResult = authorizer.isAccessAllowed(request);
-
-                ret = atlasPoliciesResult.isAllowed();
+                ret = authorizer.isAccessAllowed(request);
             } catch (AtlasAuthorizationException e) {
                 LOG.error("Unable to obtain AtlasAuthorizer", e);
             }
         } else {
-            ret = true;
+            ret = new AtlasAccessResult(true);
         }
 
         RequestContext.get().endMetricRecord(metric);
@@ -334,9 +351,13 @@ public class AtlasAuthorizationUtils {
     }
 
     public static boolean isAccessAllowed(AtlasRelationshipAccessRequest request) {
+        return isAccessAllowedResult(request).isAllowed();
+    }
+
+    static AtlasAccessResult isAccessAllowedResult(AtlasRelationshipAccessRequest request) {
         MetricRecorder metric = RequestContext.get().startMetricRecord("isAccessAllowed");
 
-        String  userName = getCurrentUserName();
+        String userName = getCurrentUserName();
 
         if (StringUtils.isNotEmpty(userName) && !RequestContext.get().isImportInProgress()) {
             try {
@@ -350,7 +371,7 @@ public class AtlasAuthorizationUtils {
 
                 RequestContext.get().endMetricRecord(metric);
                 if (!isABACAuthorizerEnabled()) {
-                    return atlasPoliciesResult.isAllowed();
+                    return atlasPoliciesResult;
                 }
 
                 metric = RequestContext.get().startMetricRecord("isAccessAllowed.abac");
@@ -360,7 +381,7 @@ public class AtlasAuthorizationUtils {
                     if (!atlasPoliciesResult.isAllowed() && atlasPoliciesResult.getPolicyPriority() == RangerPolicy.POLICY_PRIORITY_OVERRIDE) {
                         // Deny with higher priority
                         finalResult = atlasPoliciesResult;
-                        return finalResult.isAllowed();
+                        return finalResult;
                     }
 
                     AtlasAccessResult abacPoliciesResult = ABACAuthorizerUtils.isAccessAllowed(request.getRelationshipType(),
@@ -391,7 +412,7 @@ public class AtlasAuthorizationUtils {
                             }
                         }
                     }
-                    return finalResult.isAllowed();
+                    return finalResult;
 
                 } finally {
                     // log final result audit
@@ -410,10 +431,10 @@ public class AtlasAuthorizationUtils {
                 LOG.error("Unable to obtain AtlasAuthorizer", e);
             }
         } else {
-            return true;
+            return new AtlasAccessResult(true);
         }
 
-        return false;
+        return new AtlasAccessResult(false);
     }
 
     public static AtlasAccessorResponse getAccessors(AtlasEntityAccessRequest request) {

--- a/repository/src/main/java/org/apache/atlas/authorizer/AuthzDenyLogger.java
+++ b/repository/src/main/java/org/apache/atlas/authorizer/AuthzDenyLogger.java
@@ -17,6 +17,7 @@
  */
 package org.apache.atlas.authorizer;
 
+// ring-authz-deny-logging build trigger
 import org.apache.atlas.ApplicationProperties;
 import org.apache.atlas.AtlasException;
 import org.apache.atlas.authorize.AtlasAccessResult;

--- a/repository/src/main/java/org/apache/atlas/authorizer/AuthzDenyLogger.java
+++ b/repository/src/main/java/org/apache/atlas/authorizer/AuthzDenyLogger.java
@@ -1,0 +1,376 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas.authorizer;
+
+import org.apache.atlas.ApplicationProperties;
+import org.apache.atlas.AtlasException;
+import org.apache.atlas.authorize.AtlasAccessResult;
+import org.apache.atlas.authorize.AtlasAdminAccessRequest;
+import org.apache.atlas.authorize.AtlasEntityAccessRequest;
+import org.apache.atlas.authorize.AtlasPrivilege;
+import org.apache.atlas.authorize.AtlasRelationshipAccessRequest;
+import org.apache.atlas.authorize.AtlasTypeAccessRequest;
+import org.apache.atlas.discovery.AtlasDiscoveryService;
+import org.apache.atlas.discovery.PurposeDiscoveryService;
+import org.apache.atlas.discovery.PurposeDiscoveryServiceImpl;
+import org.apache.atlas.model.discovery.PurposeUserRequest;
+import org.apache.atlas.model.discovery.PurposeUserResponse;
+import org.apache.atlas.model.instance.AtlasEntityHeader;
+import org.apache.atlas.model.typedef.AtlasBaseTypeDef;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Emits a single structured WARN log line whenever authorization denies an operation and
+ * {@link org.apache.atlas.AtlasErrorCode#UNAUTHORIZED_ACCESS} (ATLAS-403-00-001) is about to be
+ * thrown. Observability only: never alters control flow or the 403 payload.
+ *
+ * Field format (pipe-separated key=value, all values quoted):
+ *   AUTHZ_DENY user="..." groups=<N> action="..." entity="<type>/<guid>" qn="..."
+ *              cause="UNAUTHORIZED_ACCESS" policyId="<id|implicit>" enforcer="..."
+ *              explicitDeny=<bool> priority=<int> purposes="[guid1, guid2]" msg="..."
+ *
+ * Logger name is {@value #LOGGER_NAME} so operators can grep and route independently of the
+ * parent {@code org.apache.atlas.authorizer} logger.
+ */
+@Component
+public class AuthzDenyLogger {
+
+    static final String LOGGER_NAME = "org.apache.atlas.authz.deny";
+
+    private static final Logger LOG      = LoggerFactory.getLogger(LOGGER_NAME);
+    private static final Logger INTERNAL = LoggerFactory.getLogger(AuthzDenyLogger.class);
+
+    private static final int MAX_QN_LEN         = 512;
+    private static final int MAX_MESSAGE_LEN    = 512;
+    private static final int MAX_PURPOSE_GUIDS  = 10;
+
+    static final String CONFIG_ENABLED = "atlas.authz.deny-logging.enabled";
+    static final String CONFIG_ENRICH  = "atlas.authz.deny-logging.enrich-personas-purposes";
+
+    private static final boolean DENY_LOGGING_ENABLED;
+    private static final boolean ENRICH_PERSONAS_PURPOSES;
+
+    static {
+        boolean enabled = true;
+        boolean enrich  = true;
+        try {
+            org.apache.commons.configuration.Configuration conf = ApplicationProperties.get();
+            enabled = conf.getBoolean(CONFIG_ENABLED, true);
+            enrich  = conf.getBoolean(CONFIG_ENRICH, true);
+        } catch (AtlasException e) {
+            INTERNAL.warn("AuthzDenyLogger: failed to read config, defaulting enabled=true enrich=true", e);
+        }
+        DENY_LOGGING_ENABLED     = enabled;
+        ENRICH_PERSONAS_PURPOSES = enrich;
+    }
+
+    private static volatile AtlasDiscoveryService   discoveryService;
+    private static volatile PurposeDiscoveryService purposeServiceOverride;
+    private static volatile PurposeDiscoveryService purposeServiceLazy;
+
+    @Inject
+    public AuthzDenyLogger(AtlasDiscoveryService discoveryService) {
+        AuthzDenyLogger.discoveryService = discoveryService;
+    }
+
+    // Package-private seam for unit tests.
+    static void setPurposeDiscoveryServiceForTesting(PurposeDiscoveryService svc) {
+        purposeServiceOverride = svc;
+        purposeServiceLazy     = null;
+    }
+
+    // ---------------------------------------------------------------------
+    // Public entry points — one per AtlasAccessRequest subtype.
+    // ---------------------------------------------------------------------
+
+    static void logEntityDeny(AtlasEntityAccessRequest req, AtlasAccessResult result, String message) {
+        if (!DENY_LOGGING_ENABLED || !LOG.isWarnEnabled()) {
+            return;
+        }
+        try {
+            String            user   = req != null ? req.getUser() : null;
+            Set<String>       groups = req != null ? req.getUserGroups() : null;
+            AtlasPrivilege    action = req != null ? req.getAction() : null;
+            AtlasEntityHeader entity = req != null ? req.getEntity() : null;
+
+            LOG.warn("AUTHZ_DENY user=\"{}\" groups={} action=\"{}\" entity=\"{}/{}\" qn=\"{}\""
+                            + " cause=\"UNAUTHORIZED_ACCESS\" policyId=\"{}\" policyName=\"{}\" enforcer=\"{}\""
+                            + " explicitDeny={} priority={} purposes=\"{}\" msg=\"{}\"",
+                    nullSafe(user),
+                    groupCount(groups),
+                    renderAction(action),
+                    entity != null ? nullSafe(entity.getTypeName()) : "null",
+                    entity != null ? nullSafe(entity.getGuid())     : "null",
+                    renderQualifiedName(entity),
+                    renderPolicyId(result),
+                    renderPolicyName(result),
+                    renderEnforcer(result),
+                    result != null && result.isExplicitDeny(),
+                    renderPriority(result),
+                    renderPurposes(user, groups),
+                    renderMessage(message));
+        } catch (Throwable t) {
+            INTERNAL.debug("AuthzDenyLogger.logEntityDeny suppressed", t);
+        }
+    }
+
+    static void logRelationshipDeny(AtlasRelationshipAccessRequest req, AtlasAccessResult result, String message) {
+        if (!DENY_LOGGING_ENABLED || !LOG.isWarnEnabled()) {
+            return;
+        }
+        try {
+            String            user   = req != null ? req.getUser() : null;
+            Set<String>       groups = req != null ? req.getUserGroups() : null;
+            AtlasPrivilege    action = req != null ? req.getAction() : null;
+            AtlasEntityHeader end1   = req != null ? req.getEnd1Entity() : null;
+            AtlasEntityHeader end2   = req != null ? req.getEnd2Entity() : null;
+            String            relType = req != null ? req.getRelationshipType() : null;
+
+            LOG.warn("AUTHZ_DENY user=\"{}\" groups={} action=\"{}\" relationshipType=\"{}\""
+                            + " end1=\"{}/{}\" end1Qn=\"{}\" end2=\"{}/{}\" end2Qn=\"{}\""
+                            + " cause=\"UNAUTHORIZED_ACCESS\" policyId=\"{}\" policyName=\"{}\" enforcer=\"{}\""
+                            + " explicitDeny={} priority={} purposes=\"{}\" msg=\"{}\"",
+                    nullSafe(user),
+                    groupCount(groups),
+                    renderAction(action),
+                    nullSafe(relType),
+                    end1 != null ? nullSafe(end1.getTypeName()) : "null",
+                    end1 != null ? nullSafe(end1.getGuid())     : "null",
+                    renderQualifiedName(end1),
+                    end2 != null ? nullSafe(end2.getTypeName()) : "null",
+                    end2 != null ? nullSafe(end2.getGuid())     : "null",
+                    renderQualifiedName(end2),
+                    renderPolicyId(result),
+                    renderPolicyName(result),
+                    renderEnforcer(result),
+                    result != null && result.isExplicitDeny(),
+                    renderPriority(result),
+                    renderPurposes(user, groups),
+                    renderMessage(message));
+        } catch (Throwable t) {
+            INTERNAL.debug("AuthzDenyLogger.logRelationshipDeny suppressed", t);
+        }
+    }
+
+    static void logTypeDeny(AtlasTypeAccessRequest req, AtlasAccessResult result, String message) {
+        if (!DENY_LOGGING_ENABLED || !LOG.isWarnEnabled()) {
+            return;
+        }
+        try {
+            String           user    = req != null ? req.getUser() : null;
+            Set<String>      groups  = req != null ? req.getUserGroups() : null;
+            AtlasPrivilege   action  = req != null ? req.getAction() : null;
+            AtlasBaseTypeDef typeDef = req != null ? req.getTypeDef() : null;
+
+            LOG.warn("AUTHZ_DENY user=\"{}\" groups={} action=\"{}\" typeDef=\"{}\""
+                            + " cause=\"UNAUTHORIZED_ACCESS\" policyId=\"{}\" policyName=\"{}\" enforcer=\"{}\""
+                            + " explicitDeny={} priority={} msg=\"{}\"",
+                    nullSafe(user),
+                    groupCount(groups),
+                    renderAction(action),
+                    typeDef != null ? nullSafe(typeDef.getName()) : "null",
+                    renderPolicyId(result),
+                    renderPolicyName(result),
+                    renderEnforcer(result),
+                    result != null && result.isExplicitDeny(),
+                    renderPriority(result),
+                    renderMessage(message));
+        } catch (Throwable t) {
+            INTERNAL.debug("AuthzDenyLogger.logTypeDeny suppressed", t);
+        }
+    }
+
+    static void logAdminDeny(AtlasAdminAccessRequest req, AtlasAccessResult result, String message) {
+        if (!DENY_LOGGING_ENABLED || !LOG.isWarnEnabled()) {
+            return;
+        }
+        try {
+            String         user   = req != null ? req.getUser() : null;
+            Set<String>    groups = req != null ? req.getUserGroups() : null;
+            AtlasPrivilege action = req != null ? req.getAction() : null;
+
+            LOG.warn("AUTHZ_DENY user=\"{}\" groups={} action=\"{}\" scope=\"admin\""
+                            + " cause=\"UNAUTHORIZED_ACCESS\" policyId=\"{}\" policyName=\"{}\" enforcer=\"{}\""
+                            + " explicitDeny={} priority={} msg=\"{}\"",
+                    nullSafe(user),
+                    groupCount(groups),
+                    renderAction(action),
+                    renderPolicyId(result),
+                    renderPolicyName(result),
+                    renderEnforcer(result),
+                    result != null && result.isExplicitDeny(),
+                    renderPriority(result),
+                    renderMessage(message));
+        } catch (Throwable t) {
+            INTERNAL.debug("AuthzDenyLogger.logAdminDeny suppressed", t);
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Rendering helpers — all NPE-safe, all bounded.
+    // ---------------------------------------------------------------------
+
+    private static String nullSafe(String s) {
+        return s == null ? "null" : s;
+    }
+
+    private static int groupCount(Set<String> groups) {
+        return groups == null ? 0 : groups.size();
+    }
+
+    private static String renderAction(AtlasPrivilege action) {
+        if (action == null) {
+            return "null";
+        }
+        String t = action.getType();
+        return t != null ? t : action.name();
+    }
+
+    private static String renderQualifiedName(AtlasEntityHeader entity) {
+        if (entity == null) {
+            return "null";
+        }
+        Object qn;
+        try {
+            qn = entity.getAttribute("qualifiedName");
+        } catch (Throwable t) {
+            return "null";
+        }
+        if (qn == null) {
+            return "null";
+        }
+        String s = String.valueOf(qn);
+        if (s.length() > MAX_QN_LEN) {
+            return s.substring(0, MAX_QN_LEN) + "...";
+        }
+        return s;
+    }
+
+    private static String renderMessage(String message) {
+        if (message == null) {
+            return "";
+        }
+        if (message.length() > MAX_MESSAGE_LEN) {
+            return message.substring(0, MAX_MESSAGE_LEN) + "...";
+        }
+        return message;
+    }
+
+    private static String renderPolicyId(AtlasAccessResult result) {
+        if (result == null) {
+            return "null";
+        }
+        String pid = result.getPolicyId();
+        if (pid == null || "-1".equals(pid)) {
+            return "implicit";
+        }
+        return pid;
+    }
+
+    private static String renderPolicyName(AtlasAccessResult result) {
+        if (result == null) {
+            return "null";
+        }
+        String name = result.getPolicyName();
+        if (name == null || name.isEmpty()) {
+            return "null";
+        }
+        return name;
+    }
+
+    private static String renderEnforcer(AtlasAccessResult result) {
+        if (result == null) {
+            return "null";
+        }
+        String e = result.getEnforcer();
+        return e != null ? e : "null";
+    }
+
+    private static int renderPriority(AtlasAccessResult result) {
+        return result == null ? -1 : result.getPolicyPriority();
+    }
+
+    private static String renderPurposes(String user, Set<String> groups) {
+        if (!ENRICH_PERSONAS_PURPOSES) {
+            return "";
+        }
+        if (user == null) {
+            return "";
+        }
+        PurposeDiscoveryService svc = resolvePurposeDiscoveryService();
+        if (svc == null) {
+            return "";
+        }
+        try {
+            PurposeUserRequest preq = new PurposeUserRequest();
+            preq.setUsername(user);
+            preq.setGroups(groups != null ? new ArrayList<>(groups) : Collections.emptyList());
+            preq.setLimit(MAX_PURPOSE_GUIDS);
+            preq.setOffset(0);
+
+            PurposeUserResponse resp = svc.discoverPurposesForUser(preq);
+            List<AtlasEntityHeader> purposes = resp != null ? resp.getPurposes() : null;
+            if (purposes == null || purposes.isEmpty()) {
+                return "";
+            }
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < purposes.size(); i++) {
+                if (i > 0) {
+                    sb.append(',');
+                }
+                AtlasEntityHeader p = purposes.get(i);
+                sb.append(p != null ? nullSafe(p.getGuid()) : "null");
+            }
+            return sb.toString();
+        } catch (Throwable t) {
+            INTERNAL.debug("AuthzDenyLogger: purpose enrichment failed for user={}", user, t);
+            return "";
+        }
+    }
+
+    private static PurposeDiscoveryService resolvePurposeDiscoveryService() {
+        PurposeDiscoveryService override = purposeServiceOverride;
+        if (override != null) {
+            return override;
+        }
+        PurposeDiscoveryService local = purposeServiceLazy;
+        if (local != null) {
+            return local;
+        }
+        AtlasDiscoveryService ds = discoveryService;
+        if (ds == null) {
+            return null;
+        }
+        synchronized (AuthzDenyLogger.class) {
+            local = purposeServiceLazy;
+            if (local == null) {
+                local = new PurposeDiscoveryServiceImpl(ds);
+                purposeServiceLazy = local;
+            }
+        }
+        return local;
+    }
+}

--- a/repository/src/main/java/org/apache/atlas/authorizer/authorizers/EntityAuthorizer.java
+++ b/repository/src/main/java/org/apache/atlas/authorizer/authorizers/EntityAuthorizer.java
@@ -50,7 +50,9 @@ public class EntityAuthorizer {
 
         AtlasAccessResult denyResult = isAccessAllowedInMemory(entity, action, POLICY_TYPE_DENY);
         if (denyResult.isAllowed() && denyResult.getPolicyPriority() == RangerPolicy.POLICY_PRIORITY_OVERRIDE) {
-            return new AtlasAccessResult(false, denyResult.getPolicyId(), denyResult.getPolicyPriority());
+            AtlasAccessResult flipped = new AtlasAccessResult(false, denyResult.getPolicyId(), denyResult.getPolicyPriority());
+            flipped.setPolicyName(denyResult.getPolicyName());
+            return flipped;
         }
 
         AtlasAccessResult allowResult = isAccessAllowedInMemory(entity, action, POLICY_TYPE_ALLOW);
@@ -60,7 +62,9 @@ public class EntityAuthorizer {
 
         if (denyResult.isAllowed() && !"-1".equals(denyResult.getPolicyId())) {
             // explicit deny
-            return new AtlasAccessResult(false, denyResult.getPolicyId(), denyResult.getPolicyPriority());
+            AtlasAccessResult flipped = new AtlasAccessResult(false, denyResult.getPolicyId(), denyResult.getPolicyPriority());
+            flipped.setPolicyName(denyResult.getPolicyName());
+            return flipped;
         } else {
             return allowResult;
         }
@@ -97,6 +101,7 @@ public class EntityAuthorizer {
             if (matched) {
                 // result here only means that a matching policy is found, allow and deny needs to be handled by caller
                 result = new AtlasAccessResult(true, policy.getGuid(), policy.getPolicyPriority());
+                result.setPolicyName(policy.getName());
                 if (policy.getPolicyPriority() == RangerPolicy.POLICY_PRIORITY_OVERRIDE) {
                     return result;
                 }

--- a/repository/src/main/java/org/apache/atlas/authorizer/authorizers/RelationshipAuthorizer.java
+++ b/repository/src/main/java/org/apache/atlas/authorizer/authorizers/RelationshipAuthorizer.java
@@ -34,7 +34,9 @@ public class RelationshipAuthorizer {
     public static AtlasAccessResult isAccessAllowedInMemory(String action, String relationshipType, AtlasEntityHeader endOneEntity, AtlasEntityHeader endTwoEntity) throws AtlasBaseException {
         AtlasAccessResult denyResult = checkRelationshipAccessAllowedInMemory(action, relationshipType, endOneEntity, endTwoEntity, POLICY_TYPE_DENY);
         if (denyResult.isAllowed() && denyResult.getPolicyPriority() == RangerPolicy.POLICY_PRIORITY_OVERRIDE) {
-            return new AtlasAccessResult(false, denyResult.getPolicyId(), denyResult.getPolicyPriority());
+            AtlasAccessResult flipped = new AtlasAccessResult(false, denyResult.getPolicyId(), denyResult.getPolicyPriority());
+            flipped.setPolicyName(denyResult.getPolicyName());
+            return flipped;
         }
 
         AtlasAccessResult allowResult = checkRelationshipAccessAllowedInMemory(action, relationshipType, endOneEntity, endTwoEntity, POLICY_TYPE_ALLOW);
@@ -44,7 +46,9 @@ public class RelationshipAuthorizer {
 
         if (denyResult.isAllowed() && !"-1".equals(denyResult.getPolicyId())) {
             // explicit deny
-            return new AtlasAccessResult(false, denyResult.getPolicyId(), denyResult.getPolicyPriority());
+            AtlasAccessResult flipped = new AtlasAccessResult(false, denyResult.getPolicyId(), denyResult.getPolicyPriority());
+            flipped.setPolicyName(denyResult.getPolicyName());
+            return flipped;
         } else {
             return allowResult;
         }
@@ -75,6 +79,7 @@ public class RelationshipAuthorizer {
                     //ret = ret || eval;
                     if (eval) {
                         result = new AtlasAccessResult(true, policy.getGuid(), policy.getPolicyPriority());
+                        result.setPolicyName(policy.getName());
                         if (policy.getPolicyPriority() == RangerPolicy.POLICY_PRIORITY_OVERRIDE) {
                             return result;
                         }

--- a/repository/src/test/java/org/apache/atlas/authorizer/AuthzDenyLoggerTest.java
+++ b/repository/src/test/java/org/apache/atlas/authorizer/AuthzDenyLoggerTest.java
@@ -1,0 +1,383 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas.authorizer;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.apache.atlas.authorize.AtlasAccessResult;
+import org.apache.atlas.authorize.AtlasAdminAccessRequest;
+import org.apache.atlas.authorize.AtlasEntityAccessRequest;
+import org.apache.atlas.authorize.AtlasPrivilege;
+import org.apache.atlas.authorize.AtlasRelationshipAccessRequest;
+import org.apache.atlas.authorize.AtlasTypeAccessRequest;
+import org.apache.atlas.discovery.PurposeDiscoveryService;
+import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.model.discovery.PurposeUserRequest;
+import org.apache.atlas.model.discovery.PurposeUserResponse;
+import org.apache.atlas.model.instance.AtlasEntityHeader;
+import org.apache.atlas.model.typedef.AtlasBaseTypeDef;
+import org.apache.atlas.model.typedef.AtlasEntityDef;
+import org.apache.atlas.type.AtlasTypeRegistry;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link AuthzDenyLogger}. Uses a Logback {@link ListAppender} to capture
+ * the WARN-level log lines and asserts on their formatted content.
+ *
+ * <p>These tests focus on two properties:
+ * <ol>
+ *   <li>The log line contains the expected fields in the expected format.</li>
+ *   <li>The logger never throws under adversarial inputs (null everything, service failure, etc.).</li>
+ * </ol>
+ */
+public class AuthzDenyLoggerTest {
+
+    private Logger                   denyLogger;
+    private ListAppender<ILoggingEvent> appender;
+    private AtlasTypeRegistry        typeRegistry;
+
+    @Before
+    public void setUp() {
+        denyLogger = (Logger) LoggerFactory.getLogger(AuthzDenyLogger.LOGGER_NAME);
+        denyLogger.setLevel(Level.WARN);
+
+        appender = new ListAppender<>();
+        appender.start();
+        denyLogger.addAppender(appender);
+
+        typeRegistry = mock(AtlasTypeRegistry.class);
+
+        AuthzDenyLogger.setPurposeDiscoveryServiceForTesting(null);
+    }
+
+    @After
+    public void tearDown() {
+        denyLogger.detachAppender(appender);
+        AuthzDenyLogger.setPurposeDiscoveryServiceForTesting(null);
+    }
+
+    // ------------------------------------------------------------
+    // Entity deny
+    // ------------------------------------------------------------
+
+    @Test
+    public void logEntityDeny_happyPath_emitsOneWarnWithAllFields() throws Exception {
+        AtlasEntityHeader entity = entity("hive_table", "guid-abc", "default.db.tbl@cluster");
+        AtlasEntityAccessRequest req = new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_DELETE, entity);
+        req.setUser("alice", set("g1", "g2"));
+
+        AtlasAccessResult result = explicitDenyResult("policy-123", "merged_auth", 100);
+
+        AuthzDenyLogger.setPurposeDiscoveryServiceForTesting(mockPurposeService("purpose-guid-1", "purpose-guid-2"));
+
+        AuthzDenyLogger.logEntityDeny(req, result, "delete entity");
+
+        String line = singleWarnLine();
+        assertContains(line, "AUTHZ_DENY");
+        assertContains(line, "user=\"alice\"");
+        assertContains(line, "groups=2");
+        assertContains(line, "action=\"entity-delete\"");
+        assertContains(line, "entity=\"hive_table/guid-abc\"");
+        assertContains(line, "qn=\"default.db.tbl@cluster\"");
+        assertContains(line, "cause=\"UNAUTHORIZED_ACCESS\"");
+        assertContains(line, "policyId=\"policy-123\"");
+        assertContains(line, "enforcer=\"merged_auth\"");
+        assertContains(line, "explicitDeny=true");
+        assertContains(line, "priority=100");
+        assertContains(line, "purposes=\"purpose-guid-1,purpose-guid-2\"");
+        assertContains(line, "msg=\"delete entity\"");
+    }
+
+    @Test
+    public void logEntityDeny_withPolicyName_includesBothPolicyIdAndName() throws Exception {
+        AtlasEntityHeader entity = entity("Table", "g1", "qn-with-name");
+        AtlasEntityAccessRequest req = new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_DELETE, entity);
+        req.setUser("juno", Collections.emptySet());
+
+        AtlasAccessResult result = explicitDenyResult("pol-9f8e2", "deny-prod-tables", "abac_auth", 100);
+
+        AuthzDenyLogger.logEntityDeny(req, result, "delete entity");
+
+        String line = singleWarnLine();
+        assertContains(line, "policyId=\"pol-9f8e2\"");
+        assertContains(line, "policyName=\"deny-prod-tables\"");
+    }
+
+    @Test
+    public void logEntityDeny_emptyPolicyName_rendersNullToken() throws Exception {
+        AtlasEntityHeader entity = entity("Table", "g1", "qn-empty-name");
+        AtlasEntityAccessRequest req = new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_READ, entity);
+        req.setUser("kai", Collections.emptySet());
+
+        // policyName explicitly empty — helper maps to null; logger should render "null".
+        AtlasAccessResult result = explicitDenyResult("pol-blank", "", "abac_auth", 0);
+        result.setPolicyName("");
+        AuthzDenyLogger.logEntityDeny(req, result, "");
+
+        String line = singleWarnLine();
+        assertContains(line, "policyId=\"pol-blank\"");
+        assertContains(line, "policyName=\"null\"");
+    }
+
+    @Test
+    public void logEntityDeny_nullPolicyName_doesNotThrow() throws Exception {
+        AtlasEntityHeader entity = entity("Table", "g1", "qn-null-name");
+        AtlasEntityAccessRequest req = new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_READ, entity);
+        req.setUser("lea", Collections.emptySet());
+
+        AtlasAccessResult result = new AtlasAccessResult(false, "pol-anon", 0);
+        // policyName remains null by default.
+
+        AuthzDenyLogger.logEntityDeny(req, result, "read");
+
+        String line = singleWarnLine();
+        assertContains(line, "policyId=\"pol-anon\"");
+        assertContains(line, "policyName=\"null\"");
+    }
+
+    @Test
+    public void logEntityDeny_implicitDeny_rendersPolicyIdAsImplicit() throws Exception {
+        AtlasEntityHeader entity = entity("Table", "g1", "qn-1");
+        AtlasEntityAccessRequest req = new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_UPDATE, entity);
+        req.setUser("bob", Collections.emptySet());
+
+        AtlasAccessResult implicit = new AtlasAccessResult(false);   // policyId defaults to "-1"
+
+        AuthzDenyLogger.logEntityDeny(req, implicit, "update entity");
+
+        String line = singleWarnLine();
+        assertContains(line, "policyId=\"implicit\"");
+        assertContains(line, "explicitDeny=false");
+    }
+
+    @Test
+    public void logEntityDeny_nullQualifiedName_rendersNullNoNpe() throws Exception {
+        AtlasEntityHeader entity = new AtlasEntityHeader();
+        entity.setTypeName("Table");
+        entity.setGuid("g1");
+        // no attributes map → qn lookup returns null
+        AtlasEntityAccessRequest req = new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_READ, entity);
+        req.setUser("carol", Collections.emptySet());
+
+        AuthzDenyLogger.logEntityDeny(req, new AtlasAccessResult(false), "");
+
+        String line = singleWarnLine();
+        assertContains(line, "qn=\"null\"");
+    }
+
+    @Test
+    public void logEntityDeny_longQualifiedName_truncates() throws Exception {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 1000; i++) {
+            sb.append('x');
+        }
+        AtlasEntityHeader entity = entity("Table", "g1", sb.toString());
+        AtlasEntityAccessRequest req = new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_READ, entity);
+        req.setUser("dave", Collections.emptySet());
+
+        AuthzDenyLogger.logEntityDeny(req, new AtlasAccessResult(false), "");
+
+        String line = singleWarnLine();
+        assertContains(line, "...");
+        assertTrue("truncated qn should appear near the max length",
+                line.length() < sb.length() + 200);
+    }
+
+    @Test
+    public void logEntityDeny_nullEverything_doesNotThrow() {
+        AuthzDenyLogger.logEntityDeny(null, null, null);
+        // Intentionally no message assertions — we only care that it did not throw.
+        assertTrue(appender.list.size() <= 1);
+    }
+
+    @Test
+    public void logEntityDeny_purposeServiceThrows_logsBaseLine() throws Exception {
+        PurposeDiscoveryService svc = mock(PurposeDiscoveryService.class);
+        when(svc.discoverPurposesForUser(any(PurposeUserRequest.class)))
+                .thenThrow(new RuntimeException("ES unavailable"));
+        AuthzDenyLogger.setPurposeDiscoveryServiceForTesting(svc);
+
+        AtlasEntityHeader entity = entity("Table", "g1", "qn-1");
+        AtlasEntityAccessRequest req = new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_READ, entity);
+        req.setUser("erin", Collections.emptySet());
+
+        AuthzDenyLogger.logEntityDeny(req, new AtlasAccessResult(false), "read");
+
+        String line = singleWarnLine();
+        assertContains(line, "purposes=\"\"");
+        verify(svc).discoverPurposesForUser(any(PurposeUserRequest.class));
+    }
+
+    @Test
+    public void logEntityDeny_enrichmentPassesUserAndGroups() throws Exception {
+        PurposeDiscoveryService svc = mockPurposeService("p1");
+        AuthzDenyLogger.setPurposeDiscoveryServiceForTesting(svc);
+
+        AtlasEntityHeader entity = entity("Table", "g1", "qn-1");
+        AtlasEntityAccessRequest req = new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_READ, entity);
+        req.setUser("frank", set("team-a", "team-b"));
+
+        AuthzDenyLogger.logEntityDeny(req, new AtlasAccessResult(false), "");
+
+        org.mockito.ArgumentCaptor<PurposeUserRequest> captor =
+                org.mockito.ArgumentCaptor.forClass(PurposeUserRequest.class);
+        verify(svc).discoverPurposesForUser(captor.capture());
+        assertEquals("frank", captor.getValue().getUsername());
+        assertNotNull(captor.getValue().getGroups());
+        assertEquals(2, captor.getValue().getGroups().size());
+    }
+
+    // ------------------------------------------------------------
+    // Relationship deny
+    // ------------------------------------------------------------
+
+    @Test
+    public void logRelationshipDeny_rendersBothEnds() throws Exception {
+        AtlasEntityHeader end1 = entity("AtlasGlossaryTerm", "term-1", "term@glossary");
+        AtlasEntityHeader end2 = entity("Table", "tbl-1", "default.db.tbl@cluster");
+
+        AtlasRelationshipAccessRequest req = new AtlasRelationshipAccessRequest(
+                typeRegistry, AtlasPrivilege.RELATIONSHIP_ADD, "atlas_glossary_semantic_assignment", end1, end2);
+        req.setUser("grace", Collections.emptySet());
+
+        AtlasAccessResult result = explicitDenyResult("rel-policy", "term-to-asset-deny", "atlas", 0);
+
+        AuthzDenyLogger.logRelationshipDeny(req, result, "add relationship");
+
+        String line = singleWarnLine();
+        assertContains(line, "action=\"add-relationship\"");
+        assertContains(line, "relationshipType=\"atlas_glossary_semantic_assignment\"");
+        assertContains(line, "end1=\"AtlasGlossaryTerm/term-1\"");
+        assertContains(line, "end1Qn=\"term@glossary\"");
+        assertContains(line, "end2=\"Table/tbl-1\"");
+        assertContains(line, "end2Qn=\"default.db.tbl@cluster\"");
+        assertContains(line, "policyId=\"rel-policy\"");
+        assertContains(line, "policyName=\"term-to-asset-deny\"");
+    }
+
+    // ------------------------------------------------------------
+    // Type + admin deny
+    // ------------------------------------------------------------
+
+    @Test
+    public void logTypeDeny_includesTypeDefName() throws Exception {
+        AtlasBaseTypeDef def = new AtlasEntityDef("MyCustomType");
+        AtlasTypeAccessRequest req = new AtlasTypeAccessRequest(AtlasPrivilege.TYPE_CREATE, def);
+        req.setUser("heidi", Collections.emptySet());
+
+        AuthzDenyLogger.logTypeDeny(req, new AtlasAccessResult(false, "policy-t1"), "");
+
+        String line = singleWarnLine();
+        assertContains(line, "typeDef=\"MyCustomType\"");
+        assertContains(line, "action=\"type-create\"");
+        assertContains(line, "policyId=\"policy-t1\"");
+        assertContains(line, "explicitDeny=true");
+    }
+
+    @Test
+    public void logAdminDeny_scopeAdmin() throws Exception {
+        AtlasAdminAccessRequest req = new AtlasAdminAccessRequest(AtlasPrivilege.ADMIN_EXPORT);
+        req.setUser("ivan", Collections.emptySet());
+
+        AuthzDenyLogger.logAdminDeny(req, new AtlasAccessResult(false), "export");
+
+        String line = singleWarnLine();
+        assertContains(line, "scope=\"admin\"");
+        assertContains(line, "action=\"admin-export\"");
+        assertContains(line, "user=\"ivan\"");
+    }
+
+    // ------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------
+
+    private AtlasEntityHeader entity(String typeName, String guid, String qualifiedName) {
+        AtlasEntityHeader h = new AtlasEntityHeader();
+        h.setTypeName(typeName);
+        h.setGuid(guid);
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put("qualifiedName", qualifiedName);
+        h.setAttributes(attrs);
+        return h;
+    }
+
+    private Set<String> set(String... values) {
+        return new HashSet<>(Arrays.asList(values));
+    }
+
+    private AtlasAccessResult explicitDenyResult(String policyId, String enforcer, int priority) {
+        return explicitDenyResult(policyId, null, enforcer, priority);
+    }
+
+    private AtlasAccessResult explicitDenyResult(String policyId, String policyName, String enforcer, int priority) {
+        AtlasAccessResult r = new AtlasAccessResult(false, policyId, priority);
+        r.setPolicyName(policyName);
+        r.setEnforcer(enforcer);
+        return r;
+    }
+
+    private PurposeDiscoveryService mockPurposeService(String... purposeGuids) throws AtlasBaseException {
+        PurposeDiscoveryService svc = mock(PurposeDiscoveryService.class);
+        List<AtlasEntityHeader> purposes = new java.util.ArrayList<>();
+        for (String g : purposeGuids) {
+            AtlasEntityHeader h = new AtlasEntityHeader();
+            h.setTypeName("Purpose");
+            h.setGuid(g);
+            purposes.add(h);
+        }
+        PurposeUserResponse resp = new PurposeUserResponse();
+        resp.setPurposes(purposes);
+        when(svc.discoverPurposesForUser(any(PurposeUserRequest.class))).thenReturn(resp);
+        return svc;
+    }
+
+    private String singleWarnLine() {
+        List<ILoggingEvent> events = appender.list;
+        assertFalse("expected at least one log event", events.isEmpty());
+        ILoggingEvent evt = events.get(events.size() - 1);
+        assertEquals(Level.WARN, evt.getLevel());
+        return evt.getFormattedMessage();
+    }
+
+    private static void assertContains(String haystack, String needle) {
+        assertTrue("expected log line to contain: " + needle + "\nactual: " + haystack,
+                haystack.contains(needle));
+    }
+}


### PR DESCRIPTION
## Ring deploy — pes0cp02 only

Deploying [feat: centralized AUTHZ_DENY logging for ATLAS-403-00-001 denies](#6594) to `pes0cp02` (support-internal.atlan.com) for validation.

**Cohort:** `atlas-custom-authz-deny-pes0cp02` (single tenant — internal support sandbox only)

**Do not merge** — ring validation PR.