### PR TITLE
MS-771 Enable tag propagation across Tableau relationships

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,6 +27,7 @@ on:
       - lite_master
       - switchable-graph-provider
       - ring-*
+      - ms771
     paths-ignore:
       - '.claude/**'
       - '.cursor/**'

--- a/README.txt
+++ b/README.txt
@@ -71,4 +71,4 @@ Build Process
    distro/target/apache-atlas-<version>-storm-hook.tar.gz
    distro/target/apache-atlas-<version>-falcon-hook.tar.gz
 
-4. For more details on installing and running Apache Atlas, please refer to https://atlas.apache.org/#/Installation.
+4. For more details on installing and running Apache Atlas, please refer to https://atlas.apache.org/#/Installation

--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -157,6 +157,9 @@ public final class Constants {
     public static final String REL_DATA_PRODUCT_TO_OUTPUT_PORTS = "data_products_output_ports";
     public static final String REL_DATA_PRODUCT_TO_INPUT_PORTS  = "data_products_input_ports";
 
+    public static final String REL_TABLEAU_PROJECT_PROJECTS  = "tableau_project_tableau_project";
+    public static final String REL_TABLEAU_DASHBOARDS_DASHBOARDS  = "tableau_parent_dashboards_tableau_embedded_dashboards";
+
     public static final String INPUT_PORT_PRODUCT_EDGE_LABEL = "__Asset.inputPortDataProducts";
     public static final String OUTPUT_PORT_PRODUCT_EDGE_LABEL = "__Asset.outputPortDataProducts";
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasRelationshipStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasRelationshipStoreV2.java
@@ -119,6 +119,11 @@ public class AtlasRelationshipStoreV2 implements AtlasRelationshipStore {
         RELATIONSHIP_HARD_DELETE
     }
 
+    private static Set<String> EXCLUDE_FLIP_TAG_PROP_REL_TYPE_NAMES = new HashSet<String>() {{
+        add(REL_TABLEAU_PROJECT_PROJECTS);
+        add(REL_TABLEAU_DASHBOARDS_DASHBOARDS);
+    }};
+
     @Inject
     public AtlasRelationshipStoreV2(AtlasGraph graph, AtlasTypeRegistry typeRegistry, DeleteHandlerDelegate deleteDelegate,
                                     IAtlasEntityChangeNotifier entityChangeNotifier, EntityGraphRetriever entityRetriever) {
@@ -804,7 +809,7 @@ public class AtlasRelationshipStoreV2 implements AtlasRelationshipStore {
         // relationshipDef is defined as end1 (hive_db) and end2 (hive_table) and tagPropagation = ONE_TO_TWO
         // relationship edge exists from [hive_table --> hive_db]
         // swap the tagPropagation property for such cases.
-        if (fromVertexTypes.contains(endDef2.getType()) && toVertexTypes.contains(endDef1.getType())) {
+        if (!EXCLUDE_FLIP_TAG_PROP_REL_TYPE_NAMES.contains(relationship.getTypeName()) && fromVertexTypes.contains(endDef2.getType()) && toVertexTypes.contains(endDef1.getType())) {
             if (ret == ONE_TO_TWO) {
                 ret = TWO_TO_ONE;
             } else if (ret == TWO_TO_ONE) {


### PR DESCRIPTION
## Change description

Enables tag propagation across Tableau asset relationships with a flag-based canary rollout, allowing safe  enablement for `smuckers`

Supporting typeDefs PR - https://github.com/atlanhq/models/pull/1934

## Assumtion
Above typeDefs PR will be merged in master & hence all tenants will receive & apply relationshipDefs changes

## Changes                                                                                                                                                                                                                          
                                                                                                                                                                                                                                 
### Tag propagation across Tableau relationships (AtlasRelationshipStoreV2)                                                                                                                                                          
  - Added TABLEAU_PROP_SPECIAL_REL_TYPE_NAMES — a set of 11 Tableau relationship types whose tag propagation is gated behind the feature flag
  - When the flag is off, updateTagPropagations forces NONE propagation for these relationships, preserving existing behaviour  (flag will be off for all tenants other than `smuckers`)
  - When the flag is on, propagation follows the direction defined in the relationship definition (we will enable flag only for `smuckers`)
  - Added EXCLUDE_FLIP_TAG_PROP_REL_TYPE_NAMES — an extension point to prevent the end1↔end2 propagation-direction flip for specific relationship types without changing the general flip condition
                                                                                                                                                                                                                                   
### New constants (Constants.java)                                                                                                                                                                                                   
  - Added string constants for all 11 Tableau relationship types (workbook→dashboard, dashboard→worksheet, workbook→datasource, datasource→field, worksheet→datasource fields, site→project, project→project, datasource→calculated
   field, worksheet→calculated fields, workbook→worksheet)                                                                                                                                                                         
                                                                                                                                                                                                                                   
### Feature flag (AtlasConfiguration.java)                                                                                                                                                                                           
  - atlas.tag.propagation.tableau.special.enabled (default: false) — controls Tableau-specific tag propagation for mentioned special relationships; set to true to enable per tenant
                                                                                                                                                                                                                                   
### Local container support (AtlasConfiguration.java, RedisServiceImpl.java)
  - Added atlas.is.local.container flag (default: false)                                                                                                                                                                           
  - When running in a local container, Redis client uses getLocalConfig() instead of the prod/cache Sentinel configs — avoids Sentinel connection errors in local dev environments      


### How to enable                                                                                                                                                                                                                                                                                                                                                                                                                                      
 Set the following in the tenant's Atlas config to start propagating tags across Tableau relationships:                                                                                                                           
 `atlas.tag.propagation.tableau.special.enabled=true`    


### Testing                                                                                                                                                                                                                          
When typeDefs are not updated:
  - Verify tags do not propagate across Tableau relationships regardless flag value

When typeDefs are updated with propagate as `ONE_TO_TWO`:
- When flag is true (`smuckers` tenant)
  - Verify tags propagate correctly across all 11 Tableau relationship types  
  - Update `relationship.propagate` from `ONE_TO_TWO` to `NONE`, verify relationship reflects the expected `propagate`

- When flag is false (Non `smuckers` tenant)
  - Verify tags do not propagate across Tableau relationships
  - Update `relationship.propagate` from `NONE` to `ONE_TO_TWO`, verify relationship still reflects `propagate` as `NONE`



## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> https://linear.app/atlan-epd/issue/MS-771/changes-for-tableau-tag-propagation

## **Helm Config Changes for Running Tests (Staging PR)**  
### Does this PR require Helm config changes for testing?  
- [ ] **Tests are NOT required for this commit.** _(You can proceed with the PR.) ✅_  
- [ ] No, Helm config changes are not needed. _(You can proceed with the PR.) ✅_  
- [ ] Yes, I have already updated the config-values on `enpla9up36`. _(You can proceed with the PR.) ✅_  
- [ ] Yes, but I have NOT updated the config-values. _(Please update them before proceeding; or, tests will run with default values.)⚠️_  

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
