### PR TITLE
revert: ms-905 nestedColumnOrder nested mapping (MS-1120)

### DIFF
--- a/addons/elasticsearch/es-mappings.json
+++ b/addons/elasticsearch/es-mappings.json
@@ -1,16 +1,5 @@
 {
   "properties": {
-    "nestedColumnOrder": {
-      "type": "nested",
-      "properties": {
-        "version": {
-          "type": "version"
-        },
-        "order": {
-          "type": "keyword"
-        }
-      }
-    },
     "relationshipList": {
       "type": "nested",
       "properties": {

--- a/graphdb/migrator/src/main/java/org/apache/atlas/repository/graphdb/migrator/ElasticsearchReindexer.java
+++ b/graphdb/migrator/src/main/java/org/apache/atlas/repository/graphdb/migrator/ElasticsearchReindexer.java
@@ -206,10 +206,7 @@ public class ElasticsearchReindexer implements AutoCloseable {
      * text fields which break sort/aggregation queries on __guid, __typeName, etc.
      */
     private static final String DEFAULT_MAPPINGS_JSON =
-        "{\"properties\":{" +
-        "\"nestedColumnOrder\":{\"type\":\"nested\",\"properties\":" +
-        "{\"version\":{\"type\":\"version\"},\"order\":{\"type\":\"keyword\"}}}," +
-        "\"relationshipList\":{\"type\":\"nested\",\"properties\":" +
+        "{\"properties\":{\"relationshipList\":{\"type\":\"nested\",\"properties\":" +
         "{\"typeName\":{\"type\":\"keyword\"},\"guid\":{\"type\":\"keyword\"}," +
         "\"provenanceType\":{\"type\":\"integer\"},\"endName\":{\"type\":\"keyword\"}," +
         "\"endGuid\":{\"type\":\"keyword\"},\"endTypeName\":{\"type\":\"keyword\"}," +

--- a/webapp/src/test/resources/deploy/elasticsearch/es-mappings.json
+++ b/webapp/src/test/resources/deploy/elasticsearch/es-mappings.json
@@ -1,16 +1,5 @@
 {
   "properties": {
-    "nestedColumnOrder": {
-      "type": "nested",
-      "properties": {
-        "version": {
-          "type": "version"
-        },
-        "order": {
-          "type": "keyword"
-        }
-      }
-    },
     "relationshipList": {
       "type": "nested",
       "properties": {


### PR DESCRIPTION
## Summary

Straight revert of #6473 / ms-905 (`243c04f599`), which introduced `nestedColumnOrder` into the ES bootstrap template as `type: nested` with sub-`properties { version, order }`.

That shape produces an invalid mapping in the downstream low-downtime reshard workflow (`marketplace-scripts/.../reindex_low_downtime.py`), which merges the live mapping against typedef-derived config and emits `keyword + properties` — an illegal ES combination:

```
RequestError(400, 'mapper_parsing_exception',
  'unknown parameter [properties] on mapper [nestedColumnOrder] of type [keyword]')
```

Blocks the atlan07p01 reshard.

## What this PR does

`git revert 243c04f599` — no manual edits. Three files go back to their pre-ms-905 state:

- `addons/elasticsearch/es-mappings.json` — `nestedColumnOrder` block removed.
- `webapp/src/test/resources/deploy/elasticsearch/es-mappings.json` — same block removed (test mirror).
- `graphdb/migrator/src/main/java/org/apache/atlas/repository/graphdb/migrator/ElasticsearchReindexer.java` — `nestedColumnOrder` entry removed from `DEFAULT_MAPPINGS_JSON` fallback.

Net diff: 1 insertion, 26 deletions.

## Effect after this lands

`nestedColumnOrder` falls back to the existing `dynamic_templates.custom_metadata_strings` rule in the same file, so on new / reindexed indexes it maps as:

```json
{ "type": "keyword", "ignore_above": 5120 }
```

No explicit `nested`, no `properties`, no hybrid shape for the reshard generator to trip over.

## Caveats

- ms-905 was originally shipped to fix `failed to find nested object under path [nestedColumnOrder]` on Columns-tab sort queries. Reverting removes that explicit `nested` block. Whatever query path depended on `nestedColumnOrder` being a nested object will need to be validated — the field is now a flat `keyword` (via dynamic template) on any new/reindexed index.
- Existing indexes on already-bootstrapped tenants are **not** touched by this PR; their mapping can only change via reindex.
- If a specific shape (e.g. `keyword + fields.version + copy_to: ["all"]`) is needed in the bootstrap template, that should be a separate follow-up commit deliberately adding it — not carried in this revert.

## Linear

MS-1120