### PR TITLE
fix: CassandraGraph connection properties + static config seeding

### DIFF
--- a/graphdb/cassandra/src/main/java/org/apache/atlas/repository/graphdb/cassandra/CassandraSessionProvider.java
+++ b/graphdb/cassandra/src/main/java/org/apache/atlas/repository/graphdb/cassandra/CassandraSessionProvider.java
@@ -67,10 +67,20 @@ public class CassandraSessionProvider {
     }
 
     private static CqlSession createSession(Configuration configuration) {
-        String hostname = configuration.getString(CONFIG_PREFIX + "hostname", DEFAULT_HOSTNAME);
-        int    port     = configuration.getInt(CONFIG_PREFIX + "port", DEFAULT_PORT);
+        // Prefer atlas.cassandra.graph.* properties; fall back to atlas.graph.storage.* (JanusGraph properties)
+        // so existing deployments work without adding new config keys.
+        String hostname = configuration.getString(CONFIG_PREFIX + "hostname", null);
+        if (hostname == null || hostname.isEmpty()) {
+            hostname = configuration.getString("atlas.graph.storage.hostname", DEFAULT_HOSTNAME);
+        }
+        int port = configuration.getInt(CONFIG_PREFIX + "port", -1);
+        if (port <= 0) {
+            port = configuration.getInt("atlas.graph.storage.cql.port",
+                    configuration.getInt("atlas.graph.storage.port", DEFAULT_PORT));
+        }
         String keyspace = configuration.getString(CONFIG_PREFIX + "keyspace", DEFAULT_KEYSPACE);
-        String dc       = configuration.getString(CONFIG_PREFIX + "datacenter", DEFAULT_DC);
+        String dc = configuration.getString(CONFIG_PREFIX + "datacenter",
+                configuration.getString("atlas.graph.storage.cql.local-datacenter", DEFAULT_DC));
 
         // Store connection config for shared session reuse by TagDAO, ConfigDAO, etc.
         configuredHostname = hostname;

--- a/repository/src/main/java/org/apache/atlas/service/config/StaticConfigKey.java
+++ b/repository/src/main/java/org/apache/atlas/service/config/StaticConfigKey.java
@@ -18,7 +18,13 @@ public enum StaticConfigKey {
 
     GRAPH_BACKEND("atlas.graphdb.backend", "janus"),
 
-    GRAPH_ID_STRATEGY("atlas.graph.id.strategy", "legacy");
+    GRAPH_ID_STRATEGY("atlas.graph.id.strategy", "legacy"),
+
+    /** CassandraGraph connection properties — seeded by the migration script. */
+    CASSANDRA_GRAPH_HOSTNAME("atlas.cassandra.graph.hostname", null),
+    CASSANDRA_GRAPH_PORT("atlas.cassandra.graph.port", null),
+    CASSANDRA_GRAPH_KEYSPACE("atlas.cassandra.graph.keyspace", null),
+    CASSANDRA_GRAPH_DATACENTER("atlas.cassandra.graph.datacenter", null);
 
     private final String key;
     private final String defaultValue;

--- a/tools/atlas_migrate_and_switch.sh
+++ b/tools/atlas_migrate_and_switch.sh
@@ -1062,6 +1062,20 @@ phase_switch() {
     log "Seeding static configs via API..."
     seed_static_config "atlas.graphdb.backend" "cassandra"
     seed_static_config "atlas.graph.id.strategy" "${ID_STRATEGY}"
+
+    # CassandraGraph connection properties — read from properties file, seed into static config store.
+    # Without these, CassandraSessionProvider defaults to localhost after earlyOverlay switches backend.
+    local cass_host_seed cass_port_seed cass_dc_seed
+    cass_host_seed=$(kubectl exec "$POD" -n "$NAMESPACE" -c "$CONTAINER" -- \
+        grep '^atlas.graph.storage.hostname=' /opt/apache-atlas/conf/atlas-application.properties 2>/dev/null | cut -d= -f2 | head -1 || echo "atlas-cassandra")
+    cass_port_seed=$(kubectl exec "$POD" -n "$NAMESPACE" -c "$CONTAINER" -- \
+        grep '^atlas.graph.storage.port=' /opt/apache-atlas/conf/atlas-application.properties 2>/dev/null | cut -d= -f2 | head -1 || echo "9042")
+    cass_dc_seed=$(kubectl exec "$POD" -n "$NAMESPACE" -c "$CONTAINER" -- \
+        grep '^atlas.graph.storage.cql.local-datacenter=' /opt/apache-atlas/conf/atlas-application.properties 2>/dev/null | cut -d= -f2 | head -1 || echo "datacenter1")
+    seed_static_config "atlas.cassandra.graph.hostname" "${cass_host_seed:-atlas-cassandra}"
+    seed_static_config "atlas.cassandra.graph.port" "${cass_port_seed:-9042}"
+    seed_static_config "atlas.cassandra.graph.keyspace" "atlas_graph"
+    seed_static_config "atlas.cassandra.graph.datacenter" "${cass_dc_seed:-datacenter1}"
     ok "Static configs seeded (will take effect after restart)"
 
     # 2.2 Patch ConfigMap for connection properties (not managed by StaticConfigStore)

--- a/tools/atlas_migrate_tenant.sh
+++ b/tools/atlas_migrate_tenant.sh
@@ -112,6 +112,7 @@ LOG_FILE=""
 # Resolved connection endpoints (populated during preflight from atlas-application.properties)
 RESOLVED_CASS_HOST=""
 RESOLVED_CASS_PORT=""
+RESOLVED_CASS_DC=""
 RESOLVED_ES_HOST=""
 RESOLVED_ES_PORT=""
 RESOLVED_ES_PROTOCOL=""
@@ -466,12 +467,16 @@ phase_preflight() {
     if [ -z "$RESOLVED_CASS_PORT" ]; then
         RESOLVED_CASS_PORT=$(kexec_quiet grep '^atlas.graph.storage.port=' /opt/apache-atlas/conf/atlas-application.properties 2>/dev/null | tail -1 | cut -d= -f2 || echo "9042")
     fi
+    RESOLVED_CASS_DC=$(kexec_quiet grep '^atlas.cassandra.graph.datacenter=' /opt/apache-atlas/conf/atlas-application.properties 2>/dev/null | tail -1 | cut -d= -f2 || echo "")
+    if [ -z "$RESOLVED_CASS_DC" ]; then
+        RESOLVED_CASS_DC=$(kexec_quiet grep '^atlas.graph.storage.cql.local-datacenter=' /opt/apache-atlas/conf/atlas-application.properties 2>/dev/null | tail -1 | cut -d= -f2 || echo "datacenter1")
+    fi
     es_raw=$(kexec_quiet grep '^atlas.graph.index.search.hostname=' /opt/apache-atlas/conf/atlas-application.properties 2>/dev/null | tail -1 | cut -d= -f2- || echo "localhost:9200")
     RESOLVED_ES_HOST=$(echo "$es_raw" | cut -d':' -f1)
     RESOLVED_ES_PORT=$(echo "$es_raw" | grep -o ':[0-9]*' | tr -d ':' || echo "9200")
     RESOLVED_ES_PORT="${RESOLVED_ES_PORT:-9200}"
     RESOLVED_ES_PROTOCOL=$(kexec_quiet grep '^atlas.graph.index.search.elasticsearch.http.protocol=' /opt/apache-atlas/conf/atlas-application.properties 2>/dev/null | tail -1 | cut -d= -f2 || echo "http")
-    log "  Resolved endpoints: Cassandra=${RESOLVED_CASS_HOST}:${RESOLVED_CASS_PORT}, ES=${RESOLVED_ES_PROTOCOL}://${RESOLVED_ES_HOST}:${RESOLVED_ES_PORT}"
+    log "  Resolved endpoints: Cassandra=${RESOLVED_CASS_HOST}:${RESOLVED_CASS_PORT} (dc=${RESOLVED_CASS_DC}), ES=${RESOLVED_ES_PROTOCOL}://${RESOLVED_ES_HOST}:${RESOLVED_ES_PORT}"
 
     # 0.6c Connectivity probes (Cassandra + ES from inside the Atlas pod)
     log "Testing Cassandra connectivity from Atlas pod..."
@@ -1538,12 +1543,19 @@ phase_switch() {
     step "Phase 5: Backend Switch"
 
     # 5.1 Seed static configs via API (persisted in Cassandra, take effect on restart)
-    #     Only 2 keys needed — connection properties are already in atlas-application.properties.
+    #     earlyOverlay() reads these from Cassandra BEFORE Spring context starts,
+    #     so CassandraGraphDatabase and Constants.java see the correct values.
     #     No ConfigMap patching — Argo would revert it.
     log "Seeding static configs via API..."
     seed_static_config "atlas.graphdb.backend" "cassandra"
     # Always seed deterministic — migration runs with legacy IDs, but runtime uses deterministic
     seed_static_config "atlas.graph.id.strategy" "deterministic"
+    # CassandraGraph connection properties — resolved during preflight from atlas-application.properties.
+    # Without these, CassandraSessionProvider defaults to localhost after the backend switch.
+    seed_static_config "atlas.cassandra.graph.hostname" "$RESOLVED_CASS_HOST"
+    seed_static_config "atlas.cassandra.graph.port" "$RESOLVED_CASS_PORT"
+    seed_static_config "atlas.cassandra.graph.keyspace" "atlas_graph"
+    seed_static_config "atlas.cassandra.graph.datacenter" "$RESOLVED_CASS_DC"
     ok "Static configs seeded (will take effect after restart)"
 
     # 5.4 Trigger rolling restart of Atlas StatefulSet


### PR DESCRIPTION
## Summary
- **CassandraSessionProvider**: falls back to `atlas.graph.storage.hostname` (JanusGraph property) when `atlas.cassandra.graph.hostname` is not set, preventing localhost default after backend switch
- **StaticConfigKey**: adds `CASSANDRA_GRAPH_HOSTNAME`, `PORT`, `KEYSPACE`, `DATACENTER` to the whitelist so earlyOverlay() can read them from Cassandra
- **Migration scripts**: Phase 5 now seeds all 6 static configs (backend, id strategy, + 4 connection properties) resolved from the running pod's properties file

## Context
After #6598 made earlyOverlay() correctly switch the backend to cassandra, CassandraSessionProvider was instantiated for the first time — and defaulted to `localhost` because `atlas.cassandra.graph.hostname` was never configured. Previously this was hidden because the backend switch silently no-op'd (JanusGraph was always used).

## Test plan
- [ ] Deploy to ring-dev tenant with migration already completed
- [ ] Verify startup logs show `Initializing Cassandra session: host=atlas-cassandra` (not localhost)
- [ ] Run new migration on a fresh tenant — Phase 5 should seed all 6 static configs
- [ ] Verify earlyOverlay logs show all 6 configs overlaid

🤖 Generated with [Claude Code](https://claude.com/claude-code)