### PR TITLE
fix: CassandraSessionProvider auto-resolves connection from JanusGraph properties

### DIFF
--- a/graphdb/cassandra/src/main/java/org/apache/atlas/repository/graphdb/cassandra/CassandraSessionProvider.java
+++ b/graphdb/cassandra/src/main/java/org/apache/atlas/repository/graphdb/cassandra/CassandraSessionProvider.java
@@ -67,10 +67,21 @@ public class CassandraSessionProvider {
     }
 
     private static CqlSession createSession(Configuration configuration) {
-        String hostname = configuration.getString(CONFIG_PREFIX + "hostname", DEFAULT_HOSTNAME);
-        int    port     = configuration.getInt(CONFIG_PREFIX + "port", DEFAULT_PORT);
+        // Prefer atlas.cassandra.graph.* properties; fall back to atlas.graph.storage.* (JanusGraph properties)
+        // so that after earlyOverlay switches backend to cassandra, CassandraGraph automatically
+        // picks up the correct connection details without requiring extra static config keys.
+        String hostname = configuration.getString(CONFIG_PREFIX + "hostname", null);
+        if (hostname == null || hostname.isEmpty()) {
+            hostname = configuration.getString("atlas.graph.storage.hostname", DEFAULT_HOSTNAME);
+        }
+        int port = configuration.getInt(CONFIG_PREFIX + "port", -1);
+        if (port <= 0) {
+            port = configuration.getInt("atlas.graph.storage.cql.port",
+                    configuration.getInt("atlas.graph.storage.port", DEFAULT_PORT));
+        }
         String keyspace = configuration.getString(CONFIG_PREFIX + "keyspace", DEFAULT_KEYSPACE);
-        String dc       = configuration.getString(CONFIG_PREFIX + "datacenter", DEFAULT_DC);
+        String dc = configuration.getString(CONFIG_PREFIX + "datacenter",
+                configuration.getString("atlas.graph.storage.cql.local-datacenter", DEFAULT_DC));
 
         // Store connection config for shared session reuse by TagDAO, ConfigDAO, etc.
         configuredHostname = hostname;

--- a/repository/src/main/java/org/apache/atlas/service/config/StaticConfigStore.java
+++ b/repository/src/main/java/org/apache/atlas/service/config/StaticConfigStore.java
@@ -112,9 +112,13 @@ public class StaticConfigStore {
             }
             int port = props.getInt("atlas.config.store.cassandra.port", -1);
             if (port <= 0) {
-                port = props.getInt("atlas.graph.storage.cql.port", 9042);
+                port = props.getInt("atlas.graph.storage.cql.port",
+                        props.getInt("atlas.graph.storage.port", 9042));
             }
-            String datacenter = props.getString("atlas.config.store.cassandra.datacenter", "datacenter1");
+            String datacenter = props.getString("atlas.config.store.cassandra.datacenter", null);
+            if (datacenter == null || datacenter.isEmpty()) {
+                datacenter = props.getString("atlas.graph.storage.cql.local-datacenter", "datacenter1");
+            }
             String keyspace = props.getString("atlas.config.store.cassandra.keyspace", "config_store");
             String table = props.getString("atlas.static.config.store.table", "static_configs");
             String appName = props.getString("atlas.static.config.store.app.name", "atlas_static");
@@ -236,7 +240,13 @@ public class StaticConfigStore {
 
         int port = props.getInt("atlas.config.store.cassandra.port", -1);
         if (port <= 0) {
-            port = props.getInt("atlas.graph.storage.cql.port", 9042);
+            port = props.getInt("atlas.graph.storage.cql.port",
+                    props.getInt("atlas.graph.storage.port", 9042));
+        }
+
+        String datacenter = props.getString("atlas.config.store.cassandra.datacenter", null);
+        if (datacenter == null || datacenter.isEmpty()) {
+            datacenter = props.getString("atlas.graph.storage.cql.local-datacenter", "datacenter1");
         }
 
         String dynamicAppName = props.getString("atlas.config.store.app.name", "atlas");
@@ -247,7 +257,7 @@ public class StaticConfigStore {
                 dynamicAppName,
                 hostname,
                 port,
-                props.getString("atlas.config.store.cassandra.datacenter", "datacenter1"),
+                datacenter,
                 replicationFactor,
                 props.getString("atlas.config.store.cassandra.consistency.level", "LOCAL_QUORUM")
         );

--- a/tools/atlas_migrate_and_switch.sh
+++ b/tools/atlas_migrate_and_switch.sh
@@ -1059,6 +1059,8 @@ phase_switch() {
     step "Phase 2: Backend Switch"
 
     # 2.1 Seed static configs via API (persisted in Cassandra, take effect on restart)
+    #     Only 2 keys needed: backend + id strategy. Connection properties auto-resolve
+    #     from atlas.graph.storage.* via CassandraSessionProvider fallback.
     log "Seeding static configs via API..."
     seed_static_config "atlas.graphdb.backend" "cassandra"
     seed_static_config "atlas.graph.id.strategy" "${ID_STRATEGY}"

--- a/tools/atlas_migrate_tenant.sh
+++ b/tools/atlas_migrate_tenant.sh
@@ -1538,7 +1538,9 @@ phase_switch() {
     step "Phase 5: Backend Switch"
 
     # 5.1 Seed static configs via API (persisted in Cassandra, take effect on restart)
-    #     Only 2 keys needed — connection properties are already in atlas-application.properties.
+    #     Only 2 keys needed: backend + id strategy. earlyOverlay() reads these from
+    #     Cassandra BEFORE Spring context starts. Connection properties (hostname, port,
+    #     datacenter) auto-resolve from atlas.graph.storage.* via CassandraSessionProvider.
     #     No ConfigMap patching — Argo would revert it.
     log "Seeding static configs via API..."
     seed_static_config "atlas.graphdb.backend" "cassandra"


### PR DESCRIPTION
## Summary

After `earlyOverlay()` switches `atlas.graphdb.backend` to `cassandra`, `CassandraSessionProvider` was connecting to `localhost` because `atlas.cassandra.graph.*` properties were never set.

**Fix:** `CassandraSessionProvider.createSession()` now falls back to `atlas.graph.storage.*` properties (already in `atlas-application.properties`) when `atlas.cassandra.graph.*` are not explicitly configured:
- `atlas.cassandra.graph.hostname` → `atlas.graph.storage.hostname` → `localhost`
- `atlas.cassandra.graph.port` → `atlas.graph.storage.cql.port` → `atlas.graph.storage.port` → `9042`
- `atlas.cassandra.graph.datacenter` → `atlas.graph.storage.cql.local-datacenter` → `datacenter1`

**Design:** Only 2 static config keys are needed for the backend switch:
- `atlas.graphdb.backend=cassandra`
- `atlas.graph.id.strategy=deterministic`

Connection properties auto-resolve — no extra seeding required.

## Test plan
- [ ] Deploy to a migration tenant and verify CassandraGraph connects to the correct host (not localhost)
- [ ] Check logs for `Initializing Cassandra session: host=<actual-host>` (not `localhost`)
- [ ] Verify migration script Phase 5 still works with just 2 seed calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)